### PR TITLE
fix arn is exported instead of id for aws_kms_external_key

### DIFF
--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -64,6 +64,10 @@ func ResourceExternalKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"key_material_base64": {
 				Type:      schema.TypeString,
 				Optional:  true,

--- a/internal/service/kms/external_key_test.go
+++ b/internal/service/kms/external_key_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestAccKMSExternalKey_basic(t *testing.T) {
-	var key kms.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -31,12 +30,12 @@ func TestAccKMSExternalKey_basic(t *testing.T) {
 			{
 				Config: testAccExternalKeyConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckExternalKeyExists(resourceName, &key),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`key/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
 					resource.TestCheckResourceAttr(resourceName, "deletion_window_in_days", "30"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "expiration_model", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckNoResourceAttr(resourceName, "key_material_base64"),
 					resource.TestCheckResourceAttr(resourceName, "key_state", "PendingImport"),
 					resource.TestCheckResourceAttr(resourceName, "key_usage", "ENCRYPT_DECRYPT"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23277

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTS=TestAccKMSExternalKey_ PKG=kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20 -run='TestAccKMSExternalKey_'  -timeout 180m
=== RUN   TestAccKMSExternalKey_basic
=== PAUSE TestAccKMSExternalKey_basic
=== RUN   TestAccKMSExternalKey_disappears
=== PAUSE TestAccKMSExternalKey_disappears
=== RUN   TestAccKMSExternalKey_multiRegion
=== PAUSE TestAccKMSExternalKey_multiRegion
=== RUN   TestAccKMSExternalKey_deletionWindowInDays
=== PAUSE TestAccKMSExternalKey_deletionWindowInDays
=== RUN   TestAccKMSExternalKey_description
=== PAUSE TestAccKMSExternalKey_description
=== RUN   TestAccKMSExternalKey_enabled
=== PAUSE TestAccKMSExternalKey_enabled
=== RUN   TestAccKMSExternalKey_keyMaterialBase64
=== PAUSE TestAccKMSExternalKey_keyMaterialBase64
=== RUN   TestAccKMSExternalKey_policy
=== PAUSE TestAccKMSExternalKey_policy
=== RUN   TestAccKMSExternalKey_policyBypass
=== PAUSE TestAccKMSExternalKey_policyBypass
=== RUN   TestAccKMSExternalKey_tags
=== PAUSE TestAccKMSExternalKey_tags
=== RUN   TestAccKMSExternalKey_validTo
=== PAUSE TestAccKMSExternalKey_validTo
=== CONT  TestAccKMSExternalKey_basic
=== CONT  TestAccKMSExternalKey_keyMaterialBase64
=== CONT  TestAccKMSExternalKey_validTo
=== CONT  TestAccKMSExternalKey_multiRegion
=== CONT  TestAccKMSExternalKey_disappears
=== CONT  TestAccKMSExternalKey_enabled
=== CONT  TestAccKMSExternalKey_deletionWindowInDays
=== CONT  TestAccKMSExternalKey_policyBypass
=== CONT  TestAccKMSExternalKey_policy
=== CONT  TestAccKMSExternalKey_description
=== CONT  TestAccKMSExternalKey_tags
--- PASS: TestAccKMSExternalKey_disappears (69.51s)
--- PASS: TestAccKMSExternalKey_basic (88.11s)
--- PASS: TestAccKMSExternalKey_multiRegion (89.31s)
--- PASS: TestAccKMSExternalKey_policyBypass (92.68s)
--- PASS: TestAccKMSExternalKey_deletionWindowInDays (133.79s)
--- PASS: TestAccKMSExternalKey_policy (143.53s)
--- PASS: TestAccKMSExternalKey_description (143.90s)
--- PASS: TestAccKMSExternalKey_tags (174.49s)
--- PASS: TestAccKMSExternalKey_keyMaterialBase64 (202.24s)
--- PASS: TestAccKMSExternalKey_enabled (249.42s)
--- PASS: TestAccKMSExternalKey_validTo (274.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        277.125s
...
```
