### PR TITLE
imagebuilder/image_recipe: Add `systems_manager_agent.uninstall_after_build` argument

### DIFF
--- a/.changelog/23293.txt
+++ b/.changelog/23293.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image_recipe: Add `systems_manager_agent.uninstall_after_build` argument
+```

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -183,6 +183,21 @@ func ResourceImageRecipe() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"systems_manager_agent": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uninstall_after_build": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"user_data_base64": {
@@ -250,14 +265,22 @@ func resourceImageRecipeCreate(d *schema.ResourceData, meta interface{}) error {
 		input.ParentImage = aws.String(v.(string))
 	}
 
+	input.AdditionalInstanceConfiguration = &imagebuilder.AdditionalInstanceConfiguration{
+		SystemsManagerAgent: &imagebuilder.SystemsManagerAgent{
+			UninstallAfterBuild: aws.Bool(false),
+		},
+	}
+
+	if v, ok := d.GetOk("systems_manager_agent"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.AdditionalInstanceConfiguration.SystemsManagerAgent = expandSystemsManagerAgent(v.([]interface{})[0].(map[string]interface{}))
+	}
+
 	if len(tags) > 0 {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("user_data_base64"); ok {
-		input.AdditionalInstanceConfiguration = &imagebuilder.AdditionalInstanceConfiguration{
-			UserDataOverride: aws.String(v.(string)),
-		}
+		input.AdditionalInstanceConfiguration.UserDataOverride = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("version"); ok {
@@ -330,6 +353,7 @@ func resourceImageRecipeRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if imageRecipe.AdditionalInstanceConfiguration != nil {
+		d.Set("systems_manager_agent", []interface{}{flattenSystemsManagerAgent(imageRecipe.AdditionalInstanceConfiguration.SystemsManagerAgent)})
 		d.Set("user_data_base64", imageRecipe.AdditionalInstanceConfiguration.UserDataOverride)
 	}
 
@@ -555,6 +579,20 @@ func expandInstanceBlockDeviceMappings(tfList []interface{}) []*imagebuilder.Ins
 	return apiObjects
 }
 
+func expandSystemsManagerAgent(tfMap map[string]interface{}) *imagebuilder.SystemsManagerAgent {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.SystemsManagerAgent{}
+
+	if v, ok := tfMap["uninstall_after_build"].(bool); ok {
+		apiObject.UninstallAfterBuild = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
 func flattenComponentConfiguration(apiObject *imagebuilder.ComponentConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
@@ -709,4 +747,18 @@ func flattenInstanceBlockDeviceMappings(apiObjects []*imagebuilder.InstanceBlock
 	}
 
 	return tfList
+}
+
+func flattenSystemsManagerAgent(apiObject *imagebuilder.SystemsManagerAgent) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.UninstallAfterBuild; v != nil {
+		tfMap["uninstall_after_build"] = aws.BoolValue(v)
+	}
+
+	return tfMap
 }

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -569,6 +569,33 @@ func TestAccImageBuilderImageRecipe_pipelineUpdateDependency(t *testing.T) {
 	})
 }
 
+func TestAccImageBuilderImageRecipe_systemsManagerAgent(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageRecipeSystemsManagerAgentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageRecipeExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "systems_manager_agent.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "systems_manager_agent.0.uninstall_after_build", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderImageRecipe_userDataBase64(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
@@ -1191,6 +1218,26 @@ resource "aws_imagebuilder_image_recipe" "test" {
   name         = %[1]q
   parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
+}
+`, rName))
+}
+
+func testAccImageRecipeSystemsManagerAgentConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccImageRecipeBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_image_recipe" "test" {
+  component {
+    component_arn = aws_imagebuilder_component.test.arn
+  }
+
+  name             = %[1]q
+  parent_image     = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version          = "1.0.0"
+
+  systems_manager_agent {
+	  uninstall_after_build = true
+  }
 }
 `, rName))
 }

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -1231,12 +1231,12 @@ resource "aws_imagebuilder_image_recipe" "test" {
     component_arn = aws_imagebuilder_component.test.arn
   }
 
-  name             = %[1]q
-  parent_image     = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
-  version          = "1.0.0"
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
 
   systems_manager_agent {
-	  uninstall_after_build = true
+    uninstall_after_build = true
   }
 }
 `, rName))

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -57,6 +57,7 @@ The following attributes are optional:
 
 * `block_device_mapping` - (Optional) Configuration block(s) with block device mappings for the image recipe. Detailed below.
 * `description` - (Optional) Description of the image recipe.
