### PR TITLE
examples/ecs-alb: Replace template_file data sources

### DIFF
--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -79,11 +79,11 @@ resource "aws_launch_configuration" "app" {
     aws_security_group.instance_sg.id,
   ]
 
-  key_name                    = var.key_name
-  image_id                    = data.aws_ami.stable_coreos.id
-  instance_type               = var.instance_type
-  iam_instance_profile        = aws_iam_instance_profile.app.name
-  user_data                   = templatefile("${path.module}/cloud-config.yml", {
+  key_name             = var.key_name
+  image_id             = data.aws_ami.stable_coreos.id
+  instance_type        = var.instance_type
+  iam_instance_profile = aws_iam_instance_profile.app.name
+  user_data = templatefile("${path.module}/cloud-config.yml", {
     aws_region         = var.aws_region
     ecs_cluster_name   = aws_ecs_cluster.main.name
     ecs_log_level      = "info"
@@ -163,7 +163,7 @@ resource "aws_ecs_cluster" "main" {
 }
 
 resource "aws_ecs_task_definition" "ghost" {
-  family                = "tf_example_ghost_td"
+  family = "tf_example_ghost_td"
   container_definitions = templatefile("${path.module}/task-definition.json", {
     image_url        = "ghost:latest"
     container_name   = "ghost"
@@ -264,8 +264,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "instance" {
-  name   = "TfEcsExampleInstanceRole"
-  role   = aws_iam_role.app_instance.name
+  name = "TfEcsExampleInstanceRole"
+  role = aws_iam_role.app_instance.name
   policy = templatefile("${path.module}/instance-profile-policy.json", {
     app_log_group_arn = aws_cloudwatch_log_group.app.arn
     ecs_log_group_arn = aws_cloudwatch_log_group.ecs.arn

--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -53,18 +53,6 @@ resource "aws_autoscaling_group" "app" {
   launch_configuration = aws_launch_configuration.app.name
 }
 
-data "template_file" "cloud_config" {
-  template = file("${path.module}/cloud-config.yml")
-
-  vars = {
-    aws_region         = var.aws_region
-    ecs_cluster_name   = aws_ecs_cluster.main.name
-    ecs_log_level      = "info"
-    ecs_agent_version  = "latest"
-    ecs_log_group_name = aws_cloudwatch_log_group.ecs.name
-  }
-}
-
 data "aws_ami" "stable_coreos" {
   most_recent = true
 
@@ -95,7 +83,13 @@ resource "aws_launch_configuration" "app" {
   image_id                    = data.aws_ami.stable_coreos.id
   instance_type               = var.instance_type
   iam_instance_profile        = aws_iam_instance_profile.app.name
-  user_data                   = data.template_file.cloud_config.rendered
+  user_data                   = templatefile("${path.module}/cloud-config.yml", {
+    aws_region         = var.aws_region
+    ecs_cluster_name   = aws_ecs_cluster.main.name
+    ecs_log_level      = "info"
+    ecs_agent_version  = "latest"
+    ecs_log_group_name = aws_cloudwatch_log_group.ecs.name
+  })
   associate_public_ip_address = true
 
   lifecycle {
@@ -168,20 +162,14 @@ resource "aws_ecs_cluster" "main" {
   name = "terraform_example_ecs_cluster"
 }
 
-data "template_file" "task_definition" {
-  template = file("${path.module}/task-definition.json")
-
-  vars = {
+resource "aws_ecs_task_definition" "ghost" {
+  family                = "tf_example_ghost_td"
+  container_definitions = templatefile("${path.module}/task-definition.json", {
     image_url        = "ghost:latest"
     container_name   = "ghost"
     log_group_region = var.aws_region
     log_group_name   = aws_cloudwatch_log_group.app.name
-  }
-}
-
-resource "aws_ecs_task_definition" "ghost" {
-  family                = "tf_example_ghost_td"
-  container_definitions = data.template_file.task_definition.rendered
+  })
 }
 
 resource "aws_ecs_service" "test" {
@@ -275,19 +263,13 @@ resource "aws_iam_role" "app_instance" {
 EOF
 }
 
-data "template_file" "instance_profile" {
-  template = file("${path.module}/instance-profile-policy.json")
-
-  vars = {
-    app_log_group_arn = aws_cloudwatch_log_group.app.arn
-    ecs_log_group_arn = aws_cloudwatch_log_group.ecs.arn
-  }
-}
-
 resource "aws_iam_role_policy" "instance" {
   name   = "TfEcsExampleInstanceRole"
   role   = aws_iam_role.app_instance.name
-  policy = data.template_file.instance_profile.rendered
+  policy = templatefile("${path.module}/instance-profile-policy.json", {
+    app_log_group_arn = aws_cloudwatch_log_group.app.arn
+    ecs_log_group_arn = aws_cloudwatch_log_group.ecs.arn
+  })
 }
 
 ## ALB


### PR DESCRIPTION
Update the examples to use the "new" `templatefile()` function.

The template provider has been deprecated since 0.12 and is not available on all platforms, such as arm64.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates #22739 

Output from acceptance testing: N/A, this is only a documentation update.