### PR TITLE
Changes `markdownlint` rules to use names instead of codes

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,23 +2,47 @@
 # https://github.com/DavidAnson/markdownlint#configuration
 
 default: true
-MD007:
+
+# MD007
+ul-indent:
   indent: 4
-MD010:
+
+# MD010
+no-hard-tabs:
   code_blocks: false
 
 # Disabled Rules
 # https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
 
-MD001: false
-MD004: false
-MD006: false
-MD012: false
-MD013: false
-MD014: false
-MD022: false
-MD024: false
-MD034: false
-MD038: false
-MD040: false
-MD047: false
+# MD001
+heading-increment: false
+
+# MD004
+ul-style: false
+
+# MD012
+no-multiple-blanks: false
+
+# MD013
+line-length: false
+
+# MD014
+commands-show-output: false
+
+# MD022
+blanks-around-headings: false
+
+# MD024
+no-duplicate-heading: false
+
+# MD034
+no-bare-urls: false
+
+# MD038
+no-space-in-code: false
+
+# MD040
+fenced-code-language: false
+
+# MD047
+single-trailing-newline: false

--- a/docs/contributing/data-handling-and-conversion.md
+++ b/docs/contributing/data-handling-and-conversion.md
@@ -96,7 +96,7 @@ To expand on the data handling that occurs specifically within the Terraform AWS
 
 To further understand the necessary data conversions used throughout the Terraform AWS Provider codebase between AWS Go SDK types and the Terraform Plugin SDK, the following table can be referenced for most scenarios:
 
-<!-- markdownlint-disable MD033 --->
+<!-- markdownlint-disable no-inline-html --->
 
 | AWS API Model | AWS Go SDK | Terraform Plugin SDK | Terraform Language/State |
 |---------------|------------|----------------------|--------------------------|
@@ -109,7 +109,7 @@ To further understand the necessary data conversions used throughout the Terrafo
 | `structure` | `struct` | `TypeList` (`[]interface{}` of `map[string]interface{}`) | `list(object(any))` |
 | `timestamp` | `*time.Time` | `TypeString` (typically RFC3339 formatted) | `string` |
 
-<!-- markdownlint-enable MD033 --->
+<!-- markdownlint-enable no-inline-html --->
 
 You may notice there are type encoding differences the AWS Go SDK and Terraform Plugin SDK:
 

--- a/internal/service/accessanalyzer/README.md
+++ b/internal/service/accessanalyzer/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AccessAnalyzer Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/accessanalyzer/README.md
+++ b/internal/service/accessanalyzer/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AccessAnalyzer resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/accessanalyzer_analyzer)

--- a/internal/service/acm/README.md
+++ b/internal/service/acm/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ACM Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/acm/README.md
+++ b/internal/service/acm/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ACM resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate)

--- a/internal/service/acmpca/README.md
+++ b/internal/service/acmpca/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ACMPCA resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate)

--- a/internal/service/acmpca/README.md
+++ b/internal/service/acmpca/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ACMPCA Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/amp/README.md
+++ b/internal/service/amp/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AMP Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 AMP (**A**mazon **M**anaged Service for **P**rometheus) is also called just _Prometheus_ or _Prometheus Service_.

--- a/internal/service/amp/README.md
+++ b/internal/service/amp/README.md
@@ -6,6 +6,7 @@ AMP (**A**mazon **M**anaged Service for **P**rometheus) is also called just _Pro
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Prometheus resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_workspace)

--- a/internal/service/amplify/README.md
+++ b/internal/service/amplify/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Amplify Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/amplify/README.md
+++ b/internal/service/amplify/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Amplify resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_app)

--- a/internal/service/apigateway/README.md
+++ b/internal/service/apigateway/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider APIGateway Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/apigateway/README.md
+++ b/internal/service/apigateway/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the APIGateway resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_account)

--- a/internal/service/apigatewayv2/README.md
+++ b/internal/service/apigatewayv2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider APIGatewayV2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/apigatewayv2/README.md
+++ b/internal/service/apigatewayv2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the APIGatewayV2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api)

--- a/internal/service/appautoscaling/README.md
+++ b/internal/service/appautoscaling/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ApplicationAutoScaling resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action)

--- a/internal/service/appautoscaling/README.md
+++ b/internal/service/appautoscaling/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ApplicationAutoScaling Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/appconfig/README.md
+++ b/internal/service/appconfig/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AppConfig Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/appconfig/README.md
+++ b/internal/service/appconfig/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AppConfig resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appconfig_application)

--- a/internal/service/appmesh/README.md
+++ b/internal/service/appmesh/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AppMesh Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/appmesh/README.md
+++ b/internal/service/appmesh/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AppMesh resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appmesh_gateway_route)

