### PR TITLE
r/s3_bucket_acl: new resource

### DIFF
--- a/.changelog/23419.txt
+++ b/.changelog/23419.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_s3_bucket_acl
+```
+
+```release-note:note
+resource/aws_s3_bucket: The `acl` and `grant` arguments have been deprecated. Use the `aws_s3_bucket_acl` resource instead.
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1586,6 +1586,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_rule_association":                route53resolver.ResourceRuleAssociation(),
 
 			"aws_s3_bucket":                                   s3.ResourceBucket(),
+			"aws_s3_bucket_acl":                               s3.ResourceBucketAcl(),
 			"aws_s3_bucket_analytics_configuration":           s3.ResourceBucketAnalyticsConfiguration(),
 			"aws_s3_bucket_intelligent_tiering_configuration": s3.ResourceBucketIntelligentTieringConfiguration(),
 			"aws_s3_bucket_inventory":                         s3.ResourceBucketInventory(),

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -81,6 +81,7 @@ func ResourceBucket() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"grant"},
 				ValidateFunc:  validation.StringInSlice(BucketCannedACL_Values(), false),
+				Deprecated:    "Use the aws_s3_bucket_acl resource instead",
 			},
 
 			"grant": {
@@ -88,11 +89,13 @@ func ResourceBucket() *schema.Resource {
 				Optional:      true,
 				Set:           grantHash,
 				ConflictsWith: []string{"acl"},
+				Deprecated:    "Use the aws_s3_bucket_acl resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the aws_s3_bucket_acl resource instead",
 						},
 						"type": {
 							Type:     schema.TypeString,
@@ -102,10 +105,12 @@ func ResourceBucket() *schema.Resource {
 								s3.TypeCanonicalUser,
 								s3.TypeGroup,
 							}, false),
+							Deprecated: "Use the aws_s3_bucket_acl resource instead",
 						},
 						"uri": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the aws_s3_bucket_acl resource instead",
 						},
 
 						"permissions": {
@@ -115,6 +120,7 @@ func ResourceBucket() *schema.Resource {
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringInSlice(s3.Permission_Values(), false),
+								Deprecated:   "Use the aws_s3_bucket_acl resource instead",
 							},
 						},
 					},

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -93,9 +93,8 @@ func ResourceBucket() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:       schema.TypeString,
-							Optional:   true,
-							Deprecated: "Use the aws_s3_bucket_acl resource instead",
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"type": {
 							Type:     schema.TypeString,
@@ -105,12 +104,10 @@ func ResourceBucket() *schema.Resource {
 								s3.TypeCanonicalUser,
 								s3.TypeGroup,
 							}, false),
