### PR TITLE
rds/opsworks: Fix bugs, tests; add opsworks sweepers

### DIFF
--- a/.changelog/23397.txt
+++ b/.changelog/23397.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_opsworks_rds_db_instance: Fix bug preventing correct removal from state
+```
+
+```release-note:bug
+resource/aws_opsworks_stack: Fix bugs where error reported on successful deletion, lack of eventual consistency wait
+```

--- a/.changelog/23397.txt
+++ b/.changelog/23397.txt
@@ -1,7 +1,63 @@
 ```release-note:bug
-resource/aws_opsworks_rds_db_instance: Fix bug preventing correct removal from state
+resource/aws_opsworks_application: Fix error reported on successful deletion
 ```
 
 ```release-note:bug
-resource/aws_opsworks_stack: Fix bugs where error reported on successful deletion, lack of eventual consistency wait
+resource/aws_opsworks_custom_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_ecs_cluster_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_ganglia_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_haproxy_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_instance: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_java_app_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_memcached_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_mysql_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_nodejs_app_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_php_app_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_rails_app_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_rds_db_instance: Correctly remove from state in certain deletion situations
+```
+
+```release-note:bug
+resource/aws_opsworks_stack: Fix error reported on successful deletion, lack of eventual consistency wait
+```
+
+```release-note:bug
+resource/aws_opsworks_static_web_layer: Fix error reported on successful deletion
+```
+
+```release-note:bug
+resource/aws_opsworks_user_profile: Fix error reported on successful deletion
 ```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1569,7 +1569,7 @@ func Provider() *schema.Provider {
 
 			"aws_opsworks_application":       opsworks.ResourceApplication(),
 			"aws_opsworks_custom_layer":      opsworks.ResourceCustomLayer(),
-			"aws_opsworks_ecs_cluster_layer": opsworks.ResourceEcsClusterLayer(),
+			"aws_opsworks_ecs_cluster_layer": opsworks.ResourceECSClusterLayer(),
 			"aws_opsworks_ganglia_layer":     opsworks.ResourceGangliaLayer(),
 			"aws_opsworks_haproxy_layer":     opsworks.ResourceHAProxyLayer(),
 			"aws_opsworks_instance":          opsworks.ResourceInstance(),

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -108,6 +108,7 @@ func init() {
 			"aws_iam_service_specific_credential",
 			"aws_iam_virtual_mfa_device",
 			"aws_iam_signing_certificate",
+			"aws_opsworks_user_profile",
 		},
 	})
 

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -262,16 +262,18 @@ func resourceApplicationRead(d *schema.ResourceData, meta interface{}) error {
 		},
 	}
 
-	log.Printf("[DEBUG] Reading OpsWorks app: %s", d.Id())
+	log.Printf("[DEBUG] Reading OpsWorks Application: %s", d.Id())
 
 	resp, err := client.DescribeApps(req)
+
+	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks Application (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
-			log.Printf("[INFO] App not found: %s", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("describing OpsWorks Application (%s): %w", d.Id(), err)
 	}
 
 	app := resp.Apps[0]

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -374,6 +374,12 @@ func resourceApplicationDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting OpsWorks application: %s", d.Id())
 
 	_, err := client.DeleteApp(req)
+
+	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks Application (%s) not found to delete; removed from state", d.Id())
+		return nil
+	}
+
 	return err
 }
 

--- a/internal/service/opsworks/application_test.go
+++ b/internal/service/opsworks/application_test.go
@@ -261,14 +261,15 @@ func testAccCheckApplicationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccApplicationCreate(name string) string {
-	return testAccStackVPCCreateConfig(name) +
+func testAccApplicationCreate(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_application" "test" {
   document_root = "foo"
   enable_ssl    = false
-  name          = %q
-  stack_id      = aws_opsworks_stack.tf-acc.id
+  name          = %[1]q
+  stack_id      = aws_opsworks_stack.test.id
   type          = "other"
 
   app_source {
@@ -281,20 +282,21 @@ resource "aws_opsworks_application" "test" {
     secure = false
   }
 }
-`, name)
+`, rName))
 }
 
-func testAccApplicationUpdate(name string) string {
-	return testAccStackVPCCreateConfig(name) +
+func testAccApplicationUpdate(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_application" "test" {
   auto_bundle_on_deploy = "true"
   document_root         = "root"
   domains               = ["example.com", "sub.example.com"]
   enable_ssl            = true
-  name                  = %q
+  name                  = %[1]q
   rails_env             = "staging"
-  stack_id              = aws_opsworks_stack.tf-acc.id
+  stack_id              = aws_opsworks_stack.test.id
   type                  = "rails"
 
   ssl_configuration {
@@ -349,5 +351,5 @@ EOS
     value = "value2"
   }
 }
-`, name)
+`, rName))
 }

--- a/internal/service/opsworks/custom_layer_test.go
+++ b/internal/service/opsworks/custom_layer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
-// and `aws-opsworks-service-role`, and Opsworks stacks named `tf-acc`.
+// and `aws-opsworks-service-role`, and Opsworks stacks named `test`.
 
 func TestAccOpsWorksCustomLayer_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -360,12 +360,13 @@ resource "aws_security_group" "tf-ops-acc-layer2" {
 }
 
 func testAccCustomLayerNoVPCCreateConfig(name string) string {
-	return testAccStackNoVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackNoVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
-  name                   = "%s"
+  stack_id               = aws_opsworks_stack.test.id
+  name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = true
   custom_security_group_ids = [
@@ -388,16 +389,17 @@ resource "aws_opsworks_custom_layer" "test" {
     encrypted       = false
   }
 }
-`, name)
+`, name))
 }
 
 func testAccCustomLayerVPCCreateConfig(name string) string {
-	return testAccStackNoVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackNoVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
-  name                   = "%s"
+  stack_id               = aws_opsworks_stack.test.id
+  name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = false
 
@@ -422,12 +424,13 @@ resource "aws_opsworks_custom_layer" "test" {
     raid_level      = 0
   }
 }
-`, name)
+`, name))
 }
 
 func testAccCustomLayerUpdateConfig(name string) string {
-	return testAccStackNoVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackNoVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_security_group" "tf-ops-acc-layer3" {
   name = "tf-ops-acc-layer-%[1]s"
@@ -441,8 +444,8 @@ resource "aws_security_group" "tf-ops-acc-layer3" {
 }
 
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
-  name                   = "%[1]s"
+  stack_id               = aws_opsworks_stack.test.id
+  name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = true
   custom_security_group_ids = [
@@ -483,15 +486,16 @@ resource "aws_opsworks_custom_layer" "test" {
 }
 EOF
 }
-`, name)
+`, name))
 }
 
 func testAccCustomLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
+  stack_id               = aws_opsworks_stack.test.id
   name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = false
@@ -521,15 +525,16 @@ resource "aws_opsworks_custom_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, name, tagKey1, tagValue1))
 }
 
 func testAccCustomLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
+  stack_id               = aws_opsworks_stack.test.id
   name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = false
@@ -560,18 +565,19 @@ resource "aws_opsworks_custom_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, name, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccOpsworksCustomLayerConfigCloudWatch(name string, enabled bool) string {
-	return testAccStackNoVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackNoVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
+  stack_id               = aws_opsworks_stack.test.id
   name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = true
@@ -589,18 +595,19 @@ resource "aws_opsworks_custom_layer" "test" {
     }
   }
 }
-`, name, enabled)
+`, name, enabled))
 }
 
 func testAccOpsworksCustomLayerConfigCloudWatchFull(name string) string {
-	return testAccStackNoVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+	return acctest.ConfigCompose(
+		testAccStackNoVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
 resource "aws_opsworks_custom_layer" "test" {
-  stack_id               = aws_opsworks_stack.tf-acc.id
+  stack_id               = aws_opsworks_stack.test.id
   name                   = %[1]q
   short_name             = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = true
@@ -626,5 +633,5 @@ resource "aws_opsworks_custom_layer" "test" {
     }
   }
 }
-`, name)
+`, name))
 }

--- a/internal/service/opsworks/ecs_cluster_layer.go
+++ b/internal/service/opsworks/ecs_cluster_layer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-func ResourceEcsClusterLayer() *schema.Resource {
+func ResourceECSClusterLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeEcsCluster,
 		DefaultLayerName: "Ecs Cluster",

--- a/internal/service/opsworks/ecs_cluster_layer_test.go
+++ b/internal/service/opsworks/ecs_cluster_layer_test.go
@@ -14,7 +14,7 @@ import (
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
 // and `aws-opsworks-service-role`.
 
-func TestAccOpsWorksEcsClusterLayer_basic(t *testing.T) {
+func TestAccOpsWorksECSClusterLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
 	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_ecs_cluster_layer.test"
@@ -22,10 +22,10 @@ func TestAccOpsWorksEcsClusterLayer_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, opsworks.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEcsClusterLayerDestroy,
+		CheckDestroy: testAccCheckECSClusterLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsClusterLayerBasic(stackName),
+				Config: testAccECSClusterLayerBasic(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "name", stackName),
@@ -36,7 +36,7 @@ func TestAccOpsWorksEcsClusterLayer_basic(t *testing.T) {
 	})
 }
 
-func TestAccOpsWorksEcsClusterLayer_tags(t *testing.T) {
+func TestAccOpsWorksECSClusterLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
 	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_ecs_cluster_layer.test"
@@ -44,10 +44,10 @@ func TestAccOpsWorksEcsClusterLayer_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, opsworks.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEcsClusterLayerDestroy,
+		CheckDestroy: testAccCheckECSClusterLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsClusterLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccECSClusterLayerTags1Config(stackName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -55,7 +55,7 @@ func TestAccOpsWorksEcsClusterLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEcsClusterLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccECSClusterLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -64,7 +64,7 @@ func TestAccOpsWorksEcsClusterLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEcsClusterLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccECSClusterLayerTags1Config(stackName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -75,20 +75,21 @@ func TestAccOpsWorksEcsClusterLayer_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckEcsClusterLayerDestroy(s *terraform.State) error {
+func testAccCheckECSClusterLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_ecs_cluster_layer", s)
 }
 
-func testAccEcsClusterLayerBasic(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccECSClusterLayerBasic(name string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
 }
 
 resource "aws_opsworks_ecs_cluster_layer" "test" {
-  stack_id        = aws_opsworks_stack.tf-acc.id
+  stack_id        = aws_opsworks_stack.test.id
   name            = %[1]q
   ecs_cluster_arn = aws_ecs_cluster.test.arn
 
@@ -97,19 +98,20 @@ resource "aws_opsworks_ecs_cluster_layer" "test" {
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, name))
 }
 
-func testAccEcsClusterLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccECSClusterLayerTags1Config(name, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
 }
 
 resource "aws_opsworks_ecs_cluster_layer" "test" {
-  stack_id        = aws_opsworks_stack.tf-acc.id
+  stack_id        = aws_opsworks_stack.test.id
   name            = %[1]q
   ecs_cluster_arn = aws_ecs_cluster.test.arn
 
@@ -122,19 +124,20 @@ resource "aws_opsworks_ecs_cluster_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, name, tagKey1, tagValue1))
 }
 
-func testAccEcsClusterLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccECSClusterLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(name),
+		testAccCustomLayerSecurityGroups(name),
 		fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
 }
 
 resource "aws_opsworks_ecs_cluster_layer" "test" {
-  stack_id        = aws_opsworks_stack.tf-acc.id
+  stack_id        = aws_opsworks_stack.test.id
   name            = %[1]q
   ecs_cluster_arn = aws_ecs_cluster.test.arn
 
@@ -148,5 +151,5 @@ resource "aws_opsworks_ecs_cluster_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, name, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/ganglia_layer_test.go
+++ b/internal/service/opsworks/ganglia_layer_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccOpsWorksGangliaLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_ganglia_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -22,10 +22,10 @@ func TestAccOpsWorksGangliaLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGangliaLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGangliaLayerVPCCreateConfig(stackName),
+				Config: testAccGangliaLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 		},
@@ -34,7 +34,7 @@ func TestAccOpsWorksGangliaLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksGangliaLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_ganglia_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -43,7 +43,7 @@ func TestAccOpsWorksGangliaLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckGangliaLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGangliaLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccGangliaLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -51,7 +51,7 @@ func TestAccOpsWorksGangliaLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGangliaLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccGangliaLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -60,7 +60,7 @@ func TestAccOpsWorksGangliaLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGangliaLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccGangliaLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -75,12 +75,13 @@ func testAccCheckGangliaLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_ganglia_layer", s)
 }
 
-func testAccGangliaLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccGangliaLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_ganglia_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+  stack_id = aws_opsworks_stack.test.id
   name     = %[1]q
   password = %[1]q
 
@@ -89,15 +90,16 @@ resource "aws_opsworks_ganglia_layer" "test" {
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccGangliaLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccGangliaLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_ganglia_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+  stack_id = aws_opsworks_stack.test.id
   name     = %[1]q
   password = %[1]q
 
@@ -110,15 +112,16 @@ resource "aws_opsworks_ganglia_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccGangliaLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccGangliaLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_ganglia_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+  stack_id = aws_opsworks_stack.test.id
   name     = %[1]q
   password = %[1]q
 
@@ -132,5 +135,5 @@ resource "aws_opsworks_ganglia_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/haproxy_layer_test.go
+++ b/internal/service/opsworks/haproxy_layer_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccOpsWorksHAProxyLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_haproxy_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -22,10 +22,10 @@ func TestAccOpsWorksHAProxyLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckHAProxyLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHAProxyLayerVPCCreateConfig(stackName),
+				Config: testAccHAProxyLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 		},
@@ -34,7 +34,7 @@ func TestAccOpsWorksHAProxyLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksHAProxyLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_haproxy_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -43,7 +43,7 @@ func TestAccOpsWorksHAProxyLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckHAProxyLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHAProxyLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccHAProxyLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -51,7 +51,7 @@ func TestAccOpsWorksHAProxyLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccHAProxyLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccHAProxyLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -60,7 +60,7 @@ func TestAccOpsWorksHAProxyLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccHAProxyLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccHAProxyLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -75,12 +75,13 @@ func testAccCheckHAProxyLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_haproxy_layer", s)
 }
 
-func testAccHAProxyLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccHAProxyLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_haproxy_layer" "test" {
-  stack_id       = aws_opsworks_stack.tf-acc.id
+  stack_id       = aws_opsworks_stack.test.id
   name           = %[1]q
   stats_password = %[1]q
 
@@ -89,15 +90,16 @@ resource "aws_opsworks_haproxy_layer" "test" {
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccHAProxyLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccHAProxyLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_haproxy_layer" "test" {
-  stack_id       = aws_opsworks_stack.tf-acc.id
+  stack_id       = aws_opsworks_stack.test.id
   name           = %[1]q
   stats_password = %[1]q
 
@@ -110,15 +112,16 @@ resource "aws_opsworks_haproxy_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccHAProxyLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccHAProxyLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_haproxy_layer" "test" {
-  stack_id       = aws_opsworks_stack.tf-acc.id
+  stack_id       = aws_opsworks_stack.test.id
   name           = %[1]q
   stats_password = %[1]q
 
@@ -132,5 +135,5 @@ resource "aws_opsworks_haproxy_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/instance.go
+++ b/internal/service/opsworks/instance.go
@@ -159,61 +159,51 @@ func ResourceInstance() *schema.Resource {
 
 			"platform": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"private_dns": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"private_ip": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"public_dns": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"public_ip": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"registered_by": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"reported_agent_version": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"reported_os_family": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"reported_os_name": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"reported_os_version": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
@@ -227,7 +217,6 @@ func ResourceInstance() *schema.Resource {
 
 			"root_device_volume_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
@@ -240,13 +229,11 @@ func ResourceInstance() *schema.Resource {
 
 			"ssh_host_dsa_key_fingerprint": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"ssh_host_rsa_key_fingerprint": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 

--- a/internal/service/opsworks/instance.go
+++ b/internal/service/opsworks/instance.go
@@ -836,6 +836,12 @@ func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting OpsWorks instance: %s", d.Id())
 
 	_, err := client.DeleteInstance(req)
+
+	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks Instance (%s) not found to delete; removed from state", d.Id())
+		return nil
+	}
+
 	return err
 }
 

--- a/internal/service/opsworks/instance_test.go
+++ b/internal/service/opsworks/instance_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccOpsWorksInstance_basic(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", sdkacctest.RandInt())
 	var opsinst opsworks.Instance
-	resourceName := "aws_opsworks_instance.tf-acc"
+	resourceName := "aws_opsworks_instance.test"
 	dataSourceName := "data.aws_availability_zones.available"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,7 +67,7 @@ func TestAccOpsWorksInstance_basic(t *testing.T) {
 
 func TestAccOpsWorksInstance_updateHostNameForceNew(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", sdkacctest.RandInt())
-	resourceName := "aws_opsworks_instance.tf-acc"
+	resourceName := "aws_opsworks_instance.test"
 	var before, after opsworks.Instance
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -221,27 +221,27 @@ resource "aws_security_group" "tf-ops-acc-php" {
   }
 }
 
-resource "aws_opsworks_static_web_layer" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_static_web_layer" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-web.id,
   ]
 }
 
-resource "aws_opsworks_php_app_layer" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_php_app_layer" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-php.id,
   ]
 }
 
-resource "aws_opsworks_instance" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_instance" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   layer_ids = [
-    aws_opsworks_static_web_layer.tf-acc.id,
+    aws_opsworks_static_web_layer.test.id,
   ]
 
   instance_type = "t2.micro"
@@ -277,27 +277,27 @@ resource "aws_security_group" "tf-ops-acc-php" {
   }
 }
 
-resource "aws_opsworks_static_web_layer" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_static_web_layer" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-web.id,
   ]
 }
 
-resource "aws_opsworks_php_app_layer" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_php_app_layer" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-php.id,
   ]
 }
 
-resource "aws_opsworks_instance" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_instance" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   layer_ids = [
-    aws_opsworks_static_web_layer.tf-acc.id,
+    aws_opsworks_static_web_layer.test.id,
   ]
 
   instance_type = "t2.micro"
@@ -333,28 +333,28 @@ resource "aws_security_group" "tf-ops-acc-php" {
   }
 }
 
-resource "aws_opsworks_static_web_layer" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_static_web_layer" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-web.id,
   ]
 }
 
-resource "aws_opsworks_php_app_layer" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_php_app_layer" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-php.id,
   ]
 }
 
-resource "aws_opsworks_instance" "tf-acc" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+resource "aws_opsworks_instance" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
   layer_ids = [
-    aws_opsworks_static_web_layer.tf-acc.id,
-    aws_opsworks_php_app_layer.tf-acc.id,
+    aws_opsworks_static_web_layer.test.id,
+    aws_opsworks_php_app_layer.test.id,
   ]
 
   instance_type = "t2.small"

--- a/internal/service/opsworks/java_app_layer_test.go
+++ b/internal/service/opsworks/java_app_layer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccOpsWorksJavaAppLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_java_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -25,10 +25,10 @@ func TestAccOpsWorksJavaAppLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckJavaAppLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJavaAppLayerVPCCreateConfig(stackName),
+				Config: testAccJavaAppLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName)),
 			},
 		},
 	})
@@ -36,7 +36,7 @@ func TestAccOpsWorksJavaAppLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksJavaAppLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_java_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -45,7 +45,7 @@ func TestAccOpsWorksJavaAppLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckJavaAppLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJavaAppLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccJavaAppLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -53,7 +53,7 @@ func TestAccOpsWorksJavaAppLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJavaAppLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccJavaAppLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -62,7 +62,7 @@ func TestAccOpsWorksJavaAppLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJavaAppLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccJavaAppLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -77,29 +77,31 @@ func testAccCheckJavaAppLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_java_app_layer", s)
 }
 
-func testAccJavaAppLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccJavaAppLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_java_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccJavaAppLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccJavaAppLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_java_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -110,16 +112,17 @@ resource "aws_opsworks_java_app_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccJavaAppLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccJavaAppLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_java_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -131,5 +134,5 @@ resource "aws_opsworks_java_app_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -646,7 +646,12 @@ func (lt *opsworksLayerType) Delete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Deleting OpsWorks layer: %s", d.Id())
 
 	_, err := conn.DeleteLayer(req)
-	if err != nil {
+
+	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks Layer (%s) not found to delete; removed from state", d.Id())
+	}
+
+	if err != nil && !tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
 		return fmt.Errorf("error Deleting Opsworks Layer (%s): %w", d.Id(), err)
 	}
 

--- a/internal/service/opsworks/memcached_layer_test.go
+++ b/internal/service/opsworks/memcached_layer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccOpsWorksMemcachedLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_memcached_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -25,10 +25,10 @@ func TestAccOpsWorksMemcachedLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckMemcachedLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMemcachedLayerVPCCreateConfig(stackName),
+				Config: testAccMemcachedLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName)),
 			},
 		},
 	})
@@ -36,7 +36,7 @@ func TestAccOpsWorksMemcachedLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksMemcachedLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_memcached_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -45,7 +45,7 @@ func TestAccOpsWorksMemcachedLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckMemcachedLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMemcachedLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccMemcachedLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -53,7 +53,7 @@ func TestAccOpsWorksMemcachedLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMemcachedLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccMemcachedLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -62,7 +62,7 @@ func TestAccOpsWorksMemcachedLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMemcachedLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccMemcachedLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -77,29 +77,31 @@ func testAccCheckMemcachedLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_memcached_layer", s)
 }
 
-func testAccMemcachedLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccMemcachedLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_memcached_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccMemcachedLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccMemcachedLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_memcached_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -110,16 +112,17 @@ resource "aws_opsworks_memcached_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccMemcachedLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccMemcachedLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_memcached_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -131,5 +134,5 @@ resource "aws_opsworks_memcached_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/mysql_layer_test.go
+++ b/internal/service/opsworks/mysql_layer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccOpsWorksMySQLLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_mysql_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -25,10 +25,10 @@ func TestAccOpsWorksMySQLLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckMySQLLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMySQLLayerVPCCreateConfig(stackName),
+				Config: testAccMySQLLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName)),
 			},
 		},
 	})
@@ -36,7 +36,7 @@ func TestAccOpsWorksMySQLLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksMySQLLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_mysql_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -45,7 +45,7 @@ func TestAccOpsWorksMySQLLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckMySQLLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMySQLLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccMySQLLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -53,7 +53,7 @@ func TestAccOpsWorksMySQLLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMySQLLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccMySQLLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -62,7 +62,7 @@ func TestAccOpsWorksMySQLLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMySQLLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccMySQLLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -77,29 +77,31 @@ func testAccCheckMySQLLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_mysql_layer", s)
 }
 
-func testAccMySQLLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccMySQLLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_mysql_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccMySQLLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccMySQLLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_mysql_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -110,16 +112,17 @@ resource "aws_opsworks_mysql_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccMySQLLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccMySQLLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_mysql_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -131,5 +134,5 @@ resource "aws_opsworks_mysql_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/nodejs_app_layer_test.go
+++ b/internal/service/opsworks/nodejs_app_layer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccOpsWorksNodejsAppLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_nodejs_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -25,10 +25,10 @@ func TestAccOpsWorksNodejsAppLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNodejsAppLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodejsAppLayerVPCCreateConfig(stackName),
+				Config: testAccNodejsAppLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName)),
 			},
 		},
 	})
@@ -36,7 +36,7 @@ func TestAccOpsWorksNodejsAppLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksNodejsAppLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_nodejs_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -45,7 +45,7 @@ func TestAccOpsWorksNodejsAppLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckNodejsAppLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodejsAppLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccNodejsAppLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -53,7 +53,7 @@ func TestAccOpsWorksNodejsAppLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNodejsAppLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccNodejsAppLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -62,7 +62,7 @@ func TestAccOpsWorksNodejsAppLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNodejsAppLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccNodejsAppLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -77,29 +77,31 @@ func testAccCheckNodejsAppLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_nodejs_app_layer", s)
 }
 
-func testAccNodejsAppLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccNodejsAppLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_nodejs_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccNodejsAppLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccNodejsAppLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_nodejs_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -110,16 +112,17 @@ resource "aws_opsworks_nodejs_app_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccNodejsAppLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccNodejsAppLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_nodejs_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -131,5 +134,5 @@ resource "aws_opsworks_nodejs_app_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/permission_test.go
+++ b/internal/service/opsworks/permission_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestAccOpsWorksPermission_basic(t *testing.T) {
-	sName := fmt.Sprintf("tf-ops-perm-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_permission.test"
 	var opsperm opsworks.Permission
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -24,71 +25,43 @@ func TestAccOpsWorksPermission_basic(t *testing.T) {
 		CheckDestroy: testAccCheckPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPermissionCreate(sName, "true", "true", "iam_only"),
+				Config: testAccPermissionCreate(rName, true, true, "iam_only"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPermissionExists(
-						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckPermissionExists(resourceName, &opsperm),
 					testAccCheckCreatePermissionAttributes(&opsperm, true, true, "iam_only"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_sudo", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "level", "iam_only",
-					),
+					resource.TestCheckResourceAttr(resourceName, "allow_ssh", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allow_sudo", "true"),
+					resource.TestCheckResourceAttr(resourceName, "level", "iam_only"),
 				),
 			},
 			{
-				Config: testAccPermissionCreate(sName, "true", "false", "iam_only"),
+				Config: testAccPermissionCreate(rName, true, false, "iam_only"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPermissionExists(
-						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckPermissionExists(resourceName, &opsperm),
 					testAccCheckCreatePermissionAttributes(&opsperm, true, false, "iam_only"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_sudo", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "level", "iam_only",
-					),
+					resource.TestCheckResourceAttr(resourceName, "allow_ssh", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allow_sudo", "false"),
+					resource.TestCheckResourceAttr(resourceName, "level", "iam_only"),
 				),
 			},
 			{
-				Config: testAccPermissionCreate(sName, "false", "false", "deny"),
+				Config: testAccPermissionCreate(rName, false, false, "deny"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPermissionExists(
-						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckPermissionExists(resourceName, &opsperm),
 					testAccCheckCreatePermissionAttributes(&opsperm, false, false, "deny"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_sudo", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "level", "deny",
-					),
+					resource.TestCheckResourceAttr(resourceName, "allow_ssh", "false"),
+					resource.TestCheckResourceAttr(resourceName, "allow_sudo", "false"),
+					resource.TestCheckResourceAttr(resourceName, "level", "deny"),
 				),
 			},
 			{
-				Config: testAccPermissionCreate(sName, "false", "false", "show"),
+				Config: testAccPermissionCreate(rName, false, false, "show"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPermissionExists(
-						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckPermissionExists(resourceName, &opsperm),
 					testAccCheckCreatePermissionAttributes(&opsperm, false, false, "show"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "allow_sudo", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_permission.tf-acc-perm", "level", "show",
-					),
+					resource.TestCheckResourceAttr(resourceName, "allow_ssh", "false"),
+					resource.TestCheckResourceAttr(resourceName, "allow_sudo", "false"),
+					resource.TestCheckResourceAttr(resourceName, "level", "show"),
 				),
 			},
 		},
@@ -162,10 +135,10 @@ func testAccCheckPermissionExists(
 }
 
 func testAccCheckCreatePermissionAttributes(
-	opsperm *opsworks.Permission, allowSsh bool, allowSudo bool, level string) resource.TestCheckFunc {
+	opsperm *opsworks.Permission, allowSSH bool, allowSudo bool, level string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *opsperm.AllowSsh != allowSsh {
-			return fmt.Errorf("Unnexpected allowSsh: %t", *opsperm.AllowSsh)
+		if *opsperm.AllowSsh != allowSSH {
+			return fmt.Errorf("Unnexpected allowSSH: %t", *opsperm.AllowSsh)
 		}
 
 		if *opsperm.AllowSudo != allowSudo {
@@ -216,7 +189,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
 
   tags = {
-    Name = "tf-acc-test-opsworks-permission"
+    Name = %[1]q
   }
 }
 
@@ -225,7 +198,7 @@ resource "aws_subnet" "test" {
   vpc_id     = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-opsworks-permissions"
+    Name = %[1]q
   }
 }
 
@@ -321,15 +294,17 @@ resource "aws_iam_instance_profile" "test" {
 `, rName)
 }
 
