### PR TITLE
iam: Improve ISO tag handling

### DIFF
--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -5,3 +5,7 @@ resource/aws_iam_instance_profile: Improve tag handling in ISO regions
 ```release-note:bug
 resource/aws_iam_openid_connect_provider: Improve tag handling in ISO regions
 ```
+
+```release-note:bug
+resource/aws_iam_policy: Improve tag handling in ISO regions
+```

--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -9,3 +9,7 @@ resource/aws_iam_openid_connect_provider: Improve tag handling in ISO regions
 ```release-note:bug
 resource/aws_iam_policy: Improve tag handling in ISO regions
 ```
+
+```release-note:bug
+resource/aws_iam_saml_provider: Improve tag handling in ISO regions
+```

--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -13,3 +13,7 @@ resource/aws_iam_policy: Improve tag handling in ISO regions
 ```release-note:bug
 resource/aws_iam_saml_provider: Improve tag handling in ISO regions
 ```
+
+```release-note:bug
+resource/aws_iam_server_certificate: Improve tag handling in ISO regions
+```

--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -21,3 +21,7 @@ resource/aws_iam_server_certificate: Improve tag handling in ISO regions
 ```release-note:bug
 resource/aws_iam_service_linked_role: Improve tag handling in ISO regions
 ```
+
+```release-note:bug
+resource/aws_iam_virtual_mfa_device: Improve tag handling in ISO regions
+```

--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_iam_instance_profile: Improve tag handling in ISO regions
 ```
+
+```release-note:bug
+resource/aws_iam_openid_connect_provider: Improve tag handling in ISO regions
+```

--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_instance_profile: Improve tag handling in ISO regions
+```

--- a/.changelog/23283.txt
+++ b/.changelog/23283.txt
@@ -17,3 +17,7 @@ resource/aws_iam_saml_provider: Improve tag handling in ISO regions
 ```release-note:bug
 resource/aws_iam_server_certificate: Improve tag handling in ISO regions
 ```