-							Deprecated: "Use the aws_s3_bucket_acl resource instead",
 						},
 						"uri": {
-							Type:       schema.TypeString,
-							Optional:   true,
-							Deprecated: "Use the aws_s3_bucket_acl resource instead",
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"permissions": {
@@ -120,7 +117,6 @@ func ResourceBucket() *schema.Resource {
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringInSlice(s3.Permission_Values(), false),
-								Deprecated:   "Use the aws_s3_bucket_acl resource instead",
 							},
 						},
 					},

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -1,0 +1,507 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+const BucketAclSeparator = ","
+
+func ResourceBucketAcl() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBucketAclCreate,
+		ReadContext:   resourceBucketAclRead,
+		UpdateContext: resourceBucketAclUpdate,
+		DeleteContext: resourceBucketAclDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"access_control_policy": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"acl"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"grant": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"grantee": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"email_address": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"display_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"type": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(s3.Type_Values(), false),
+												},
+												"uri": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"permission": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(s3.Permission_Values(), false),
+									},
+								},
+							},
+						},
+						"owner": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"display_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"acl": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"access_control_policy"},
+				ValidateFunc:  validation.StringInSlice(BucketCannedACL_Values(), false),
+			},
+			"bucket": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 63),
+			},
+			"expected_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+		},
+	}
+}
+
+func resourceBucketAclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket := d.Get("bucket").(string)
+	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
+	acl := d.Get("acl").(string)
+
+	input := &s3.PutBucketAclInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if acl != "" {
+		input.ACL = aws.String(acl)
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	if v, ok := d.GetOk("access_control_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.AccessControlPolicy = expandBucketAclAccessControlPolicy(v.([]interface{}))
+	}
+
+	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.PutBucketAclWithContext(ctx, input)
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating S3 bucket ACL for %s: %w", bucket, err))
+	}
+
+	d.SetId(BucketACLCreateResourceID(bucket, expectedBucketOwner, acl))
+
+	return resourceBucketAclRead(ctx, d, meta)
+}
+
+func resourceBucketAclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, acl, err := BucketACLParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.GetBucketAclInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	output, err := conn.GetBucketAclWithContext(ctx, input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket ACL (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting S3 bucket ACL (%s): %w", d.Id(), err))
+	}
+
+	if output == nil {
+		return diag.FromErr(fmt.Errorf("error getting S3 bucket ACL (%s): empty output", d.Id()))
+	}
+
+	d.Set("acl", acl)
+	d.Set("bucket", bucket)
+	d.Set("expected_bucket_owner", expectedBucketOwner)
+	if err := d.Set("access_control_policy", flattenBucketAclAccessControlPolicy(output)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting access_control_policy: %w", err))
+	}
+
+	return nil
+}
+
+func resourceBucketAclUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, acl, err := BucketACLParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.PutBucketAclInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	if d.HasChange("access_control_policy") {
+		input.AccessControlPolicy = expandBucketAclAccessControlPolicy(d.Get("access_control_policy").([]interface{}))
+	}
+
+	if d.HasChange("acl") {
+		acl = d.Get("acl").(string)
+		input.ACL = aws.String(acl)
+	}
+
+	_, err = conn.PutBucketAclWithContext(ctx, input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating S3 bucket ACL (%s): %w", d.Id(), err))
+	}
+
+	if d.HasChange("acl") {
+		// Set new ACL value back in resource ID
+		d.SetId(BucketACLCreateResourceID(bucket, expectedBucketOwner, acl))
+	}
+
+	return resourceBucketAclRead(ctx, d, meta)
+}
+
+func resourceBucketAclDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[WARN] Cannot destroy S3 Bucket ACL. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}
+
+func expandBucketAclAccessControlPolicy(l []interface{}) *s3.AccessControlPolicy {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.AccessControlPolicy{}
+
+	if v, ok := tfMap["grant"].(*schema.Set); ok && v.Len() > 0 {
+		result.Grants = expandBucketAclAccessControlPolicyGrants(v.List())
+	}
+
+	if v, ok := tfMap["owner"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		result.Owner = expandBucketAclAccessControlPolicyOwner(v)
+	}
+
+	return result
+}
+
+func expandBucketAclAccessControlPolicyGrants(l []interface{}) []*s3.Grant {
+	var grants []*s3.Grant
+
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		grant := &s3.Grant{}
+
+		if v, ok := tfMap["grantee"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			grant.Grantee = expandBucketAclAccessControlPolicyGrantsGrantee(v)
+		}
+
+		if v, ok := tfMap["permission"].(string); ok && v != "" {
+			grant.Permission = aws.String(v)
+		}
+
+		grants = append(grants, grant)
+	}
+
+	return grants
+}
+
+func expandBucketAclAccessControlPolicyGrantsGrantee(l []interface{}) *s3.Grantee {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.Grantee{}
+
+	if v, ok := tfMap["email_address"].(string); ok && v != "" {
+		result.EmailAddress = aws.String(v)
+	}
+
+	if v, ok := tfMap["id"].(string); ok && v != "" {
+		result.ID = aws.String(v)
+	}
+
+	if v, ok := tfMap["type"].(string); ok && v != "" {
+		result.Type = aws.String(v)
+	}
+
+	if v, ok := tfMap["uri"].(string); ok && v != "" {
+		result.URI = aws.String(v)
+	}
+
+	return result
+}
+
+func expandBucketAclAccessControlPolicyOwner(l []interface{}) *s3.Owner {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	owner := &s3.Owner{}
+
+	if v, ok := tfMap["display_name"].(string); ok && v != "" {
+		owner.DisplayName = aws.String(v)
+	}
+
+	if v, ok := tfMap["id"].(string); ok && v != "" {
+		owner.ID = aws.String(v)
+	}
+
+	return owner
+}
+
+func flattenBucketAclAccessControlPolicy(output *s3.GetBucketAclOutput) []interface{} {
+	if output == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if len(output.Grants) > 0 {
+		m["grant"] = flattenBucketAclAccessControlPolicyGrants(output.Grants)
+	}
+
+	if output.Owner != nil {
+		m["owner"] = flattenBucketAclAccessControlPolicyOwner(output.Owner)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenBucketAclAccessControlPolicyGrants(grants []*s3.Grant) []interface{} {
+	var results []interface{}
+
+	for _, grant := range grants {
+		if grant == nil {
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if grant.Grantee != nil {
+			m["grantee"] = flattenBucketAclAccessControlPolicyGrantsGrantee(grant.Grantee)
+		}
+
+		if grant.Permission != nil {
+			m["permission"] = aws.StringValue(grant.Permission)
+		}
+
+		results = append(results, m)
+	}
+
+	return results
+}
+
+func flattenBucketAclAccessControlPolicyGrantsGrantee(grantee *s3.Grantee) []interface{} {
+	if grantee == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if grantee.DisplayName != nil {
+		m["display_name"] = aws.StringValue(grantee.DisplayName)
+	}
+
+	if grantee.EmailAddress != nil {
+		m["email_address"] = aws.StringValue(grantee.EmailAddress)
+	}
+
+	if grantee.ID != nil {
+		m["id"] = aws.StringValue(grantee.ID)
+	}
+
+	if grantee.Type != nil {
+		m["type"] = aws.StringValue(grantee.Type)
+	}
+
+	if grantee.URI != nil {
+		m["uri"] = aws.StringValue(grantee.URI)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenBucketAclAccessControlPolicyOwner(owner *s3.Owner) []interface{} {
+	if owner == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if owner.DisplayName != nil {
+		m["display_name"] = aws.StringValue(owner.DisplayName)
+	}
+
+	if owner.ID != nil {
+		m["id"] = aws.StringValue(owner.ID)
+	}
+
+	return []interface{}{m}
+}
+
+// BucketACLCreateResourceID is a method for creating an ID string
+// with the bucket name and optional accountID and/or ACL.
+func BucketACLCreateResourceID(bucket, expectedBucketOwner, acl string) string {
+	if expectedBucketOwner == "" {
+		if acl == "" {
+			return bucket
+		}
+		return strings.Join([]string{bucket, acl}, BucketAclSeparator)
+	}
+
+	if acl == "" {
+		return strings.Join([]string{bucket, expectedBucketOwner}, BucketAclSeparator)
+	}
+
+	return strings.Join([]string{bucket, expectedBucketOwner, acl}, BucketAclSeparator)
+}
+
+// BucketACLParseResourceID is a method for parsing the ID string
+// for the bucket name, accountID, and ACL if provided.
+func BucketACLParseResourceID(id string) (string, string, string, error) {
+	// For only  bucket name in the ID  e.g. bucket
+	// ~> Bucket names can consist of only lowercase letters, numbers, dots, and hyphens; Max 63 characters
+	bucketRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63}$`)
+	// For bucket and accountID in the ID e.g. bucket,123456789101
+	// ~> Account IDs must consist of 12 digits
+	bucketAndOwnerRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63},\d{12}$`)
+	// For bucket and ACL in the ID e.g. bucket,public-read
+	// ~> (Canned) ACL values include: private, public-read, public-read-write, authenticated-read, aws-exec-read, and log-delivery-write
+	bucketAndAclRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63},[a-z-]+$`)
+	// For bucket, accountID, and ACL in the ID e.g. bucket,123456789101,public-read
+	bucketOwnerAclRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63},\d{12},[a-z-]+$`)
+
+	// Bucket name ONLY
+	if bucketRegex.MatchString(id) {
+		return id, "", "", nil
+	}
+
+	// Bucket and Account ID ONLY
+	if bucketAndOwnerRegex.MatchString(id) {
+		parts := strings.Split(id, BucketAclSeparator)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", "", fmt.Errorf("unexpected format for ID (%s), expected BUCKET%sEXPECTED_BUCKET_OWNER", id, BucketAclSeparator)
+		}
+		return parts[0], parts[1], "", nil
+	}
+
+	// Bucket and ACL ONLY
+	if bucketAndAclRegex.MatchString(id) {
+		parts := strings.Split(id, BucketAclSeparator)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", "", fmt.Errorf("unexpected format for ID (%s), expected BUCKET%sACL", id, BucketAclSeparator)
+		}
+		return parts[0], "", parts[1], nil
+	}
+
+	// Bucket, Account ID, and ACL
+	if bucketOwnerAclRegex.MatchString(id) {
+		parts := strings.Split(id, BucketAclSeparator)
+		if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return "", "", "", fmt.Errorf("unexpected format for ID (%s), expected BUCKET%[2]sEXPECTED_BUCKET_OWNER%[2]sACL", id, BucketAclSeparator)
+		}
+		return parts[0], parts[1], parts[2], nil
+	}
+
+	return "", "", "", fmt.Errorf("unexpected format for ID (%s), expected BUCKET or BUCKET%[2]sEXPECTED_BUCKET_OWNER or BUCKET%[2]sACL "+
+		"or BUCKET%[2]sEXPECTED_BUCKET_OWNER%[2]sACL", id, BucketAclSeparator)
+}

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -1,0 +1,535 @@
+package s3_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestBucketACLParseResourceID(t *testing.T) {
+	testCases := []struct {
+		TestName            string
+		InputID             string
+		ExpectError         bool
+		ExpectedACL         string
+		ExpectedBucket      string
+		ExpectedBucketOwner string
+	}{
+		{
+			TestName:    "empty ID",
+			InputID:     "",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect bucket and account ID format with slash separator",
+			InputID:     "test/123456789012",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect bucket, account ID, and ACL format with slash separators",
+			InputID:     "test/123456789012/private",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect bucket, account ID, and ACL format with mixed separators",
+			InputID:     "test/123456789012,private",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect bucket, ACL, and account ID format",
+			InputID:     "test,private,123456789012",
+			ExpectError: true,
+		},
+		{
+			TestName:            "valid ID with bucket",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example-bucket", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example-bucket",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot and hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example.bucket",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has dots, hyphen, and numbers",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example.bucket.4000",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and acl",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "", s3.BucketCannedACLPrivate),
+			ExpectedACL:         s3.BucketCannedACLPrivate,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot, hyphen, and number and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "my-example.bucket.4000",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and bucket owner",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot, hyphen, and number and bucket owner",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "123456789012", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example.bucket.4000",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket, bucket owner, and acl",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPrivate),
+			ExpectedACL:         s3.BucketCannedACLPrivate,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket, bucket owner, and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot, hyphen, and numbers, bucket owner, and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "123456789012", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "my-example.bucket.4000",
+			ExpectedBucketOwner: "123456789012",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotBucket, gotExpectedBucketOwner, gotAcl, err := tfs3.BucketACLParseResourceID(testCase.InputID)
+
+			if err == nil && testCase.ExpectError {
+				t.Fatalf("expected error")
+			}
+
+			if err != nil && !testCase.ExpectError {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if gotAcl != testCase.ExpectedACL {
+				t.Errorf("got ACL %s, expected %s", gotAcl, testCase.ExpectedACL)
+			}
+
+			if gotBucket != testCase.ExpectedBucket {
+				t.Errorf("got bucket %s, expected %s", gotBucket, testCase.ExpectedBucket)
+			}
+
+			if gotExpectedBucketOwner != testCase.ExpectedBucketOwner {
+				t.Errorf("got ExpectedBucketOwner %s, expected %s", gotExpectedBucketOwner, testCase.ExpectedBucketOwner)
+			}
+		})
+	}
+}
+
+func TestAccS3BucketAcl_basic(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionFullControl,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_disappears(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					// Bucket ACL cannot be destroyed, but we can verify Bucket deletion
+					// will result in a missing Bucket ACL resource
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucket(), "aws_s3_bucket.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_updateACL(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPublicRead),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
+				),
+			},
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_updateGrant(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAcl_GrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionFullControl,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionWrite,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketAcl_GrantsUpdateConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionRead,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeGroup,
+						"permission":     s3.PermissionReadAcp,
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]*regexp.Regexp{
+						"grantee.0.uri": regexp.MustCompile(`http://acs.*/groups/s3/LogDelivery`),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_ACLToGrant(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+				),
+			},
+			{
+				Config: testAccBucketAcl_GrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_grantToACL(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAcl_GrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+				),
+			},
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckBucketAclExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+		bucket, expectedBucketOwner, _, err := tfs3.BucketACLParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketAclInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketAcl(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.Grants) == 0 || output.Owner == nil {
+			return fmt.Errorf("S3 bucket ACL %s not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccBucketAclBasicConfig(rName, acl string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = %[2]q
+}
+`, rName, acl)
+}
+
+func testAccBucketAcl_GrantsConfig(bucketName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "WRITE"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+`, bucketName)
+}
+
+func testAccBucketAcl_GrantsUpdateConfig(bucketName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.${data.aws_partition.current.dns_suffix}/groups/s3/LogDelivery"
+      }
+      permission = "READ_ACP"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+`, bucketName)
+}

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -219,6 +219,159 @@ func TestAccS3BucketAcl_disappears(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketAcl_migrate_aclNoChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.bucket"
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithACLConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPublicRead),
+				),
+			},
+			{
+				Config: testAccBucketAcl_Migrate_AclConfig(bucketName, s3.BucketCannedACLPublicRead),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_migrate_aclWithChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.bucket"
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithACLConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPublicRead),
+				),
+			},
+			{
+				Config: testAccBucketAcl_Migrate_AclConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_migrate_grantsNoChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.bucket"
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithGrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "grant.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(bucketResourceName, "grant.*", map[string]string{
+						"permissions.#": "2",
+						"type":          "CanonicalUser",
+					}),
+					resource.TestCheckTypeSetElemAttr(bucketResourceName, "grant.*.permissions.*", "FULL_CONTROL"),
+					resource.TestCheckTypeSetElemAttr(bucketResourceName, "grant.*.permissions.*", "WRITE"),
+				),
+			},
+			{
+				Config: testAccBucketAcl_Migrate_GrantsNoChangeConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionFullControl,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionWrite,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_migrate_grantsWithChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.bucket"
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithACLConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPublicRead),
+				),
+			},
+			{
+				Config: testAccBucketAcl_Migrate_GrantsWithChangeConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionRead,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeGroup,
+						"permission":     s3.PermissionReadAcp,
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]*regexp.Regexp{
+						"grantee.0.uri": regexp.MustCompile(`http://acs.*/groups/s3/LogDelivery`),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccS3BucketAcl_updateACL(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket_acl.test"
@@ -532,4 +685,107 @@ resource "aws_s3_bucket_acl" "test" {
   }
 }
 `, bucketName)
+}
+
+func testAccBucketAcl_Migrate_AclConfig(rName, acl string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = %[2]q
+}
+`, rName, acl)
+}
+
+func testAccBucketAcl_Migrate_GrantsNoChangeConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "WRITE"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+`, rName)
+}
+
+func testAccBucketAcl_Migrate_GrantsWithChangeConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.${data.aws_partition.current.dns_suffix}/groups/s3/LogDelivery"
+      }
+      permission = "READ_ACP"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+`, rName)
 }

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -12,6 +12,14 @@ Provides a S3 bucket resource.
 
 -> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the [`aws_s3control_bucket`](/docs/providers/aws/r/s3control_bucket.html) resource.
 