--- a/internal/service/apprunner/README.md
+++ b/internal/service/apprunner/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AppRunner resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_auto_scaling_configuration_version)

--- a/internal/service/apprunner/README.md
+++ b/internal/service/apprunner/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AppRunner Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/appstream/README.md
+++ b/internal/service/appstream/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AppStream resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appstream_fleet)

--- a/internal/service/appstream/README.md
+++ b/internal/service/appstream/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AppStream Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/appsync/README.md
+++ b/internal/service/appsync/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AppSync resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_api_key)

--- a/internal/service/appsync/README.md
+++ b/internal/service/appsync/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AppSync Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/athena/README.md
+++ b/internal/service/athena/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Athena resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_database)

--- a/internal/service/athena/README.md
+++ b/internal/service/athena/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Athena Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/autoscaling/README.md
+++ b/internal/service/autoscaling/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AutoScaling resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment)

--- a/internal/service/autoscaling/README.md
+++ b/internal/service/autoscaling/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AutoScaling Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/autoscalingplans/README.md
+++ b/internal/service/autoscalingplans/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider AutoScalingPlans Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/autoscalingplans/README.md
+++ b/internal/service/autoscalingplans/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the AutoScalingPlans resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscalingplans_scaling_plan)

--- a/internal/service/backup/README.md
+++ b/internal/service/backup/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Backup resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_global_settings)

--- a/internal/service/backup/README.md
+++ b/internal/service/backup/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Backup Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/batch/README.md
+++ b/internal/service/batch/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Batch Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/batch/README.md
+++ b/internal/service/batch/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Batch resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_compute_environment)

--- a/internal/service/budgets/README.md
+++ b/internal/service/budgets/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Budgets resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget)

--- a/internal/service/budgets/README.md
+++ b/internal/service/budgets/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Budgets Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/chime/README.md
+++ b/internal/service/chime/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Chime Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/chime/README.md
+++ b/internal/service/chime/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Chime resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/chime_voice_connector)

--- a/internal/service/cloud9/README.md
+++ b/internal/service/cloud9/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Cloud9 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloud9/README.md
+++ b/internal/service/cloud9/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Cloud9 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloud9_environment_ec2)

--- a/internal/service/cloudcontrol/README.md
+++ b/internal/service/cloudcontrol/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudControl resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudcontrolapi_resource)

--- a/internal/service/cloudcontrol/README.md
+++ b/internal/service/cloudcontrol/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudControl Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudformation/README.md
+++ b/internal/service/cloudformation/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudFormation resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack)

--- a/internal/service/cloudformation/README.md
+++ b/internal/service/cloudformation/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudFormation Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudfront/README.md
+++ b/internal/service/cloudfront/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudFront resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy)

--- a/internal/service/cloudfront/README.md
+++ b/internal/service/cloudfront/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudFront Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudhsmv2/README.md
+++ b/internal/service/cloudhsmv2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudHSMV2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudhsmv2/README.md
+++ b/internal/service/cloudhsmv2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudHSMV2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudhsm_v2_hsm)

--- a/internal/service/cloudsearch/README.md
+++ b/internal/service/cloudsearch/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Budgets resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudsearch_domain)

--- a/internal/service/cloudsearch/README.md
+++ b/internal/service/cloudsearch/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudSearch Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudtrail/README.md
+++ b/internal/service/cloudtrail/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudTrail data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudtrail_service_account)

--- a/internal/service/cloudtrail/README.md
+++ b/internal/service/cloudtrail/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudTrail Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudwatch/README.md
+++ b/internal/service/cloudwatch/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudWatch Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudwatch/README.md
+++ b/internal/service/cloudwatch/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudWatch resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_composite_alarm)

--- a/internal/service/cloudwatchlogs/README.md
+++ b/internal/service/cloudwatchlogs/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CloudWatchLogs Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cloudwatchlogs/README.md
+++ b/internal/service/cloudwatchlogs/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CloudWatchLogs resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_destination)

--- a/internal/service/codeartifact/README.md
+++ b/internal/service/codeartifact/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodeArtifact Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codeartifact/README.md
+++ b/internal/service/codeartifact/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodeArtifact resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codeartifact_domain)

--- a/internal/service/codebuild/README.md
+++ b/internal/service/codebuild/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodeBuild Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codebuild/README.md
+++ b/internal/service/codebuild/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodeBuild resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project)

--- a/internal/service/codecommit/README.md
+++ b/internal/service/codecommit/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodeCommit resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codecommit_repository)

--- a/internal/service/codecommit/README.md
+++ b/internal/service/codecommit/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodeCommit Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codedeploy/README.md
+++ b/internal/service/codedeploy/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodeDeploy resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app)

