### PR TITLE
r/s3_bucket_object_lock_configuration: clarify usage in docs and mark token as `sensitive`

### DIFF
--- a/.changelog/23368.txt
+++ b/.changelog/23368.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_object_lock_configuration: Mark `token` argument as sensitive
+```

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -79,8 +79,9 @@ func ResourceBucketObjectLockConfiguration() *schema.Resource {
 				},
 			},
 			"token": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -60,8 +60,9 @@ See the [`aws_s3_bucket_lifecycle_configuration` resource](s3_bucket_lifecycle_c
 ### Using object lock configuration
 
 The `object_lock_configuration.rule` argument is read-only as of version 4.0 of the Terraform AWS Provider.
-To **enable** Object Lock on your bucket, use must still use the `object_lock_configuration.object_lock_enabled` argument in **this** resource.
+To **enable** Object Lock on a **new** bucket, use the `object_lock_configuration.object_lock_enabled` argument in **this** resource. See [Object Lock Configuration](#object-lock-configuration) below for details.
 To configure the default retention rule of the Object Lock configuration, see the [`aws_s3_bucket_object_lock_configuration` resource](s3_bucket_object_lock_configuration.html.markdown) for configuration details.
+To **enable** Object Lock on an **existing** bucket, please contact AWS Support and refer to the [Object lock configuration for an existing bucket](s3_bucket_object_lock_configuration.html.markdown#object-lock-configuration-for-an-existing-bucket) example for more details.
 
 ### Using replication configuration
 
@@ -90,7 +91,7 @@ The following arguments are supported:
 
 ### Object Lock Configuration
 
-~> **NOTE:** You can only enable S3 Object Lock for _new_ buckets. If you need to turn on S3 Object Lock for an _existing_ bucket, please contact AWS Support.
+~> **NOTE:** You can only **enable** S3 Object Lock for **new** buckets. If you need to **enable** S3 Object Lock for an **existing** bucket, please contact AWS Support.
 When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
 Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
 To configure the default retention rule of the Object Lock configuration, see the [`aws_s3_bucket_object_lock_configuration` resource](s3_bucket_object_lock_configuration.html.markdown) for configuration details.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -57,6 +57,12 @@ See the [`aws_s3_bucket_logging` resource](s3_bucket_logging.html.markdown) for 
 The `lifecycle_rule` argument is read-only as of version 4.0 of the Terraform AWS Provider.
 See the [`aws_s3_bucket_lifecycle_configuration` resource](s3_bucket_lifecycle_configuration.html.markdown) for configuration details.
 
+### Using object lock configuration
+
+The `object_lock_configuration.rule` argument is read-only as of version 4.0 of the Terraform AWS Provider.
+To **enable** Object Lock on your bucket, use must still use the `object_lock_configuration.object_lock_enabled` argument in **this** resource.
+To configure the default retention rule of the Object Lock configuration, see the [`aws_s3_bucket_object_lock_configuration` resource](s3_bucket_object_lock_configuration.html.markdown) for configuration details.
+
 ### Using replication configuration
 
 The `replication_configuration` argument is read-only as of version 4.0 of the Terraform AWS Provider.
@@ -78,17 +84,20 @@ The following arguments are supported:
 
 * `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-* `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
-* `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+* `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See [Object Lock Configuration](#object-lock-configuration) below.
+* `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-The `object_lock_configuration` object supports the following:
+### Object Lock Configuration
 
-* `object_lock_enabled` - (Required) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
-
-~> **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
+~> **NOTE:** You can only enable S3 Object Lock for _new_ buckets. If you need to turn on S3 Object Lock for an _existing_ bucket, please contact AWS Support.
 When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
 Once you create a bucket with S3 Object Lock enabled, you can't disable Object Lock or suspend versioning for the bucket.
+To configure the default retention rule of the Object Lock configuration, see the [`aws_s3_bucket_object_lock_configuration` resource](s3_bucket_object_lock_configuration.html.markdown) for configuration details.
+
+The `object_lock_configuration` configuration block supports the following argument:
+
+* `object_lock_enabled` - (Required) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
 
 ## Attributes Reference
 