-func testAccPermissionCreate(name, ssh, sudo, level string) string {
-	return fmt.Sprintf(`
-resource "aws_opsworks_permission" "tf-acc-perm" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+func testAccPermissionCreate(rName string, allowSSH, allowSudo bool, level string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_opsworks_permission" "test" {
+  stack_id = aws_opsworks_stack.test.id
 
-  allow_ssh  = %s
-  allow_sudo = %s
+  allow_ssh  = %[1]t
+  allow_sudo = %[2]t
   user_arn   = aws_opsworks_user_profile.user.user_arn
-  level      = "%s"
+  level      = %[3]q
 }
 
 resource "aws_opsworks_user_profile" "user" {
@@ -338,15 +313,16 @@ resource "aws_opsworks_user_profile" "user" {
 }
 
 resource "aws_iam_user" "user" {
-  name = "%s"
+  name = %[4]q
   path = "/"
 }
-%s
-`, ssh, sudo, level, name, testAccStackVPCCreateConfig(name))
+`, allowSSH, allowSudo, level, rName))
 }
 
-func testAccPermissionSelf(rName string, allowSsh bool, allowSudo bool) string {
-	return testAccPermissionBase(rName) + fmt.Sprintf(`
+func testAccPermissionSelf(rName string, allowSSH bool, allowSudo bool) string {
+	return acctest.ConfigCompose(
+		testAccPermissionBase(rName),
+		fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 resource "aws_opsworks_permission" "test" {
@@ -355,5 +331,5 @@ resource "aws_opsworks_permission" "test" {
   stack_id   = aws_opsworks_stack.test.id
   user_arn   = data.aws_caller_identity.current.arn
 }
-`, allowSsh, allowSudo)
+`, allowSSH, allowSudo))
 }

--- a/internal/service/opsworks/php_app_layer_test.go
+++ b/internal/service/opsworks/php_app_layer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccOpsWorksPHPAppLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_php_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -25,10 +25,10 @@ func TestAccOpsWorksPHPAppLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckPHPAppLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPHPAppLayerVPCCreateConfig(stackName),
+				Config: testAccPHPAppLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName)),
 			},
 			{
 				ResourceName:      resourceName,
@@ -41,7 +41,7 @@ func TestAccOpsWorksPHPAppLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksPHPAppLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_php_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -50,7 +50,7 @@ func TestAccOpsWorksPHPAppLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckPHPAppLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPHPAppLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccPHPAppLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -63,7 +63,7 @@ func TestAccOpsWorksPHPAppLayer_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPHPAppLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccPHPAppLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -72,7 +72,7 @@ func TestAccOpsWorksPHPAppLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPHPAppLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccPHPAppLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -87,29 +87,31 @@ func testAccCheckPHPAppLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_php_app_layer", s)
 }
 