--- a/internal/service/codedeploy/README.md
+++ b/internal/service/codedeploy/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodeDeploy Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codepipeline/README.md
+++ b/internal/service/codepipeline/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodePipeline resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codepipeline_webhook)

--- a/internal/service/codepipeline/README.md
+++ b/internal/service/codepipeline/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodePipeline Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codestarconnections/README.md
+++ b/internal/service/codestarconnections/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodeStarConnections Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codestarconnections/README.md
+++ b/internal/service/codestarconnections/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodeStarConnections resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_connection)

--- a/internal/service/codestarnotifications/README.md
+++ b/internal/service/codestarnotifications/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CodeStarNotifications Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/codestarnotifications/README.md
+++ b/internal/service/codestarnotifications/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CodeStarNotifications resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarnotifications_notification_rule)

--- a/internal/service/cognitoidentity/README.md
+++ b/internal/service/cognitoidentity/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CognitoIdentity resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_pool_roles_attachment)

--- a/internal/service/cognitoidentity/README.md
+++ b/internal/service/cognitoidentity/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CognitoIdentity Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cognitoidp/README.md
+++ b/internal/service/cognitoidp/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CognitoIDP Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cognitoidp/README.md
+++ b/internal/service/cognitoidp/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CognitoIDP resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_provider)

--- a/internal/service/configservice/README.md
+++ b/internal/service/configservice/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Config Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/configservice/README.md
+++ b/internal/service/configservice/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Config resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization)

--- a/internal/service/connect/README.md
+++ b/internal/service/connect/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Connect resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/connect_contact_flow)

--- a/internal/service/connect/README.md
+++ b/internal/service/connect/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Connect Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cur/README.md
+++ b/internal/service/cur/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider CUR Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/cur/README.md
+++ b/internal/service/cur/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the CUR resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cur_report_definition)

--- a/internal/service/dataexchange/README.md
+++ b/internal/service/dataexchange/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for DataExch
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go DataExchange](https://docs.aws.amazon.com/sdk-for-go/api/service/dataexchange/)

--- a/internal/service/dataexchange/README.md
+++ b/internal/service/dataexchange/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DataExchange Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/datapipeline/README.md
+++ b/internal/service/datapipeline/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DataPipeline Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/datapipeline/README.md
+++ b/internal/service/datapipeline/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DataPipeline resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/datapipeline_pipeline)

--- a/internal/service/datasync/README.md
+++ b/internal/service/datasync/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DataSync Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/datasync/README.md
+++ b/internal/service/datasync/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DataSync resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/datasync_agent)

--- a/internal/service/dax/README.md
+++ b/internal/service/dax/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DAX Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/dax/README.md
+++ b/internal/service/dax/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DAX resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dax_cluster)

--- a/internal/service/devicefarm/README.md
+++ b/internal/service/devicefarm/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DeviceFarm Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/devicefarm/README.md
+++ b/internal/service/devicefarm/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DeviceFarm resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/devicefarm_project)

--- a/internal/service/directconnect/README.md
+++ b/internal/service/directconnect/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DirectConnect resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_connection)

--- a/internal/service/directconnect/README.md
+++ b/internal/service/directconnect/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DirectConnect Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/dlm/README.md
+++ b/internal/service/dlm/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DLM resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dlm_lifecycle_policy)

--- a/internal/service/dlm/README.md
+++ b/internal/service/dlm/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DLM Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/dms/README.md
+++ b/internal/service/dms/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DMS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/dms/README.md
+++ b/internal/service/dms/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DMS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_certificate)

--- a/internal/service/docdb/README.md
+++ b/internal/service/docdb/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DocDB resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster)

--- a/internal/service/docdb/README.md
+++ b/internal/service/docdb/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DocDB Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ds/README.md
+++ b/internal/service/ds/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DirectoryService Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ds/README.md
+++ b/internal/service/ds/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DirectoryService resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory)

--- a/internal/service/dynamodb/README.md
+++ b/internal/service/dynamodb/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider DynamoDB Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/dynamodb/README.md
+++ b/internal/service/dynamodb/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the DynamoDB resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_global_table)

--- a/internal/service/ec2/README.md
+++ b/internal/service/ec2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider EC2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ec2/README.md
+++ b/internal/service/ec2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the EC2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance)

--- a/internal/service/ecr/README.md
+++ b/internal/service/ecr/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ECR Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ecr/README.md
+++ b/internal/service/ecr/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ECR resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy)

--- a/internal/service/ecrpublic/README.md
+++ b/internal/service/ecrpublic/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for ECRPubli
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ECRPublic resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecrpublic_repository)