+* `systems_manager_agent` - (Optional) Configuration block for the Systems Manager Agent installed by default by Image Builder. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags for the image recipe. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `user_data_base64` (Optional) Base64 encoded user data. Use this to provide commands or a command script to run when you launch your build instance.
 * `working_directory` - (Optional) The working directory to be used during build and test workflows.
@@ -95,6 +96,12 @@ The following arguments are required:
 
 * `name` - (Required) The name of the component parameter.
 * `value` - (Required) The value for the named component parameter.
+
+### systems_manager_agent
+
+The following arguments are required:
+
+* `uninstall_after_build` - (Required) Whether to remove the Systems Manager Agent after the image has been built. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22159

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccImageBuilderImageRecipe PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipe'  -timeout 180m
=== RUN   TestAccImageBuilderImageRecipeDataSource_arn
=== PAUSE TestAccImageBuilderImageRecipeDataSource_arn
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_disappears
=== PAUSE TestAccImageBuilderImageRecipe_disappears
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderImageRecipe_component
=== PAUSE TestAccImageBuilderImageRecipe_component
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== RUN   TestAccImageBuilderImageRecipe_description
=== PAUSE TestAccImageBuilderImageRecipe_description
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImageRecipe_workingDirectory
=== PAUSE TestAccImageBuilderImageRecipe_workingDirectory
=== RUN   TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageBuilderImageRecipe_systemsManagerAgent
=== PAUSE TestAccImageBuilderImageRecipe_systemsManagerAgent
=== RUN   TestAccImageBuilderImageRecipe_userDataBase64
=== PAUSE TestAccImageBuilderImageRecipe_userDataBase64
=== RUN   TestAccImageBuilderImageRecipesDataSource_owner
    image_recipes_data_source_test.go:21: Step 1/1 error: Check failed: Check 3/6 error: data.aws_imagebuilder_image_recipes.self: Attribute 'arns.#' expected "1", got "2"
--- FAIL: TestAccImageBuilderImageRecipesDataSource_owner (22.29s)
=== RUN   TestAccImageBuilderImageRecipesDataSource_filter
=== PAUSE TestAccImageBuilderImageRecipesDataSource_filter
=== CONT  TestAccImageBuilderImageRecipeDataSource_arn
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== CONT  TestAccImageBuilderImageRecipe_workingDirectory
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== CONT  TestAccImageBuilderImageRecipesDataSource_filter
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageBuilderImageRecipe_systemsManagerAgent
=== CONT  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== CONT  TestAccImageBuilderImageRecipe_userDataBase64
=== CONT  TestAccImageBuilderImageRecipe_component
=== CONT  TestAccImageBuilderImageRecipe_description
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (67.90s)
=== CONT  TestAccImageBuilderImageRecipe_tags
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (71.16s)
=== CONT  TestAccImageBuilderImageRecipe_disappears
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (71.72s)
=== CONT  TestAccImageBuilderImageRecipe_basic
--- PASS: TestAccImageBuilderImageRecipe_description (71.83s)
--- PASS: TestAccImageBuilderImageRecipesDataSource_filter (73.75s)
--- PASS: TestAccImageBuilderImageRecipeDataSource_arn (74.01s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (75.52s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (76.48s)
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (78.92s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (80.54s)
--- PASS: TestAccImageBuilderImageRecipe_systemsManagerAgent (80.94s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (81.77s)
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (83.22s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (83.32s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (83.40s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (84.63s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (84.72s)
--- PASS: TestAccImageBuilderImageRecipe_component (85.67s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (90.54s)
--- PASS: TestAccImageBuilderImageRecipe_disappears (36.44s)
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (109.48s)
--- PASS: TestAccImageBuilderImageRecipe_basic (41.86s)
--- PASS: TestAccImageBuilderImageRecipe_tags (86.03s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	176.273s
FAIL
make: *** [GNUmakefile:36: testacc] Error 1
```
Note that the failure in the datasource fails on current main branch too