+
+```release-note:bug
+resource/aws_iam_service_linked_role: Improve tag handling in ISO regions
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1432,7 +1432,7 @@ func Provider() *schema.Provider {
 			"aws_iam_user_policy":                 iam.ResourceUserPolicy(),
 			"aws_iam_user_policy_attachment":      iam.ResourceUserPolicyAttachment(),
 			"aws_iam_user_ssh_key":                iam.ResourceUserSSHKey(),
-			"aws_iam_virtual_mfa_device":          iam.ResourceVirtualMfaDevice(),
+			"aws_iam_virtual_mfa_device":          iam.ResourceVirtualMFADevice(),
 
 			"aws_imagebuilder_component":                    imagebuilder.ResourceComponent(),
 			"aws_imagebuilder_container_recipe":             imagebuilder.ResourceContainerRecipe(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1421,7 +1421,7 @@ func Provider() *schema.Provider {
 			"aws_iam_role":                        iam.ResourceRole(),
 			"aws_iam_role_policy":                 iam.ResourceRolePolicy(),
 			"aws_iam_role_policy_attachment":      iam.ResourceRolePolicyAttachment(),
-			"aws_iam_saml_provider":               iam.ResourceSamlProvider(),
+			"aws_iam_saml_provider":               iam.ResourceSAMLProvider(),
 			"aws_iam_server_certificate":          iam.ResourceServerCertificate(),
 			"aws_iam_service_linked_role":         iam.ResourceServiceLinkedRole(),
 			"aws_iam_service_specific_credential": iam.ResourceServiceSpecificCredential(),

--- a/internal/service/iam/find.go
+++ b/internal/service/iam/find.go
@@ -174,7 +174,7 @@ func FindRoleByName(conn *iam.IAM, name string) (*iam.Role, error) {
 	return output.Role, nil
 }
 
-func FindVirtualMfaDevice(conn *iam.IAM, serialNum string) (*iam.VirtualMFADevice, error) {
+func FindVirtualMFADevice(conn *iam.IAM, serialNum string) (*iam.VirtualMFADevice, error) {
 	input := &iam.ListVirtualMFADevicesInput{}
 
 	output, err := conn.ListVirtualMFADevices(input)

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -141,7 +141,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating tags for IAM Instance Profile (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM Instance Profile (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -94,14 +94,27 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 	request := &iam.CreateInstanceProfileInput{
 		InstanceProfileName: aws.String(name),
 		Path:                aws.String(d.Get("path").(string)),
-		Tags:                Tags(tags.IgnoreAWS()),
+	}
+
+	if len(tags) > 0 {
+		request.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	var err error
 	response, err := conn.CreateInstanceProfile(request)
-	if err == nil {
-		err = instanceProfileReadResult(d, response.InstanceProfile, meta)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed creating IAM Instance Profile (%s) with tags: %s. Trying create without tags.", name, err)
+		request.Tags = nil
+
+		response, err = conn.CreateInstanceProfile(request)
 	}
+
+	if err == nil {
+		err = instanceProfileReadResult(d, response.InstanceProfile, meta) // sets id
+	}
+
 	if err != nil {
 		return fmt.Errorf("creating IAM instance profile %s: %w", name, err)
 	}
@@ -115,6 +128,21 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 	err = conn.WaitUntilInstanceProfileExists(waiterRequest)
 	if err != nil {
 		return fmt.Errorf("timed out while waiting for instance profile %s: %w", name, err)
+	}
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if request.Tags == nil && len(tags) > 0 {
+		err := instanceProfileUpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM Instance Profile (%s): %s", d.Id(), err)
+			return resourceInstanceProfileUpdate(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating tags for IAM Instance Profile (%s): %w", d.Id(), err)
+		}
 	}
 
 	return resourceInstanceProfileUpdate(d, meta)
@@ -197,8 +225,16 @@ func resourceInstanceProfileUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := instanceProfileUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags for IAM Instance Profile (%s): %w", d.Id(), err)
+		err := instanceProfileUpdateTags(conn, d.Id(), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed updating tags for IAM Instance Profile (%s): %s", d.Id(), err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed updating tags for IAM Instance Profile (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -71,15 +71,42 @@ func resourceOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{
 		Url:            aws.String(d.Get("url").(string)),
 		ClientIDList:   flex.ExpandStringList(d.Get("client_id_list").([]interface{})),
 		ThumbprintList: flex.ExpandStringList(d.Get("thumbprint_list").([]interface{})),
-		Tags:           Tags(tags.IgnoreAWS()),
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	out, err := conn.CreateOpenIDConnectProvider(input)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed creating IAM OIDC Provider with tags: %s. Trying create without tags.", err)
+		input.Tags = nil
+
+		out, err = conn.CreateOpenIDConnectProvider(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating IAM OIDC Provider: %w", err)
 	}
 
 	d.SetId(aws.StringValue(out.OpenIDConnectProviderArn))
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if input.Tags == nil && len(tags) > 0 {
+		err := openIDConnectProviderUpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM OIDC Provider (%s): %s", d.Id(), err)
+			return resourceOpenIDConnectProviderRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating tags for IAM OIDC Provider (%s): %w", d.Id(), err)
+		}
+	}
 
 	return resourceOpenIDConnectProviderRead(d, meta)
 }
@@ -139,8 +166,16 @@ func resourceOpenIDConnectProviderUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := openIDConnectProviderUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags for IAM OIDC Provider (%s): %w", d.Id(), err)
+		err := openIDConnectProviderUpdateTags(conn, d.Id(), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed updating tags for IAM OIDC Provider (%s): %s", d.Id(), err)
+			return resourceOpenIDConnectProviderRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed updating tags for IAM OIDC Provider (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -104,7 +104,7 @@ func resourceOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating tags for IAM OIDC Provider (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM OIDC Provider (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -15,7 +15,7 @@ import (
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 )
 
-func TestAccIAMOpenidConnectProvider_basic(t *testing.T) {
+func TestAccIAMOpenIDConnectProvider_basic(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	url := "accounts.testle.com/" + rString
 	resourceName := "aws_iam_openid_connect_provider.test"
@@ -62,7 +62,7 @@ func TestAccIAMOpenidConnectProvider_basic(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenidConnectProvider_tags(t *testing.T) {
+func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 
@@ -107,7 +107,7 @@ func TestAccIAMOpenidConnectProvider_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenidConnectProvider_disappears(t *testing.T) {
+func TestAccIAMOpenIDConnectProvider_disappears(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -139,7 +139,7 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating tags for IAM Policy (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM Policy (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -106,15 +106,42 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 		Path:           aws.String(d.Get("path").(string)),
 		PolicyDocument: aws.String(policy),
 		PolicyName:     aws.String(name),
-		Tags:           Tags(tags.IgnoreAWS()),
+	}
+
+	if len(tags) > 0 {
+		request.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	response, err := conn.CreatePolicy(request)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed creating IAM Policy (%s) with tags: %s. Trying create without tags.", name, err)
+		request.Tags = nil
+
+		response, err = conn.CreatePolicy(request)
+	}
+
 	if err != nil {
-		return fmt.Errorf("error creating IAM policy %s: %w", name, err)
+		return fmt.Errorf("error creating IAM Policy %s: %w", name, err)
 	}
 
 	d.SetId(aws.StringValue(response.Policy.Arn))
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if request.Tags == nil && len(tags) > 0 {
+		err := policyUpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM Policy (%s): %s", d.Id(), err)
+			return resourcePolicyRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating tags for IAM Policy (%s): %w", d.Id(), err)
+		}
+	}
 
 	return resourcePolicyRead(d, meta)
 }
@@ -277,8 +304,16 @@ func resourcePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := policyUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags for IAM Policy (%s): %w", d.Id(), err)
+		err := policyUpdateTags(conn, d.Id(), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed updating tags for IAM Policy (%s): %s", d.Id(), err)
+			return resourcePolicyRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed updating tags for IAM Policy (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -321,12 +321,6 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags := KeyValueTags(role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] failed listing tags for IAM Role (%s): %s", d.Id(), err)
-		return nil
-	}
-
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -2,17 +2,14 @@ package iam
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceRole() *schema.Resource {
@@ -99,12 +96,6 @@ func dataSourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tags := KeyValueTags(output.Role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for IAM Role %s: %s", d.Id(), err)
-		return nil
-	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.Map()); err != nil {

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -17,12 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-func ResourceSamlProvider() *schema.Resource {
+func ResourceSAMLProvider() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceSamlProviderCreate,
-		Read:   resourceSamlProviderRead,
-		Update: resourceSamlProviderUpdate,
-		Delete: resourceSamlProviderDelete,
+		Create: resourceSAMLProviderCreate,
+		Read:   resourceSAMLProviderRead,
+		Update: resourceSAMLProviderUpdate,
+		Delete: resourceSAMLProviderDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -56,7 +56,7 @@ func ResourceSamlProvider() *schema.Resource {
 	}
 }
 
-func resourceSamlProviderCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceSAMLProviderCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -93,7 +93,7 @@ func resourceSamlProviderCreate(d *schema.ResourceData, meta interface{}) error 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] failed adding tags after create for IAM SAML Provider (%s): %s", d.Id(), err)
-			return resourceSamlProviderRead(d, meta)
+			return resourceSAMLProviderRead(d, meta)
 		}
 
 		if err != nil {
@@ -101,10 +101,10 @@ func resourceSamlProviderCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	return resourceSamlProviderRead(d, meta)
+	return resourceSAMLProviderRead(d, meta)
 }
 
-func resourceSamlProviderRead(d *schema.ResourceData, meta interface{}) error {
+func resourceSAMLProviderRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
@@ -123,7 +123,7 @@ func resourceSamlProviderRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("arn", d.Id())
-	name, err := extractNameFromIAMSamlProviderArn(d.Id())
+	name, err := extractNameFromIAMSAMLProviderArn(d.Id())
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func resourceSamlProviderRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceSamlProviderUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceSAMLProviderUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -167,7 +167,7 @@ func resourceSamlProviderUpdate(d *schema.ResourceData, meta interface{}) error 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] failed updating tags for IAM SAML Provider (%s): %s", d.Id(), err)
-			return resourceSamlProviderRead(d, meta)
+			return resourceSAMLProviderRead(d, meta)
 		}
 
 		if err != nil {
@@ -175,10 +175,10 @@ func resourceSamlProviderUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	return resourceSamlProviderRead(d, meta)
+	return resourceSAMLProviderRead(d, meta)
 }
 
-func resourceSamlProviderDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceSAMLProviderDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 
 	input := &iam.DeleteSAMLProviderInput{
@@ -195,7 +195,7 @@ func resourceSamlProviderDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func extractNameFromIAMSamlProviderArn(samlArn string) (string, error) {
+func extractNameFromIAMSAMLProviderArn(samlArn string) (string, error) {
 	parsedArn, err := arn.Parse(samlArn)
 	if err != nil {
 		return "", fmt.Errorf("Unable to extract name from a given ARN: %q", samlArn)

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -97,7 +97,7 @@ func resourceSAMLProviderCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating tags for IAM SAML Provider (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM SAML Provider (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/saml_provider_test.go
+++ b/internal/service/iam/saml_provider_test.go
@@ -15,7 +15,7 @@ import (
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 )
 
-func TestAccIAMSamlProvider_basic(t *testing.T) {
+func TestAccIAMSAMLProvider_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	idpEntityIdModified := fmt.Sprintf("https://%s", acctest.RandomDomainName())
@@ -25,12 +25,12 @@ func TestAccIAMSamlProvider_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckIAMSamlProviderDestroy,
+		CheckDestroy: testAccCheckIAMSAMLProviderDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMSamlProviderConfig(rName, idpEntityId),
+				Config: testAccIAMSAMLProviderConfig(rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMSamlProviderExists(resourceName),
+					testAccCheckIAMSAMLProviderExists(resourceName),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("saml-provider/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "saml_metadata_document"),
@@ -39,9 +39,9 @@ func TestAccIAMSamlProvider_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIAMSamlProviderConfigUpdate(rName, idpEntityIdModified),
+				Config: testAccIAMSAMLProviderConfigUpdate(rName, idpEntityIdModified),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMSamlProviderExists(resourceName),
+					testAccCheckIAMSAMLProviderExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "saml_metadata_document"),
 				),
@@ -55,7 +55,7 @@ func TestAccIAMSamlProvider_basic(t *testing.T) {
 	})
 }
 
-func TestAccIAMSamlProvider_tags(t *testing.T) {
+func TestAccIAMSAMLProvider_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_iam_saml_provider.test"
@@ -64,12 +64,12 @@ func TestAccIAMSamlProvider_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckIAMSamlProviderDestroy,
+		CheckDestroy: testAccCheckIAMSAMLProviderDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMSamlProviderConfigTags1(rName, idpEntityId, "key1", "value1"),
+				Config: testAccIAMSAMLProviderConfigTags1(rName, idpEntityId, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMSamlProviderExists(resourceName),
+					testAccCheckIAMSAMLProviderExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -80,18 +80,18 @@ func TestAccIAMSamlProvider_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMSamlProviderConfigTags2(rName, idpEntityId, "key1", "value1updated", "key2", "value2"),
+				Config: testAccIAMSAMLProviderConfigTags2(rName, idpEntityId, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMSamlProviderExists(resourceName),
+					testAccCheckIAMSAMLProviderExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccIAMSamlProviderConfigTags1(rName, idpEntityId, "key2", "value2"),
+				Config: testAccIAMSAMLProviderConfigTags1(rName, idpEntityId, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMSamlProviderExists(resourceName),
+					testAccCheckIAMSAMLProviderExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -100,7 +100,7 @@ func TestAccIAMSamlProvider_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMSamlProvider_disappears(t *testing.T) {
+func TestAccIAMSAMLProvider_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_iam_saml_provider.test"
@@ -109,13 +109,13 @@ func TestAccIAMSamlProvider_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckIAMSamlProviderDestroy,
+		CheckDestroy: testAccCheckIAMSAMLProviderDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMSamlProviderConfig(rName, idpEntityId),
+				Config: testAccIAMSAMLProviderConfig(rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMSamlProviderExists(resourceName),
-					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceSamlProvider(), resourceName),
+					testAccCheckIAMSAMLProviderExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceSAMLProvider(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -123,7 +123,7 @@ func TestAccIAMSamlProvider_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckIAMSamlProviderDestroy(s *terraform.State) error {
+func testAccCheckIAMSAMLProviderDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -152,7 +152,7 @@ func testAccCheckIAMSamlProviderDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckIAMSamlProviderExists(id string) resource.TestCheckFunc {
+func testAccCheckIAMSAMLProviderExists(id string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
@@ -172,7 +172,7 @@ func testAccCheckIAMSamlProviderExists(id string) resource.TestCheckFunc {
 	}
 }
 
-func testAccIAMSamlProviderConfig(rName, idpEntityId string) string {
+func testAccIAMSAMLProviderConfig(rName, idpEntityId string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test" {
   name                   = %[1]q
@@ -181,7 +181,7 @@ resource "aws_iam_saml_provider" "test" {
 `, rName, idpEntityId)
 }
 
