### PR TITLE
imagebuilder/image_pipeline: Add `schedule.timezone` parameter

### DIFF
--- a/.changelog/23322.txt
+++ b/.changelog/23322.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image_pipeline: Add `schedule.timezone` argument
+````

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -129,6 +129,14 @@ func ResourceImagePipeline() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.StringLenBetween(1, 1024),
 						},
+						"timezone": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(3, 100),
+								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9]{2,}(?:\/[a-zA-z0-9-_+]+)*`), "")),
+						},
 					},
 				},
 			},
@@ -402,6 +410,10 @@ func expandPipelineSchedule(tfMap map[string]interface{}) *imagebuilder.Schedule
 		apiObject.ScheduleExpression = aws.String(v)
 	}
 
+	if v, ok := tfMap["timezone"].(string); ok && v != "" {
+		apiObject.Timezone = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -436,6 +448,10 @@ func flattenSchedule(apiObject *imagebuilder.Schedule) map[string]interface{} {
 
 	if v := apiObject.ScheduleExpression; v != nil {
 		tfMap["schedule_expression"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Timezone; v != nil {
+		tfMap["timezone"] = aws.StringValue(v)
 	}
 
 	return tfMap

--- a/website/docs/r/imagebuilder_image_pipeline.html.markdown
+++ b/website/docs/r/imagebuilder_image_pipeline.html.markdown
@@ -60,6 +60,8 @@ The following arguments are optional:
 
 * `pipeline_execution_start_condition` - (Optional) Condition when the pipeline should trigger a new image build. Valid values are `EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE` and `EXPRESSION_MATCH_ONLY`. Defaults to `EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE`.
 
+* `timezone` - (Optional) The timezone that applies to the scheduling expression. For example, "Etc/UTC", "America/Los_Angeles" in the [IANA timezone format](https://www.joda.org/joda-time/timezones.html). If not specified this defaults to UTC.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23238

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccImageBuilderImagePipeline PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImagePipeline'  -timeout 180m
=== RUN   TestAccImageBuilderImagePipelineDataSource_arn
=== PAUSE TestAccImageBuilderImagePipelineDataSource_arn
=== RUN   TestAccImageBuilderImagePipelineDataSource_containerRecipeARN
=== PAUSE TestAccImageBuilderImagePipelineDataSource_containerRecipeARN
=== RUN   TestAccImageBuilderImagePipeline_basic
=== PAUSE TestAccImageBuilderImagePipeline_basic
=== RUN   TestAccImageBuilderImagePipeline_disappears
=== PAUSE TestAccImageBuilderImagePipeline_disappears
=== RUN   TestAccImageBuilderImagePipeline_description
=== PAUSE TestAccImageBuilderImagePipeline_description
=== RUN   TestAccImageBuilderImagePipeline_distributionARN
=== PAUSE TestAccImageBuilderImagePipeline_distributionARN
=== RUN   TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled
=== PAUSE TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled
=== RUN   TestAccImageBuilderImagePipeline_imageRecipeARN
=== PAUSE TestAccImageBuilderImagePipeline_imageRecipeARN
=== RUN   TestAccImageBuilderImagePipeline_containerRecipeARN
=== PAUSE TestAccImageBuilderImagePipeline_containerRecipeARN
=== RUN   TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled
=== PAUSE TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled
=== RUN   TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes
=== PAUSE TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes
=== RUN   TestAccImageBuilderImagePipeline_infrastructureARN
=== PAUSE TestAccImageBuilderImagePipeline_infrastructureARN
=== RUN   TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition
=== PAUSE TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition
=== RUN   TestAccImageBuilderImagePipeline_Schedule_scheduleExpression
=== PAUSE TestAccImageBuilderImagePipeline_Schedule_scheduleExpression
=== RUN   TestAccImageBuilderImagePipeline_Schedule_timezone
=== PAUSE TestAccImageBuilderImagePipeline_Schedule_timezone
=== RUN   TestAccImageBuilderImagePipeline_status
=== PAUSE TestAccImageBuilderImagePipeline_status
=== RUN   TestAccImageBuilderImagePipeline_tags
=== PAUSE TestAccImageBuilderImagePipeline_tags
=== CONT  TestAccImageBuilderImagePipelineDataSource_arn
=== CONT  TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled
=== CONT  TestAccImageBuilderImagePipeline_distributionARN
=== CONT  TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition
=== CONT  TestAccImageBuilderImagePipeline_Schedule_scheduleExpression
=== CONT  TestAccImageBuilderImagePipeline_infrastructureARN
=== CONT  TestAccImageBuilderImagePipeline_imageRecipeARN
=== CONT  TestAccImageBuilderImagePipeline_containerRecipeARN
=== CONT  TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled
=== CONT  TestAccImageBuilderImagePipeline_Schedule_timezone
=== CONT  TestAccImageBuilderImagePipeline_description
=== CONT  TestAccImageBuilderImagePipeline_disappears
=== CONT  TestAccImageBuilderImagePipeline_tags
=== CONT  TestAccImageBuilderImagePipeline_status
=== CONT  TestAccImageBuilderImagePipelineDataSource_containerRecipeARN
=== CONT  TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes
=== CONT  TestAccImageBuilderImagePipeline_basic
--- PASS: TestAccImageBuilderImagePipelineDataSource_arn (75.68s)
--- PASS: TestAccImageBuilderImagePipeline_disappears (80.04s)
--- PASS: TestAccImageBuilderImagePipelineDataSource_containerRecipeARN (82.62s)
--- PASS: TestAccImageBuilderImagePipeline_basic (91.83s)
--- PASS: TestAccImageBuilderImagePipeline_containerRecipeARN (119.51s)
--- PASS: TestAccImageBuilderImagePipeline_status (119.81s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_scheduleExpression (121.48s)
--- PASS: TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled (122.67s)
--- PASS: TestAccImageBuilderImagePipeline_infrastructureARN (122.67s)
--- PASS: TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled (124.10s)
--- PASS: TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes (125.13s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_timezone (125.86s)
--- PASS: TestAccImageBuilderImagePipeline_description (126.30s)
--- PASS: TestAccImageBuilderImagePipeline_imageRecipeARN (126.53s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition (127.29s)
--- PASS: TestAccImageBuilderImagePipeline_distributionARN (127.39s)
--- PASS: TestAccImageBuilderImagePipeline_tags (149.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	150.006s
```
