### PR TITLE
ecs/iso: Fix describe with configuration

### DIFF
--- a/.changelog/23341.txt
+++ b/.changelog/23341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_cluster: Fix bug preventing describing clusters in ISO regions
+```

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -226,7 +226,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
 
 	if _, err := waitClusterAvailable(context.Background(), conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available while creating: %w", d.Id(), err)
 	}
 
 	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
@@ -345,7 +345,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := waitClusterAvailable(context.Background(), conn, d.Id()); err != nil {
-			return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available while updating setting and configuration: %w", d.Id(), err)
 		}
 	}
 
@@ -363,7 +363,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := waitClusterAvailable(context.Background(), conn, d.Id()); err != nil {
-			return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available while updating capacity_providers, default_capacity_provider_strategy: %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/cluster_capacity_providers.go
+++ b/internal/service/ecs/cluster_capacity_providers.go
@@ -88,11 +88,11 @@ func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.Resource
 	err := retryClusterCapacityProvidersPut(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error updating ECS Cluster (%s) capacity providers: %s", clusterName, err)
+		return diag.Errorf("error updating ECS Cluster (%s) Capacity Providers: %s", clusterName, err)
 	}
 
 	if _, err := waitClusterAvailable(ctx, conn, clusterName); err != nil {
-		return diag.Errorf("error waiting for ECS Cluster (%s) to become available: %s", clusterName, err)
+		return diag.Errorf("error waiting for ECS Cluster (%s) to become available while putting Capacity Providers: %s", clusterName, err)
 	}
 
 	d.SetId(clusterName)
@@ -144,7 +144,7 @@ func resourceClusterCapacityProvidersDelete(ctx context.Context, d *schema.Resou
 		DefaultCapacityProviderStrategy: []*ecs.CapacityProviderStrategyItem{},
 	}
 
-	log.Printf("[DEBUG] Removing ECS cluster (%s) capacity providers", d.Id())
+	log.Printf("[DEBUG] Removing ECS Cluster (%s) Capacity Providers", d.Id())
 
 	err := retryClusterCapacityProvidersPut(ctx, conn, input)
 
@@ -153,11 +153,11 @@ func resourceClusterCapacityProvidersDelete(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting ECS Cluster (%s) capacity providers: %s", d.Id(), err)
+		return diag.Errorf("error deleting ECS Cluster (%s) Capacity Providers: %s", d.Id(), err)
 	}
 
 	if _, err := waitClusterAvailable(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for ECS Cluster (%s) to become available: %s", d.Id(), err)
+		return diag.Errorf("error waiting for ECS Cluster (%s) to become available while deleting Capacity Providers: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -61,9 +61,17 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed describing Cluster (%s) with tags: %s; retrying without tags", nameOrARN, err)
+		log.Printf("[WARN] failed describing ECS Cluster (%s) including tags: %s; retrying without tags", nameOrARN, err)
 
 		input.Include = aws.StringSlice([]string{ecs.ClusterFieldConfigurations, ecs.ClusterFieldSettings})
+		output, err = conn.DescribeClustersWithContext(ctx, input)
+	}
+
+	// Some partitions (i.e., ISO) may not support describe including configuration, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed describing ECS Cluster (%s) including configuration: %s; retrying without configuration", nameOrARN, err)
+
+		input.Include = aws.StringSlice([]string{ecs.ClusterFieldSettings})
 		output, err = conn.DescribeClustersWithContext(ctx, input)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22532
Closes #23342

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccECSCluster_ PKG=ecs TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCluster_' -short -timeout 180m
--- PASS: TestAccECSCluster_disappears (29.55s)
--- PASS: TestAccECSCluster_basic (34.73s)
--- PASS: TestAccECSCluster_capacityProviders (48.55s)
--- PASS: TestAccECSCluster_tags (55.15s)
--- PASS: TestAccECSCluster_configuration (56.29s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (62.52s)
--- PASS: TestAccECSCluster_singleCapacityProvider (66.22s)
--- PASS: TestAccECSCluster_containerInsights (74.17s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (82.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	84.370s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccECSCluster_ PKG=ecs TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCluster_' -short -timeout 180m
--- PASS: TestAccECSCluster_disappears (24.32s)
--- PASS: TestAccECSCluster_basic (28.39s)
--- PASS: TestAccECSCluster_capacityProviders (37.61s)
--- PASS: TestAccECSCluster_tags (48.72s)
--- PASS: TestAccECSCluster_configuration (50.45s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (51.77s)
--- PASS: TestAccECSCluster_singleCapacityProvider (65.77s)
--- PASS: TestAccECSCluster_containerInsights (66.75s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (71.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	73.020s
```