--- a/internal/service/ecrpublic/README.md
+++ b/internal/service/ecrpublic/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ECRPublic Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ecs/README.md
+++ b/internal/service/ecs/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ECS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ecs/README.md
+++ b/internal/service/ecs/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ECS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider)

--- a/internal/service/efs/README.md
+++ b/internal/service/efs/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the EFS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point)

--- a/internal/service/efs/README.md
+++ b/internal/service/efs/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider EFS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/eks/README.md
+++ b/internal/service/eks/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider EKS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/eks/README.md
+++ b/internal/service/eks/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the EKS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon)

--- a/internal/service/elasticache/README.md
+++ b/internal/service/elasticache/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ElastiCache Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/elasticache/README.md
+++ b/internal/service/elasticache/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ElastiCache resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster)

--- a/internal/service/elasticbeanstalk/README.md
+++ b/internal/service/elasticbeanstalk/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ElasticBeanstalk Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/elasticbeanstalk/README.md
+++ b/internal/service/elasticbeanstalk/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ElasticBeanstalk resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_application)

--- a/internal/service/elasticsearch/README.md
+++ b/internal/service/elasticsearch/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Elasticsearch Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/elasticsearch/README.md
+++ b/internal/service/elasticsearch/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Elasticsearch resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain)

--- a/internal/service/elastictranscoder/README.md
+++ b/internal/service/elastictranscoder/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ElasticTranscoder resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastictranscoder_pipeline)

--- a/internal/service/elastictranscoder/README.md
+++ b/internal/service/elastictranscoder/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ElasticTranscoder Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/elb/README.md
+++ b/internal/service/elb/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ELB Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/elb/README.md
+++ b/internal/service/elb/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ELB resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/load_balancer_policy)

--- a/internal/service/elbv2/README.md
+++ b/internal/service/elbv2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ELBV2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/elbv2/README.md
+++ b/internal/service/elbv2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ELBV2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb)

--- a/internal/service/emr/README.md
+++ b/internal/service/emr/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider EMR Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/emr/README.md
+++ b/internal/service/emr/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the EMR resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_cluster)

--- a/internal/service/events/README.md
+++ b/internal/service/events/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider EventBridge Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 _EventBridge_ was formerly called _CloudWatch Events_. In the AWS CLI, you use `events` to identify EventBridge commands. The functionality is identical.

--- a/internal/service/events/README.md
+++ b/internal/service/events/README.md
@@ -5,6 +5,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 _EventBridge_ was formerly called _CloudWatch Events_. In the AWS CLI, you use `events` to identify EventBridge commands. The functionality is identical.
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the EventBridge resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule)

--- a/internal/service/firehose/README.md
+++ b/internal/service/firehose/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Firehose Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/firehose/README.md
+++ b/internal/service/firehose/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Firehose resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream)

--- a/internal/service/fms/README.md
+++ b/internal/service/fms/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider FMS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/fms/README.md
+++ b/internal/service/fms/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the FMS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account)

--- a/internal/service/fsx/README.md
+++ b/internal/service/fsx/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider FSx Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/fsx/README.md
+++ b/internal/service/fsx/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the FSx resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fsx_backup)

--- a/internal/service/gamelift/README.md
+++ b/internal/service/gamelift/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the GameLift resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/gamelift_alias)

--- a/internal/service/gamelift/README.md
+++ b/internal/service/gamelift/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider GameLift Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/glacier/README.md
+++ b/internal/service/glacier/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Glacier resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glacier_vault)

--- a/internal/service/glacier/README.md
+++ b/internal/service/glacier/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Glacier Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/globalaccelerator/README.md
+++ b/internal/service/globalaccelerator/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider GlobalAccelerator Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/globalaccelerator/README.md
+++ b/internal/service/globalaccelerator/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the GlobalAccelerator resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_accelerator)

--- a/internal/service/glue/README.md
+++ b/internal/service/glue/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Glue Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/glue/README.md
+++ b/internal/service/glue/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Glue resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_database)

--- a/internal/service/grafana/README.md
+++ b/internal/service/grafana/README.md
@@ -7,6 +7,7 @@ _The Terraform AWS Provider does not yet have support for Grafana._
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go v1 Managed Grafana](https://docs.aws.amazon.com/sdk-for-go/api/service/managedgrafana/)

--- a/internal/service/grafana/README.md
+++ b/internal/service/grafana/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Grafana Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/greengrass/README.md
+++ b/internal/service/greengrass/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Greengrass Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/greengrass/README.md
+++ b/internal/service/greengrass/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for Greengra
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go Greengrass](https://docs.aws.amazon.com/sdk-for-go/api/service/greengrass/)

--- a/internal/service/guardduty/README.md
+++ b/internal/service/guardduty/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider GuardDuty Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/guardduty/README.md
+++ b/internal/service/guardduty/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the GuardDuty resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector)

