### PR TITLE
r/aws_ec2_network_insights_path - new resource

### DIFF
--- a/.changelog/23330.txt
+++ b/.changelog/23330.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ec2_network_insights_path
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -295,7 +295,7 @@ func Provider() *schema.Provider {
 				}, nil),
 				Description: "The region where AWS operations will take place. Examples\n" +
 					"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003,
-				InputDefault: "us-east-1", // lintignore:AWSAT003
+				InputDefault: "us-east-1",            // lintignore:AWSAT003
 			},
 			"s3_force_path_style": {
 				Type:       schema.TypeBool,
@@ -1199,6 +1199,7 @@ func Provider() *schema.Provider {
 			"aws_ec2_local_gateway_route_table_vpc_association":    ec2.ResourceLocalGatewayRouteTableVPCAssociation(),
 			"aws_ec2_managed_prefix_list":                          ec2.ResourceManagedPrefixList(),
 			"aws_ec2_managed_prefix_list_entry":                    ec2.ResourceManagedPrefixListEntry(),
+			"aws_ec2_network_insights_path":                        ec2.ResourceNetworkInsightsPath(),
 			"aws_ec2_subnet_cidr_reservation":                      ec2.ResourceSubnetCIDRReservation(),
 			"aws_ec2_tag":                                          ec2.ResourceTag(),
 			"aws_ec2_traffic_mirror_filter":                        ec2.ResourceTrafficMirrorFilter(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -295,7 +295,7 @@ func Provider() *schema.Provider {
 				}, nil),
 				Description: "The region where AWS operations will take place. Examples\n" +
 					"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003,
-				InputDefault: "us-east-1",            // lintignore:AWSAT003
+				InputDefault: "us-east-1", // lintignore:AWSAT003
 			},
 			"s3_force_path_style": {
 				Type:       schema.TypeBool,

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -38,6 +38,7 @@ const (
 	ErrCodeInvalidNetworkAclEntryNotFound                 = "InvalidNetworkAclEntry.NotFound"
 	ErrCodeInvalidNetworkAclIDNotFound                    = "InvalidNetworkAclID.NotFound"
 	ErrCodeInvalidNetworkInterfaceIDNotFound              = "InvalidNetworkInterfaceID.NotFound"
+	ErrCodeInvalidNetworkInsightsPathIDNotFound           = "InvalidNetworkInsightsPathId.NotFound"
 	ErrCodeInvalidParameter                               = "InvalidParameter"
 	ErrCodeInvalidParameterException                      = "InvalidParameterException"
 	ErrCodeInvalidParameterValue                          = "InvalidParameterValue"

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -38,7 +38,7 @@ const (
 	ErrCodeInvalidNetworkAclEntryNotFound                 = "InvalidNetworkAclEntry.NotFound"
 	ErrCodeInvalidNetworkAclIDNotFound                    = "InvalidNetworkAclID.NotFound"
 	ErrCodeInvalidNetworkInterfaceIDNotFound              = "InvalidNetworkInterfaceID.NotFound"
-	ErrCodeInvalidNetworkInsightsPathIDNotFound           = "InvalidNetworkInsightsPathId.NotFound"
+	ErrCodeInvalidNetworkInsightsPathIdNotFound           = "InvalidNetworkInsightsPathId.NotFound"
 	ErrCodeInvalidParameter                               = "InvalidParameter"
 	ErrCodeInvalidParameterException                      = "InvalidParameterException"
 	ErrCodeInvalidParameterValue                          = "InvalidParameterValue"

--- a/internal/service/ec2/network_insights_path.go
+++ b/internal/service/ec2/network_insights_path.go
@@ -1,0 +1,177 @@
+package ec2
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceNetworkInsightsPath() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNetworkInsightsPathCreate,
+		ReadContext:   resourceNetworkInsightsPathRead,
+		UpdateContext: resourceNetworkInsightsPathUpdate,
+		DeleteContext: resourceNetworkInsightsPathDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"source": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"source_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"destination_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"destination_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"tcp",
+					"udp",
+				}, false),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: customdiff.Sequence(
+			verify.SetTagsDiff,
+		),
+	}
+}
+
+func resourceNetworkInsightsPathCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &ec2.CreateNetworkInsightsPathInput{
+		Source:            aws.String(d.Get("source").(string)),
+		Destination:       aws.String(d.Get("destination").(string)),
+		Protocol:          aws.String(d.Get("protocol").(string)),
+		TagSpecifications: ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeNetworkInsightsPath),
+	}
+
+	if v, ok := d.GetOk("source_ip"); ok {
+		input.SourceIp = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("destination_ip"); ok {
+		input.DestinationIp = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("destination_port"); ok {
+		input.DestinationPort = aws.Int64(int64(v.(int)))
+	}
+
+	response, err := conn.CreateNetworkInsightsPath(input)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating Network Insights Path: %w", err))
+	}
+
+	d.SetId(aws.StringValue(response.NetworkInsightsPath.NetworkInsightsPathId))
+	return resourceNetworkInsightsPathRead(ctx, d, meta)
+}
+
+func resourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	nip, err := FindNetworkInsightsPathByID(conn, d.Id())
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeInvalidNetworkInsightsPathIDNotFound) {
+		log.Printf("[WARN] Network Insights Path (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting Network Insights Path (%s): %w", d.Id(), err))
+	}
+
+	if nip == nil {
+		return diag.FromErr(fmt.Errorf("error getting Network Insights Path (%s): empty output", d.Id()))
+	}
+
+	d.Set("source", nip.Source)
+	d.Set("destination", nip.Destination)
+	d.Set("protocol", nip.Protocol)
+	d.Set("arn", nip.NetworkInsightsPathArn)
+	d.Set("source_ip", nip.SourceIp)
+	d.Set("destination_ip", nip.DestinationIp)
+	d.Set("destination_port", nip.DestinationPort)
+
+	tags := KeyValueTags(nip.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
+	}
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+	}
+
+	return nil
+}
+
+func resourceNetworkInsightsPathUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).EC2Conn
+	if d.HasChange("tags_all") && !d.IsNewResource() {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return diag.FromErr(fmt.Errorf("error updating Network Insights Path (%s) tags: %w", d.Id(), err))
+		}
+	}
+	return resourceNetworkInsightsPathRead(ctx, d, meta)
+}
+
+func resourceNetworkInsightsPathDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).EC2Conn
+	_, err := conn.DeleteNetworkInsightsPath(&ec2.DeleteNetworkInsightsPathInput{
+		NetworkInsightsPathId: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting Network Insights Path (%s): %w", d.Id(), err))
+	}
+
+	return nil
+}

