### PR TITLE
provider: Make `region` optional

### DIFF
--- a/.changelog/23384.txt
+++ b/.changelog/23384.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Makes `region` an optional parameter to allow sourcing from shared config files and IMDS
+```

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1187,14 +1187,6 @@ func (client *AWSClient) RegionalHostname(prefix string) string {
 
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
-	// Get the auth and region. This can fail if keys/regions were not
-	// specified and we're attempting to use the environment.
-	if !c.SkipRegionValidation {
-		if err := awsbase.ValidateRegion(c.Region); err != nil {
-			return nil, err
-		}
-	}
-
 	awsbaseConfig := awsbase.Config{
 		AccessKey:               c.AccessKey,
 		APNInfo:                 StdUserAgentProducts(c.TerraformVersion),
@@ -1245,6 +1237,12 @@ func (c *Config) Client() (interface{}, error) {
 	cfg, err := awsbase.GetAwsConfig(ctx, &awsbaseConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Terraform AWS Provider: %w", err)
+	}
+
+	if !c.SkipRegionValidation {
+		if err := awsbase.ValidateRegion(cfg.Region); err != nil {
+			return nil, err
+		}
 	}
 
 	sess, err := awsbasev1.GetSession(&cfg, &awsbaseConfig)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -288,14 +288,9 @@ func Provider() *schema.Provider {
 			},
 			"region": {
 				Type:     schema.TypeString,
-				Required: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"AWS_REGION",
-					"AWS_DEFAULT_REGION",
-				}, nil),
+				Optional: true,
 				Description: "The region where AWS operations will take place. Examples\n" +
 					"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003,
-				InputDefault: "us-east-1", // lintignore:AWSAT003
 			},
 			"s3_force_path_style": {
 				Type:       schema.TypeBool,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -281,7 +281,10 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   and the shared configuration parameter `max_attempts`.
 * `profile` - (Optional) AWS profile name as set in the shared configuration and credentials files.
   Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
-* `region` - (Optional) AWS region. Can also be set using either the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables, or via the shared configuration and credentials files if `profile` is used.
+* `region` - (Optional) The AWS region where the provider will operate. The region must be set.
+  Can also be set with either the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
+  or via a shared config file parameter `region` if `profile` is used.
+  If credentials are retrieved from the EC2 Instance Metadata Service, the region can also be retrieved from the metadata.
 * `s3_force_path_style` - (Optional, **Deprecated**) Whether to enable the request to use path-style addressing, i.e., `https://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing, `https://BUCKET.s3.amazonaws.com/KEY`, when possible. Specific to the Amazon S3 service.
 * `s3_use_path_style` - (Optional) Whether to enable the request to use path-style addressing, i.e., `https://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing, `https://BUCKET.s3.amazonaws.com/KEY`, when possible. Specific to the Amazon S3 service.
 * `secret_key` - (Optional) AWS secret key. Can also be set with the `AWS_SECRET_ACCESS_KEY` environment variable, or via a shared configuration and credentials files if `profile` is used. See also `access_key`.


### PR DESCRIPTION
The region can now be sourced from:

* Provider config
* Environment variables
* Shared config or credentials files
* IMDS

It can no longer be a required parameter

Closes #23321