--- a/internal/service/iam/README.md
+++ b/internal/service/iam/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider IAM Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/iam/README.md
+++ b/internal/service/iam/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the IAM resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key)

--- a/internal/service/identitystore/README.md
+++ b/internal/service/identitystore/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the IdentityStore data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group)

--- a/internal/service/identitystore/README.md
+++ b/internal/service/identitystore/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider IdentityStore Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/imagebuilder/README.md
+++ b/internal/service/imagebuilder/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ImageBuilder resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_component)

--- a/internal/service/imagebuilder/README.md
+++ b/internal/service/imagebuilder/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ImageBuilder Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/inspector/README.md
+++ b/internal/service/inspector/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Inspector Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/inspector/README.md
+++ b/internal/service/inspector/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Inspector resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector_assessment_target)

--- a/internal/service/iot/README.md
+++ b/internal/service/iot/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider IoT Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/iot/README.md
+++ b/internal/service/iot/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the IoT resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iot_authorizer)

--- a/internal/service/iotanalytics/README.md
+++ b/internal/service/iotanalytics/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider IoTAnalytics Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/iotanalytics/README.md
+++ b/internal/service/iotanalytics/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for IoTAnaly
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go IoTAnalytics](https://docs.aws.amazon.com/sdk-for-go/api/service/iotanalytics/)

--- a/internal/service/iotevents/README.md
+++ b/internal/service/iotevents/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider IoTEvents Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/iotevents/README.md
+++ b/internal/service/iotevents/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for IoTEvent
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go IoTEvents](https://docs.aws.amazon.com/sdk-for-go/api/service/iotevents/)

--- a/internal/service/kafka/README.md
+++ b/internal/service/kafka/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Kafka resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster)

--- a/internal/service/kafka/README.md
+++ b/internal/service/kafka/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Kafka Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/kinesis/README.md
+++ b/internal/service/kinesis/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Kinesis Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/kinesis/README.md
+++ b/internal/service/kinesis/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Kinesis resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_stream)

--- a/internal/service/kinesisanalytics/README.md
+++ b/internal/service/kinesisanalytics/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the KinesisAnalytics resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_analytics_application)

--- a/internal/service/kinesisanalytics/README.md
+++ b/internal/service/kinesisanalytics/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider KinesisAnalytics Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/kinesisanalyticsv2/README.md
+++ b/internal/service/kinesisanalyticsv2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider KinesisAnalyticsV2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/kinesisanalyticsv2/README.md
+++ b/internal/service/kinesisanalyticsv2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the KinesisAnalyticsV2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesisanalyticsv2_application_snapshot)

--- a/internal/service/kinesisvideo/README.md
+++ b/internal/service/kinesisvideo/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the KinesisVideo resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_video_stream)

--- a/internal/service/kinesisvideo/README.md
+++ b/internal/service/kinesisvideo/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider KinesisVideo Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/kms/README.md
+++ b/internal/service/kms/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider KMS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/kms/README.md
+++ b/internal/service/kms/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the KMS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias)

--- a/internal/service/lakeformation/README.md
+++ b/internal/service/lakeformation/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the LakeFormation resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings)

--- a/internal/service/lakeformation/README.md
+++ b/internal/service/lakeformation/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider LakeFormation Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/lambda/README.md
+++ b/internal/service/lambda/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Lambda resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias)

--- a/internal/service/lambda/README.md
+++ b/internal/service/lambda/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Lambda Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/lexmodels/README.md
+++ b/internal/service/lexmodels/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Lex Model Building Service Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 The AWS CLI refers to the Amazon Lex Model Building Service as _Lex Models_.

--- a/internal/service/lexmodels/README.md
+++ b/internal/service/lexmodels/README.md
@@ -5,6 +5,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 The AWS CLI refers to the Amazon Lex Model Building Service as _Lex Models_.
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Lex Models resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lex_bot)

--- a/internal/service/licensemanager/README.md
+++ b/internal/service/licensemanager/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the LicenseManager resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/licensemanager_association)

--- a/internal/service/licensemanager/README.md
+++ b/internal/service/licensemanager/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider LicenseManager Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/lightsail/README.md
+++ b/internal/service/lightsail/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Lightsail resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lightsail_domain)

--- a/internal/service/lightsail/README.md
+++ b/internal/service/lightsail/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Lightsail Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/macie/README.md
+++ b/internal/service/macie/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Macie resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie_member_account_association)

--- a/internal/service/macie/README.md
+++ b/internal/service/macie/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Macie Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/macie2/README.md
+++ b/internal/service/macie2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Macie2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)