-func testAccPHPAppLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccPHPAppLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_php_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccPHPAppLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccPHPAppLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_php_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -120,16 +122,17 @@ resource "aws_opsworks_php_app_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccPHPAppLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccPHPAppLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_php_app_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
-  name     = "%s"
+  stack_id = aws_opsworks_stack.test.id
+  name     = %[1]q
 
   custom_security_group_ids = [
     aws_security_group.tf-ops-acc-layer1.id,
@@ -141,5 +144,5 @@ resource "aws_opsworks_php_app_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/rds_db_instance.go
+++ b/internal/service/opsworks/rds_db_instance.go
@@ -82,13 +82,13 @@ func resourceRDSDBInstanceDeregister(d *schema.ResourceData, meta interface{}) e
 
 	_, err := client.DeregisterRdsDbInstance(req)
 
+	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks RDS DB instance (%s) not found to delete; removed from state", d.Id())
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
-			log.Printf("[INFO] The db instance could not be found. Remove it from state.")
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error deregistering Opsworks RDS DB instance: %s", err)
+		return fmt.Errorf("deregistering Opsworks RDS DB instance: %s", err)
 	}
 
 	return nil

--- a/internal/service/opsworks/rds_db_instance_test.go
+++ b/internal/service/opsworks/rds_db_instance_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -15,58 +15,48 @@ import (
 )
 
 func TestAccOpsWorksRDSDBInstance_basic(t *testing.T) {
-	sName := fmt.Sprintf("test-db-instance-%d", sdkacctest.RandInt())
+	resourceName := "aws_opsworks_rds_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var opsdb opsworks.RdsDbInstance
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
-		ErrorCheck:   acctest.ErrorCheck(t, opsworks.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckRDSDBDestroy,
+		PreCheck:   func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
+		ErrorCheck: acctest.ErrorCheck(t, opsworks.EndpointsID),
+		Providers:  acctest.Providers,
+		//CheckDestroy: testAccCheckRDSDBDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRDSDBInstance(sName, "foo", "barbarbarbar"),
+				Config: testAccRDSDBInstance(rName, "foo", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSDBExists(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckRDSDBExists(resourceName, &opsdb),
 					testAccCheckCreateRDSDBAttributes(&opsdb, "foo"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
-					),
+					resource.TestCheckResourceAttr(resourceName, "db_user", "foo"),
 				),
 			},
-			{
-				Config: testAccRDSDBInstance(sName, "bar", "barbarbarbar"),
+			/*{
+				Config: testAccRDSDBInstance(rName, "bar", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSDBExists(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckRDSDBExists(resourceName, &opsdb),
 					testAccCheckCreateRDSDBAttributes(&opsdb, "bar"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "bar",
-					),
+					resource.TestCheckResourceAttr(resourceName, "db_user", "bar"),
 				),
 			},
 			{
-				Config: testAccRDSDBInstance(sName, "bar", "foofoofoofoofoo"),
+				Config: testAccRDSDBInstance(rName, "bar", "foofoofoofoofoo"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSDBExists(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckRDSDBExists(resourceName, &opsdb),
 					testAccCheckCreateRDSDBAttributes(&opsdb, "bar"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "bar",
-					),
+					resource.TestCheckResourceAttr(resourceName, "db_user", "bar"),
 				),
 			},
 			{
-				Config: testAccRDSDBInstanceForceNew(sName),
+				Config: testAccRDSDBInstanceForceNew(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSDBExists(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckRDSDBExists(resourceName, &opsdb),
 					testAccCheckCreateRDSDBAttributes(&opsdb, "foo"),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
-					),
+					resource.TestCheckResourceAttr(resourceName, "db_user", "foo"),
 				),
-			},
+			},*/
 		},
 	})
 }
@@ -140,57 +130,66 @@ func testAccCheckRDSDBDestroy(s *terraform.State) error {
 			}
 		}
 
-		if awserr, ok := err.(awserr.Error); ok {
-			if awserr.Code() != "ResourceNotFoundException" {
-				return err
-			}
+		if !tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+			return err
 		}
+		/*
+			if awserr, ok := err.(awserr.Error); ok {
+				if awserr.Code() != "ResourceNotFoundException" {
+					return fmt.Errorf("checking RDS DB destroy: %w", err)
+				}
+			}
+		*/
 	}
 	return nil
 }
 
-func testAccRDSDBInstance(name, userName, password string) string {
-	return fmt.Sprintf(`
-resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
+func testAccRDSDBInstance(rName, userName, password string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccDBInstanceBasicConfig(),
+		fmt.Sprintf(`
+resource "aws_opsworks_rds_db_instance" "test" {
   stack_id = aws_opsworks_stack.tf-acc.id
 
   rds_db_instance_arn = aws_db_instance.bar.arn
-  db_user             = "%s"
-  db_password         = "%s"
+  db_user             = %[1]q
+  db_password         = %[2]q
 }
-%s
-%s
-`, userName, password, testAccStackVPCCreateConfig(name), testAccDBInstanceBasicConfig())
+`, userName, password))
 }
 
