### PR TITLE
Add 'Context' as an optional parameter for EC2 'CreateFleet'

### DIFF
--- a/.changelog/23304.txt
+++ b/.changelog/23304.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_fleet: Add `context` argument
+```

--- a/internal/service/ec2/fleet.go
+++ b/internal/service/ec2/fleet.go
@@ -502,6 +502,7 @@ func resourceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	input := &ec2.ModifyFleetInput{
+		Context:                         aws.String(d.Get("context").(string)),
 		ExcessCapacityTerminationPolicy: aws.String(d.Get("excess_capacity_termination_policy").(string)),
 		LaunchTemplateConfigs:           expandEc2FleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]interface{})),
 		FleetId:                         aws.String(d.Id()),

--- a/internal/service/ec2/fleet.go
+++ b/internal/service/ec2/fleet.go
@@ -339,7 +339,6 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateFleetInput{
-		Context:                          aws.String(d.Get("context").(string)),
 		ExcessCapacityTerminationPolicy:  aws.String(d.Get("excess_capacity_termination_policy").(string)),
 		LaunchTemplateConfigs:            expandEc2FleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]interface{})),
 		OnDemandOptions:                  expandEc2OnDemandOptionsRequest(d.Get("on_demand_options").([]interface{})),
@@ -356,6 +355,10 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[WARN] EC2 Fleet (%s) has an invalid configuration and can not be created. Capacity Rebalance maintenance strategies can only be specified for fleets of type maintain.", input)
 			return nil
 		}
+	}
+
+	if v, ok := d.GetOk("context"); ok {
+		input.Context = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Fleet: %s", input)
@@ -457,6 +460,7 @@ func resourceFleetRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	d.Set("context", fleet.Context)
 	d.Set("excess_capacity_termination_policy", fleet.ExcessCapacityTerminationPolicy)
 
 	if err := d.Set("launch_template_config", flattenEc2FleetLaunchTemplateConfigs(fleet.LaunchTemplateConfigs)); err != nil {

--- a/internal/service/ec2/fleet.go
+++ b/internal/service/ec2/fleet.go
@@ -35,6 +35,10 @@ func ResourceFleet() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"context": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"excess_capacity_termination_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -335,6 +339,7 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateFleetInput{
+		Context:                          aws.String(d.Get("context").(string)),
 		ExcessCapacityTerminationPolicy:  aws.String(d.Get("excess_capacity_termination_policy").(string)),
 		LaunchTemplateConfigs:            expandEc2FleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]interface{})),
 		OnDemandOptions:                  expandEc2OnDemandOptionsRequest(d.Get("on_demand_options").([]interface{})),

--- a/internal/service/ec2/fleet_test.go
+++ b/internal/service/ec2/fleet_test.go
@@ -33,6 +33,7 @@ func TestAccEC2Fleet_basic(t *testing.T) {
 				Config: testAccFleetConfig_TargetCapacitySpecification_DefaultTargetCapacityType(rName, "spot"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
+					resource.TestCheckResourceAttr(resourceName, "context", ""),
 					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "termination"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.0.launch_template_specification.#", "1"),

--- a/website/docs/r/ec2_fleet.html.markdown
+++ b/website/docs/r/ec2_fleet.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 
 * `launch_template_config` - (Required) Nested argument containing EC2 Launch Template configurations. Defined below.
 * `target_capacity_specification` - (Required) Nested argument containing target capacity configurations. Defined below.
+* `context` - (Optional) Reserved.
 * `excess_capacity_termination_policy` - (Optional) Whether running instances should be terminated if the total target capacity of the EC2 Fleet is decreased below the current size of the EC2. Valid values: `no-termination`, `termination`. Defaults to `termination`.
 * `on_demand_options` - (Optional) Nested argument containing On-Demand configurations. Defined below.
 * `replace_unhealthy_instances` - (Optional) Whether EC2 Fleet should replace unhealthy instances. Defaults to `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23302

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Fleet'  -timeout 180m
=== RUN   TestAccEC2Fleet_basic
=== PAUSE TestAccEC2Fleet_basic
=== RUN   TestAccEC2Fleet_disappears
=== PAUSE TestAccEC2Fleet_disappears
=== RUN   TestAccEC2Fleet_excessCapacityTerminationPolicy
=== PAUSE TestAccEC2Fleet_excessCapacityTerminationPolicy
=== RUN   TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID
=== PAUSE TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID
=== RUN   TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== PAUSE TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== RUN   TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version
=== PAUSE TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version
=== RUN   TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone
=== RUN   TestAccEC2Fleet_LaunchTemplateOverride_instanceType
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverride_instanceType
=== RUN   TestAccEC2Fleet_LaunchTemplateOverride_maxPrice
    acctest.go:68: EC2 API is not correctly returning MaxPrice override
