### PR TITLE
r/s3_bucket_lifecycle_configuration: improve documentation and officially deprecate `prefix`

### DIFF
--- a/.changelog/23325.txt
+++ b/.changelog/23325.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket_lifecycle_configuration: The `prefix` argument of the `rule` configuration block has been deprecated. Use the `filter` configuration block instead.
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -201,8 +201,9 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 						},
 
 						"prefix": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use filter instead",
 						},
 
 						"status": {

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -242,6 +242,8 @@ func ExpandLifecycleRuleFilter(l []interface{}) *s3.LifecycleRuleFilter {
 		result.Tag = ExpandLifecycleRuleFilterTag(v[0].(map[string]interface{}))
 	}
 
+	// Per AWS S3 API, "A Filter must have exactly one of Prefix, Tag, or And specified";
+	// Specifying more than one of the listed parameters results in a MalformedXML error.
 	if v, ok := m["prefix"].(string); ok && result.And == nil && result.Tag == nil {
 		result.Prefix = aws.String(v)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23299
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23228

### Description:

* The `prefix` argument is deprecated as suggested in the documentation; AWS has already announced its deprecation.
* The resource documentation examples are enhanced to encourage `filter` use and provide more specifics on how to use filtering based on use-case

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