-func testAccIAMSamlProviderConfigUpdate(rName, idpEntityIdModified string) string {
+func testAccIAMSAMLProviderConfigUpdate(rName, idpEntityIdModified string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test" {
   name                   = %[1]q
@@ -190,7 +190,7 @@ resource "aws_iam_saml_provider" "test" {
 `, rName, idpEntityIdModified)
 }
 
-func testAccIAMSamlProviderConfigTags1(rName, idpEntityId, tagKey1, tagValue1 string) string {
+func testAccIAMSAMLProviderConfigTags1(rName, idpEntityId, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test" {
   name                   = %[1]q
@@ -203,7 +203,7 @@ resource "aws_iam_saml_provider" "test" {
 `, rName, idpEntityId, tagKey1, tagValue1)
 }
 
-func testAccIAMSamlProviderConfigTags2(rName, idpEntityId, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccIAMSAMLProviderConfigTags2(rName, idpEntityId, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test" {
   name                   = %[1]q

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -164,7 +164,7 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating tags for IAM Server Certificate (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM Server Certificate (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -121,7 +121,10 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 		CertificateBody:       aws.String(d.Get("certificate_body").(string)),
 		PrivateKey:            aws.String(d.Get("private_key").(string)),
 		ServerCertificateName: aws.String(sslCertName),
-		Tags:                  Tags(tags.IgnoreAWS()),
+	}
+
+	if len(tags) > 0 {
+		createOpts.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("certificate_chain"); ok {
@@ -134,12 +137,36 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Creating IAM Server Certificate with opts: %s", createOpts)
 	resp, err := conn.UploadServerCertificate(createOpts)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed creating IAM Server Certificate (%s) with tags: %s. Trying create without tags.", sslCertName, err)
+		createOpts.Tags = nil
+
+		resp, err = conn.UploadServerCertificate(createOpts)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error uploading server certificate: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.ServerCertificateMetadata.ServerCertificateId))
 	d.Set("name", sslCertName)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if createOpts.Tags == nil && len(tags) > 0 {
+		err := serverCertificateUpdateTags(conn, d.Get("name").(string), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM Server Certificate (%s): %s", d.Id(), err)
+			return resourceServerCertificateRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating tags for IAM Server Certificate (%s): %w", d.Id(), err)
+		}
+	}
 
 	return resourceServerCertificateRead(d, meta)
 }
@@ -203,8 +230,16 @@ func resourceServerCertificateUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := serverCertificateUpdateTags(conn, d.Get("name").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags for IAM Server Certificate (%s): %w", d.Get("name").(string), err)
+		err := serverCertificateUpdateTags(conn, d.Get("name").(string), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed updating tags for IAM Server Certificate (%s): %s", d.Id(), err)
+			return resourceServerCertificateRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed updating tags for IAM Server Certificate (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -112,7 +112,15 @@ func resourceServiceLinkedRoleCreate(d *schema.ResourceData, meta interface{}) e
 			return err
 		}
 
-		if err := roleUpdateTags(conn, roleName, nil, tags); err != nil {
+		err = roleUpdateTags(conn, roleName, nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM Service Linked Role (%s): %s", d.Id(), err)
+			return resourceServiceLinkedRoleRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating IAM Service Linked Role (%s) tags: %w", d.Id(), err)
 		}
 	}
@@ -196,7 +204,15 @@ func resourceServiceLinkedRoleUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := roleUpdateTags(conn, roleName, o, n); err != nil {
+		err := roleUpdateTags(conn, roleName, o, n)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM Service Linked Role (%s): %s", d.Id(), err)
+			return resourceServiceLinkedRoleRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating IAM Service Linked Role (%s) tags: %w", d.Id(), err)
 		}
 	}

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -121,7 +121,7 @@ func resourceServiceLinkedRoleCreate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating IAM Service Linked Role (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM Service Linked Role (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -208,12 +208,12 @@ func resourceServiceLinkedRoleUpdate(d *schema.ResourceData, meta interface{}) e
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] failed adding tags after create for IAM Service Linked Role (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed updating tags for IAM Service Linked Role (%s): %s", d.Id(), err)
 			return resourceServiceLinkedRoleRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating IAM Service Linked Role (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed updating tags for IAM Service Linked Role (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/service_specific_credential_test.go
+++ b/internal/service/iam/service_specific_credential_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccServiceSpecificCredential_basic(t *testing.T) {
+func TestAccIAMServiceSpecificCredential_basic(t *testing.T) {
 	var cred iam.ServiceSpecificCredentialMetadata
 
 	resourceName := "aws_iam_service_specific_credential.test"
@@ -47,7 +47,7 @@ func TestAccServiceSpecificCredential_basic(t *testing.T) {
 	})
 }
 
-func TestAccServiceSpecificCredential_multi(t *testing.T) {
+func TestAccIAMServiceSpecificCredential_multi(t *testing.T) {
 	var cred iam.ServiceSpecificCredentialMetadata
 
 	resourceName := "aws_iam_service_specific_credential.test"
@@ -86,7 +86,7 @@ func TestAccServiceSpecificCredential_multi(t *testing.T) {
 	})
 }
 
-func TestAccServiceSpecificCredential_status(t *testing.T) {
+func TestAccIAMServiceSpecificCredential_status(t *testing.T) {
 	var cred iam.ServiceSpecificCredentialMetadata
 
 	resourceName := "aws_iam_service_specific_credential.test"
@@ -129,7 +129,7 @@ func TestAccServiceSpecificCredential_status(t *testing.T) {
 	})
 }
 
-func TestAccServiceSpecificCredential_disappears(t *testing.T) {
+func TestAccIAMServiceSpecificCredential_disappears(t *testing.T) {
 	var cred iam.ServiceSpecificCredentialMetadata
 	resourceName := "aws_iam_service_specific_credential.test"
 

--- a/internal/service/iam/signing_certificate_test.go
+++ b/internal/service/iam/signing_certificate_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccSigningCertificate_basic(t *testing.T) {
+func TestAccIAMSigningCertificate_basic(t *testing.T) {
 	var cred iam.SigningCertificate
 
 	resourceName := "aws_iam_signing_certificate.test"
@@ -47,7 +47,7 @@ func TestAccSigningCertificate_basic(t *testing.T) {
 	})
 }
 
-func TestAccSigningCertificate_status(t *testing.T) {
+func TestAccIAMSigningCertificate_status(t *testing.T) {
 	var cred iam.SigningCertificate
 
 	resourceName := "aws_iam_signing_certificate.test"
@@ -91,7 +91,7 @@ func TestAccSigningCertificate_status(t *testing.T) {
 	})
 }
 
-func TestAccSigningCertificate_disappears(t *testing.T) {
+func TestAccIAMSigningCertificate_disappears(t *testing.T) {
 	var cred iam.SigningCertificate
 	resourceName := "aws_iam_signing_certificate.test"
 

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -78,7 +78,7 @@ func init() {
 
 	resource.AddTestSweepers("aws_iam_saml_provider", &resource.Sweeper{
 		Name: "aws_iam_saml_provider",
-		F:    sweepSamlProvider,
+		F:    sweepSAMLProvider,
 	})
 
 	resource.AddTestSweepers("aws_iam_service_specific_credential", &resource.Sweeper{
@@ -525,7 +525,7 @@ func sweepRoles(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func sweepSamlProvider(region string) error {
+func sweepSAMLProvider(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
@@ -539,7 +539,7 @@ func sweepSamlProvider(region string) error {
 	for _, sampProvider := range out.SAMLProviderList {
 		arn := aws.StringValue(sampProvider.Arn)
 
-		r := ResourceSamlProvider()
+		r := ResourceSAMLProvider()
 		d := r.Data(nil)
 		d.SetId(arn)
 		err := r.Delete(d, client)

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -113,7 +113,7 @@ func init() {
 
 	resource.AddTestSweepers("aws_iam_virtual_mfa_device", &resource.Sweeper{
 		Name: "aws_iam_virtual_mfa_device",
-		F:    sweepVirtualMfaDevice,
+		F:    sweepVirtualMFADevice,
 	})
 }
 
@@ -869,7 +869,7 @@ func roleNameFilter(name string) bool {
 	return false
 }
 
-func sweepVirtualMfaDevice(region string) error {
+func sweepVirtualMFADevice(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
@@ -891,7 +891,7 @@ func sweepVirtualMfaDevice(region string) error {
 				continue
 			}
 
-			r := ResourceVirtualMfaDevice()
+			r := ResourceVirtualMFADevice()
 			d := r.Data(nil)
 			d.SetId(serialNum)
 			err := r.Delete(d, client)

--- a/internal/service/iam/tags.go
+++ b/internal/service/iam/tags.go
@@ -258,9 +258,9 @@ func serverCertificateUpdateTags(conn *iam.IAM, identifier string, oldTagsMap in
 	return nil
 }
 
-// virtualMfaUpdateTags updates IAM Virtual MFA Device tags.
+// virtualMFAUpdateTags updates IAM Virtual MFA Device tags.
 // The identifier is the Virtual MFA Device ARN.
-func virtualMfaUpdateTags(conn *iam.IAM, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+func virtualMFAUpdateTags(conn *iam.IAM, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
 	oldTags := tftags.New(oldTagsMap)
 	newTags := tftags.New(newTagsMap)
 

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -187,12 +187,6 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags := KeyValueTags(output.User.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] failed listing tags for IAM User (%s): %s", d.Id(), err)
-		return nil
-	}
-
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/internal/service/iam/user_data_source.go
+++ b/internal/service/iam/user_data_source.go
@@ -5,12 +5,10 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceUser() *schema.Resource {
@@ -69,12 +67,6 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("user_id", user.UserId)
 
 	tags := KeyValueTags(user.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for IAM User %s: %s", d.Id(), err)
-		return nil
-	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.Map()); err != nil {

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -16,12 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-func ResourceVirtualMfaDevice() *schema.Resource {
+func ResourceVirtualMFADevice() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVirtualMfaDeviceCreate,
-		Read:   resourceVirtualMfaDeviceRead,
-		Update: resourceVirtualMfaDeviceUpdate,
-		Delete: resourceVirtualMfaDeviceDelete,
+		Create: resourceVirtualMFADeviceCreate,
+		Read:   resourceVirtualMFADeviceRead,
+		Update: resourceVirtualMFADeviceUpdate,
+		Delete: resourceVirtualMFADeviceDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -62,7 +62,7 @@ func ResourceVirtualMfaDevice() *schema.Resource {
 	}
 }
 
-func resourceVirtualMfaDeviceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMFADeviceCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -78,24 +78,49 @@ func resourceVirtualMfaDeviceCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	output, err := conn.CreateVirtualMFADevice(request)
-	if err != nil {
-		return fmt.Errorf("Error creating IAM Virtual MFA Device %s: %w", name, err)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed creating IAM Virtual MFA Device (%s) with tags: %s. Trying create without tags.", name, err)
+		request.Tags = nil
+
+		output, err = conn.CreateVirtualMFADevice(request)
 	}
+
+	if err != nil {
+		return fmt.Errorf("failed creating IAM Virtual MFA Device %s: %w", name, err)
+	}
+
 	vMfa := output.VirtualMFADevice
 	d.SetId(aws.StringValue(vMfa.SerialNumber))
 
 	d.Set("base_32_string_seed", string(vMfa.Base32StringSeed))
 	d.Set("qr_code_png", string(vMfa.QRCodePNG))
 
-	return resourceVirtualMfaDeviceRead(d, meta)
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if request.Tags == nil && len(tags) > 0 {
+		err := virtualMFAUpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+			log.Printf("[WARN] failed adding tags after create for IAM Virtual MFA Device (%s): %s", d.Id(), err)
+			return resourceVirtualMFADeviceRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating tags for IAM Virtual MFA Device (%s): %w", d.Id(), err)
+		}
+	}
+
+	return resourceVirtualMFADeviceRead(d, meta)
 }
 
-func resourceVirtualMfaDeviceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMFADeviceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	output, err := FindVirtualMfaDevice(conn, d.Id())
+	output, err := FindVirtualMFADevice(conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] IAM Virtual MFA Device (%s) not found, removing from state", d.Id())
@@ -133,19 +158,27 @@ func resourceVirtualMfaDeviceRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceVirtualMfaDeviceUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMFADeviceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 
 	o, n := d.GetChange("tags_all")
 
-	if err := virtualMfaUpdateTags(conn, d.Id(), o, n); err != nil {
+	err := virtualMFAUpdateTags(conn, d.Id(), o, n)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed updating tags for IAM Virtual MFA Device (%s): %s", d.Id(), err)
+		return resourceVirtualMFADeviceRead(d, meta)
+	}
+
+	if err != nil {
 		return fmt.Errorf("error updating tags for IAM Virtual MFA Device (%s): %w", d.Id(), err)
 	}
 
-	return resourceVirtualMfaDeviceRead(d, meta)
+	return resourceVirtualMFADeviceRead(d, meta)
 }
 
-func resourceVirtualMfaDeviceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMFADeviceDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 
 	request := &iam.DeleteVirtualMFADeviceInput{

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -108,7 +108,7 @@ func resourceVirtualMFADeviceCreate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating tags for IAM Virtual MFA Device (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM Virtual MFA Device (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -172,7 +172,7 @@ func resourceVirtualMFADeviceUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err != nil {
-		return fmt.Errorf("error updating tags for IAM Virtual MFA Device (%s): %w", d.Id(), err)
+		return fmt.Errorf("failed updating tags for IAM Virtual MFA Device (%s): %w", d.Id(), err)
 	}
 
 	return resourceVirtualMFADeviceRead(d, meta)

--- a/internal/service/iam/virtual_mfa_device_test.go
+++ b/internal/service/iam/virtual_mfa_device_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccVirtualMfaDevice_basic(t *testing.T) {
+func TestAccVirtualMFADevice_basic(t *testing.T) {
 	var conf iam.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
 
@@ -25,12 +25,12 @@ func TestAccVirtualMfaDevice_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckVirtualMfaDeviceDestroy,
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVirtualMfaDeviceConfig(rName),
+				Config: testAccVirtualMFADeviceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVirtualMfaDeviceExists(resourceName, &conf),
+					testAccCheckVirtualMFADeviceExists(resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("mfa/%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "base_32_string_seed"),
 					resource.TestCheckResourceAttrSet(resourceName, "qr_code_png"),
@@ -46,7 +46,7 @@ func TestAccVirtualMfaDevice_basic(t *testing.T) {
 	})
 }
 
-func TestAccVirtualMfaDevice_tags(t *testing.T) {
+func TestAccVirtualMFADevice_tags(t *testing.T) {
 	var conf iam.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
 
@@ -56,12 +56,12 @@ func TestAccVirtualMfaDevice_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckVirtualMfaDeviceDestroy,
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVirtualMfaDeviceConfigTags1(rName, "key1", "value1"),
+				Config: testAccVirtualMFADeviceConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVirtualMfaDeviceExists(resourceName, &conf),
+					testAccCheckVirtualMFADeviceExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -73,18 +73,18 @@ func TestAccVirtualMfaDevice_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"path", "virtual_mfa_device_name", "base_32_string_seed", "qr_code_png"},
 			},
 			{
-				Config: testAccVirtualMfaDeviceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVirtualMFADeviceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVirtualMfaDeviceExists(resourceName, &conf),
+					testAccCheckVirtualMFADeviceExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccVirtualMfaDeviceConfigTags1(rName, "key2", "value2"),
+				Config: testAccVirtualMFADeviceConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVirtualMfaDeviceExists(resourceName, &conf),
+					testAccCheckVirtualMFADeviceExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -93,7 +93,7 @@ func TestAccVirtualMfaDevice_tags(t *testing.T) {
 	})
 }
 
-func TestAccVirtualMfaDevice_disappears(t *testing.T) {
+func TestAccVirtualMFADevice_disappears(t *testing.T) {
 	var conf iam.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
 
@@ -103,14 +103,14 @@ func TestAccVirtualMfaDevice_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckVirtualMfaDeviceDestroy,
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVirtualMfaDeviceConfig(rName),
+				Config: testAccVirtualMFADeviceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVirtualMfaDeviceExists(resourceName, &conf),
-					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceVirtualMfaDevice(), resourceName),
-					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceVirtualMfaDevice(), resourceName),
+					testAccCheckVirtualMFADeviceExists(resourceName, &conf),
+					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceVirtualMFADevice(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceVirtualMFADevice(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -118,7 +118,7 @@ func TestAccVirtualMfaDevice_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckVirtualMfaDeviceDestroy(s *terraform.State) error {
+func testAccCheckVirtualMFADeviceDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -126,7 +126,7 @@ func testAccCheckVirtualMfaDeviceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		output, err := tfiam.FindVirtualMfaDevice(conn, rs.Primary.ID)
+		output, err := tfiam.FindVirtualMFADevice(conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -141,7 +141,7 @@ func testAccCheckVirtualMfaDeviceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckVirtualMfaDeviceExists(n string, res *iam.VirtualMFADevice) resource.TestCheckFunc {
+func testAccCheckVirtualMFADeviceExists(n string, res *iam.VirtualMFADevice) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -154,7 +154,7 @@ func testAccCheckVirtualMfaDeviceExists(n string, res *iam.VirtualMFADevice) res
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn
 
-		output, err := tfiam.FindVirtualMfaDevice(conn, rs.Primary.ID)
+		output, err := tfiam.FindVirtualMFADevice(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func testAccCheckVirtualMfaDeviceExists(n string, res *iam.VirtualMFADevice) res
 	}
 }
 
-func testAccVirtualMfaDeviceConfig(rName string) string {
+func testAccVirtualMFADeviceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_virtual_mfa_device" "test" {
   virtual_mfa_device_name = %[1]q
@@ -173,7 +173,7 @@ resource "aws_iam_virtual_mfa_device" "test" {
 `, rName)
 }
 
-func testAccVirtualMfaDeviceConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVirtualMFADeviceConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_virtual_mfa_device" "test" {
   virtual_mfa_device_name = %[1]q
@@ -185,7 +185,7 @@ resource "aws_iam_virtual_mfa_device" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccVirtualMfaDeviceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVirtualMFADeviceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_virtual_mfa_device" "test" {
   virtual_mfa_device_name = %[1]q

--- a/internal/service/iam/virtual_mfa_device_test.go
+++ b/internal/service/iam/virtual_mfa_device_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccVirtualMFADevice_basic(t *testing.T) {
+func TestAccIAMVirtualMFADevice_basic(t *testing.T) {
 	var conf iam.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
 
@@ -46,7 +46,7 @@ func TestAccVirtualMFADevice_basic(t *testing.T) {
 	})
 }
 
-func TestAccVirtualMFADevice_tags(t *testing.T) {
+func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 	var conf iam.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
 
@@ -93,7 +93,7 @@ func TestAccVirtualMFADevice_tags(t *testing.T) {
 	})
 }
 
-func TestAccVirtualMFADevice_disappears(t *testing.T) {
+func TestAccIAMVirtualMFADevice_disappears(t *testing.T) {
 	var conf iam.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22532 
Closes #23286

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccIAMInstanceProfile_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMInstanceProfile_'  -timeout 180m
--- PASS: TestAccIAMInstanceProfile_Disappears_role (22.21s)
--- PASS: TestAccIAMInstanceProfile_disappears (22.49s)
--- PASS: TestAccIAMInstanceProfile_withoutRole (24.29s)
--- PASS: TestAccIAMInstanceProfile_basic (24.89s)
--- PASS: TestAccIAMInstanceProfile_namePrefix (24.90s)
--- PASS: TestAccIAMInstanceProfile_tags (46.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	48.541s
% make testacc TESTS=TestAccIAMOpenIDConnectProvider_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOpenIDConnectProvider_'  -timeout 180m
--- PASS: TestAccIAMOpenIDConnectProvider_disappears (12.61s)
--- PASS: TestAccIAMOpenIDConnectProvider_basic (27.61s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags (37.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	39.338s
% make testacc TESTS=TestAccIAMPolicy_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy_'  -timeout 180m
--- PASS: TestAccIAMPolicy_disappears (14.01s)
--- PASS: TestAccIAMPolicy_namePrefix (18.04s)
--- PASS: TestAccIAMPolicy_basic (18.04s)
--- PASS: TestAccIAMPolicy_description (18.08s)
--- PASS: TestAccIAMPolicy_path (18.09s)
--- PASS: TestAccIAMPolicy_policy (27.58s)
--- PASS: TestAccIAMPolicy_tags (36.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	38.506s
% make testacc TESTS=TestAccIAMSAMLProvider PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMSAMLProvider'  -timeout 180m
--- PASS: TestAccIAMSAMLProvider_disappears (13.93s)
--- PASS: TestAccIAMSAMLProvider_basic (29.92s)
--- PASS: TestAccIAMSAMLProvider_tags (40.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	42.488s
% make testacc TESTS=TestAccIAMServerCertificate PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMServerCertificate'  -timeout 180m
--- PASS: TestAccIAMServerCertificateDataSource_matchNamePrefix (4.66s)
--- PASS: TestAccIAMServerCertificate_disappears (17.80s)
--- PASS: TestAccIAMServerCertificate_Name_prefix (20.35s)
--- PASS: TestAccIAMServerCertificateDataSource_basic (20.68s)
--- PASS: TestAccIAMServerCertificateDataSource_path (20.77s)
--- PASS: TestAccIAMServerCertificate_path (22.88s)
--- PASS: TestAccIAMServerCertificate_basic (22.93s)
--- PASS: TestAccIAMServerCertificate_file (32.95s)
--- PASS: TestAccIAMServerCertificate_tags (46.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	48.800s
% make testacc TESTS=TestAccIAMServiceLinkedRole PKG=iam     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMServiceLinkedRole'  -timeout 180m
--- PASS: TestAccIAMServiceLinkedRole_disappears (25.11s)
--- PASS: TestAccIAMServiceLinkedRole_basic (30.96s)
--- PASS: TestAccIAMServiceLinkedRole_CustomSuffix_diffSuppressFunc (30.98s)
--- PASS: TestAccIAMServiceLinkedRole_customSuffix (31.02s)
--- PASS: TestAccIAMServiceLinkedRole_description (43.59s)
--- PASS: TestAccIAMServiceLinkedRole_tags (53.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	55.516s
% make testacc TESTS=TestAccIAMVirtualMFADevice_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMVirtualMFADevice_'  -timeout 180m
--- PASS: TestAccIAMVirtualMFADevice_disappears (13.35s)
--- PASS: TestAccIAMVirtualMFADevice_basic (17.62s)
--- PASS: TestAccIAMVirtualMFADevice_tags (40.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	42.001s
```