--- a/internal/service/macie2/README.md
+++ b/internal/service/macie2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Macie2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/mediaconnect/README.md
+++ b/internal/service/mediaconnect/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MediaConnect Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/mediaconnect/README.md
+++ b/internal/service/mediaconnect/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for MediaCon
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go MediaConnect](https://docs.aws.amazon.com/sdk-for-go/api/service/mediaconnect/)

--- a/internal/service/mediaconvert/README.md
+++ b/internal/service/mediaconvert/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MediaConvert Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/mediaconvert/README.md
+++ b/internal/service/mediaconvert/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the MediaConvert resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/media_convert_queue)

--- a/internal/service/medialive/README.md
+++ b/internal/service/medialive/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MediaLive Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/medialive/README.md
+++ b/internal/service/medialive/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for MediaLiv
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go MediaLive](https://docs.aws.amazon.com/sdk-for-go/api/service/medialive/)

--- a/internal/service/mediapackage/README.md
+++ b/internal/service/mediapackage/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MediaPackage Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/mediapackage/README.md
+++ b/internal/service/mediapackage/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the MediaPackage resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/media_package_channel)

--- a/internal/service/mediastore/README.md
+++ b/internal/service/mediastore/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MediaStore Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/mediastore/README.md
+++ b/internal/service/mediastore/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the MediaStore resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/media_store_container)

--- a/internal/service/mq/README.md
+++ b/internal/service/mq/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MQ Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/mq/README.md
+++ b/internal/service/mq/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the MQ resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_broker)

--- a/internal/service/mwaa/README.md
+++ b/internal/service/mwaa/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the MWAA resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mwaa_environment)

--- a/internal/service/mwaa/README.md
+++ b/internal/service/mwaa/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider MWAA Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/neptune/README.md
+++ b/internal/service/neptune/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Neptune Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/neptune/README.md
+++ b/internal/service/neptune/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Neptune resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/neptune_cluster)

--- a/internal/service/networkfirewall/README.md
+++ b/internal/service/networkfirewall/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the NetworkFirewall resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall)

--- a/internal/service/networkfirewall/README.md
+++ b/internal/service/networkfirewall/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider NetworkFirewall Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/networkmanager/README.md
+++ b/internal/service/networkmanager/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider NetworkManager Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/networkmanager/README.md
+++ b/internal/service/networkmanager/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for NetworkM
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Docs: [AWS SDK for Go NetworkManager](https://docs.aws.amazon.com/sdk-for-go/api/service/networkmanager/)

--- a/internal/service/opsworks/README.md
+++ b/internal/service/opsworks/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider OpsWorks Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/opsworks/README.md
+++ b/internal/service/opsworks/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the OpsWorks resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opsworks_application)

--- a/internal/service/organizations/README.md
+++ b/internal/service/organizations/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Organizations resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_account)

--- a/internal/service/organizations/README.md
+++ b/internal/service/organizations/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Organizations Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/outposts/README.md
+++ b/internal/service/outposts/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Outposts data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/outposts_outpost)

--- a/internal/service/outposts/README.md
+++ b/internal/service/outposts/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Outposts Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/pinpoint/README.md
+++ b/internal/service/pinpoint/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Pinpoint resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/pinpoint_adm_channel)

--- a/internal/service/pinpoint/README.md
+++ b/internal/service/pinpoint/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Pinpoint Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/pricing/README.md
+++ b/internal/service/pricing/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Pricing Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/pricing/README.md
+++ b/internal/service/pricing/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Pricing data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/pricing_product)

--- a/internal/service/qldb/README.md
+++ b/internal/service/qldb/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the QLDB resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/qldb_ledger)

--- a/internal/service/qldb/README.md
+++ b/internal/service/qldb/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider QLDB Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/quicksight/README.md
+++ b/internal/service/quicksight/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider QuickSight Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/quicksight/README.md
+++ b/internal/service/quicksight/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the QuickSight resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source)

--- a/internal/service/ram/README.md
+++ b/internal/service/ram/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the RAM resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association)

--- a/internal/service/ram/README.md
+++ b/internal/service/ram/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider RAM Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/rds/README.md
+++ b/internal/service/rds/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider RDS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/rds/README.md
+++ b/internal/service/rds/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the RDS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster)

--- a/internal/service/redshift/README.md
+++ b/internal/service/redshift/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Redshift Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/redshift/README.md
+++ b/internal/service/redshift/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Redshift resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster)

--- a/internal/service/resourcegroups/README.md
+++ b/internal/service/resourcegroups/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ResourceGroups resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group)

