### PR TITLE
r/db_instance: add backup_replication

### DIFF
--- a/internal/service/rds/enum.go
+++ b/internal/service/rds/enum.go
@@ -20,6 +20,8 @@ func StorageType_Values() []string {
 	}
 }
 
+const DefaultKmsKeyAlias = "alias/aws/rds"
+
 // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html#Overview.DBInstance.Status.
 const (
 	InstanceStatusAvailable                     = "available"

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -88,6 +88,7 @@ Defaults to true.
 * `availability_zone` - (Optional) The AZ for the RDS instance.
 * `backup_retention_period` - (Optional) The days to retain backups for. Must be
 between `0` and `35`. Must be greater than `0` if the database is used as a source for a Read Replica. [See Read Replica][1].
+* `backup_replication` - (Optional) Store automated snapshots in another region. When specifying `backup_replication`, `backup_retention_period` needs to be set to true. See [Replicating automated backups to another AWS Region](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReplicateBackups.html#AutomatedBackups.Replicating.Enable).
 * `backup_window` - (Optional) The daily time range (in UTC) during which
 automated backups are created if they are enabled. Example: "09:46-10:16". Must
 not overlap with `maintenance_window`.
@@ -252,6 +253,16 @@ resource "aws_db_instance" "db" {
 * `source_engine_version` - (Required, as of Feb 2018 only '5.6' supported) Version of the source engine used to make the backup
 
 This will not recreate the resource if the S3 object changes in some way.  It's only used to initialize the database
+
+### Backup Replication Options
+
+You can configure the database to store the automated snapshots in a different region. Full details in the API Docs: [StartDBInstanceAutomatedBackupsReplication](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartDBInstanceAutomatedBackupsReplication.html).
+
+The `backup_replication` block supports the following arguments:
+
+* `destination_region` - (Required) The region to replicate the backups to (must be a different region than the database resides in)
+* `backup_retention_period` - (Optional) How many days to to store backups for in the destination region
+* `kms_key_id` - (Optional) If `storage_encrypted` is enabled and this is not provided, the default aws kms key for rds is used
 
 ### Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

This adds a `backup_replication` block (as mentioned in the original issue) that enables automatic backups to be replicated to a `destination_region`.

**AWS Docs**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReplicateBackups.html#AutomatedBackups.Replicating.Enable

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20606

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS='TestAccRDSInstance_backupReplication_basic' PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_backupReplication_basic'  -timeout 180m
=== RUN   TestAccRDSInstance_backupReplication_basic
=== PAUSE TestAccRDSInstance_backupReplication_basic
=== CONT  TestAccRDSInstance_backupReplication_basic
--- PASS: TestAccRDSInstance_backupReplication_basic (651.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        651.910s
```
