### PR TITLE
Added service client for CloudWatch RUM

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -101,7 +101,7 @@ service/cloudwatch:
 service/cloudwatchlogs:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_(log_|query_)'
 service/cloudwatchrum:
-  - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_rum_'
+  - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatchrum_'
 service/codeartifact:
   - '((\*|-) ?`?|(data|resource) "?)aws_codeartifact_'
 service/codebuild:

--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -100,6 +100,8 @@ service/cloudwatch:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_(?!(event_|log_|query_))'
 service/cloudwatchlogs:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_(log_|query_)'
+service/cloudwatchrum:
+  - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_rum_'
 service/codeartifact:
   - '((\*|-) ?`?|(data|resource) "?)aws_codeartifact_'
 service/codebuild:

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -153,6 +153,9 @@ service/cloudwatchlogs:
   - 'internal/service/cloudwatchlogs/**/*'
   - 'website/**/cloudwatch_log_*'
   - 'website/**/cloudwatch_query_definition*'
+service/cloudwatchrum:
+  - 'internal/service/cloudwatchrum/**/*'
+  - 'website/**/cloudwatch_rum_*'
 service/codeartifact:
   - 'internal/service/codeartifact/**/*'
   - 'website/**/codeartifact_*'

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -155,7 +155,7 @@ service/cloudwatchlogs:
   - 'website/**/cloudwatch_query_definition*'
 service/cloudwatchrum:
   - 'internal/service/cloudwatchrum/**/*'
-  - 'website/**/cloudwatch_rum_*'
+  - 'website/**/cloudwatchrum_*'
 service/codeartifact:
   - 'internal/service/codeartifact/**/*'
   - 'website/**/codeartifact_*'

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -44,6 +44,7 @@ variable "service_labels" {
     "cloudtrail",
     "cloudwatch",
     "cloudwatchlogs",
+    "cloudwatchrum",
     "codeartifact",
     "codebuild",
     "codecommit",

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -53,6 +53,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/cloudwatchrum"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/aws/aws-sdk-go/service/codebuild"
 	"github.com/aws/aws-sdk-go/service/codecommit"
@@ -333,6 +334,7 @@ const (
 	CloudTrail                    = "cloudtrail"
 	CloudWatch                    = "cloudwatch"
 	CloudWatchLogs                = "cloudwatchlogs"
+	CloudWatchRUM                 = "cloudwatchrum"
 	CodeArtifact                  = "codeartifact"
 	CodeBuild                     = "codebuild"
 	CodeCommit                    = "codecommit"
@@ -631,6 +633,7 @@ func init() {
 	serviceData[CloudTrail] = &ServiceDatum{AWSClientName: "CloudTrail", AWSServiceName: cloudtrail.ServiceName, AWSEndpointsID: cloudtrail.EndpointsID, AWSServiceID: cloudtrail.ServiceID, ProviderNameUpper: "CloudTrail", HCLKeys: []string{"cloudtrail"}}
 	serviceData[CloudWatch] = &ServiceDatum{AWSClientName: "CloudWatch", AWSServiceName: cloudwatch.ServiceName, AWSEndpointsID: cloudwatch.EndpointsID, AWSServiceID: cloudwatch.ServiceID, ProviderNameUpper: "CloudWatch", HCLKeys: []string{"cloudwatch"}}
 	serviceData[CloudWatchLogs] = &ServiceDatum{AWSClientName: "CloudWatchLogs", AWSServiceName: cloudwatchlogs.ServiceName, AWSEndpointsID: cloudwatchlogs.EndpointsID, AWSServiceID: cloudwatchlogs.ServiceID, ProviderNameUpper: "CloudWatchLogs", HCLKeys: []string{"cloudwatchlogs"}}
+	serviceData[CloudWatchRUM] = &ServiceDatum{AWSClientName: "CloudWatchRUM", AWSServiceName: cloudwatchrum.ServiceName, AWSEndpointsID: cloudwatchrum.EndpointsID, AWSServiceID: cloudwatchrum.ServiceID, ProviderNameUpper: "CloudWatchRUM", HCLKeys: []string{"cloudwatchrum"}}
 	serviceData[CodeArtifact] = &ServiceDatum{AWSClientName: "CodeArtifact", AWSServiceName: codeartifact.ServiceName, AWSEndpointsID: codeartifact.EndpointsID, AWSServiceID: codeartifact.ServiceID, ProviderNameUpper: "CodeArtifact", HCLKeys: []string{"codeartifact"}}
 	serviceData[CodeBuild] = &ServiceDatum{AWSClientName: "CodeBuild", AWSServiceName: codebuild.ServiceName, AWSEndpointsID: codebuild.EndpointsID, AWSServiceID: codebuild.ServiceID, ProviderNameUpper: "CodeBuild", HCLKeys: []string{"codebuild"}}
 	serviceData[CodeCommit] = &ServiceDatum{AWSClientName: "CodeCommit", AWSServiceName: codecommit.ServiceName, AWSEndpointsID: codecommit.EndpointsID, AWSServiceID: codecommit.ServiceID, ProviderNameUpper: "CodeCommit", HCLKeys: []string{"codecommit"}}
@@ -938,6 +941,7 @@ type AWSClient struct {
 	CloudTrailConn                    *cloudtrail.CloudTrail
 	CloudWatchConn                    *cloudwatch.CloudWatch
 	CloudWatchLogsConn                *cloudwatchlogs.CloudWatchLogs
+	CloudWatchRUMConn                 *cloudwatchrum.CloudWatchRUM
 	CodeArtifactConn                  *codeartifact.CodeArtifact
 	CodeBuildConn                     *codebuild.CodeBuild
 	CodeCommitConn                    *codecommit.CodeCommit
@@ -1336,6 +1340,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		CloudTrailConn:                    cloudtrail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudTrail])})),
 		CloudWatchConn:                    cloudwatch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudWatch])})),
 		CloudWatchLogsConn:                cloudwatchlogs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudWatchLogs])})),
