### PR TITLE
r/aws_backup_framework: Serialize acceptance tests

### DIFF
--- a/internal/service/backup/framework_data_source_test.go
+++ b/internal/service/backup/framework_data_source_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccBackupFrameworkDataSource_basic(t *testing.T) {
+func testAccBackupFrameworkDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_backup_framework.test"
 	resourceName := "aws_backup_framework.test"
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:  acctest.Providers,
@@ -67,12 +67,12 @@ func TestAccBackupFrameworkDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccBackupFrameworkDataSource_controlScopeTag(t *testing.T) {
+func testAccBackupFrameworkDataSource_controlScopeTag(t *testing.T) {
 	datasourceName := "data.aws_backup_framework.test"
 	resourceName := "aws_backup_framework.test"
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:  acctest.Providers,

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -14,7 +14,36 @@ import (
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 )
 
-func TestAccBackupFramework_basic(t *testing.T) {
+func TestAccBackupFramework_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Resource": {
+			"basic":                        testAccBackupFramework_basic,
+			"disappears":                   testAccBackupFramework_disappears,
+			"UpdateTags":                   testAccBackupFramework_updateTags,
+			"UpdateControlScope":           testAccBackupFramework_updateControlScope,
+			"UpdateControlInputParameters": testAccBackupFramework_updateControlInputParameters,
+			"UpdateControls":               testAccBackupFramework_updateControls,
+		},
+		"DataSource": {
+			"basic":           testAccBackupFrameworkDataSource_basic,
+			"ControlScopeTag": testAccBackupFrameworkDataSource_controlScopeTag,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
+func testAccBackupFramework_basic(t *testing.T) {
 	var framework backup.DescribeFrameworkOutput
 
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
@@ -22,7 +51,7 @@ func TestAccBackupFramework_basic(t *testing.T) {
 	updatedDescription := "updated description"
 	resourceName := "aws_backup_framework.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
@@ -75,14 +104,14 @@ func TestAccBackupFramework_basic(t *testing.T) {
 	})
 }
 
-func TestAccBackupFramework_updateTags(t *testing.T) {
+func testAccBackupFramework_updateTags(t *testing.T) {
 	var framework backup.DescribeFrameworkOutput
 
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	description := "example description"
 	resourceName := "aws_backup_framework.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
@@ -162,7 +191,7 @@ func TestAccBackupFramework_updateTags(t *testing.T) {
 	})
 }
 
-func TestAccBackupFramework_updateControlScope(t *testing.T) {
+func testAccBackupFramework_updateControlScope(t *testing.T) {
 	var framework backup.DescribeFrameworkOutput
 
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
@@ -171,7 +200,7 @@ func TestAccBackupFramework_updateControlScope(t *testing.T) {
 	updatedControlScopeTagValue := ""
 	resourceName := "aws_backup_framework.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
@@ -274,7 +303,7 @@ func TestAccBackupFramework_updateControlScope(t *testing.T) {
 	})
 }
 
-func TestAccBackupFramework_updateControlInputParameters(t *testing.T) {
+func testAccBackupFramework_updateControlInputParameters(t *testing.T) {
 	var framework backup.DescribeFrameworkOutput
 
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
@@ -283,7 +312,7 @@ func TestAccBackupFramework_updateControlInputParameters(t *testing.T) {
 	updatedRequiredRetentionDays := "34"
 	resourceName := "aws_backup_framework.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
@@ -356,14 +385,14 @@ func TestAccBackupFramework_updateControlInputParameters(t *testing.T) {
 	})
 }
 
-func TestAccBackupFramework_updateControls(t *testing.T) {
+func testAccBackupFramework_updateControls(t *testing.T) {
 	var framework backup.DescribeFrameworkOutput
 
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	description := "example description"
 	resourceName := "aws_backup_framework.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
@@ -434,14 +463,14 @@ func TestAccBackupFramework_updateControls(t *testing.T) {
 	})
 }
 
-func TestAccBackupFramework_disappears(t *testing.T) {
+func testAccBackupFramework_disappears(t *testing.T) {
 	var framework backup.DescribeFrameworkOutput
 
 	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	description := "disappears"
 	resourceName := "aws_backup_framework.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23382.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBackupFramework_serial PKG=backup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 20 -run='TestAccBackupFramework_serial'  -timeout 180m
=== RUN   TestAccBackupFramework_serial
=== RUN   TestAccBackupFramework_serial/Resource
=== RUN   TestAccBackupFramework_serial/Resource/UpdateTags
=== RUN   TestAccBackupFramework_serial/Resource/UpdateControlScope
=== RUN   TestAccBackupFramework_serial/Resource/UpdateControlInputParameters
=== RUN   TestAccBackupFramework_serial/Resource/UpdateControls
=== RUN   TestAccBackupFramework_serial/Resource/basic
=== RUN   TestAccBackupFramework_serial/Resource/disappears
=== RUN   TestAccBackupFramework_serial/DataSource
=== RUN   TestAccBackupFramework_serial/DataSource/basic
=== RUN   TestAccBackupFramework_serial/DataSource/ControlScopeTag
--- PASS: TestAccBackupFramework_serial (522.33s)
    --- PASS: TestAccBackupFramework_serial/Resource (412.32s)
        --- PASS: TestAccBackupFramework_serial/Resource/UpdateTags (65.77s)
        --- PASS: TestAccBackupFramework_serial/Resource/UpdateControlScope (143.05s)
        --- PASS: TestAccBackupFramework_serial/Resource/UpdateControlInputParameters (58.12s)
        --- PASS: TestAccBackupFramework_serial/Resource/UpdateControls (70.26s)
        --- PASS: TestAccBackupFramework_serial/Resource/basic (41.75s)
        --- PASS: TestAccBackupFramework_serial/Resource/disappears (33.38s)
    --- PASS: TestAccBackupFramework_serial/DataSource (110.01s)
        --- PASS: TestAccBackupFramework_serial/DataSource/basic (67.24s)
        --- PASS: TestAccBackupFramework_serial/DataSource/ControlScopeTag (42.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	525.937s
```