--- a/internal/service/ec2/network_insights_path.go
+++ b/internal/service/ec2/network_insights_path.go
@@ -118,7 +118,7 @@ func resourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData
 
 	nip, err := FindNetworkInsightsPathByID(conn, d.Id())
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeInvalidNetworkInsightsPathIDNotFound) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeInvalidNetworkInsightsPathIdNotFound) {
 		log.Printf("[WARN] Network Insights Path (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/ec2/network_insights_path.go
+++ b/internal/service/ec2/network_insights_path.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -29,19 +28,13 @@ func ResourceNetworkInsightsPath() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"source": {
+			"arn": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
 			},
 			"destination": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
-			},
-			"source_ip": {
-				Type:     schema.TypeString,
-				Optional: true,
 				ForceNew: true,
 			},
 			"destination_ip": {
@@ -54,18 +47,21 @@ func ResourceNetworkInsightsPath() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"protocol": {
+			"source": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"tcp",
-					"udp",
-				}, false),
 			},
-			"arn": {
+			"source_ip": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+			"protocol": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ec2.Protocol_Values(), false),
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/ec2/network_insights_path.go
+++ b/internal/service/ec2/network_insights_path.go
@@ -162,12 +162,18 @@ func resourceNetworkInsightsPathUpdate(ctx context.Context, d *schema.ResourceDa
 
 func resourceNetworkInsightsPathDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
-	_, err := conn.DeleteNetworkInsightsPath(&ec2.DeleteNetworkInsightsPathInput{
+
+	log.Printf("[DEBUG] DeletingEC2 Network Insights Path: %s", d.Id())
+	_, err := conn.DeleteNetworkInsightsPathWithContext(ctx, &ec2.DeleteNetworkInsightsPathInput{
 		NetworkInsightsPathId: aws.String(d.Id()),
 	})
 
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidNetworkInsightsPathIdNotFound) {
+		return nil
+	}
+
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Network Insights Path (%s): %w", d.Id(), err))
+		return diag.Errorf("error deleting EC2 Network Insights Path (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ec2/network_insights_path.go
+++ b/internal/service/ec2/network_insights_path.go
@@ -150,20 +150,22 @@ func resourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData
 
 func resourceNetworkInsightsPathUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
-	if d.HasChange("tags_all") && !d.IsNewResource() {
+
+	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Network Insights Path (%s) tags: %w", d.Id(), err))
+			return diag.Errorf("error updating EC2 Network Insights Path (%s) tags: %s", d.Id(), err)
 		}
 	}
+
 	return resourceNetworkInsightsPathRead(ctx, d, meta)
 }
 
 func resourceNetworkInsightsPathDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	log.Printf("[DEBUG] DeletingEC2 Network Insights Path: %s", d.Id())
+	log.Printf("[DEBUG] Deleting EC2 Network Insights Path: %s", d.Id())
 	_, err := conn.DeleteNetworkInsightsPathWithContext(ctx, &ec2.DeleteNetworkInsightsPathInput{
 		NetworkInsightsPathId: aws.String(d.Id()),
 	})

--- a/internal/service/ec2/network_insights_path.go
+++ b/internal/service/ec2/network_insights_path.go
@@ -19,10 +19,11 @@ import (
 
 func ResourceNetworkInsightsPath() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceNetworkInsightsPathCreate,
-		ReadContext:   resourceNetworkInsightsPathRead,
-		UpdateContext: resourceNetworkInsightsPathUpdate,
-		DeleteContext: resourceNetworkInsightsPathDelete,
+		CreateWithoutTimeout: resourceNetworkInsightsPathCreate,
+		ReadWithoutTimeout:   resourceNetworkInsightsPathRead,
+		UpdateWithoutTimeout: resourceNetworkInsightsPathUpdate,
+		DeleteWithoutTimeout: resourceNetworkInsightsPathDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -70,9 +71,7 @@ func ResourceNetworkInsightsPath() *schema.Resource {
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			verify.SetTagsDiff,
-		),
+		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 

--- a/internal/service/ec2/network_insights_path_test.go
+++ b/internal/service/ec2/network_insights_path_test.go
@@ -1,0 +1,297 @@
+package ec2_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+)
+
+func TestAccEC2NetworkInsightsPath_basic(t *testing.T) {
+	resourceName := "aws_ec2_network_insights_path.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2NetworkInsightsPath("tcp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "source", "aws_network_interface.test_source", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination", "aws_network_interface.test_destination", "id"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`network-insights-path/.+$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccEC2NetworkInsightsPath_SourceIP(t *testing.T) {
+	resourceName := "aws_ec2_network_insights_path.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2NetworkInsightsPath_source_ip("1.1.1.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "source_ip", "1.1.1.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEC2NetworkInsightsPath_source_ip("8.8.8.8"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "source_ip", "8.8.8.8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2NetworkInsightsPath_DestinationIP(t *testing.T) {
+	resourceName := "aws_ec2_network_insights_path.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2NetworkInsightsPath_destination_ip("1.1.1.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "destination_ip", "1.1.1.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEC2NetworkInsightsPath_destination_ip("8.8.8.8"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "destination_ip", "8.8.8.8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2NetworkInsightsPath_DestinationPort(t *testing.T) {
+	resourceName := "aws_ec2_network_insights_path.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2NetworkInsightsPath_destination_port("80"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "destination_port", "80"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEC2NetworkInsightsPath_destination_port("443"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEC2NetworkInsightsPathExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "destination_port", "443"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEC2NetworkInsightsPathExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Network Insights Path is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+		id := rs.Primary.ID
+
+		response, err := tfec2.FindNetworkInsightsPathByID(conn, id)
+		if err != nil {
+			return err
+		}
+
+		if response == nil || *response.NetworkInsightsPathId != id {
+			return fmt.Errorf("Network Insights Path (%s) not found", id)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEmailIdentityDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_network_insights_path" {
+			continue
+		}
+
+		id := rs.Primary.ID
+
+		_, err := tfec2.FindNetworkInsightsPathByID(conn, id)
+		if err != nil && !tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidNetworkInsightsPathIDNotFound) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccEC2NetworkInsightsPath(protocol string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_network_interface" "test_source" {
+  subnet_id = aws_subnet.test.id
+}
+
+resource "aws_network_interface" "test_destination" {
+  subnet_id = aws_subnet.test.id
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source      = aws_network_interface.test_source.id
+  destination = aws_network_interface.test_destination.id
+  protocol    = "%s"
+}
+`, protocol)
+}
+
+func testAccEC2NetworkInsightsPath_source_ip(source_ip string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source      = aws_internet_gateway.test.id
+  destination = aws_network_interface.test.id
+  protocol    = "tcp"
+  source_ip   = "%s"
+}
+`, source_ip)
+}
+
+func testAccEC2NetworkInsightsPath_destination_ip(destination_ip string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source         = aws_network_interface.test.id
+  destination    = aws_internet_gateway.test.id
+  protocol       = "tcp"
+  destination_ip = "%s"
+}
+`, destination_ip)
+}
+
+func testAccEC2NetworkInsightsPath_destination_port(destination_port string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_network_interface" "test_source" {
+  subnet_id = aws_subnet.test.id
+}
+
+resource "aws_network_interface" "test_destination" {
+  subnet_id = aws_subnet.test.id
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source           = aws_network_interface.test_source.id
+  destination      = aws_network_interface.test_destination.id
+  protocol         = "tcp"
+  destination_port = %s
+}
+`, destination_port)
+}