--- a/internal/service/resourcegroups/README.md
+++ b/internal/service/resourcegroups/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ResourceGroups Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/resourcegroupstaggingapi/README.md
+++ b/internal/service/resourcegroupstaggingapi/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ResourceGroupsTaggingAPI Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/resourcegroupstaggingapi/README.md
+++ b/internal/service/resourcegroupstaggingapi/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ResourceGroupsTaggingAPI data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/resourcegroupstaggingapi_resources)

--- a/internal/service/route53/README.md
+++ b/internal/service/route53/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Route53 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/route53/README.md
+++ b/internal/service/route53/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Route53 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_delegation_set)

--- a/internal/service/route53recoverycontrolconfig/README.md
+++ b/internal/service/route53recoverycontrolconfig/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Route53RecoveryControlConfig Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/route53recoverycontrolconfig/README.md
+++ b/internal/service/route53recoverycontrolconfig/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Route53RecoveryControlConfig resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53recoverycontrolconfig_cluster)

--- a/internal/service/route53recoveryreadiness/README.md
+++ b/internal/service/route53recoveryreadiness/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Route53RecoveryReadiness resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53recoveryreadiness_cell)

--- a/internal/service/route53recoveryreadiness/README.md
+++ b/internal/service/route53recoveryreadiness/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Route53RecoveryReadiness Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/route53resolver/README.md
+++ b/internal/service/route53resolver/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Route53Resolver resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule)

--- a/internal/service/route53resolver/README.md
+++ b/internal/service/route53resolver/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Route53Resolver Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/s3/README.md
+++ b/internal/service/s3/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the S3 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_access_point)

--- a/internal/service/s3/README.md
+++ b/internal/service/s3/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider S3 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/s3control/README.md
+++ b/internal/service/s3control/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the S3Control resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3control_bucket)

--- a/internal/service/s3control/README.md
+++ b/internal/service/s3control/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider S3Control Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/s3outposts/README.md
+++ b/internal/service/s3outposts/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider S3Outposts Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/s3outposts/README.md
+++ b/internal/service/s3outposts/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the S3Outposts resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3outposts_endpoint)

--- a/internal/service/sagemaker/README.md
+++ b/internal/service/sagemaker/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SageMaker resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_app)

--- a/internal/service/sagemaker/README.md
+++ b/internal/service/sagemaker/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SageMaker Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/schemas/README.md
+++ b/internal/service/schemas/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Schemas Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/schemas/README.md
+++ b/internal/service/schemas/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Schemas resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/schemas_discoverer)

--- a/internal/service/secretsmanager/README.md
+++ b/internal/service/secretsmanager/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SecretsManager Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/secretsmanager/README.md
+++ b/internal/service/secretsmanager/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SecretsManager resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret)

--- a/internal/service/securityhub/README.md
+++ b/internal/service/securityhub/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SecurityHub resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account)

--- a/internal/service/securityhub/README.md
+++ b/internal/service/securityhub/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SecurityHub Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/serverlessrepo/README.md
+++ b/internal/service/serverlessrepo/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Serverless Application Repository Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 The AWS Serverless Application Repository is also referred to as `serverlessrepo` in the AWS CLI.

--- a/internal/service/serverlessrepo/README.md
+++ b/internal/service/serverlessrepo/README.md
@@ -5,6 +5,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 The AWS Serverless Application Repository is also referred to as `serverlessrepo` in the AWS CLI.
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ServerlessRepo resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/serverlessapplicationrepository_cloudformation_stack)

--- a/internal/service/servicecatalog/README.md
+++ b/internal/service/servicecatalog/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ServiceCatalog resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalog_budget_resource_association)

--- a/internal/service/servicecatalog/README.md
+++ b/internal/service/servicecatalog/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ServiceCatalog Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/servicediscovery/README.md
+++ b/internal/service/servicediscovery/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ServiceDiscovery resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_instance)

--- a/internal/service/servicediscovery/README.md
+++ b/internal/service/servicediscovery/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ServiceDiscovery Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/servicequotas/README.md
+++ b/internal/service/servicequotas/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the ServiceQuotas resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicequotas_service_quota)

--- a/internal/service/servicequotas/README.md
+++ b/internal/service/servicequotas/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider ServiceQuotas Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ses/README.md
+++ b/internal/service/ses/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SES resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_active_receipt_rule_set)

--- a/internal/service/ses/README.md
+++ b/internal/service/ses/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SES Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/sfn/README.md
+++ b/internal/service/sfn/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SFN Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/sfn/README.md
+++ b/internal/service/sfn/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SFN resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_activity)

--- a/internal/service/shield/README.md
+++ b/internal/service/shield/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Shield resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection)

--- a/internal/service/shield/README.md
+++ b/internal/service/shield/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Shield Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/signer/README.md
+++ b/internal/service/signer/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Signer resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/signer_signing_job)