+		CloudWatchRUMConn:                 cloudwatchrum.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudWatchRUM])})),
 		CodeArtifactConn:                  codeartifact.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeArtifact])})),
 		CodeBuildConn:                     codebuild.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeBuild])})),
 		CodeCommitConn:                    codecommit.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeCommit])})),

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -29,6 +29,7 @@ CloudHSM v2
 CloudSearch
 CloudTrail
 CloudWatch
+CloudWatch RUM
 CodeArtifact
 CodeBuild
 CodeCommit

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -110,6 +110,7 @@ provider "aws" {
   <li><code>cloudtrail</code></li>
   <li><code>cloudwatch</code></li>
   <li><code>cloudwatchlogs</code></li>
+  <li><code>cloudwatchrum</code></li>
   <li><code>codeartifact</code></li>
   <li><code>codebuild</code></li>
   <li><code>codecommit</code></li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

This PR adds a client for CloudWatch RUM as the first step towards implementing a resource for App Monitors. I figure it's in a similar situation as that of CloudWatch Logs so it doesn't need its own entry in `website/allowed-subcategories.txt` either, but let me know if I'm wrong.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22201

Output from make test:
```
make test
==> Checking that code complies with gofmt requirements...
go test ./...  -timeout=5m
?       github.com/hashicorp/terraform-provider-aws     [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/acctest    6.285s
?       github.com/hashicorp/terraform-provider-aws/internal/attrmap    [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/conns      0.786s
ok      github.com/hashicorp/terraform-provider-aws/internal/create     0.328s
ok      github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable      0.383s
?       github.com/hashicorp/terraform-provider-aws/internal/experimental/sync  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/flex       0.571s
ok      github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters 5.253s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider   0.560s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer     2.456s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account    3.657s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        10.254s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acmpca     12.264s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        3.693s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amplify    2.087s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 4.713s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       6.053s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling     2.157s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  3.143s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appmesh    2.135s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  2.062s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  2.058s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    2.061s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     2.121s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        2.033s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans   2.073s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     3.344s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      2.288s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/budgets    2.258s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      2.026s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloud9     2.200s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol       2.041s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     2.163s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 3.616s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2 2.131s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch        2.966s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail 2.077s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch 2.219s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs     3.208s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact       2.736s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  2.230s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codecommit 2.519s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codedeploy 2.472s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       3.234s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections        2.984s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications      1.982s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity    2.782s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 2.213s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      3.012s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    2.267s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cur        3.710s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange       3.961s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline       2.910s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   2.020s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dax        2.191s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/detective  3.745s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm 2.676s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      2.808s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dlm        2.132s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        2.362s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/docdb      2.116s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ds 2.400s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   2.703s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        17.308s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        2.070s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic  2.352s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        2.607s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        2.079s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        2.477s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        3.274s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk   2.240s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      2.922s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder  2.032s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elb        3.470s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      6.411s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        2.268s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     4.298s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/firehose   2.756s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fms        3.871s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1.958s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   2.031s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glacier    2.061s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  2.682s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       3.526s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/grafana    2.731s
?       github.com/hashicorp/terraform-provider-aws/internal/service/greengrass [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  2.391s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        5.737s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/identitystore      1.981s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       4.757s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector  2.169s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        3.245s
?       github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics       [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/service/iotevents  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      5.066s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect       5.897s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesis    2.129s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics   2.153s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2 2.504s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo       3.125s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        4.386s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      2.321s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     2.322s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels  2.177s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager     4.244s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  2.402s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie      2.099s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie2     2.470s
?       github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect       [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert       2.491s
?       github.com/hashicorp/terraform-provider-aws/internal/service/medialive  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage       2.296s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediastore 2.316s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   2.217s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       3.251s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 2.283s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mwaa       3.055s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    1.958s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    1.962s
?       github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opsworks   2.109s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/organizations      3.622s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts   1.994s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint   2.404s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pricing    2.825s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/qldb       2.078s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 1.959s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ram        2.175s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        3.483s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   2.853s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups     2.163s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi   2.123s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    2.315s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53domains     2.160s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig       1.953s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness   2.047s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    2.120s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 4.405s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3control  2.536s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts 2.197s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  2.021s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/schemas    1.977s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     2.359s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/securityhub        2.420s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo     2.549s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     2.178s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery   2.040s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      2.110s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        2.303s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sfn        2.229s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/shield     2.409s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/signer     2.099s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/simpledb   1.998s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        2.077s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sqs        2.065s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        2.227s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   1.987s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway     2.338s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        2.014s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/swf        3.548s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/synthetics 2.393s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite    2.099s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/transfer   2.064s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/waf        2.721s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafregional        2.325s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      3.119s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/worklink   4.498s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/workspaces 5.197s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/xray       4.248s
ok      github.com/hashicorp/terraform-provider-aws/internal/tags       0.559s
ok      github.com/hashicorp/terraform-provider-aws/internal/tfresource 32.445s
ok      github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys       1.443s
ok      github.com/hashicorp/terraform-provider-aws/internal/vault/sdk/helper/jsonutil  0.282s
ok      github.com/hashicorp/terraform-provider-aws/internal/verify     3.773s
?       github.com/hashicorp/terraform-provider-aws/version     [no test files]
```

Output from acceptance testing:

N/A
