### PR TITLE
provider: Sets provider client region from resolved AWS configuration

### DIFF
--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1244,6 +1244,7 @@ func (c *Config) Client() (interface{}, error) {
 			return nil, err
 		}
 	}
+	c.Region = cfg.Region
 
 	sess, err := awsbasev1.GetSession(&cfg, &awsbaseConfig)
 	if err != nil {

--- a/internal/service/meta/region_data_source.go
+++ b/internal/service/meta/region_data_source.go
@@ -96,7 +96,7 @@ func FindRegionByEndpoint(endpoint string) (*endpoints.Region, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("region not found for endpoint: %s", endpoint)
+	return nil, fmt.Errorf("region not found for endpoint %q", endpoint)
 }
 
 func FindRegionByName(name string) (*endpoints.Region, error) {
@@ -107,5 +107,5 @@ func FindRegionByName(name string) (*endpoints.Region, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("region not found for name: %s", name)
+	return nil, fmt.Errorf("region not found for name %q", name)
 }


### PR DESCRIPTION
Sets `AWSClient.Region` based on resolved AWS configuration

Relates #23384

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=meta TESTS=TestAccMetaRegionDataSource_basic

--- PASS: TestAccMetaRegionDataSource_basic (27.41s)
```
