### PR TITLE
r/aws_route: NAT Gateway targets support IPv6 destinations

### DIFF
--- a/.changelog/23427.txt
+++ b/.changelog/23427.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route: `nat_gateway_id` target no longer conflicts with `destination_ipv6_cidr_block`
+```

--- a/internal/service/ec2/route.go
+++ b/internal/service/ec2/route.go
@@ -115,10 +115,9 @@ func ResourceRoute() *schema.Resource {
 				ExactlyOneOf: routeValidTargets,
 			},
 			"nat_gateway_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ExactlyOneOf:  routeValidTargets,
-				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
 			},
 			"network_interface_id": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/route_test.go
+++ b/internal/service/ec2/route_test.go
@@ -3048,7 +3048,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   vpc_id                          = aws_vpc.test.id
-  cidr_block                       = "10.1.1.0/24"
+  cidr_block                      = "10.1.1.0/24"
   ipv6_cidr_block                 = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
 

--- a/internal/service/ec2/route_test.go
+++ b/internal/service/ec2/route_test.go
@@ -729,6 +729,51 @@ func TestAccEC2Route_ipv4ToNatGateway(t *testing.T) {
 	})
 }
 
+func TestAccEC2Route_ipv6ToNatGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	ngwResourceName := "aws_nat_gateway.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	destinationCidr := "::/0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteIPv6NatGatewayConfig(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccEC2Route_doesNotCrashWithVPCEndpoint(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -2986,6 +3031,55 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
   nat_gateway_id         = aws_nat_gateway.test.id
+}
+`, rName, destinationCidr)
+}
+
+func testAccRouteIPv6NatGatewayConfig(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id                          = aws_vpc.test.id
+  cidr_block                       = "10.1.1.0/24"
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
+  assign_ipv6_address_on_creation = true
+
+  enable_resource_name_dns_aaaa_record_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test" {
+  connectivity_type = "private"
+  subnet_id         = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
+  nat_gateway_id              = aws_nat_gateway.test.id
 }
 `, rName, destinationCidr)
 }

--- a/internal/service/ec2/route_test.go
+++ b/internal/service/ec2/route_test.go
@@ -734,7 +734,7 @@ func TestAccEC2Route_ipv6ToNatGateway(t *testing.T) {
 	resourceName := "aws_route.test"
 	ngwResourceName := "aws_nat_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	destinationCidr := "::/0"
+	destinationCidr := "64:ff9b::/96"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23413.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEC2Route_ipv6ToNatGateway PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Route_ipv6ToNatGateway'  -timeout 180m
=== RUN   TestAccEC2Route_ipv6ToNatGateway
=== PAUSE TestAccEC2Route_ipv6ToNatGateway
=== CONT  TestAccEC2Route_ipv6ToNatGateway
--- PASS: TestAccEC2Route_ipv6ToNatGateway (191.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	195.021s
```