-func testAccRDSDBInstanceForceNew(name string) string {
-	return fmt.Sprintf(`
-resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
+func testAccRDSDBInstanceForceNew(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		`
+resource "aws_opsworks_rds_db_instance" "test" {
   stack_id = aws_opsworks_stack.tf-acc.id
 
   rds_db_instance_arn = aws_db_instance.foo.arn
   db_user             = "foo"
   db_password         = "foofoofoofoo"
 }
-%s
 
 resource "aws_db_instance" "foo" {
   allocated_storage    = 10
   engine               = "mysql"
-  engine_version       = "5.6.35"
+  engine_version       = "8.0.25"
   instance_class       = "db.t2.micro"
   name                 = "baz"
   password             = "foofoofoofoo"
   username             = "foo"
-  parameter_group_name = "default.mysql5.6"
+  parameter_group_name = "default.mysql8.0"
 
   skip_final_snapshot = true
 }
-`, testAccStackVPCCreateConfig(name))
+`)
 }
 
 func testAccDBInstanceBasicConfig() string {
-	return acctest.ConfigCompose(testAccDBInstanceConfig_orderableClassMySQL(), `
+	return acctest.ConfigCompose(
+		testAccDBInstanceConfig_orderableClassMySQL(),
+		`
 resource "aws_db_instance" "bar" {
   allocated_storage       = 10
   backup_retention_period = 0
@@ -198,7 +197,7 @@ resource "aws_db_instance" "bar" {
   engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   name                    = "baz"
-  parameter_group_name    = "default.mysql5.6"
+  parameter_group_name    = "default.mysql8.0"
   password                = "barbarbarbar"
   skip_final_snapshot     = true
   username                = "foo"
@@ -214,9 +213,9 @@ resource "aws_db_instance" "bar" {
 func testAccDBInstanceConfig_orderableClass(engine, version, license string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
-  engine         = %q
-  engine_version = %q
-  license_model  = %q
+  engine         = %[1]q
+  engine_version = %[2]q
+  license_model  = %[3]q
   storage_type   = "standard"
 
   preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
@@ -225,5 +224,5 @@ data "aws_rds_orderable_db_instance" "test" {
 }
 
 func testAccDBInstanceConfig_orderableClassMySQL() string {
-	return testAccDBInstanceConfig_orderableClass("mysql", "5.6.35", "general-public-license")
+	return testAccDBInstanceConfig_orderableClass("mysql", "8.0.25", "general-public-license")
 }

--- a/internal/service/opsworks/rds_db_instance_test.go
+++ b/internal/service/opsworks/rds_db_instance_test.go
@@ -20,10 +20,10 @@ func TestAccOpsWorksRDSDBInstance_basic(t *testing.T) {
 	var opsdb opsworks.RdsDbInstance
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
-		ErrorCheck: acctest.ErrorCheck(t, opsworks.EndpointsID),
-		Providers:  acctest.Providers,
-		//CheckDestroy: testAccCheckRDSDBDestroy,
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, opsworks.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckRDSDBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRDSDBInstance(rName, "foo", "barbarbarbar"),
@@ -33,7 +33,7 @@ func TestAccOpsWorksRDSDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "db_user", "foo"),
 				),
 			},
-			/*{
+			{
 				Config: testAccRDSDBInstance(rName, "bar", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRDSDBExists(resourceName, &opsdb),
@@ -56,7 +56,7 @@ func TestAccOpsWorksRDSDBInstance_basic(t *testing.T) {
 					testAccCheckCreateRDSDBAttributes(&opsdb, "foo"),
 					resource.TestCheckResourceAttr(resourceName, "db_user", "foo"),
 				),
-			},*/
+			},
 		},
 	})
 }

--- a/internal/service/opsworks/rds_db_instance_test.go
+++ b/internal/service/opsworks/rds_db_instance_test.go
@@ -101,10 +101,10 @@ func testAccCheckRDSDBExists(
 func testAccCheckCreateRDSDBAttributes(
 	opsdb *opsworks.RdsDbInstance, user string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *opsdb.DbUser != user {
+		if aws.StringValue(opsdb.DbUser) != user {
 			return fmt.Errorf("Unnexpected user: %s", *opsdb.DbUser)
 		}
-		if *opsdb.Engine != "mysql" {
+		if aws.StringValue(opsdb.Engine) != "mysql" {
 			return fmt.Errorf("Unnexpected engine: %s", *opsdb.Engine)
 		}
 		return nil
@@ -133,13 +133,6 @@ func testAccCheckRDSDBDestroy(s *terraform.State) error {
 		if !tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
 			return err
 		}
-		/*
-			if awserr, ok := err.(awserr.Error); ok {
-				if awserr.Code() != "ResourceNotFoundException" {
-					return fmt.Errorf("checking RDS DB destroy: %w", err)
-				}
-			}
-		*/
 	}
 	return nil
 }

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -613,6 +613,7 @@ func resourceStackDelete(d *schema.ResourceData, meta interface{}) error {
 	_, err := client.DeleteStack(req)
 
 	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks Stack (%s) not found to delete; removed from state", d.Id())
 		return nil
 	}
 

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -341,7 +341,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -428,7 +428,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -616,7 +616,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -719,7 +719,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -822,7 +822,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -896,7 +896,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_service_new" {
-  name = "%[1]s_new"
+  name = "%[1]s-new"
 
   assume_role_policy = <<EOT
 {
@@ -916,7 +916,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service_new" {
-  name = "%[1]s_new"
+  name = "%[1]s-new"
   role = aws_iam_role.opsworks_service_new.id
 
   policy = <<EOT
@@ -966,7 +966,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -1089,7 +1089,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -1215,7 +1215,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {
@@ -1348,7 +1348,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_instance"
+  name = "%[1]s-instance"
 
   assume_role_policy = <<EOT
 {

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -20,8 +20,8 @@ import (
 ///////////////////////////////
 
 func TestAccOpsWorksStack_noVPCBasic(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", sdkacctest.RandInt())
-	resourceName := "aws_opsworks_stack.tf-acc"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_stack.test"
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,10 +35,10 @@ func TestAccOpsWorksStack_noVPCBasic(t *testing.T) {
 		CheckDestroy: testAccCheckStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackNoVPCCreateConfig(stackName),
+				Config: testAccStackNoVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, false, &opsstack),
-					testAccCheckCreateStackAttributes(stackName),
+					testAccCheckCreateStackAttributes(rName),
 				),
 			},
 			{
@@ -51,8 +51,8 @@ func TestAccOpsWorksStack_noVPCBasic(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", sdkacctest.RandInt())
-	resourceName := "aws_opsworks_stack.tf-acc"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_stack.test"
 	var before, after opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -66,7 +66,7 @@ func TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackNoVPCCreateConfig(stackName),
+				Config: testAccStackNoVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, false, &before),
 				),
@@ -77,7 +77,7 @@ func TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStackNoVPCCreateUpdateServiceRoleConfig(stackName),
+				Config: testAccStackNoVPCCreateUpdateServiceRoleConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, false, &after),
 					testAccCheckStackRecreated(t, &before, &after),
@@ -88,8 +88,8 @@ func TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_vpc(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", sdkacctest.RandInt())
-	resourceName := "aws_opsworks_stack.tf-acc"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_stack.test"
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -103,10 +103,10 @@ func TestAccOpsWorksStack_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackVPCCreateConfig(stackName),
+				Config: testAccStackVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, true, &opsstack),
-					testAccCheckCreateStackAttributes(stackName),
+					testAccCheckCreateStackAttributes(rName),
 				),
 			},
 			{
@@ -115,10 +115,10 @@ func TestAccOpsWorksStack_vpc(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStackVPCUpdateConfig(stackName),
+				Config: testAccStackVPCUpdateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, true, &opsstack),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "default_availability_zone", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "default_os", "Amazon Linux 2015.09"),
 					resource.TestCheckResourceAttr(resourceName, "default_root_device_type", "ebs"),
@@ -137,8 +137,8 @@ func TestAccOpsWorksStack_vpc(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_noVPCCreateTags(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", sdkacctest.RandInt())
-	resourceName := "aws_opsworks_stack.tf-acc"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_stack.test"
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -152,7 +152,7 @@ func TestAccOpsWorksStack_noVPCCreateTags(t *testing.T) {
 		CheckDestroy: testAccCheckStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackNoVPCCreateTagsConfig(stackName),
+				Config: testAccStackNoVPCCreateTagsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, false, &opsstack),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -165,7 +165,7 @@ func TestAccOpsWorksStack_noVPCCreateTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStackNoVPCUpdateTagsConfig(stackName),
+				Config: testAccStackNoVPCUpdateTagsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, false, &opsstack),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -181,8 +181,8 @@ func TestAccOpsWorksStack_noVPCCreateTags(t *testing.T) {
 /////////////////////////////
 
 func TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties(t *testing.T) {
-	resourceName := "aws_opsworks_stack.tf-acc"
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", sdkacctest.RandInt())
+	resourceName := "aws_opsworks_stack.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -196,10 +196,10 @@ func TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties(t *testing.T) {
 		CheckDestroy: testAccCheckStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackConfig_CustomCookbooks_Set(stackName),
+				Config: testAccStackConfig_CustomCookbooks_Set(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, true, &opsstack),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "default_availability_zone", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "default_os", "Amazon Linux 2016.09"),
 					resource.TestCheckResourceAttr(resourceName, "default_root_device_type", "ebs"),
@@ -223,9 +223,8 @@ func TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties(t *testing.T) {
 // to create Stack's prior to v0.9.0.
 // See https://github.com/hashicorp/terraform/issues/12842
 func TestAccOpsWorksStack_classicEndpoints(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", sdkacctest.RandInt())
-	resourceName := "aws_opsworks_stack.main"
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_stack.test"
 	var opsstack opsworks.Stack
 
 	// This test cannot be parallel with other tests, because it changes the provider region in a non-standard way
@@ -237,7 +236,7 @@ func TestAccOpsWorksStack_classicEndpoints(t *testing.T) {
 		CheckDestroy: testAccCheckStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStack_classic_endpoint(stackName, rInt),
+				Config: testAccStack_classicEndpoint(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackExists(resourceName, false, &opsstack),
 				),
@@ -249,7 +248,7 @@ func TestAccOpsWorksStack_classicEndpoints(t *testing.T) {
 			},
 			// Ensure that changing region results in no plan
 			{
-				Config:   testAccStack_regional_endpoint(stackName, rInt),
+				Config:   testAccStack_regionalEndpoint(rName),
 				PlanOnly: true,
 			},
 		},
@@ -281,14 +280,14 @@ func testAccPreCheckStacks(t *testing.T) {
 	}
 }
 
-func testAccStack_classic_endpoint(rName string, rInt int) string {
+func testAccStack_classicEndpoint(rName string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_opsworks_stack" "main" {
-  name                          = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                          = %[1]q
   region                        = "us-west-2"
   service_role_arn              = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn  = aws_iam_instance_profile.opsworks_instance.arn
@@ -297,7 +296,7 @@ resource "aws_opsworks_stack" "main" {
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "tf_opsworks_service_%[2]d"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -317,7 +316,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "tf_opsworks_service_%[2]d"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -342,7 +341,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "tf_opsworks_instance_%[2]d"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -362,20 +361,20 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_profile"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, rName, rInt) //lintignore:AWSAT003,AT004
+`, rName) //lintignore:AWSAT003,AT004
 }
 
-func testAccStack_regional_endpoint(rName string, rInt int) string {
+func testAccStack_regionalEndpoint(rName string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-west-2"
 }
 
-resource "aws_opsworks_stack" "main" {
-  name                          = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                          = %[1]q
   region                        = "us-west-2"
   service_role_arn              = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn  = aws_iam_instance_profile.opsworks_instance.arn
@@ -384,7 +383,7 @@ resource "aws_opsworks_stack" "main" {
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "tf_opsworks_service_%[2]d"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -404,7 +403,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "tf_opsworks_service_%[2]d"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -429,7 +428,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "tf_opsworks_instance_%[2]d"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -449,20 +448,20 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_profile"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, rName, rInt) //lintignore:AWSAT003,AT004
+`, rName) //lintignore:AWSAT003,AT004
 }
 
 ////////////////////////////
 //// Checkers and Utilities
 ////////////////////////////
 
-func testAccCheckCreateStackAttributes(stackName string) resource.TestCheckFunc {
-	resourceName := "aws_opsworks_stack.tf-acc"
+func testAccCheckCreateStackAttributes(rName string) resource.TestCheckFunc {
+	resourceName := "aws_opsworks_stack.test"
 	return resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr(resourceName, "name", stackName),
+		resource.TestCheckResourceAttr(resourceName, "name", rName),
 		resource.TestCheckResourceAttrPair(resourceName, "default_availability_zone", "data.aws_availability_zones.available", "names.0"),
 		resource.TestCheckResourceAttr(resourceName, "default_os", "Amazon Linux 2016.09"),
 		resource.TestCheckResourceAttr(resourceName, "default_root_device_type", "ebs"),
@@ -544,14 +543,16 @@ func testAccCheckStackDestroy(s *terraform.State) error {
 //// Helper configs for the necessary IAM objects
 //////////////////////////////////////////////////
 
-func testAccStackNoVPCCreateConfig(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackNoVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
   service_role_arn             = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
@@ -570,7 +571,7 @@ EOF
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service2"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -590,7 +591,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service1"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -615,7 +616,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -635,20 +636,22 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name))
+`, rName))
 }
 
-func testAccStackNoVPCCreateTagsConfig(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackNoVPCCreateTagsConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
   service_role_arn             = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
@@ -671,7 +674,7 @@ EOF
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -691,7 +694,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -716,7 +719,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -736,20 +739,22 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name))
+`, rName))
 }
 
-func testAccStackNoVPCUpdateTagsConfig(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackNoVPCUpdateTagsConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
   service_role_arn             = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
@@ -772,7 +777,7 @@ EOF
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -792,7 +797,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -817,7 +822,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -837,20 +842,22 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name))
+`, rName))
 }
 
-func testAccStackNoVPCCreateUpdateServiceRoleConfig(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackNoVPCCreateUpdateServiceRoleConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
   service_role_arn             = aws_iam_role.opsworks_service_new.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
@@ -869,7 +876,7 @@ EOF
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -889,7 +896,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_service_new" {
-  name = "%[1]s_opsworks_service_new"
+  name = "%[1]s_new"
 
   assume_role_policy = <<EOT
 {
@@ -909,7 +916,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service_new" {
-  name = "%[1]s_opsworks_service_new"
+  name = "%[1]s_new"
   role = aws_iam_role.opsworks_service_new.id
 
   policy = <<EOT
@@ -934,7 +941,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -959,7 +966,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -979,45 +986,47 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name))
+`, rName))
 }
 
 ////////////////////////////
 //// Tests for the VPC case
 ////////////////////////////
 
-func testAccStackVPCCreateConfig(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_vpc" "tf-acc" {
+resource "aws_vpc" "test" {
   cidr_block = "10.3.5.0/24"
 
   tags = {
-    Name = "terraform-testacc-opsworks-stack-vpc-create"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "tf-acc" {
-  vpc_id            = aws_vpc.tf-acc.id
-  cidr_block        = aws_vpc.tf-acc.cidr_block
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = aws_vpc.test.cidr_block
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-opsworks-stack-vpc-create"
+    Name = %[1]q
   }
 }
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
-  vpc_id                       = aws_vpc.tf-acc.id
-  default_subnet_id            = aws_subnet.tf-acc.id
+  vpc_id                       = aws_vpc.test.id
+  default_subnet_id            = aws_subnet.test.id
   service_role_arn             = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
   default_os                   = "Amazon Linux 2016.09"
@@ -1034,7 +1043,7 @@ EOF
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -1054,7 +1063,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -1080,7 +1089,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -1100,41 +1109,43 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name))
+`, rName))
 }
 
-func testAccStackVPCUpdateConfig(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackVPCUpdateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_vpc" "tf-acc" {
+resource "aws_vpc" "test" {
   cidr_block = "10.3.5.0/24"
 
   tags = {
-    Name = "terraform-testacc-opsworks-stack-vpc-update"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "tf-acc" {
-  vpc_id            = aws_vpc.tf-acc.id
-  cidr_block        = aws_vpc.tf-acc.cidr_block
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = aws_vpc.test.cidr_block
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-opsworks-stack-vpc-update"
+    Name = %[1]q
   }
 }
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
-  vpc_id                       = aws_vpc.tf-acc.id
-  default_subnet_id            = aws_subnet.tf-acc.id
+  vpc_id                       = aws_vpc.test.id
+  default_subnet_id            = aws_subnet.test.id
   service_role_arn             = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
   default_os                   = "Amazon Linux 2015.09"
@@ -1159,7 +1170,7 @@ EOF
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -1179,7 +1190,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -1204,7 +1215,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -1224,45 +1235,47 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name))
+`, rName))
 }
 
 /////////////////////////////////////////
 // Helpers for Custom Cookbook properties
 /////////////////////////////////////////
 
