### PR TITLE
Add retry to eks cluster delete

### DIFF
--- a/.changelog/23366.txt
+++ b/.changelog/23366.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Retry when `ResourceInUseException` errors are returned from the AWS API during resource deletion
+```

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -410,7 +410,7 @@ rules:
 
   - id: helper-schema-TimeoutError-check-doesnt-return-output
     languages: [go]
-    message: If the resource.Retry() or resource.RetryContext() function returns a value, ensure the isResourceTimeoutError() check does as well
+    message: If the resource.Retry(), resource.RetryContext(), or tfresource.RetryConfigContext() function returns a value, ensure the isResourceTimeoutError() check does as well
     paths:
       exclude:
         - "*_test.go"
@@ -439,6 +439,14 @@ rules:
               })
               ...
               if isResourceTimeoutError($ERR) { ... }
+          - pattern-not-inside: |
+              $ERR = tfresource.RetryConfigContext(..., func() *resource.RetryError {
+                ...
+                _, $ERR2 = $CONN.$FUNC(...)
+                ...
+              })
+              ...
+              if tfresource.TimedOut($ERR) { ... }
         - patterns:
           - pattern: |
               if tfresource.TimedOut($ERR) {
@@ -454,6 +462,14 @@ rules:
               if tfresource.TimedOut($ERR) { ... }
           - pattern-not-inside: |
               $ERR = resource.RetryContext(..., func() *resource.RetryError {
+                ...
+                _, $ERR2 = $CONN.$FUNC(...)
+                ...
+              })
+              ...
+              if tfresource.TimedOut($ERR) { ... }
+          - pattern-not-inside: |
+              $ERR = tfresource.RetryConfigContext(..., func() *resource.RetryError {
                 ...
                 _, $ERR2 = $CONN.$FUNC(...)
                 ...

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -498,31 +498,41 @@ func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EKSConn
 
 	log.Printf("[DEBUG] Deleting EKS Cluster: %s", d.Id())
-	_, err := conn.DeleteCluster(&eks.DeleteClusterInput{
-		Name: aws.String(d.Id()),
+
+	// If a cluster is scaling up due to load a delete request will fail
+	// This is a temporary workaround until EKS supports multiple parallel mutating operations
+	return tfresource.RetryConfigContext(context.TODO(), 0*time.Second, 1*time.Minute, 0*time.Second, 30*time.Second, clusterDeleteRetryTimeout, func() *resource.RetryError {
+		_, err := conn.DeleteCluster(&eks.DeleteClusterInput{
+			Name: aws.String(d.Id()),
+		})
+
+		if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+
+		// Sometimes the EKS API returns the ResourceNotFound error in this form:
+		// ClientException: No cluster found for name: tf-acc-test-0o1f8
+		if tfawserr.ErrMessageContains(err, eks.ErrCodeClientException, "No cluster found for name:") {
+			return nil
+		}
+
+		if tfawserr.ErrMessageContains(err, eks.ErrCodeResourceInUseException, "in progress") {
+			log.Printf("[DEBUG] eks cluster update in progress: %v", err)
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error deleting EKS Cluster (%s): %w", d.Id(), err))
+		}
+
+		_, err = waitClusterDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error waiting for EKS Cluster (%s) to delete: %w", d.Id(), err))
+		}
+
+		return nil
 	})
-
-	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
-		return nil
-	}
-
-	// Sometimes the EKS API returns the ResourceNotFound error in this form:
-	// ClientException: No cluster found for name: tf-acc-test-0o1f8
-	if tfawserr.ErrMessageContains(err, eks.ErrCodeClientException, "No cluster found for name:") {
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error deleting EKS Cluster (%s): %w", d.Id(), err)
-	}
-
-	_, err = waitClusterDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-
-	if err != nil {
-		return fmt.Errorf("error waiting for EKS Cluster (%s) to delete: %w", d.Id(), err)
-	}
-
-	return nil
 }
 
 func expandEksEncryptionConfig(tfList []interface{}) []*eks.EncryptionConfig {

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -14,6 +14,8 @@ const (
 	addonCreatedTimeout = 20 * time.Minute
 	addonUpdatedTimeout = 20 * time.Minute
 	addonDeletedTimeout = 40 * time.Minute
+
+	clusterDeleteRetryTimeout = 60 * time.Minute
 )
 
 func waitAddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {


### PR DESCRIPTION
EKS delete cluster calls can fail due to an in-progress cluster upgrade operation (customer initiated or automated scaling by EKS) or service outage.

This PR helps mitigate delete cluster failures by adding a retry with backoff.

~The suite is currently running and I will update when it finishes.~ The failure seems like a flake?

<details><summary>Output from acceptance testing:</summary>

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$  make testacc TESTS=TestAccEKSCluster PKG=eks AWS_PROFILE=burner ACCTEST_PARALLELISM=5 ACCTEST_TIMEOUT=5000m

==> Checking that code complies with gofmt requirements...                                                                                                                                     
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 5 -run='TestAccEKSCluster'  -timeout 5000m
=== RUN   TestAccEKSClusterAuthDataSource_basic
=== PAUSE TestAccEKSClusterAuthDataSource_basic
=== RUN   TestAccEKSClusterDataSource_basic
=== PAUSE TestAccEKSClusterDataSource_basic
=== RUN   TestAccEKSCluster_basic
=== PAUSE TestAccEKSCluster_basic
=== RUN   TestAccEKSCluster_disappears
=== PAUSE TestAccEKSCluster_disappears
=== RUN   TestAccEKSCluster_Encryption_create
=== PAUSE TestAccEKSCluster_Encryption_create
=== RUN   TestAccEKSCluster_Encryption_update
=== PAUSE TestAccEKSCluster_Encryption_update
=== RUN   TestAccEKSCluster_Encryption_versionUpdate
=== PAUSE TestAccEKSCluster_Encryption_versionUpdate
=== RUN   TestAccEKSCluster_version
=== PAUSE TestAccEKSCluster_version
=== RUN   TestAccEKSCluster_logging
=== PAUSE TestAccEKSCluster_logging
=== RUN   TestAccEKSCluster_tags
=== PAUSE TestAccEKSCluster_tags
=== RUN   TestAccEKSCluster_VPC_securityGroupIDs
=== PAUSE TestAccEKSCluster_VPC_securityGroupIDs
=== RUN   TestAccEKSCluster_VPC_endpointPrivateAccess
=== PAUSE TestAccEKSCluster_VPC_endpointPrivateAccess
=== RUN   TestAccEKSCluster_VPC_endpointPublicAccess
=== PAUSE TestAccEKSCluster_VPC_endpointPublicAccess
=== RUN   TestAccEKSCluster_VPC_publicAccessCIDRs
=== PAUSE TestAccEKSCluster_VPC_publicAccessCIDRs
=== RUN   TestAccEKSCluster_Network_serviceIPv4CIDR
=== PAUSE TestAccEKSCluster_Network_serviceIPv4CIDR
=== RUN   TestAccEKSCluster_Network_ipFamily
=== PAUSE TestAccEKSCluster_Network_ipFamily
=== RUN   TestAccEKSClustersDataSource_basic
=== PAUSE TestAccEKSClustersDataSource_basic
=== CONT  TestAccEKSClusterAuthDataSource_basic
=== CONT  TestAccEKSCluster_tags
=== CONT  TestAccEKSClustersDataSource_basic
=== CONT  TestAccEKSCluster_VPC_publicAccessCIDRs                                                                                                                                                     === CONT  TestAccEKSCluster_Encryption_update
--- PASS: TestAccEKSClusterAuthDataSource_basic (5.64s)
=== CONT  TestAccEKSCluster_VPC_endpointPublicAccess
--- PASS: TestAccEKSClustersDataSource_basic (805.65s)
=== CONT  TestAccEKSCluster_VPC_endpointPrivateAccess
--- PASS: TestAccEKSCluster_tags (855.32s)
=== CONT  TestAccEKSCluster_VPC_securityGroupIDs
--- PASS: TestAccEKSCluster_VPC_publicAccessCIDRs (1150.25s)
=== CONT  TestAccEKSCluster_Network_ipFamily
--- PASS: TestAccEKSCluster_VPC_securityGroupIDs (881.04s)
=== CONT  TestAccEKSCluster_version
--- PASS: TestAccEKSCluster_VPC_endpointPublicAccess (1834.17s)
=== CONT  TestAccEKSCluster_logging
--- PASS: TestAccEKSCluster_Network_ipFamily (1465.34s)
=== CONT  TestAccEKSCluster_disappears
--- PASS: TestAccEKSCluster_logging (941.18s)
=== CONT  TestAccEKSCluster_Encryption_create
--- PASS: TestAccEKSCluster_VPC_endpointPrivateAccess (2414.62s)
=== CONT  TestAccEKSCluster_Encryption_versionUpdate
--- PASS: TestAccEKSCluster_disappears (799.48s)
=== CONT  TestAccEKSCluster_basic
--- PASS: TestAccEKSCluster_Encryption_create (839.34s)
=== CONT  TestAccEKSCluster_Network_serviceIPv4CIDR
    cluster_test.go:495: Step 6/9 error: Error running apply: exit status 1

        Error: error associating EC2 Subnet (subnet-0f7909314a41e5e17) IPv6 CIDR block (2600:1f13:894:aa00::/64): InvalidSubnet.Conflict: The CIDR '2600:1f13:894:aa00::/64' conflicts with another subnet
                status code: 400, request id: 1917bc0e-92cc-4e93-833d-deb32cf0d515

          with aws_subnet.test[0],
          on terraform_plugin_test.tf line 48, in resource "aws_subnet" "test":
          48: resource "aws_subnet" "test" {

--- FAIL: TestAccEKSCluster_Network_serviceIPv4CIDR (133.53s)
=== CONT  TestAccEKSClusterDataSource_basic
--- PASS: TestAccEKSCluster_Encryption_update (3925.55s)
--- PASS: TestAccEKSCluster_basic (779.18s)
--- PASS: TestAccEKSCluster_version (2541.70s)
--- PASS: TestAccEKSClusterDataSource_basic (838.88s)
--- PASS: TestAccEKSCluster_Encryption_versionUpdate (2773.93s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/eks        5994.229s
FAIL
make: *** [GNUmakefile:36: testacc] Error 1
```
</details>

