### PR TITLE
ses: domain_mail_from: Update docs for email identity usecase

### DIFF
--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -14,6 +14,8 @@ Provides an SES domain MAIL FROM resource.
 
 ## Example Usage
 
+### Domain Identity MAIL FROM
+
 ```terraform
 resource "aws_ses_domain_mail_from" "example" {
   domain           = aws_ses_domain_identity.example.domain
@@ -44,11 +46,25 @@ resource "aws_route53_record" "example_ses_domain_mail_from_txt" {
 }
 ```
 
+### Email Identity MAIL FROM
+
+```terraform
+# Example SES Email Identity
+resource "aws_ses_email_identity" "example" {
+  email = "user@example.com"
+}
+
+resource "aws_ses_domain_mail_from" "example" {
+  domain           = aws_ses_email_identity.example.email
+  mail_from_domain = "mail.example.com"
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
-* `domain` - (Required) Verified domain name to generate DKIM tokens for.
+* `domain` - (Required) Verified domain name or email identity to generate DKIM tokens for.
 * `mail_from_domain` - (Required) Subdomain (of above domain) which is to be used as MAIL FROM address (Required for DMARC validation)
 
 The following arguments are optional:

--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an SES domain MAIL FROM resource.
 
-~> **NOTE:** For the MAIL FROM domain to be fully usable, this resource should be paired with the [aws_ses_domain_identity resource](/docs/providers/aws/r/ses_domain_identity.html). To validate the MAIL FROM domain, a DNS MX record is required. To pass SPF checks, a DNS TXT record may also be required. See the [Amazon SES MAIL FROM documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-set.html) for more information.
+~> **NOTE:** For the MAIL FROM domain to be fully usable, this resource should be paired with the [aws_ses_domain_identity resource](/docs/providers/aws/r/ses_domain_identity.html). To validate the MAIL FROM domain, a DNS MX record is required. To pass SPF checks, a DNS TXT record may also be required. See the [Amazon SES MAIL FROM documentation](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html) for more information.
 
 ## Example Usage
 


### PR DESCRIPTION
Currently, the docs for `ses_domain_mail_from` do not contain any references to the fact that an SES Verified Email address can be used in place of the `domain` property to allow a custom MAIL FROM domain as well. This is the root cause of some customer pain, identified via this Issue (https://github.com/hashicorp/terraform-provider-aws/issues/14378) and a support ticket (#67513 for internal reference)

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #14378

Output from acceptance testing:

- N/A, this is only a doc update.