--- a/internal/service/ec2/network_insights_path_test.go
+++ b/internal/service/ec2/network_insights_path_test.go
@@ -52,7 +52,7 @@ func TestAccNetworkInsightsPath_sourceIP(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEC2NetworkInsightsPath_source_ip("1.1.1.1"),
+				Config: testAccEC2NetworkInsightsPath_sourceIP("1.1.1.1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source_ip", "1.1.1.1"),
@@ -64,7 +64,7 @@ func TestAccNetworkInsightsPath_sourceIP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEC2NetworkInsightsPath_source_ip("8.8.8.8"),
+				Config: testAccEC2NetworkInsightsPath_sourceIP("8.8.8.8"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source_ip", "8.8.8.8"),
@@ -84,7 +84,7 @@ func TestAccNetworkInsightsPath_destinationIP(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEC2NetworkInsightsPath_destination_ip("1.1.1.1"),
+				Config: testAccEC2NetworkInsightsPath_destinationIP("1.1.1.1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_ip", "1.1.1.1"),
@@ -96,7 +96,7 @@ func TestAccNetworkInsightsPath_destinationIP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEC2NetworkInsightsPath_destination_ip("8.8.8.8"),
+				Config: testAccEC2NetworkInsightsPath_destinationIP("8.8.8.8"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_ip", "8.8.8.8"),
@@ -116,7 +116,7 @@ func TestAccNetworkInsightsPath_destinationPort(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEC2NetworkInsightsPath_destination_port("80"),
+				Config: testAccEC2NetworkInsightsPath_destinationPort("80"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_port", "80"),
@@ -128,7 +128,7 @@ func TestAccNetworkInsightsPath_destinationPort(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEC2NetworkInsightsPath_destination_port("443"),
+				Config: testAccEC2NetworkInsightsPath_destinationPort("443"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_port", "443"),
@@ -212,7 +212,7 @@ resource "aws_ec2_network_insights_path" "test" {
 `, protocol)
 }
 
-func testAccEC2NetworkInsightsPath_source_ip(source_ip string) string {
+func testAccEC2NetworkInsightsPath_sourceIP(sourceIP string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -237,10 +237,10 @@ resource "aws_ec2_network_insights_path" "test" {
   protocol    = "tcp"
   source_ip   = "%s"
 }
-`, source_ip)
+`, sourceIP)
 }
 
-func testAccEC2NetworkInsightsPath_destination_ip(destination_ip string) string {
+func testAccEC2NetworkInsightsPath_destinationIP(destinationIP string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -265,10 +265,10 @@ resource "aws_ec2_network_insights_path" "test" {
   protocol       = "tcp"
   destination_ip = "%s"
 }
-`, destination_ip)
+`, destinationIP)
 }
 
-func testAccEC2NetworkInsightsPath_destination_port(destination_port string) string {
+func testAccEC2NetworkInsightsPath_destinationPort(destinationPort string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -293,5 +293,5 @@ resource "aws_ec2_network_insights_path" "test" {
   protocol         = "tcp"
   destination_port = %s
 }
-`, destination_port)
+`, destinationPort)
 }

--- a/internal/service/ec2/network_insights_path_test.go
+++ b/internal/service/ec2/network_insights_path_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkInsightsPath_basic(t *testing.T) {
+func TestAccNetworkInsightsPath_basic(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,7 +42,7 @@ func TestAccEC2NetworkInsightsPath_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInsightsPath_SourceIP(t *testing.T) {
+func TestAccNetworkInsightsPath_sourceIP(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -74,7 +74,7 @@ func TestAccEC2NetworkInsightsPath_SourceIP(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInsightsPath_DestinationIP(t *testing.T) {
+func TestAccNetworkInsightsPath_destinationIP(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -106,7 +106,7 @@ func TestAccEC2NetworkInsightsPath_DestinationIP(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInsightsPath_DestinationPort(t *testing.T) {
+func TestAccNetworkInsightsPath_destinationPort(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/network_insights_path_test.go
+++ b/internal/service/ec2/network_insights_path_test.go
@@ -177,7 +177,7 @@ func testAccCheckEmailIdentityDestroy(s *terraform.State) error {
 		id := rs.Primary.ID
 
 		_, err := tfec2.FindNetworkInsightsPathByID(conn, id)
-		if err != nil && !tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidNetworkInsightsPathIDNotFound) {
+		if err != nil && !tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidNetworkInsightsPathIdNotFound) {
 			return err
 		}
 	}

--- a/website/docs/r/ec2_network_insights_path.html.markdown
+++ b/website/docs/r/ec2_network_insights_path.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_ec2_network_insights_path"
+description: |-
+  Provides a Network Insights Path resource.
+---
+
+# Resource: aws_ec2_network_insights_path
+
+Provides a Network Insights Path resource. Part of the "Reachability Analyzer" service in the AWS VPC console.
+
+## Example Usage
+
+```terraform
+resource "aws_ec2_network_insights_path" "test" {
+  source      = aws_network_interface.source.id
+  destination = aws_network_interface.destination.id
+  protocol    = "tcp"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `source` - (Required) ID of the resource which is the source of the path. Can be an Instance, Internet Gateway, Network Interface, Transit Gateway, VPC Endpoint, VPC Peering Connection or VPN Gateway.
+* `destination` - (Required) ID of the resource which is the source of the path. Can be an Instance, Internet Gateway, Network Interface, Transit Gateway, VPC Endpoint, VPC Peering Connection or VPN Gateway.
+* `protocol` - (Required) Protocol to use for analysis. Valid options are `tcp` or `udp`.
+
+The following arguments are optional:
+
+* `source_ip` - (Optional) IP address of the source resource.
+* `destination_ip` - (Optional) IP address of the destination resource.
+* `destination_port` - (Optional) Destination port to analyze access to.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Network Insights Path.
+* `id` - ID of the Network Insights Path.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Network Insights Paths can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_ec2_network_insights_path.test nip-00edfba169923aefd
+```


### PR DESCRIPTION
Adds a new resource `aws_ec2_network_insights_path` to partially address #16715.
Adds tests, sweeper and find functions for the new resource type.
Adds documentation for the new resource type.

Example config: 
```terraform
resource "aws_ec2_network_insights_path" "test" {
  source           = aws_network_interface.test.id
  destination      = aws_internet_gateway.test.id
  protocol         = "tcp"
  destination_port = 443
}
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16715

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2NetworkInsightsPath PKG=ec2                                                                                                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2NetworkInsightsPath'  -timeout 180m
=== RUN   TestAccEC2NetworkInsightsPath_basic
=== PAUSE TestAccEC2NetworkInsightsPath_basic
=== RUN   TestAccEC2NetworkInsightsPath_SourceIP
=== PAUSE TestAccEC2NetworkInsightsPath_SourceIP
=== RUN   TestAccEC2NetworkInsightsPath_DestinationIP
=== PAUSE TestAccEC2NetworkInsightsPath_DestinationIP
=== RUN   TestAccEC2NetworkInsightsPath_DestinationPort
=== PAUSE TestAccEC2NetworkInsightsPath_DestinationPort
=== CONT  TestAccEC2NetworkInsightsPath_basic
=== CONT  TestAccEC2NetworkInsightsPath_DestinationIP
=== CONT  TestAccEC2NetworkInsightsPath_SourceIP
=== CONT  TestAccEC2NetworkInsightsPath_DestinationPort
--- PASS: TestAccEC2NetworkInsightsPath_basic (36.25s)
--- PASS: TestAccEC2NetworkInsightsPath_SourceIP (55.64s)
--- PASS: TestAccEC2NetworkInsightsPath_DestinationIP (58.29s)
--- PASS: TestAccEC2NetworkInsightsPath_DestinationPort (66.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        68.392s
```