I tested this manually by creating an EKS cluster using https://github.com/hashicorp/learn-terraform-provision-eks-cluster. I deployed the sample as is and then updated the config to use Kubernetes 1.21. I then built a copy of the provider that commented out [`waitClusterUpdateSuccessful`](https://github.com/hashicorp/terraform-provider-aws/blob/b2290be9a4345265410db374f566ac837f490abd/internal/service/eks/cluster.go#L410). I applied the change and started the cluster upgrade. Then I ran the destroy and observed that it retries successfully while an upgrade is in progress.

<details><summary>Output</summary>

```
$ terraform destroy                                                                                              
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/aws in /tmp/GOPATH/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
random_string.suffix: Refreshing state... [id=cOG3qldS]
module.vpc.aws_vpc.this[0]: Refreshing state... [id=vpc-0e2c849d939ff6725]
module.eks.aws_iam_policy.cluster_elb_sl_role_creation[0]: Refreshing state... [id=a..
module.eks.aws_iam_role.workers[0]: Destruction complete after 1s
module.eks.aws_eks_cluster.this[0]: Destroying... [id=education-eks-cOG3qldS]
aws_security_group.worker_group_mgmt_one: Destruction complete after 1s
aws_security_group.worker_group_mgmt_two: Destruction complete after 1s
module.eks.aws_security_group_rule.workers_egress_internet[0]: Destruction complete after 1s
module.eks.aws_security_group_rule.workers_ingress_cluster[0]: Destruction complete after 1s
module.eks.aws_security_group_rule.workers_ingress_self[0]: Destruction complete after 2s
...
...
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 10s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 20s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 30s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 40s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 50s elapsed]
...
...
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 26m20s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 26m30s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 26m40s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 26m50s elapsed]
module.eks.aws_eks_cluster.this[0]: Still destroying... [id=education-eks-cOG3qldS, 27m0s elapsed]
module.eks.aws_eks_cluster.this[0]: Destruction complete after 27m5s
module.eks.aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy[0]: Destroying... [id=education-eks-cOG3qldS20220224182823855600000003-20220224182825030700000007]
module.eks.aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceControllerPolicy[0]: Destroying... [id=education-eks-cOG3qldS20220224182823855600000003-20220224182824921900000005]
module.eks.aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy[0]: Destroying... [id=education-eks-cOG3qldS20220224182823855600000003-20220224182824922100000006]
...
...
random_string.suffix: Destroying... [id=cOG3qldS]
random_string.suffix: Destruction complete after 0s

Destroy complete! Resources: 53 destroyed.
```
</details>





<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->