--- SKIP: TestAccEC2Fleet_LaunchTemplateOverride_maxPrice (0.00s)
=== RUN   TestAccEC2Fleet_LaunchTemplateOverride_priority
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverride_priority
=== RUN   TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple
=== RUN   TestAccEC2Fleet_LaunchTemplateOverride_subnetID
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverride_subnetID
=== RUN   TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity
=== RUN   TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple
=== PAUSE TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple
=== RUN   TestAccEC2Fleet_OnDemandOptions_allocationStrategy
=== PAUSE TestAccEC2Fleet_OnDemandOptions_allocationStrategy
=== RUN   TestAccEC2Fleet_replaceUnhealthyInstances
=== PAUSE TestAccEC2Fleet_replaceUnhealthyInstances
=== RUN   TestAccEC2Fleet_SpotOptions_allocationStrategy
=== PAUSE TestAccEC2Fleet_SpotOptions_allocationStrategy
=== RUN   TestAccEC2Fleet_SpotOptions_capacityRebalance
=== PAUSE TestAccEC2Fleet_SpotOptions_capacityRebalance
=== RUN   TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior
=== PAUSE TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior
=== RUN   TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount
=== PAUSE TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount
=== RUN   TestAccEC2Fleet_tags
=== PAUSE TestAccEC2Fleet_tags
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType
=== RUN   TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDemand
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDemand
=== RUN   TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== RUN   TestAccEC2Fleet_terminateInstancesWithExpiration
=== PAUSE TestAccEC2Fleet_terminateInstancesWithExpiration
=== RUN   TestAccEC2Fleet_type
=== PAUSE TestAccEC2Fleet_type
=== RUN   TestAccEC2Fleet_templateMultipleNetworkInterfaces
=== PAUSE TestAccEC2Fleet_templateMultipleNetworkInterfaces
=== CONT  TestAccEC2Fleet_basic
=== CONT  TestAccEC2Fleet_replaceUnhealthyInstances
=== CONT  TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple
=== CONT  TestAccEC2Fleet_templateMultipleNetworkInterfaces
=== CONT  TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple
=== CONT  TestAccEC2Fleet_LaunchTemplateOverride_subnetID
=== CONT  TestAccEC2Fleet_OnDemandOptions_allocationStrategy
=== CONT  TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity
=== CONT  TestAccEC2Fleet_LaunchTemplateOverride_instanceType
=== CONT  TestAccEC2Fleet_tags
=== CONT  TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount
=== CONT  TestAccEC2Fleet_LaunchTemplateOverride_priority
=== CONT  TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior
=== CONT  TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== CONT  TestAccEC2Fleet_SpotOptions_capacityRebalance
=== CONT  TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== CONT  TestAccEC2Fleet_type
=== CONT  TestAccEC2Fleet_SpotOptions_allocationStrategy
=== CONT  TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version
=== CONT  TestAccEC2Fleet_terminateInstancesWithExpiration
--- PASS: TestAccEC2Fleet_SpotOptions_capacityRebalance (107.96s)
--- PASS: TestAccEC2Fleet_basic (120.33s)
=== CONT  TestAccEC2Fleet_excessCapacityTerminationPolicy
--- PASS: TestAccEC2Fleet_type (122.70s)
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType
--- PASS: TestAccEC2Fleet_OnDemandOptions_allocationStrategy (175.64s)
=== CONT  TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID
--- PASS: TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior (187.38s)
=== CONT  TestAccEC2Fleet_disappears
--- PASS: TestAccEC2Fleet_replaceUnhealthyInstances (187.51s)
=== CONT  TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDemand
--- PASS: TestAccEC2Fleet_SpotOptions_allocationStrategy (187.66s)
=== CONT  TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot
--- PASS: TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount (187.93s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple (200.35s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity (210.04s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_priority (210.10s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceType (219.71s)
--- PASS: TestAccEC2Fleet_tags (222.73s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version (223.20s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple (223.30s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateName (223.33s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone (223.36s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_subnetID (224.53s)
--- PASS: TestAccEC2Fleet_excessCapacityTerminationPolicy (120.83s)
--- PASS: TestAccEC2Fleet_terminateInstancesWithExpiration (133.70s)
--- PASS: TestAccEC2Fleet_disappears (67.90s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDemand (69.92s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType (136.75s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot (75.00s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID (122.53s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity (596.31s)
--- PASS: TestAccEC2Fleet_templateMultipleNetworkInterfaces (598.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        602.909s
```
