### PR TITLE
Feature/f aws grafana license association

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -622,7 +622,7 @@ func Provider() *schema.Provider {
 			"aws_glue_data_catalog_encryption_settings": glue.DataSourceDataCatalogEncryptionSettings(),
 			"aws_glue_script":                           glue.DataSourceScript(),
 
-			"aws_grafana_workspace": grafana.DataSourceWorkspace(),
+			"aws_grafana_workspace": grafana.DataSourceWorkspace()
 
 			"aws_guardduty_detector": guardduty.DataSourceDetector(),
 
@@ -1405,7 +1405,8 @@ func Provider() *schema.Provider {
 			"aws_glue_user_defined_function":            glue.ResourceUserDefinedFunction(),
 			"aws_glue_workflow":                         glue.ResourceWorkflow(),
 
-			"aws_grafana_workspace": grafana.ResourceWorkspace(),
+			"aws_grafana_workspace":           grafana.ResourceWorkspace(),
+			"aws_grafana_license_association": grafana.ResourceLicenseAssociation(),
 
 			"aws_guardduty_detector":                   guardduty.ResourceDetector(),
 			"aws_guardduty_filter":                     guardduty.ResourceFilter(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -622,7 +622,7 @@ func Provider() *schema.Provider {
 			"aws_glue_data_catalog_encryption_settings": glue.DataSourceDataCatalogEncryptionSettings(),
 			"aws_glue_script":                           glue.DataSourceScript(),
 
-			"aws_grafana_workspace": grafana.DataSourceWorkspace()
+			"aws_grafana_workspace": grafana.DataSourceWorkspace(),
 
 			"aws_guardduty_detector": guardduty.DataSourceDetector(),
 

--- a/internal/service/grafana/license_association.go
+++ b/internal/service/grafana/license_association.go
@@ -1,0 +1,155 @@
+package grafana
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/managedgrafana"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceLicenseAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLicenseAssociationCreate,
+		Read:   resourceLicenseAssociationRead,
+		Update: resourceLicenseAssociationUpdate,
+		Delete: resourceLicenseAssociationDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"free_trial_expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"license_expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"license_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(managedgrafana.LicenseType_Values(), false),
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceLicenseAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).GrafanaConn
+
+	workspaceID := d.Get("workspace_id").(string)
+	_, err := FindWorkspaceByID(conn, workspaceID)
+
+	if err != nil {
+		return fmt.Errorf("error reading Grafana Workspace (%s): %w", workspaceID, err)
+	}
+
+	input := &managedgrafana.AssociateLicenseInput{
+		LicenseType: aws.String(d.Get("license_type").(string)),
+		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating Grafana License Association: %s", input)
+	output, err := conn.AssociateLicense(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating Grafana License Association: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.Workspace.Id))
+
+	_, err = waitLicenseAssociationCreated(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Grafana License Association (%s) create: %w", d.Id(), err)
+	}
+	return resourceLicenseAssociationRead(d, meta)
+}
+
+func resourceLicenseAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).GrafanaConn
+
+	workspace, err := FindWorkspaceByID(conn, d.Id())
+
+	if tfresource.NotFound(err) && !d.IsNewResource() {
+		log.Printf("[WARN] Grafana Workspace (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Grafana Workspace (%s): %w", d.Id(), err)
+	}
+
+	d.Set("license_type", workspace.LicenseType)
+
+	if workspace.FreeTrialExpiration != nil {
+		d.Set("free_trial_expiration", workspace.FreeTrialExpiration.Format(time.RFC3339))
+	}
+
+	if workspace.LicenseExpiration != nil {
+		d.Set("license_expiration", workspace.LicenseExpiration.Format(time.RFC3339))
+	}
+
+	return nil
+}
+
+func resourceLicenseAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
+	err := resourceLicenseAssociationDelete(d, meta)
+
+	if err != nil {
+		return fmt.Errorf("error updating Grafana License Assocation (%s): %w", d.Id(), err)
+	}
+
+	err = resourceLicenseAssociationCreate(d, meta)
+
+	if err != nil {
+		return fmt.Errorf("error updating Grafana License Assocation (%s): %w", d.Id(), err)
+	}
+
+	return resourceLicenseAssociationRead(d, meta)
+}
+
+func resourceLicenseAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).GrafanaConn
+
+	log.Printf("[DEBUG] Deleting Grafana License Association: %s", d.Id())
+	_, err := conn.DisassociateLicense(&managedgrafana.DisassociateLicenseInput{
+		LicenseType: aws.String(d.Get("license_type").(string)),
+		WorkspaceId: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, managedgrafana.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Grafana License Assocation (%s): %w", d.Id(), err)
+	}
+
+	_, err = waitWorkspaceUpdated(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Grafana License Association (%s) delete: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/grafana/license_association_test.go
+++ b/internal/service/grafana/license_association_test.go
@@ -1,0 +1,126 @@
+package grafana_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/managedgrafana"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfgrafana "github.com/hashicorp/terraform-provider-aws/internal/service/grafana"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func testAccGrafanaLicenseAssociation_freeTrial(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_grafana_license_association.test"
+	workspaceResourceName := "aws_grafana_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(managedgrafana.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, managedgrafana.EndpointsID),
+		CheckDestroy: testAccCheckLicenseAssociationDestroy,
+		Providers:    acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLicenseAssociation(rName, managedgrafana.LicenseTypeEnterpriseFreeTrial),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLicenseAssociationExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "free_trial_expiration"),
+					resource.TestCheckResourceAttr(resourceName, "license_type", managedgrafana.LicenseTypeEnterpriseFreeTrial),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGrafanaLicenseAssociation_enterprise(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_grafana_license_association.test"
+	workspaceResourceName := "aws_grafana_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(managedgrafana.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, managedgrafana.EndpointsID),
+		CheckDestroy: nil,
+		Providers:    acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLicenseAssociation(rName, managedgrafana.LicenseTypeEnterprise),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLicenseAssociationExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "license_expiration"),
+					resource.TestCheckResourceAttr(resourceName, "license_type", managedgrafana.LicenseTypeEnterprise),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLicenseAssociation(rName string, licenseType string) string {
+	return acctest.ConfigCompose(testAccWorkspaceConfigAuthenticationProvider(rName, "SAML"), fmt.Sprintf(`
+resource "aws_grafana_license_association" "test" {
+  workspace_id = aws_grafana_workspace.test.id
+  license_type = %[1]q
+}
+`, licenseType))
+}
+
+func testAccCheckLicenseAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Grafana Workspace ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GrafanaConn
+
+		workspace, err := tfgrafana.FindWorkspaceByID(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if workspace.LicenseType == nil {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckLicenseAssociationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).GrafanaConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_grafana_license_association" {
+			continue
+		}
+
+		workspace, err := tfgrafana.FindWorkspaceByID(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if workspace.LicenseType == nil {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Grafana License Association %s still exists", rs.Primary.ID)
+	}
+	return nil
+}

--- a/internal/service/grafana/wait.go
+++ b/internal/service/grafana/wait.go
@@ -57,3 +57,20 @@ func waitWorkspaceDeleted(conn *managedgrafana.ManagedGrafana, id string, timeou
 
 	return nil, err
 }
+
+func waitLicenseAssociationCreated(conn *managedgrafana.ManagedGrafana, id string, timeout time.Duration) (*managedgrafana.WorkspaceDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{managedgrafana.WorkspaceStatusUpgrading},
+		Target:  []string{managedgrafana.WorkspaceStatusActive},
+		Refresh: statusWorkspaceStatus(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*managedgrafana.WorkspaceDescription); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -29,6 +29,10 @@ func TestAccGrafana_serial(t *testing.T) {
 		"DataSource": {
 			"basic": testAccGrafanaWorkspaceDataSource_basic,
 		},
+		"LicenseAssociation": {
+			"enterpriseFreeTrial": testAccGrafanaLicenseAssociation_freeTrial,
+			"enterprise":          testAccGrafanaLicenseAssociation_enterprise,
+		},
 	}
 
 	for group, m := range testCases {
@@ -423,7 +427,7 @@ func testAccCheckWorkspaceDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).GrafanaConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_managed_grafana" {
+		if rs.Type != "aws_grafana_workspace" {
 			continue
 		}
 

--- a/website/docs/r/grafana_license_association.html.markdown
+++ b/website/docs/r/grafana_license_association.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Grafana"
+layout: "aws"
+page_title: "AWS: aws_grafana_license_association"
+description: |-
+Provides an Amazon Managed Grafana workspace license association resource.
+---
+
+# Resource: aws_grafana_license_association
+
+Provides an Amazon Managed Grafana workspace license association resource.
+
+## Example Usage
+
+### Basic configuration
+
+```terraform
+resource "aws_grafana_license_association" "example" {
+  license_type = "ENTERPRISE_FREE_TRIAL"
+  workspace_id = aws_grafana_workspace.example.id
+}
+
+resource "aws_grafana_workspace" "example" {
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["SAML"]
+  permission_type          = "SERVICE_MANAGED"
+  role_arn                 = aws_iam_role.assume.arn
+}
+
+resource "aws_iam_role" "assume" {
+  name = "grafana-assume"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "grafana.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `license_type` - (Required) The type of license for the workspace license association. Valid values are `ENTERPRISE` and `ENTERPRISE_FREE_TRIAL`.
+* `workspace_id` - (Required) The workspace id.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `free_trial_expiration` - If `license_type` is set to `ENTERPRISE_FREE_TRIAL`, this is the expiration date of the free trial.
+* `license_expiration` - If `license_type` is set to `ENTERPRISE`, this is the expiration date of the enterprise license.
+
+## Import
+
+Grafana workspace license association can be imported using the workspace's `id`, e.g.,
+
+```
+$ terraform import aws_grafana_license_association.example g-2054c75a02
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16789

Output from acceptance testing (I didn't run the enterprise test):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccGrafana_serial PKG=grafana
=== RUN   TestAccGrafana_serial
--- FAIL: TestAccGrafana_serial (1648.35s)
=== RUN   TestAccGrafana_serial/Workspace
    --- FAIL: TestAccGrafana_serial/Workspace (1222.37s)
=== RUN   TestAccGrafana_serial/Workspace/disappears
        --- PASS: TestAccGrafana_serial/Workspace/disappears (184.00s)
=== RUN   TestAccGrafana_serial/Workspace/organization
        --- PASS: TestAccGrafana_serial/Workspace/organization (177.26s)
=== RUN   TestAccGrafana_serial/Workspace/dataSources
    workspace_test.go:201: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 2/20 error: aws_grafana_workspace.test: Attribute 'arn' didn't match "arn:aws:grafana:us-east-2:ACCT:/workspaces/.+", got "arn:aws:grafana::ACCT:/workspaces/g-cbc0b35aad"
        
        --- FAIL: TestAccGrafana_serial/Workspace/dataSources (164.46s)

=== RUN   TestAccGrafana_serial/Workspace/permissionType
        --- PASS: TestAccGrafana_serial/Workspace/permissionType (184.93s)
=== RUN   TestAccGrafana_serial/Workspace/notificationDestinations
        --- PASS: TestAccGrafana_serial/Workspace/notificationDestinations (183.10s)
=== RUN   TestAccGrafana_serial/Workspace/saml
    workspace_test.go:56: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 2/17 error: aws_grafana_workspace.test: Attribute 'arn' didn't match "arn:aws:grafana:us-east-2:ACCT:/workspaces/.+", got "arn:aws:grafana::ACCT:/workspaces/g-4d967fd914"
        

        --- FAIL: TestAccGrafana_serial/Workspace/saml (163.89s)

=== RUN   TestAccGrafana_serial/Workspace/sso
    workspace_test.go:98: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 2/17 error: aws_grafana_workspace.test: Attribute 'arn' didn't match "arn:aws:grafana:us-east-2:ACCT:/workspaces/.+", got "arn:aws:grafana::ACCT:/workspaces/g-d8abd47428"
        
        --- FAIL: TestAccGrafana_serial/Workspace/sso (164.74s)


=== RUN   TestAccGrafana_serial/DataSource
    --- PASS: TestAccGrafana_serial/DataSource (169.73s)
=== RUN   TestAccGrafana_serial/DataSource/basic
        --- PASS: TestAccGrafana_serial/DataSource/basic (169.73s)
=== RUN   TestAccGrafana_serial/LicenseAssociation
    --- PASS: TestAccGrafana_serial/LicenseAssociation (256.25s)
=== RUN   TestAccGrafana_serial/LicenseAssociation/enterpriseFreeTrial
        --- PASS: TestAccGrafana_serial/LicenseAssociation/enterpriseFreeTrial (256.25s)

FAIL
```
