### PR TITLE
Updates `aws-sdk-go-base`

### DIFF
--- a/.changelog/23388.txt
+++ b/.changelog/23388.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+provider: Retrieves region from IMDS when credentials retrieved from IMDS.
+```
+
+```release-note:enhancement
+provider: Improves error message when `Profile` and static credential environment variables are set.
+```
+
+```release-note:bug
+provider: Validates names of named profiles before use.
+```

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/beevik/etree v1.1.0
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.16.0
-	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.8
-	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.9
+	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.10
+	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.11
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -190,10 +190,10 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.16.0 h1:r2RUzeK2gAitl0HY9SLH1axAEu+6aPBY20g1jOoBepM=
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.16.0/go.mod h1:C6GVuO9RWOrt6QCGTmLCOYuSHpkfQSBDuRqTteOlo0g=
-github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.8 h1:BlV2HAJxG5/UHMgBQ9rKrGLg6ThIkqTs6Hnr3OHOjps=
-github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.8/go.mod h1:O0d2KtdvgHuWVQ9go3oK6BFPLht6254JIHjLfEzo+lM=
-github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.9 h1:sFb+svRVSNWtVd4JDHen7R+rd0TB3yKt8+OgbYcpamU=
-github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.9/go.mod h1:bUMECpdj5Vo+mLFC8gYUb+epVTg1ocf6xx9T7QVeK18=
+github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.10 h1:HvzuTawTMw+enUgu4plvLJ3kgH/Gaz1MRFmZcVAnEeo=
+github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.10/go.mod h1:O0d2KtdvgHuWVQ9go3oK6BFPLht6254JIHjLfEzo+lM=
+github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.11 h1:GQ5vECuNqulzr2Jizlvrf4C8JcK50BFqieB/PprHYc8=
+github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.11/go.mod h1:rDvk2q2KbYHahKgYmFHJh0eM310hYWUSTTJ1LAZY4Vs=
 github.com/hashicorp/awspolicyequivalence v1.5.0 h1:tGw6h9qN1AWNBaUf4OUcdCyE/kqNBItTiyTPQeV/KUg=
 github.com/hashicorp/awspolicyequivalence v1.5.0/go.mod h1:9IOaIHx+a7C0NfUNk1A93M7kHd5rJ19aoUx37LZGC14=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=


### PR DESCRIPTION
Updates `aws-sdk-go-base`

CHANGELOG

* Now returns an error if an invalid profile is specified.
* Retrieves region from IMDS when credentials sourced from IMDS.
* Adds warning log when `Profile` and static credentials environment variables are set.
* Adds logging for explicitly set authentication parameters.

Closes #23261