+~> **NOTE on S3 Bucket canned ACL Configuration:** S3 Bucket canned ACL can be configured in either the standalone resource [`aws_s3_bucket_acl`](s3_bucket_acl.html.markdown)
+or with the deprecated parameter `acl` in the resource `aws_s3_bucket`.
+Configuring with both will cause inconsistencies and may overwrite configuration.
+
+~> **NOTE on S3 Bucket ACL Grants Configuration:** S3 Bucket grants can be configured in either the standalone resource [`aws_s3_bucket_acl`](s3_bucket_acl.html.markdown)
+or with the deprecated parameter `grant` in the resource `aws_s3_bucket`.
+Configuring with both will cause inconsistencies and may overwrite configuration.
+
 ## Example Usage
 
 ### Private Bucket w/ Tags
@@ -327,6 +335,9 @@ resource "aws_s3_bucket" "mybucket" {
 
 ### Using ACL policy grants
 
+-> **NOTE:** The parameters `acl` and `grant` are deprecated.
+Use the resource [`aws_s3_bucket_acl`](s3_bucket_acl.html.markdown) instead.
+
 ```terraform
 data "aws_canonical_user_id" "current_user" {}
 
@@ -353,8 +364,8 @@ The following arguments are supported:
 
 * `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-* `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
-* `grant` - (Optional) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+* `acl` - (Optional, **Deprecated**) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. Use the resource [`aws_s3_bucket_acl`](s3_bucket_acl.html.markdown) instead.
+* `grant` - (Optional, **Deprecated**) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`. Use the resource [`aws_s3_bucket_acl`](s3_bucket_acl.html.markdown) instead.
 * `policy` - (Optional) A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a `terraform plan`. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -1,0 +1,169 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_acl"
+description: |-
+  Provides an S3 bucket ACL resource.
+---
+
+# Resource: aws_s3_bucket_acl
+
+Provides an S3 bucket ACL resource.
+
+~> **Note:** `terraform destroy` does not delete the S3 Bucket ACL but does remove the resource from Terraform state.
+
+## Example Usage
+
+### With ACL
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "my-tf-example-bucket"
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "example_bucket_acl" {
+  bucket = aws_s3_bucket.example.id
+  acl    = "private"
+}
+```
+
+### With Grants
+
+```terraform
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "my-tf-example-bucket"
+
+  lifecycle {
+    ignore_changes = [
+      grant
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.example.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+      }
+      permission = "READ_ACP"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+```
+
+## Usage Notes
+
+~> **NOTE:** To avoid conflicts always add the following lifecycle object to the `aws_s3_bucket` resource of the source bucket.
+
+This resource implements the same features that are provided by the `acl` argument and `grant` configuration blocks of the [`aws_s3_bucket` resource](s3_bucket.html.markdown). To avoid conflicts or unexpected apply results, a lifecycle configuration is needed on the `aws_s3_bucket` to ignore changes to the internal `grant` configuration blocks.  Failure to add the `lifecycle` configuration to the `aws_s3_bucket` will result in conflicting state results.
+
+```
+lifecycle {
+  ignore_changes = [
+    grant
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `acl` - (Optional, Conflicts with `access_control_policy`) The canned ACL to apply to the bucket.
+* `access_control_policy` - (Optional, Conflicts with `acl`) A configuration block that sets the ACL permissions for an object per grantee [documented below](#access_control_policy).
+* `bucket` - (Required, Forces new resource) The name of the bucket.
+* `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
+
+### access_control_policy
+
+The `access_control_policy` configuration block supports the following arguments:
+
+* `grant` - (Required) Set of `grant` configuration blocks [documented below](#grant).
+* `owner` - (Required) Configuration block of the bucket owner's display name and ID [documented below](#owner).
+
+### grant
+
+The `grant` configuration block supports the following arguments:
+
+* `grantee` - (Required) Configuration block for the person being granted permissions [documented below](#grantee).
+* `permission` - (Required) Logging permissions assigned to the grantee for the bucket.
+
+### owner
+
+The `owner` configuration block supports the following arguments:
+
+* `id` - (Required) The ID of the owner.
+* `display_name` - (Optional) The display name of the owner.
+
+### grantee
+
+The `grantee` configuration block supports the following arguments:
+
+* `email_address` - (Optional) Email address of the grantee. See [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for supported AWS regions where this argument can be specified.
+* `id` - (Optional) The canonical user ID of the grantee.
+* `type` - (Required) Type of grantee. Valid values: `CanonicalUser`, `AmazonCustomerByEmail`, `Group`.
+* `uri` - (Optional) URI of the grantee group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The `bucket`, `expected_bucket_owner` (if configured), and `acl` (if configured) separated by commas (`,`).
+
+## Import
+
+S3 bucket ACL can be imported in one of four ways.
+
+
+If the owner (account ID) of the source bucket is the _same_ account used to configure the Terraform AWS Provider, and the source bucket is **not configured** with a
+[canned ACL][1] (i.e. predefined grant), the S3 bucket ACL resource should be imported using the `bucket` e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name
+```
+
+If the owner (account ID) of the source bucket is the _same_ account used to configure the Terraform AWS Provider, and the source bucket is **configured** with a
+[canned ACL][1] (i.e. predefined grant), the S3 bucket ACL resource should be imported using the `bucket` and `acl` separated by a comma (`,`), e.g.
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name,private
+```
+
+If the owner (account ID) of the source bucket _differs_ from the account used to configure the Terraform AWS Provider, and the source bucket is **not configured** with a
+[canned ACL][1] (i.e. predefined grant), the S3 bucket ACL resource should be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name,123456789012
+```
+
+If the owner (account ID) of the source bucket _differs_ from the account used to configure the Terraform AWS Provider, and the source bucket is **configured** with a
+[canned ACL][1] (i.e. predefined grant), the S3 bucket ACL resource should be imported using the `bucket`, `expected_bucket_owner`, and `acl` separated by commas (`,`), e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name,123456789012,private
+```
+
+[1]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23106

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAcl_disappears (21.49s)
--- PASS: TestAccS3BucketAcl_basic (31.13s)
--- PASS: TestAccS3BucketAcl_migrate_aclNoChange (54.67s)
--- PASS: TestAccS3BucketAcl_migrate_grantsNoChange (55.54s)
--- PASS: TestAccS3BucketAcl_grantToACL (55.84s)
--- PASS: TestAccS3BucketAcl_migrate_aclWithChange (56.05s)
--- PASS: TestAccS3BucketAcl_updateACL (56.81s)
--- PASS: TestAccS3BucketAcl_migrate_grantsWithChange (57.51s)
--- PASS: TestAccS3BucketAcl_ACLToGrant (57.65s)
--- PASS: TestAccS3BucketAcl_updateGrant (59.26s)

--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (43.15s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (76.68s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (77.12s)
--- PASS: TestAccS3Bucket_Basic_basic (78.10s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (120.09s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (127.18s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (169.53s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (268.14s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (109.14s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (439.68s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (279.35s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (66.77s)
--- PASS: TestAccS3Bucket_Manage_objectLock (275.19s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (204.40s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (204.55s)
--- PASS: TestAccS3Bucket_Replication_basic (745.08s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (395.35s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (240.20s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (706.45s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (400.81s)
--- PASS: TestAccS3Bucket_Basic_generatedName (108.52s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (178.90s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (51.55s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (183.97s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (101.72s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (276.82s)
--- PASS: TestAccS3Bucket_Manage_versioning (573.10s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (1159.01s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (644.07s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (420.25s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (146.58s)
--- PASS: TestAccS3Bucket_Security_updateGrant (790.15s)
--- PASS: TestAccS3Bucket_Security_updateACL (317.21s)
--- PASS: TestAccS3Bucket_Basic_acceleration (249.85s)
--- PASS: TestAccS3Bucket_Web_routingRules (228.92s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (122.59s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (193.15s)
--- PASS: TestAccS3Bucket_Web_redirect (316.45s)
--- PASS: TestAccS3Bucket_Security_grantToACL (193.62s)
--- PASS: TestAccS3Bucket_Web_simple (314.42s)
--- PASS: TestAccS3Bucket_Basic_emptyString (140.44s)
--- PASS: TestAccS3Bucket_Tags_basic (152.97s)
--- PASS: TestAccS3Bucket_Security_corsDelete (96.70s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (463.52s)
--- PASS: TestAccS3Bucket_Security_logging (197.75s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (162.16s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (525.98s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (86.48s)
--- PASS: TestAccS3Bucket_Security_policy (314.89s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (229.76s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (225.71s)
```