--- a/internal/service/signer/README.md
+++ b/internal/service/signer/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Signer Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/simpledb/README.md
+++ b/internal/service/simpledb/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SimpleDB Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/simpledb/README.md
+++ b/internal/service/simpledb/README.md
@@ -7,6 +7,7 @@ _At the moment, the Terraform AWS Provider has little or no support for SimpleDB
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SimpleDB resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/simpledb_domain)

--- a/internal/service/sns/README.md
+++ b/internal/service/sns/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SNS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/sns/README.md
+++ b/internal/service/sns/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SNS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_platform_application)

--- a/internal/service/sqs/README.md
+++ b/internal/service/sqs/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SQS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/sqs/README.md
+++ b/internal/service/sqs/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SQS resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue)

--- a/internal/service/ssm/README.md
+++ b/internal/service/ssm/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SSM Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/ssm/README.md
+++ b/internal/service/ssm/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SSM resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_activation)

--- a/internal/service/ssoadmin/README.md
+++ b/internal/service/ssoadmin/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SSOAdmin resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment)

--- a/internal/service/ssoadmin/README.md
+++ b/internal/service/ssoadmin/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SSOAdmin Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/storagegateway/README.md
+++ b/internal/service/storagegateway/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider StorageGateway Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/storagegateway/README.md
+++ b/internal/service/storagegateway/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the StorageGateway resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/storagegateway_cache)

--- a/internal/service/sts/README.md
+++ b/internal/service/sts/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the STS data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)

--- a/internal/service/sts/README.md
+++ b/internal/service/sts/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider STS Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/swf/README.md
+++ b/internal/service/swf/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider SWF Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/swf/README.md
+++ b/internal/service/swf/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the SWF resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/swf_domain)

--- a/internal/service/synthetics/README.md
+++ b/internal/service/synthetics/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Synthetics resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/synthetics_canary)

--- a/internal/service/synthetics/README.md
+++ b/internal/service/synthetics/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Synthetics Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/timestreamwrite/README.md
+++ b/internal/service/timestreamwrite/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider TimestreamWrite Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/timestreamwrite/README.md
+++ b/internal/service/timestreamwrite/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the TimestreamWrite resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/timestreamwrite_database)

--- a/internal/service/transfer/README.md
+++ b/internal/service/transfer/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider Transfer Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/transfer/README.md
+++ b/internal/service/transfer/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the Transfer resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_access)

--- a/internal/service/waf/README.md
+++ b/internal/service/waf/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the WAF resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_byte_match_set)

--- a/internal/service/waf/README.md
+++ b/internal/service/waf/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider WAF Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/wafregional/README.md
+++ b/internal/service/wafregional/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the WAFRegional resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_byte_match_set)

--- a/internal/service/wafregional/README.md
+++ b/internal/service/wafregional/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider WAFRegional Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/wafv2/README.md
+++ b/internal/service/wafv2/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider WAFV2 Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/wafv2/README.md
+++ b/internal/service/wafv2/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the WAFV2 resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set)

--- a/internal/service/worklink/README.md
+++ b/internal/service/worklink/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the WorkLink resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/worklink_fleet)

--- a/internal/service/worklink/README.md
+++ b/internal/service/worklink/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider WorkLink Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/workspaces/README.md
+++ b/internal/service/workspaces/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the WorkSpaces resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/workspaces_directory)

--- a/internal/service/workspaces/README.md
+++ b/internal/service/workspaces/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider WorkSpaces Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/internal/service/xray/README.md
+++ b/internal/service/xray/README.md
@@ -4,6 +4,7 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 
 ## Handy Links
+
 * [Find out about contributing](../../../docs/contributing) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 * AWS Provider Docs: [One of the XRay resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/xray_encryption_config)

--- a/internal/service/xray/README.md
+++ b/internal/service/xray/README.md
@@ -1,5 +1,5 @@
 # Terraform AWS Provider XRay Package
-<!-- markdownlint-disable MD026 -->
+
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
 

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -58,7 +58,7 @@ provider "aws" {
 }
 ```
 
-<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable no-inline-html -->
 <!--
     The division splits this long list into multiple columns without manually
     maintaining a table. The terraform.io Markdown parser previously allowed
@@ -340,7 +340,7 @@ provider "aws" {
   <li><code>xray</code></li>
 </ul>
 </div>
-<!-- markdownlint-enable MD033 -->
+<!-- markdownlint-enable no-inline-html -->
 
 As a convenience, for compatibility with the [Terraform S3 Backend](https://www.terraform.io/language/settings/backends/s3),
 the following service endpoints can be configured using environment variables:


### PR DESCRIPTION
Updates `markdownlint.yml` to use rule names instead of codes.

Also removes unneeded rule exclusion and updates heading spacing in service README files