--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 Provides an S3 bucket Object Lock configuration resource. For more information about Object Locking, go to [Using S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) in the Amazon S3 User Guide.
 
-~> **NOTE:** This resource **does not enable** Object Lock for _new_ buckets. It configures a default retention period for objects placed in the specified bucket.
-Thus, to **enable** Object Lock for a _new_ bucket, see the the [`aws_s3_bucket` resource](s3_bucket.html.markdown) or the [following example](#Example-Usage).
-If you want to turn on Object Lock for an _existing_ bucket, contact AWS Support.
+~> **NOTE:** This resource **does not enable** Object Lock for **new** buckets. It configures a default retention period for objects placed in the specified bucket.
+Thus, to **enable** Object Lock for a **new** bucket, see the [Using object lock configuration](s3_bucket.html.markdown#Using-object-lock-configuration) section in  the `aws_s3_bucket` resource or the [Object Lock configuration for a new bucket](#object-lock-configuration-for-a-new-bucket) example below.
+If you want to **enable** Object Lock for an **existing** bucket, contact AWS Support and see the [Object Lock configuration for an existing bucket](#object-lock-configuration-for-an-existing-bucket) example below.
 
 ## Example Usage
 
@@ -39,6 +39,44 @@ resource "aws_s3_bucket_object_lock_configuration" "example" {
 }
 ```
 
+### Object Lock configuration for an existing bucket
+
+This is a multistep process that requires AWS Support intervention.
+
+1. Enable versioning on your S3 bucket, if you have not already done so.
+Doing so will generate an "Object Lock token" in the back-end.
+
+   ```terraform
+    resource "aws_s3_bucket" "example" {
+      bucket = "mybucket"
+    }
+
+    resource "aws_s3_bucket_versioning" "example" {
+      bucket = aws_s3_bucket.example.bucket
+
+      versioning_configuration {
+        status = "Enabled"
+      }
+    }
+    ```
+
+2. Contact AWS Support to provide you with the "Object Lock token" for the specified bucket and use the token within your new `aws_s3_bucket_object_lock_configuration` resource.
+
+    ```terraform
+    resource "aws_s3_bucket_object_lock_configuration" "example" {
+      bucket = aws_s3_bucket.example.bucket
+
+      rule {
+        default_retention {
+          mode = "COMPLIANCE"
+          days = 5
+        }
+      }
+
+      token = "exampletoken1234"
+    }
+    ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -47,7 +85,8 @@ The following arguments are supported:
 * `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
 * `object_lock_enabled` - (Optional, Forces new resource) Indicates whether this bucket has an Object Lock configuration enabled. Defaults to `Enabled`. Valid values: `Enabled`.
 * `rule` - (Required) Configuration block for specifying the Object Lock rule for the specified object [detailed below](#rule).
-* `token` - (Optional) A token to allow Object Lock to be enabled for an existing bucket.
+* `token` - (Optional) A token to allow Object Lock to be enabled for an existing bucket. You must contact AWS support for the bucket's "Object Lock token".
+The token is generated in the back-end when [versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html) is enabled on a bucket. For more details on versioning, see the [`aws_s3_bucket_versioning` resource](s3_bucket_versioning.html.markdown).
 
 ### rule
 

--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -10,9 +10,13 @@ description: |-
 
 Provides an S3 bucket Object Lock configuration resource. For more information about Object Locking, go to [Using S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) in the Amazon S3 User Guide.
 
-~> **NOTE:** You can only enable Object Lock for new buckets. If you want to turn on Object Lock for an existing bucket, contact AWS Support.
+~> **NOTE:** This resource **does not enable** Object Lock for _new_ buckets. It configures a default retention period for objects placed in the specified bucket.
+Thus, to **enable** Object Lock for a _new_ bucket, see the the [`aws_s3_bucket` resource](s3_bucket.html.markdown) or the [following example](#Example-Usage).
+If you want to turn on Object Lock for an _existing_ bucket, contact AWS Support.
 
 ## Example Usage
+
+### Object Lock configuration for a new bucket
 
 ```terraform
 resource "aws_s3_bucket" "example" {

--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -60,7 +60,8 @@ Doing so will generate an "Object Lock token" in the back-end.
     }
     ```
 
-2. Contact AWS Support to provide you with the "Object Lock token" for the specified bucket and use the token within your new `aws_s3_bucket_object_lock_configuration` resource.
+2. Contact AWS Support to provide you with the "Object Lock token" for the specified bucket and use the token (or token ID) within your new `aws_s3_bucket_object_lock_configuration` resource.
+   Notice the `object_lock_enabled` argument does not need to be specified as it defaults to `Enabled`.
 
     ```terraform
     resource "aws_s3_bucket_object_lock_configuration" "example" {
@@ -73,7 +74,7 @@ Doing so will generate an "Object Lock token" in the back-end.
         }
       }
 
-      token = "exampletoken1234"
+      token = "NG2MKsfoLqV3A+aquXneSG4LOu/ekrlXkRXwIPFVfERT7XOPos+/k444d7RIH0E3W3p5QU6ml2exS2F/eYCFmMWHJ3hFZGk6al1sIJkmNhUMYmsv0jYVQyTTZNLM+DnfooA6SATt39mM1VW1yJh4E+XljMlWzaBwHKbss3/EjlGDjOmVhaSs4Z6427mMCaFD0RLwsYY7zX49gEc31YfOMJGxbXCXSeyNwAhhM/A8UH7gQf38RmjHjjAFbbbLtl8arsxTPW8F1IYohqwmKIr9DnotLLj8Tg44U2SPwujVaqmlKKP9s41rfgb4UbIm7khSafDBng0LGfxC4pMlT9Ny2w=="
     }
     ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23363

TODO:
- [x] get confirmation from AWS Support case on how `token` is used with the AWS Go SDK
- [x] confirm if you need to update your `aws_s3_bucket` configuration with `object_lock_enabled` to suppress diffs
^^ not actually necessary after apply/refresh:

```
$ cat main.tf

resource "aws_s3_bucket" "example" {
  bucket = "my-example-log-bucket-4444"
}

resource "aws_s3_bucket_versioning" "example" {
  bucket = aws_s3_bucket.example.id

  versioning_configuration {
    status = "Enabled"
  }
}

resource "aws_s3_bucket_object_lock_configuration" "example"{
  bucket = aws_s3_bucket.example.id

  rule {
    default_retention {
      mode = "COMPLIANCE"
      days = 5
    }
  }

  token = (Sensitive)
}

```
```
$ terraform apply

Terraform will perform the following actions:

  # aws_s3_bucket_object_lock_configuration.example will be created
  + resource "aws_s3_bucket_object_lock_configuration" "example" {
      + bucket              = "my-example-log-bucket-4444"
      + id                  = (known after apply)
      + object_lock_enabled = "Enabled"
      + token               = "xxxxxxxxxx"

      + rule {
          + default_retention {
              + days = 5
              + mode = "COMPLIANCE"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
aws_s3_bucket_object_lock_configuration.example: Creating...
aws_s3_bucket_object_lock_configuration.example: Creation complete after 1s [id=my-example-log-bucket-4444]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
```
$ terraform plan
aws_s3_bucket.example: Refreshing state... [id=my-example-log-bucket-4444]
aws_s3_bucket_versioning.example: Refreshing state... [id=my-example-log-bucket-4444]
aws_s3_bucket_object_lock_configuration.example: Refreshing state... [id=my-example-log-bucket-4444]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # aws_s3_bucket.example has changed
  ~ resource "aws_s3_bucket" "example" {
        id                                   = "my-example-log-bucket-4444"
        tags                                 = {}
        # (17 unchanged attributes hidden)

      + object_lock_configuration {
          + object_lock_enabled = "Enabled"
          + rule                = [
              + {
                  + default_retention = [
                      + {
                          + days  = 5
                          + mode  = "COMPLIANCE"
                          + years = 0
                        },
                    ]
                },
            ]
        }
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes,
the following plan may include actions to undo or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

No changes. Your infrastructure matches the configuration.

```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