-func testAccStackConfig_CustomCookbooks_Set(name string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+func testAccStackConfig_CustomCookbooks_Set(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
-resource "aws_vpc" "tf-acc" {
+resource "aws_vpc" "test" {
   cidr_block = "10.3.5.0/24"
 
   tags = {
-    Name = "terraform-testacc-opsworks-stack-vpc-update"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "tf-acc" {
-  vpc_id            = aws_vpc.tf-acc.id
-  cidr_block        = aws_vpc.tf-acc.cidr_block
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = aws_vpc.test.cidr_block
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-opsworks-stack-vpc-update"
+    Name = %[1]q
   }
 }
 
-resource "aws_opsworks_stack" "tf-acc" {
-  name                         = "%[1]s"
+resource "aws_opsworks_stack" "test" {
+  name                         = %[1]q
   region                       = data.aws_region.current.name
-  vpc_id                       = aws_vpc.tf-acc.id
-  default_subnet_id            = aws_subnet.tf-acc.id
+  vpc_id                       = aws_vpc.test.id
+  default_subnet_id            = aws_subnet.test.id
   service_role_arn             = aws_iam_role.opsworks_service.arn
   default_instance_profile_arn = aws_iam_instance_profile.opsworks_instance.arn
   default_os                   = "Amazon Linux 2016.09"
@@ -1285,12 +1298,12 @@ EOF
     url      = "https://github.com/aws/opsworks-example-cookbooks.git"
     username = "username"
     password = "password"
-    ssh_key  = "%[2]s"
+    ssh_key  = %[2]q
   }
 }
 
 resource "aws_iam_role" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
 
   assume_role_policy = <<EOT
 {
@@ -1310,7 +1323,7 @@ EOT
 }
 
 resource "aws_iam_role_policy" "opsworks_service" {
-  name = "%[1]s_opsworks_service"
+  name = %[1]q
   role = aws_iam_role.opsworks_service.id
 
   policy = <<EOT
@@ -1335,7 +1348,7 @@ EOT
 }
 
 resource "aws_iam_role" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = "%[1]s_instance"
 
   assume_role_policy = <<EOT
 {
@@ -1355,10 +1368,10 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
-  name = "%[1]s_opsworks_instance"
+  name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, name, sshKey))
+`, rName, sshKey))
 }
 
 // One-off, bogus private key generated for use in testing

--- a/internal/service/opsworks/static_web_layer_test.go
+++ b/internal/service/opsworks/static_web_layer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccOpsWorksStaticWebLayer_basic(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_static_web_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -25,10 +25,10 @@ func TestAccOpsWorksStaticWebLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckStaticWebLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStaticWebLayerVPCCreateConfig(stackName),
+				Config: testAccStaticWebLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName)),
 			},
 			{
 				ResourceName:      resourceName,
@@ -41,7 +41,7 @@ func TestAccOpsWorksStaticWebLayer_basic(t *testing.T) {
 
 func TestAccOpsWorksStaticWebLayer_tags(t *testing.T) {
 	var opslayer opsworks.Layer
-	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_static_web_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
@@ -50,7 +50,7 @@ func TestAccOpsWorksStaticWebLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckStaticWebLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStaticWebLayerTags1Config(stackName, "key1", "value1"),
+				Config: testAccStaticWebLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -63,7 +63,7 @@ func TestAccOpsWorksStaticWebLayer_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStaticWebLayerTags2Config(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccStaticWebLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -72,7 +72,7 @@ func TestAccOpsWorksStaticWebLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStaticWebLayerTags1Config(stackName, "key2", "value2"),
+				Config: testAccStaticWebLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -87,12 +87,13 @@ func testAccCheckStaticWebLayerDestroy(s *terraform.State) error {
 	return testAccCheckLayerDestroy("aws_opsworks_static_web_layer", s)
 }
 
-func testAccStaticWebLayerVPCCreateConfig(name string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccStaticWebLayerVPCCreateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_static_web_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+  stack_id = aws_opsworks_stack.test.id
   name     = "%s"
 
   custom_security_group_ids = [
@@ -100,15 +101,16 @@ resource "aws_opsworks_static_web_layer" "test" {
     aws_security_group.tf-ops-acc-layer2.id,
   ]
 }
-`, name)
+`, rName))
 }
 
-func testAccStaticWebLayerTags1Config(name, tagKey1, tagValue1 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccStaticWebLayerTags1Config(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_static_web_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+  stack_id = aws_opsworks_stack.test.id
   name     = "%s"
 
   custom_security_group_ids = [
@@ -120,15 +122,16 @@ resource "aws_opsworks_static_web_layer" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccStaticWebLayerTags2Config(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccStackVPCCreateConfig(name) +
-		testAccCustomLayerSecurityGroups(name) +
+func testAccStaticWebLayerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccStackVPCCreateConfig(rName),
+		testAccCustomLayerSecurityGroups(rName),
 		fmt.Sprintf(`
 resource "aws_opsworks_static_web_layer" "test" {
-  stack_id = aws_opsworks_stack.tf-acc.id
+  stack_id = aws_opsworks_stack.test.id
   name     = "%s"
 
   custom_security_group_ids = [
@@ -141,5 +144,5 @@ resource "aws_opsworks_static_web_layer" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -1,0 +1,342 @@
+//go:build sweep
+// +build sweep
+
+package opsworks
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_opsworks_stack", &resource.Sweeper{
+		Name: "aws_opsworks_stack",
+		F:    sweepStacks,
+		Dependencies: []string{
+			"aws_opsworks_application",
+			"aws_opsworks_custom_layer",
+			"aws_opsworks_ecs_cluster_layer",
+			"aws_opsworks_ganglia_layer",
+			"aws_opsworks_haproxy_layer",
+			"aws_opsworks_instance",
+			"aws_opsworks_java_app_layer",
+			"aws_opsworks_memcached_layer",
+			"aws_opsworks_mysql_layer",
+			"aws_opsworks_nodejs_app_layer",
+			"aws_opsworks_permission",
+			"aws_opsworks_php_app_layer",
+			"aws_opsworks_rails_app_layer",
+			"aws_opsworks_rds_db_instance",
+			"aws_opsworks_static_web_layer",
+		},
+	})
+
+	resource.AddTestSweepers("aws_opsworks_application", &resource.Sweeper{
+		Name: "aws_opsworks_application",
+		F:    sweepApplication,
+	})
+
+	resource.AddTestSweepers("aws_opsworks_instance", &resource.Sweeper{
+		Name: "aws_opsworks_instance",
+		F:    sweepInstance,
+		Dependencies: []string{
+			"aws_opsworks_custom_layer",
+			"aws_opsworks_ecs_cluster_layer",
+			"aws_opsworks_ganglia_layer",
+			"aws_opsworks_haproxy_layer",
+			"aws_opsworks_java_app_layer",
+			"aws_opsworks_memcached_layer",
+			"aws_opsworks_mysql_layer",
+			"aws_opsworks_nodejs_app_layer",
+			"aws_opsworks_php_app_layer",
+			"aws_opsworks_rails_app_layer",
+			"aws_opsworks_static_web_layer",
+		},
+	})
+
+	resource.AddTestSweepers("aws_opsworks_permission", &resource.Sweeper{
+		Name: "aws_opsworks_permission",
+		F:    sweepPermission,
+	})
+
+	resource.AddTestSweepers("aws_opsworks_rds_db_instance", &resource.Sweeper{
+		Name: "aws_opsworks_rds_db_instance",
+		F:    sweepRDSDBInstance,
+	})
+
+	resource.AddTestSweepers("aws_opsworks_user_profile", &resource.Sweeper{
+		Name: "aws_opsworks_user_profile",
+		F:    sweepUserProfiles,
+		Dependencies: []string{
+			"aws_opsworks_permission",
+		},
+	})
+}
+
+func sweepApplication(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.DescribeDBInstancesPages(&opsworks.DescribeDBInstancesInput{}, func(out *opsworks.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbi := range out.DBInstances {
+			r := ResourceInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(dbi.DBInstanceIdentifier))
+			d.Set("skip_final_snapshot", true)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+		return !lastPage
+	})
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving DB instances: %s", err)
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}
+
+func sweepInstance(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.DescribeDBInstancesPages(&opsworks.DescribeDBInstancesInput{}, func(out *opsworks.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbi := range out.DBInstances {
+			r := ResourceInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(dbi.DBInstanceIdentifier))
+			d.Set("skip_final_snapshot", true)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+		return !lastPage
+	})
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving DB instances: %s", err)
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}
+
+func sweepPermission(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.DescribeDBInstancesPages(&opsworks.DescribeDBInstancesInput{}, func(out *opsworks.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbi := range out.DBInstances {
+			r := ResourceInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(dbi.DBInstanceIdentifier))
+			d.Set("skip_final_snapshot", true)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+		return !lastPage
+	})
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving DB instances: %s", err)
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}
+
+func sweepRDSDBInstance(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.DescribeDBInstancesPages(&opsworks.DescribeDBInstancesInput{}, func(out *opsworks.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbi := range out.DBInstances {
+			r := ResourceInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(dbi.DBInstanceIdentifier))
+			d.Set("skip_final_snapshot", true)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+		return !lastPage
+	})
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving DB instances: %s", err)
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}
+
+func sweepStacks(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
+
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping OpsWorks Stack sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("retrieving OpsWorks Stacks: %s", err)
+	}
+
+	var sweeperErrs *multierror.Error
+
+	for _, stack := range output.Stacks {
+		if stack == nil {
+			continue
+		}
+
+		r := ResourceStack()
+		d := r.Data(nil)
+		d.SetId(aws.StringValue(stack.StackId))
+
+		if aws.StringValue(stack.Region) != region {
+			d.Set("stack_endpoint", stack.Region)
+		}
+
+		if aws.StringValue(stack.VpcId) != "" {
+			d.Set("vpc_id", stack.VpcId)
+		}
+
+		if aws.BoolValue(stack.UseOpsworksSecurityGroups) {
+			d.Set("use_opsworks_security_groups", true)
+		}
+
+		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}
+
+func sweepLayers(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
+
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping OpsWorks Layer sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("retrieving OpsWorks Stacks (Layer sweep): %s", err)
+	}
+
+	var sweeperErrs *multierror.Error
+
+	for _, stack := range output.Stacks {
+		input := &opsworks.DescribeLayersInput{
+			StackId: stack.StackId,
+		}
+
+		layerOutput, err := conn.DescribeLayers(input)
+
+		if err != nil {
+			sweeperErr := fmt.Errorf("describing OpsWorks Layers for Stack (%s): %w", aws.StringValue(stack.StackId), err)
+			log.Printf("[ERROR] %s", sweeperErr)
+			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+			continue
+		}
+
+		for _, layer := range layerOutput.Layers {
+			if layer == nil {
+				continue
+			}
+
+			l := &opsworksLayerType{}
+			r := l.SchemaResource()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(layer.LayerId))
+
+			if layer.Attributes != nil {
+				if v, ok := layer.Attributes[opsworks.LayerAttributesKeysEcsClusterArn].(string); v != "" {
+					r = ResourceEcsClusterLayer()
+					d = r.Data(nil)
+					d.SetId(aws.StringValue(layer.LayerId))
+					d.Set("ecs_cluster_arn", v)
+				}
+			}
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}
+
+func sweepUserProfiles(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).OpsWorksConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	output, err := conn.DescribeUserProfiles(&opsworks.DescribeUserProfilesInput{})
+
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping OpsWorks User Profile sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("retrieving OpsWorks User Profiles: %w", err)
+	}
+
+	for _, profile := range output.UserProfiles {
+		r := ResourceUserProfile()
+		d := r.Data(nil)
+		d.SetId(aws.StringValue(profile.IamUserArn))
+		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+	}
+
+	return sweep.SweepOrchestrator(sweepResources)
+}

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -298,7 +298,7 @@ func sweepLayers(region string) error {
 
 			if layer.Attributes != nil {
 				if v, ok := layer.Attributes[opsworks.LayerAttributesKeysEcsClusterArn].(string); v != "" {
-					r = ResourceEcsClusterLayer()
+					r = ResourceECSClusterLayer()
 					d = r.Data(nil)
 					d.SetId(aws.StringValue(layer.LayerId))
 					d.Set("ecs_cluster_arn", v)

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -6,12 +6,9 @@ package opsworks
 import (
 	"fmt"
 	"log"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -24,20 +21,9 @@ func init() {
 		F:    sweepStacks,
 		Dependencies: []string{
 			"aws_opsworks_application",
-			"aws_opsworks_custom_layer",
-			"aws_opsworks_ecs_cluster_layer",
-			"aws_opsworks_ganglia_layer",
-			"aws_opsworks_haproxy_layer",
+			"aws_opsworks_layer",
 			"aws_opsworks_instance",
-			"aws_opsworks_java_app_layer",
-			"aws_opsworks_memcached_layer",
-			"aws_opsworks_mysql_layer",
-			"aws_opsworks_nodejs_app_layer",
-			"aws_opsworks_permission",
-			"aws_opsworks_php_app_layer",
-			"aws_opsworks_rails_app_layer",
 			"aws_opsworks_rds_db_instance",
-			"aws_opsworks_static_web_layer",
 		},
 	})
 
@@ -49,24 +35,16 @@ func init() {
 	resource.AddTestSweepers("aws_opsworks_instance", &resource.Sweeper{
 		Name: "aws_opsworks_instance",
 		F:    sweepInstance,
-		Dependencies: []string{
-			"aws_opsworks_custom_layer",
-			"aws_opsworks_ecs_cluster_layer",
-			"aws_opsworks_ganglia_layer",
-			"aws_opsworks_haproxy_layer",
-			"aws_opsworks_java_app_layer",
-			"aws_opsworks_memcached_layer",
-			"aws_opsworks_mysql_layer",
-			"aws_opsworks_nodejs_app_layer",
-			"aws_opsworks_php_app_layer",
-			"aws_opsworks_rails_app_layer",
-			"aws_opsworks_static_web_layer",
-		},
 	})
 
-	resource.AddTestSweepers("aws_opsworks_permission", &resource.Sweeper{
-		Name: "aws_opsworks_permission",
-		F:    sweepPermission,
+	// This sweep all the custom, ecs, ganglia, etc. layers
+	resource.AddTestSweepers("aws_opsworks_layer", &resource.Sweeper{
+		Name: "aws_opsworks_layer",
+		F:    sweepLayers,
+		Dependencies: []string{
+			"aws_opsworks_instance",
+			"aws_opsworks_rds_db_instance",
+		},
 	})
 
 	resource.AddTestSweepers("aws_opsworks_rds_db_instance", &resource.Sweeper{
@@ -77,9 +55,6 @@ func init() {
 	resource.AddTestSweepers("aws_opsworks_user_profile", &resource.Sweeper{
 		Name: "aws_opsworks_user_profile",
 		F:    sweepUserProfiles,
-		Dependencies: []string{
-			"aws_opsworks_permission",
-		},
 	})
 }
 
@@ -177,39 +152,10 @@ func sweepInstance(region string) error {
 			r := ResourceInstance()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(instance.InstanceId))
+			d.Set("status", instance.Status)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
-	}
-
-	return sweep.SweepOrchestrator(sweepResources)
-}
-
-func sweepPermission(region string) error {
-	client, err := sweep.SharedRegionalSweepClient(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-
-	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
-
-	err = conn.DescribeDBInstancesPages(&opsworks.DescribeDBInstancesInput{}, func(out *opsworks.DescribeDBInstancesOutput, lastPage bool) bool {
-		for _, dbi := range out.DBInstances {
-			r := ResourceInstance()
-			d := r.Data(nil)
-			d.SetId(aws.StringValue(dbi.DBInstanceIdentifier))
-			d.Set("skip_final_snapshot", true)
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-		}
-		return !lastPage
-	})
-	if err != nil {
-		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("Error retrieving DB instances: %s", err)
 	}
 
 	return sweep.SweepOrchestrator(sweepResources)
@@ -224,22 +170,44 @@ func sweepRDSDBInstance(region string) error {
 	conn := client.(*conns.AWSClient).OpsWorksConn
 	sweepResources := make([]*sweep.SweepResource, 0)
 
-	err = conn.DescribeDBInstancesPages(&opsworks.DescribeDBInstancesInput{}, func(out *opsworks.DescribeDBInstancesOutput, lastPage bool) bool {
-		for _, dbi := range out.DBInstances {
-			r := ResourceInstance()
-			d := r.Data(nil)
-			d.SetId(aws.StringValue(dbi.DBInstanceIdentifier))
-			d.Set("skip_final_snapshot", true)
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-		}
-		return !lastPage
-	})
+	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
+
 	if err != nil {
 		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping OpsWorks RDS DB Instance sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving DB instances: %s", err)
+		return fmt.Errorf("retrieving OpsWorks Stacks (RDS DB Instance sweep): %s", err)
+	}
+
+	var sweeperErrs *multierror.Error
+
+	for _, stack := range output.Stacks {
+		input := &opsworks.DescribeRdsDbInstancesInput{
+			StackId: stack.StackId,
+		}
+
+		dbInstOutput, err := conn.DescribeRdsDbInstances(input)
+
+		if err != nil {
+			sweeperErr := fmt.Errorf("describing OpsWorks RDS DB Instances for Stack (%s): %w", aws.StringValue(stack.StackId), err)
+			log.Printf("[ERROR] %s", sweeperErr)
+			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+			continue
+		}
+
+		for _, dbInstance := range dbInstOutput.RdsDbInstances {
+			if dbInstance == nil {
+				continue
+			}
+
+			r := ResourceRDSDBInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(dbInstance.DbInstanceIdentifier))
+			d.Set("rds_db_instance_arn", dbInstance.RdsDbInstanceArn)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	return sweep.SweepOrchestrator(sweepResources)
@@ -264,8 +232,6 @@ func sweepStacks(region string) error {
 		return fmt.Errorf("retrieving OpsWorks Stacks: %s", err)
 	}
 
-	var sweeperErrs *multierror.Error
-
 	for _, stack := range output.Stacks {
 		if stack == nil {
 			continue
@@ -274,10 +240,6 @@ func sweepStacks(region string) error {
 		r := ResourceStack()
 		d := r.Data(nil)
 		d.SetId(aws.StringValue(stack.StackId))
-
-		if aws.StringValue(stack.Region) != region {
-			d.Set("stack_endpoint", stack.Region)
-		}
 
 		if aws.StringValue(stack.VpcId) != "" {
 			d.Set("vpc_id", stack.VpcId)
@@ -339,7 +301,7 @@ func sweepLayers(region string) error {
 			d.SetId(aws.StringValue(layer.LayerId))
 
 			if layer.Attributes != nil {
-				if v, ok := layer.Attributes[opsworks.LayerAttributesKeysEcsClusterArn].(string); v != "" {
+				if v, ok := layer.Attributes[opsworks.LayerAttributesKeysEcsClusterArn]; ok && aws.StringValue(v) != "" {
 					r = ResourceECSClusterLayer()
 					d = r.Data(nil)
 					d.SetId(aws.StringValue(layer.LayerId))

--- a/internal/service/opsworks/user_profile.go
+++ b/internal/service/opsworks/user_profile.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
@@ -127,6 +128,11 @@ func resourceUserProfileDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting OpsWorks user profile: %s", d.Id())
 
 	_, err := client.DeleteUserProfile(req)
+
+	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		log.Printf("[DEBUG] OpsWorks User Profile (%s) not found to delete; removed from state", d.Id())
+		return nil
+	}
 
 	return err
 }

--- a/internal/service/opsworks/user_profile_test.go
+++ b/internal/service/opsworks/user_profile_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 func TestAccOpsWorksUserProfile_basic(t *testing.T) {
-	rName := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
-	updateRName := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opsworks_user_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(opsworks.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, opsworks.EndpointsID),
@@ -26,33 +27,19 @@ func TestAccOpsWorksUserProfile_basic(t *testing.T) {
 			{
 				Config: testAccUserProfileCreate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserProfileExists(
-						"aws_opsworks_user_profile.user", rName),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "ssh_public_key", "",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "ssh_username", rName,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "allow_self_management", "false",
-					),
+					testAccCheckUserProfileExists(resourceName, rName),
+					resource.TestCheckResourceAttr(resourceName, "ssh_public_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssh_username", rName),
+					resource.TestCheckResourceAttr(resourceName, "allow_self_management", "false"),
 				),
 			},
 			{
-				Config: testAccUserProfileUpdate(rName, updateRName),
+				Config: testAccUserProfileUpdate(rName, rName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserProfileExists(
-						"aws_opsworks_user_profile.user", updateRName),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "ssh_public_key", "",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "ssh_username", updateRName,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "allow_self_management", "false",
-					),
+					testAccCheckUserProfileExists(resourceName, rName2),
+					resource.TestCheckResourceAttr(resourceName, "ssh_public_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssh_username", rName2),
+					resource.TestCheckResourceAttr(resourceName, "allow_self_management", "false"),
 				),
 			},
 		},
@@ -133,35 +120,35 @@ func testAccCheckUserProfileDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccUserProfileCreate(rn string) string {
+func testAccUserProfileCreate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_opsworks_user_profile" "user" {
-  user_arn     = aws_iam_user.user.arn
-  ssh_username = aws_iam_user.user.name
+resource "aws_opsworks_user_profile" "test" {
+  user_arn     = aws_iam_user.test.arn
+  ssh_username = aws_iam_user.test.name
 }
 
-resource "aws_iam_user" "user" {
-  name = "%s"
+resource "aws_iam_user" "test" {
+  name = %[1]q
   path = "/"
 }
-`, rn)
+`, rName)
 }
 
-func testAccUserProfileUpdate(rn, updateRn string) string {
+func testAccUserProfileUpdate(rName, rName2 string) string {
 	return fmt.Sprintf(`
-resource "aws_opsworks_user_profile" "user" {
-  user_arn     = aws_iam_user.new-user.arn
-  ssh_username = aws_iam_user.new-user.name
+resource "aws_opsworks_user_profile" "test" {
+  user_arn     = aws_iam_user.new-test.arn
+  ssh_username = aws_iam_user.new-test.name
 }
 
-resource "aws_iam_user" "user" {
-  name = "%s"
+resource "aws_iam_user" "test" {
+  name = %[1]q
   path = "/"
 }
 
-resource "aws_iam_user" "new-user" {
-  name = "%s"
+resource "aws_iam_user" "new-test" {
+  name = %[2]q
   path = "/"
 }
-`, rn, updateRn)
+`, rName, rName2)
 }

--- a/internal/service/rds/orderable_instance_data_source_test.go
+++ b/internal/service/rds/orderable_instance_data_source_test.go
@@ -330,7 +330,7 @@ data "aws_rds_orderable_db_instance" "test" {
   storage_type                 = "standard"
   supports_enhanced_monitoring = true
 
-  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_engine_versions  = ["8.0.25", "8.0.26", "8.0.27"]
   preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
 }
 `
@@ -344,7 +344,7 @@ data "aws_rds_orderable_db_instance" "test" {
   storage_type                         = "standard"
   supports_iam_database_authentication = true
 
-  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_engine_versions  = ["8.0.25", "8.0.26", "8.0.27"]
   preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
 }
 `
@@ -384,7 +384,7 @@ data "aws_rds_orderable_db_instance" "test" {
   license_model                 = "general-public-license"
   supports_performance_insights = true
 
-  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_engine_versions  = ["8.0.25", "8.0.26", "8.0.27"]
   preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
 }
 `
@@ -411,7 +411,7 @@ data "aws_rds_orderable_db_instance" "test" {
   storage_type                = "standard"
   supports_storage_encryption = true
 
-  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_engine_versions  = ["8.0.25", "8.0.26", "8.0.27"]
   preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
 }
 `

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -56,6 +56,9 @@ func init() {
 	resource.AddTestSweepers("aws_db_instance", &resource.Sweeper{
 		Name: "aws_db_instance",
 		F:    sweepInstances,
+		Dependencies: []string{
+			"aws_opsworks_rds_db_instance",
+		},
 	})
 
 	resource.AddTestSweepers("aws_db_option_group", &resource.Sweeper{

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -82,6 +82,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/mwaa"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/neptune"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/opsworks"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/qldb"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -35,9 +35,9 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `agent_version` - (Optional) The AWS OpsWorks agent to install. Default is `INHERIT`.
-* `ami_id` - (Optional) The AMI to use for the instance.  If an AMI is specified, `os` must be `Custom`.
-* `architecture` - (Optional) Machine architecture for created instances.  Valid values are `x86_64` (the default), `i386`.
+* `agent_version` - (Optional) OpsWorks agent to install. Default is `INHERIT`.
+* `ami_id` - (Optional) AMI to use for the instance.  If an AMI is specified, `os` must be `Custom`.
+* `architecture` - (Optional) Machine architecture for created instances.  Valid values are `x86_64` or `i386`. The default is `x86_64`.
 * `auto_scaling_type` - (Optional) Creates load-based or time-based instances.  Valid values are `load`, `timer`.
 * `availability_zone` - (Optional) Name of the availability zone where instances will be created by default.
 * `delete_ebs` - (Optional) Whether to delete EBS volume on deletion. Default is `true`.
@@ -47,16 +47,16 @@ The following arguments are optional:
 * `ecs_cluster_arn` - (Optional) ECS cluster's ARN for container instances.
 * `elastic_ip` - (Optional) Instance Elastic IP address.
 * `ephemeral_block_device` - (Optional) Configuration block for ephemeral (also known as "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below.
-* `hostname` - (Optional) The instance's host name.
+* `hostname` - (Optional) Instance's host name.
 * `infrastructure_class` - (Optional) For registered instances, infrastructure class: ec2 or on-premises.
 * `install_updates_on_boot` - (Optional) Controls where to install OS and package updates when the instance boots.  Default is `true`.
 * `instance_profile_arn` - (Optional) ARN of the instance's IAM profile.
-* `instance_type` - (Optional) The type of instance to start.
+* `instance_type` - (Optional) Type of instance to start.
 * `os` - (Optional) Name of operating system that will be installed.
 * `root_block_device` - (Optional) Configuration block for the root block device of the instance. See [Block Devices](#block-devices) below.
 * `root_device_type` - (Optional) Name of the type of root device instances will have by default. Valid values are `ebs` or `instance-store`.
 * `ssh_key_name` - (Optional) Name of the SSH keypair that instances will have by default.
-* `state` - (Optional) The desired state of the instance. Valid values are `running` or `stopped`.
+* `state` - (Optional) Desired state of the instance. Valid values are `running` or `stopped`.
 * `subnet_id` - (Optional) Subnet ID to attach to.
 * `tenancy` - (Optional) Instance tenancy to use. Valid values are `default`, `dedicated` or `host`.
 * `virtualization_type` - (Optional) Keyword to choose what virtualization mode created instances will use. Valid values are `paravirtual` or `hvm`.
@@ -71,17 +71,17 @@ to understand the implications of using these attributes.
 ### `ebs_block_device`
 
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination Default is `true`.
-* `device_name` - (Required) The name of the device to mount.
-* `iops` - (Optional) The amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
-* `snapshot_id` - (Optional) The Snapshot ID to mount.
-* `volume_size` - (Optional) The size of the volume in gigabytes.
-* `volume_type` - (Optional) The type of volume. Valid values are `standard`, `gp2`, or `io1`. Default is `standard`.
+* `device_name` - (Required) Name of the device to mount.
+* `iops` - (Optional) Amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
+* `snapshot_id` - (Optional) Snapshot ID to mount.
+* `volume_size` - (Optional) Size of the volume in gigabytes.
+* `volume_type` - (Optional) Type of volume. Valid values are `standard`, `gp2`, or `io1`. Default is `standard`.
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 
 ### `ephemeral_block_device`
 
-* `device_name` - The name of the block device to mount on the instance.
+* `device_name` - Name of the block device to mount on the instance.
 * `virtual_name` - The [Instance Store Device Name](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) (e.g., `ephemeral0`).
 
 Each AWS Instance type has a different set of Instance Store block devices
@@ -93,9 +93,9 @@ identified by the `virtual_name` in the format `ephemeral{0..N}`.
 ### `root_block_device`
 
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination. Default is `true`.
-* `iops` - (Optional) The amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
-* `volume_size` - (Optional) The size of the volume in gigabytes.
-* `volume_type` - (Optional) The type of volume. Valid values are `standard`, `gp2`, or `io1`. Default is `standard`.
+* `iops` - (Optional) Amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
+* `volume_size` - (Optional) Size of the volume in gigabytes.
+* `volume_type` - (Optional) Type of volume. Valid values are `standard`, `gp2`, or `io1`. Default is `standard`.
 
 Modifying any of the `root_block_device` settings requires resource
 replacement.
@@ -115,16 +115,16 @@ In addition to all arguments above, the following attributes are exported:
 * `last_service_error_id` - ID of the last service error.
 * `platform` - Instance's platform.
 * `private_dns` - Private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC.
-* `private_ip` - The private IP address assigned to the instance.
-* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
-* `public_ip` - The public IP address assigned to the instance, if applicable.
+* `private_ip` - Private IP address assigned to the instance.
+* `public_dns` - Public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
+* `public_ip` - Public IP address assigned to the instance, if applicable.
 * `registered_by` - For registered instances, who performed the registration.
-* `reported_agent_version` - The instance's reported AWS OpsWorks Stacks agent version.
+* `reported_agent_version` - Instance's reported AWS OpsWorks Stacks agent version.
 * `reported_os_family` - For registered instances, the reported operating system family.
 * `reported_os_name` - For registered instances, the reported operating system name.
 * `reported_os_version` - For registered instances, the reported operating system version.
 * `root_device_volume_id` - Root device volume ID.
-* `security_group_ids` - The associated security groups.
+* `security_group_ids` - Associated security groups.
 * `ssh_host_dsa_key_fingerprint` - SSH key's Deep Security Agent (DSA) fingerprint.
 * `ssh_host_rsa_key_fingerprint` - SSH key's RSA fingerprint.
 * `status` - Instance status. Will be one of `booting`, `connection_lost`, `online`, `pending`, `rebooting`, `requested`, `running_setup`, `setup_failed`, `shutting_down`, `start_failed`, `stop_failed`, `stopped`, `stopping`, `terminated`, or `terminating`.

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -70,7 +70,7 @@ to understand the implications of using these attributes.
 
 ### `ebs_block_device`
 
-* `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination Default is `true`.
+* `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination. Default is `true`.
 * `device_name` - (Required) Name of the device to mount.
 * `iops` - (Optional) Amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
 * `snapshot_id` - (Optional) Snapshot ID to mount.

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -28,35 +28,38 @@ resource "aws_opsworks_instance" "my-instance" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `instance_type` - (Required) The type of instance to start
-* `stack_id` - (Required) The id of the stack the instance will belong to.
-* `layer_ids` - (Required) The ids of the layers the instance will belong to.
-* `state` - (Optional) The desired state of the instance.  Can be either `"running"` or `"stopped"`.
-* `install_updates_on_boot` - (Optional) Controls where to install OS and package updates when the instance boots.  Defaults to `true`.
-* `auto_scaling_type` - (Optional) Creates load-based or time-based instances.  If set, can be either: `"load"` or `"timer"`.
-* `availability_zone` - (Optional) Name of the availability zone where instances will be created
-  by default.
-* `ebs_optimized` - (Optional) If true, the launched EC2 instance will be EBS-optimized.
+* `layer_ids` - (Required) List of the layers the instance will belong to.
+* `stack_id` - (Required) Identifier of the stack the instance will belong to.
+
+The following arguments are optional:
+
+* `agent_version` - (Optional) The AWS OpsWorks agent to install. Default is `INHERIT`.
+* `ami_id` - (Optional) The AMI to use for the instance.  If an AMI is specified, `os` must be `Custom`.
+* `architecture` - (Optional) Machine architecture for created instances.  Valid values are `x86_64` (the default), `i386`.
+* `auto_scaling_type` - (Optional) Creates load-based or time-based instances.  Valid values are `load`, `timer`.
+* `availability_zone` - (Optional) Name of the availability zone where instances will be created by default.
+* `delete_ebs` - (Optional) Whether to delete EBS volume on deletion. Default is `true`.
+* `delete_eip` - (Optional) Whether to delete the Elastic IP on deletion.
+* `ebs_block_device` - (Optional) Configuration block for additional EBS block devices to attach to the instance. See [Block Devices](#block-devices) below.
+* `ebs_optimized` - (Optional) Whether the launched EC2 instance will be EBS-optimized.
+* `ecs_cluster_arn` - (Optional) ECS cluster's ARN for container instances.
+* `elastic_ip` - (Optional) Instance Elastic IP address.
+* `ephemeral_block_device` - (Optional) Configuration block for ephemeral (also known as "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below.
 * `hostname` - (Optional) The instance's host name.
-* `architecture` - (Optional) Machine architecture for created instances.  Can be either `"x86_64"` (the default) or `"i386"`
-* `ami_id` - (Optional) The AMI to use for the instance.  If an AMI is specified, `os` must be `"Custom"`.
+* `infrastructure_class` - (Optional) For registered instances, infrastructure class: ec2 or on-premises.
+* `install_updates_on_boot` - (Optional) Controls where to install OS and package updates when the instance boots.  Default is `true`.
+* `instance_profile_arn` - (Optional) ARN of the instance's IAM profile.
+* `instance_type` - (Optional) The type of instance to start.
 * `os` - (Optional) Name of operating system that will be installed.
-* `root_device_type` - (Optional) Name of the type of root device instances will have by default.  Can be either `"ebs"` or `"instance-store"`
+* `root_block_device` - (Optional) Configuration block for the root block device of the instance. See [Block Devices](#block-devices) below.
+* `root_device_type` - (Optional) Name of the type of root device instances will have by default. Valid values are `ebs` or `instance-store`.
 * `ssh_key_name` - (Optional) Name of the SSH keypair that instances will have by default.
-* `agent_version` - (Optional) The AWS OpsWorks agent to install.  Defaults to `"INHERIT"`.
-* `subnet_id` - (Optional) Subnet ID to attach to
-* `tenancy` - (Optional) Instance tenancy to use. Can be one of `"default"`, `"dedicated"` or `"host"`
-* `virtualization_type` - (Optional) Keyword to choose what virtualization mode created instances
-  will use. Can be either `"paravirtual"` or `"hvm"`.
-* `root_block_device` - (Optional) Customize details about the root block
-  device of the instance. See [Block Devices](#block-devices) below for details.
-* `ebs_block_device` - (Optional) Additional EBS block devices to attach to the
-  instance.  See [Block Devices](#block-devices) below for details.
-* `ephemeral_block_device` - (Optional) Customize Ephemeral (also known as
-  "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below for details.
-
+* `state` - (Optional) The desired state of the instance. Valid values are `running` or `stopped`.
+* `subnet_id` - (Optional) Subnet ID to attach to.
+* `tenancy` - (Optional) Instance tenancy to use. Valid values are `default`, `dedicated` or `host`.
+* `virtualization_type` - (Optional) Keyword to choose what virtualization mode created instances will use. Valid values are `paravirtual` or `hvm`.
 
 ## Block devices
 
@@ -65,73 +68,66 @@ Instance's "Block Device Mapping". It's a good idea to familiarize yourself with
 Mapping docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html)
 to understand the implications of using these attributes.
 
-The `root_block_device` mapping supports the following:
+### `ebs_block_device`
 
-* `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`,
-  or `"io1"`. (Default: `"standard"`).
-* `volume_size` - (Optional) The size of the volume in gigabytes.
-* `iops` - (Optional) The amount of provisioned
-  [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
-  This must be set with a `volume_type` of `"io1"`.
-* `delete_on_termination` - (Optional) Whether the volume should be destroyed
-  on instance termination (Default: `true`).
-
-Modifying any of the `root_block_device` settings requires resource
-replacement.
-
-Each `ebs_block_device` supports the following:
-
-* `device_name` - The name of the device to mount.
+* `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination Default is `true`.
+* `device_name` - (Required) The name of the device to mount.
+* `iops` - (Optional) The amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
 * `snapshot_id` - (Optional) The Snapshot ID to mount.
-* `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`,
-  or `"io1"`. (Default: `"standard"`).
 * `volume_size` - (Optional) The size of the volume in gigabytes.
-* `iops` - (Optional) The amount of provisioned
-  [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
-  This must be set with a `volume_type` of `"io1"`.
-* `delete_on_termination` - (Optional) Whether the volume should be destroyed
-  on instance termination (Default: `true`).
+* `volume_type` - (Optional) The type of volume. Valid values are `standard`, `gp2`, or `io1`. Default is `standard`.
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 
-Each `ephemeral_block_device` supports the following:
+### `ephemeral_block_device`
 
 * `device_name` - The name of the block device to mount on the instance.
-* `virtual_name` - The [Instance Store Device
-  Name](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)
-  (e.g., `"ephemeral0"`)
+* `virtual_name` - The [Instance Store Device Name](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) (e.g., `ephemeral0`).
 
 Each AWS Instance type has a different set of Instance Store block devices
 available for attachment. AWS [publishes a
 list](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#StorageOnInstanceTypes)
 of which ephemeral devices are available on each type. The devices are always
-identified by the `virtual_name` in the format `"ephemeral{0..N}"`.
+identified by the `virtual_name` in the format `ephemeral{0..N}`.
+
+### `root_block_device`
+
+* `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination. Default is `true`.
+* `iops` - (Optional) The amount of provisioned [IOPS](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). This must be set with a `volume_type` of `io1`.
+* `volume_size` - (Optional) The size of the volume in gigabytes.
+* `volume_type` - (Optional) The type of volume. Valid values are `standard`, `gp2`, or `io1`. Default is `standard`.
+
+Modifying any of the `root_block_device` settings requires resource
+replacement.
 
 ~> **NOTE:** Currently, changes to `*_block_device` configuration of _existing_
 resources cannot be automatically detected by Terraform. After making updates
 to block device configuration, resource recreation can be manually triggered by
 using the [`taint` command](https://www.terraform.io/docs/commands/taint.html).
 
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The id of the OpsWorks instance.
-* `agent_version` - The AWS OpsWorks agent version.
-* `availability_zone` - The availability zone of the instance.
-* `ec2_instance_id` - EC2 instance ID
-* `ssh_key_name` - The key name of the instance
-* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this
-  is only available if you've enabled DNS hostnames for your VPC
+* `created_at` - Time that the instance was created.
+* `ec2_instance_id` - EC2 instance ID.
+* `id` - ID of the OpsWorks instance.
+* `last_service_error_id` - ID of the last service error.
+* `platform` - Instance's platform.
+* `private_dns` - Private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC.
+* `private_ip` - The private IP address assigned to the instance.
+* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
 * `public_ip` - The public IP address assigned to the instance, if applicable.
-* `private_dns` - The private DNS name assigned to the instance. Can only be
-  used inside the Amazon EC2, and only available if you've enabled DNS hostnames
-  for your VPC
-* `private_ip` - The private IP address assigned to the instance
-* `subnet_id` - The VPC subnet ID.
-* `tenancy` - The Instance tenancy
+* `registered_by` - For registered instances, who performed the registration.
+* `reported_agent_version` - The instance's reported AWS OpsWorks Stacks agent version.
+* `reported_os_family` - For registered instances, the reported operating system family.
+* `reported_os_name` - For registered instances, the reported operating system name.
+* `reported_os_version` - For registered instances, the reported operating system version.
+* `root_device_volume_id` - Root device volume ID.
 * `security_group_ids` - The associated security groups.
+* `ssh_host_dsa_key_fingerprint` - SSH key's Deep Security Agent (DSA) fingerprint.
+* `ssh_host_rsa_key_fingerprint` - SSH key's RSA fingerprint.
+* `status` - Instance status. Will be one of `booting`, `connection_lost`, `online`, `pending`, `rebooting`, `requested`, `running_setup`, `setup_failed`, `shutting_down`, `start_failed`, `stop_failed`, `stopped`, `stopping`, `terminated`, or `terminating`.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccOpsWorks PKG=opsworks
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 20 -run='TestAccOpsWorks'  -timeout 180m
--- PASS: TestAccOpsWorksStack_classicEndpoints (84.92s)
--- PASS: TestAccOpsWorksGangliaLayer_basic (48.45s)
--- PASS: TestAccOpsWorksUserProfile_basic (50.20s)
--- PASS: TestAccOpsWorksHAProxyLayer_basic (60.06s)
--- PASS: TestAccOpsWorksNodejsAppLayer_basic (67.10s)
--- PASS: TestAccOpsWorksStack_noVPCCreateTags (69.58s)
--- PASS: TestAccOpsWorksJavaAppLayer_basic (74.76s)
--- PASS: TestAccOpsWorksPermission_self (76.21s)
--- PASS: TestAccOpsWorksRailsAppLayer_basic (86.47s)
--- PASS: TestAccOpsWorksInstance_updateHostNameForceNew (100.01s)
--- PASS: TestAccOpsWorksGangliaLayer_tags (101.77s)
--- PASS: TestAccOpsWorksStaticWebLayer_basic (52.51s)
--- PASS: TestAccOpsWorksApplication_basic (111.30s)
--- PASS: TestAccOpsWorksHAProxyLayer_tags (116.36s)
--- PASS: TestAccOpsWorksECSClusterLayer_tags (118.93s)
--- PASS: TestAccOpsWorksMemcachedLayer_basic (54.32s)
--- PASS: TestAccOpsWorksInstance_basic (126.23s)
--- PASS: TestAccOpsWorksStaticWebLayer_tags (127.54s)
--- PASS: TestAccOpsWorksPHPAppLayer_tags (130.35s)
--- PASS: TestAccOpsWorksNodejsAppLayer_tags (135.40s)
--- PASS: TestAccOpsWorksPHPAppLayer_basic (139.95s)
--- PASS: TestAccOpsWorksECSClusterLayer_basic (35.26s)
--- PASS: TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties (91.81s)
--- PASS: TestAccOpsWorksMySQLLayer_tags (100.90s)
--- PASS: TestAccOpsWorksStack_noVPCBasic (61.94s)
--- PASS: TestAccOpsWorksRailsAppLayer_tags (163.31s)
--- PASS: TestAccOpsWorksCustomLayer_disappears (46.36s)
--- PASS: TestAccOpsWorksCustomLayer_basic (38.17s)
--- PASS: TestAccOpsWorksMemcachedLayer_tags (92.83s)
--- PASS: TestAccOpsWorksJavaAppLayer_tags (95.66s)
--- PASS: TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew (74.26s)
--- PASS: TestAccOpsWorksStack_vpc (103.18s)
--- PASS: TestAccOpsWorksPermission_basic (199.39s)
--- PASS: TestAccOpsWorksCustomLayer_cloudwatch (128.84s)
--- PASS: TestAccOpsWorksCustomLayer_noVPC (108.37s)
--- PASS: TestAccOpsWorksCustomLayer_tags (125.42s)
--- PASS: TestAccOpsWorksMySQLLayer_basic (219.87s)
--- PASS: TestAccOpsWorksRDSDBInstance_basic (817.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	1030.176s
```
