### PR TITLE
r/s3_bucket_website_configuration: backport resource

### DIFF
--- a/.changelog/23435.txt
+++ b/.changelog/23435.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_s3_bucket_website_configuration
+```
+
+```release-note:note
+resource/aws_s3_bucket: The `website`, `website_domain`, and `website_endpoint` arguments have been deprecated. Use the `aws_s3_bucket_website_configuration` resource instead.
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1596,6 +1596,7 @@ func Provider() *schema.Provider {
 			"aws_s3_bucket_policy":                            s3.ResourceBucketPolicy(),
 			"aws_s3_bucket_public_access_block":               s3.ResourceBucketPublicAccessBlock(),
 			"aws_s3_bucket_replication_configuration":         s3.ResourceBucketReplicationConfiguration(),
+			"aws_s3_bucket_website_configuration":             s3.ResourceBucketWebsiteConfiguration(),
 			"aws_s3_object_copy":                              s3.ResourceObjectCopy(),
 
 			"aws_s3_access_point":                             s3control.ResourceAccessPoint(),

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -162,19 +162,22 @@ func ResourceBucket() *schema.Resource {
 			},
 
 			"website": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:       schema.TypeList,
+				Optional:   true,
+				MaxItems:   1,
+				Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"index_document": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
 						},
 
 						"error_document": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
 						},
 
 						"redirect_all_requests_to": {
@@ -184,12 +187,14 @@ func ResourceBucket() *schema.Resource {
 								"website.0.error_document",
 								"website.0.routing_rules",
 							},
-							Optional: true,
+							Optional:   true,
+							Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
 						},
 
 						"routing_rules": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Deprecated:   "Use the aws_s3_bucket_website_configuration resource instead",
 							ValidateFunc: validation.StringIsJSON,
 							StateFunc: func(v interface{}) string {
 								json, _ := structure.NormalizeJsonString(v)
@@ -211,14 +216,16 @@ func ResourceBucket() *schema.Resource {
 				Computed: true,
 			},
 			"website_endpoint": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
 			},
 			"website_domain": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
 			},
 
 			"versioning": {

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -171,15 +171,13 @@ func ResourceBucket() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"index_document": {
-							Type:       schema.TypeString,
-							Optional:   true,
-							Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"error_document": {
-							Type:       schema.TypeString,
-							Optional:   true,
-							Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"redirect_all_requests_to": {
@@ -189,14 +187,12 @@ func ResourceBucket() *schema.Resource {
 								"website.0.error_document",
 								"website.0.routing_rules",
 							},
-							Optional:   true,
-							Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
+							Optional: true,
 						},
 
 						"routing_rules": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Deprecated:   "Use the aws_s3_bucket_website_configuration resource instead",
 							ValidateFunc: validation.StringIsJSON,
 							StateFunc: func(v interface{}) string {
 								json, _ := structure.NormalizeJsonString(v)

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -1,0 +1,626 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceBucketWebsiteConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBucketWebsiteConfigurationCreate,
+		ReadContext:   resourceBucketWebsiteConfigurationRead,
+		UpdateContext: resourceBucketWebsiteConfigurationUpdate,
+		DeleteContext: resourceBucketWebsiteConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 63),
+			},
+			"error_document": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"expected_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"index_document": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"suffix": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"redirect_all_requests_to": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ConflictsWith: []string{
+					"error_document",
+					"index_document",
+					"routing_rule",
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"protocol": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(s3.Protocol_Values(), false),
+						},
+					},
+				},
+			},
+			"routing_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"http_error_code_returned_equals": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"key_prefix_equals": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"redirect": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"http_redirect_code": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"protocol": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(s3.Protocol_Values(), false),
+									},
+									"replace_key_prefix_with": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"replace_key_with": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"website_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"website_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket := d.Get("bucket").(string)
+	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
+
+	websiteConfig := &s3.WebsiteConfiguration{}
+
+	if v, ok := d.GetOk("error_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.ErrorDocument = expandS3BucketWebsiteConfigurationErrorDocument(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("index_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.IndexDocument = expandS3BucketWebsiteConfigurationIndexDocument(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("redirect_all_requests_to"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.RedirectAllRequestsTo = expandS3BucketWebsiteConfigurationRedirectAllRequestsTo(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.RoutingRules = expandS3BucketWebsiteConfigurationRoutingRules(v.([]interface{}))
+	}
+
+	input := &s3.PutBucketWebsiteInput{
+		Bucket:               aws.String(bucket),
+		WebsiteConfiguration: websiteConfig,
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.PutBucketWebsiteWithContext(ctx, input)
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating S3 bucket (%s) website configuration: %w", bucket, err))
+	}
+
+	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
+
+	return resourceBucketWebsiteConfigurationRead(ctx, d, meta)
+}
+
+func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.GetBucketWebsiteInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	output, err := conn.GetBucketWebsiteWithContext(ctx, input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, ErrCodeNoSuchWebsiteConfiguration) {
+		log.Printf("[WARN] S3 Bucket Website Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if output == nil {
+		if d.IsNewResource() {
+			return diag.FromErr(fmt.Errorf("error reading S3 bucket website configuration (%s): empty output", d.Id()))
+		}
+		log.Printf("[WARN] S3 Bucket Website Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("bucket", bucket)
+	d.Set("expected_bucket_owner", expectedBucketOwner)
+
+	if err := d.Set("error_document", flattenS3BucketWebsiteConfigurationErrorDocument(output.ErrorDocument)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting error_document: %w", err))
+	}
+
+	if err := d.Set("index_document", flattenS3BucketWebsiteConfigurationIndexDocument(output.IndexDocument)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting index_document: %w", err))
+	}
+
+	if err := d.Set("redirect_all_requests_to", flattenS3BucketWebsiteConfigurationRedirectAllRequestsTo(output.RedirectAllRequestsTo)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting redirect_all_requests_to: %w", err))
+	}
+
+	if err := d.Set("routing_rule", flattenS3BucketWebsiteConfigurationRoutingRules(output.RoutingRules)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting routing_rule: %w", err))
+	}
+
+	// Add website_endpoint and website_domain as attributes
+	websiteEndpoint, err := resourceBucketWebsiteConfigurationWebsiteEndpoint(ctx, meta.(*conns.AWSClient), bucket, expectedBucketOwner)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if websiteEndpoint != nil {
+		d.Set("website_endpoint", websiteEndpoint.Endpoint)
+		d.Set("website_domain", websiteEndpoint.Domain)
+	}
+
+	return nil
+}
+
+func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	websiteConfig := &s3.WebsiteConfiguration{}
+
+	if v, ok := d.GetOk("error_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.ErrorDocument = expandS3BucketWebsiteConfigurationErrorDocument(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("index_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.IndexDocument = expandS3BucketWebsiteConfigurationIndexDocument(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("redirect_all_requests_to"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.RedirectAllRequestsTo = expandS3BucketWebsiteConfigurationRedirectAllRequestsTo(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		websiteConfig.RoutingRules = expandS3BucketWebsiteConfigurationRoutingRules(v.([]interface{}))
+	}
+
+	input := &s3.PutBucketWebsiteInput{
+		Bucket:               aws.String(bucket),
+		WebsiteConfiguration: websiteConfig,
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	_, err = conn.PutBucketWebsiteWithContext(ctx, input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating S3 bucket website configuration (%s): %w", d.Id(), err))
+	}
+
+	return resourceBucketWebsiteConfigurationRead(ctx, d, meta)
+}
+
+func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.DeleteBucketWebsiteInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	_, err = conn.DeleteBucketWebsiteWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, ErrCodeNoSuchWebsiteConfiguration) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting S3 bucket website configuration (%s): %w", d.Id(), err))
+	}
+
+	return nil
+}
+
+func resourceBucketWebsiteConfigurationWebsiteEndpoint(ctx context.Context, client *conns.AWSClient, bucket, expectedBucketOwner string) (*S3Website, error) {
+	conn := client.S3Conn
+
+	input := &s3.GetBucketLocationInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	output, err := conn.GetBucketLocationWithContext(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("error getting S3 Bucket (%s) Location: %w", bucket, err)
+	}
+
+	var region string
+	if output.LocationConstraint != nil {
+		region = aws.StringValue(output.LocationConstraint)
+	}
+
+	return WebsiteEndpoint(client, bucket, region), nil
+}
+
+func expandS3BucketWebsiteConfigurationErrorDocument(l []interface{}) *s3.ErrorDocument {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.ErrorDocument{}
+
+	if v, ok := tfMap["key"].(string); ok && v != "" {
+		result.Key = aws.String(v)
+	}
+
+	return result
+}
+
+func expandS3BucketWebsiteConfigurationIndexDocument(l []interface{}) *s3.IndexDocument {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.IndexDocument{}
+
+	if v, ok := tfMap["suffix"].(string); ok && v != "" {
+		result.Suffix = aws.String(v)
+	}
+
+	return result
+}
+
+func expandS3BucketWebsiteConfigurationRedirectAllRequestsTo(l []interface{}) *s3.RedirectAllRequestsTo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.RedirectAllRequestsTo{}
+
+	if v, ok := tfMap["host_name"].(string); ok && v != "" {
+		result.HostName = aws.String(v)
+	}
+
+	if v, ok := tfMap["protocol"].(string); ok && v != "" {
+		result.Protocol = aws.String(v)
+	}
+
+	return result
+}
+
+func expandS3BucketWebsiteConfigurationRoutingRules(l []interface{}) []*s3.RoutingRule {
+	var results []*s3.RoutingRule
+
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rule := &s3.RoutingRule{}
+
+		if v, ok := tfMap["condition"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			rule.Condition = expandS3BucketWebsiteConfigurationRoutingRuleCondition(v)
+		}
+
+		if v, ok := tfMap["redirect"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			rule.Redirect = expandS3BucketWebsiteConfigurationRoutingRuleRedirect(v)
+		}
+
+		results = append(results, rule)
+	}
+
+	return results
+}
+
+func expandS3BucketWebsiteConfigurationRoutingRuleCondition(l []interface{}) *s3.Condition {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.Condition{}
+
+	if v, ok := tfMap["http_error_code_returned_equals"].(string); ok && v != "" {
+		result.HttpErrorCodeReturnedEquals = aws.String(v)
+	}
+
+	if v, ok := tfMap["key_prefix_equals"].(string); ok && v != "" {
+		result.KeyPrefixEquals = aws.String(v)
+	}
+
+	return result
+}
+
+func expandS3BucketWebsiteConfigurationRoutingRuleRedirect(l []interface{}) *s3.Redirect {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.Redirect{}
+
+	if v, ok := tfMap["host_name"].(string); ok && v != "" {
+		result.HostName = aws.String(v)
+	}
+
+	if v, ok := tfMap["http_redirect_code"].(string); ok && v != "" {
+		result.HttpRedirectCode = aws.String(v)
+	}
+
+	if v, ok := tfMap["protocol"].(string); ok && v != "" {
+		result.Protocol = aws.String(v)
+	}
+
+	if v, ok := tfMap["replace_key_prefix_with"].(string); ok && v != "" {
+		result.ReplaceKeyPrefixWith = aws.String(v)
+	}
+
+	if v, ok := tfMap["replace_key_with"].(string); ok && v != "" {
+		result.ReplaceKeyWith = aws.String(v)
+	}
+
+	return result
+}
+
+func flattenS3BucketWebsiteConfigurationIndexDocument(i *s3.IndexDocument) []interface{} {
+	if i == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if i.Suffix != nil {
+		m["suffix"] = aws.StringValue(i.Suffix)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenS3BucketWebsiteConfigurationErrorDocument(e *s3.ErrorDocument) []interface{} {
+	if e == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if e.Key != nil {
+		m["key"] = aws.StringValue(e.Key)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenS3BucketWebsiteConfigurationRedirectAllRequestsTo(r *s3.RedirectAllRequestsTo) []interface{} {
+	if r == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if r.HostName != nil {
+		m["host_name"] = aws.StringValue(r.HostName)
+	}
+
+	if r.Protocol != nil {
+		m["protocol"] = aws.StringValue(r.Protocol)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenS3BucketWebsiteConfigurationRoutingRules(rules []*s3.RoutingRule) []interface{} {
+	var results []interface{}
+
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if rule.Condition != nil {
+			m["condition"] = flattenS3BucketWebsiteConfigurationRoutingRuleCondition(rule.Condition)
+		}
+
+		if rule.Redirect != nil {
+			m["redirect"] = flattenS3BucketWebsiteConfigurationRoutingRuleRedirect(rule.Redirect)
+		}
+
+		results = append(results, m)
+	}
+
+	return results
+}
+
+func flattenS3BucketWebsiteConfigurationRoutingRuleCondition(c *s3.Condition) []interface{} {
+	if c == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if c.KeyPrefixEquals != nil {
+		m["key_prefix_equals"] = aws.StringValue(c.KeyPrefixEquals)
+	}
+
+	if c.HttpErrorCodeReturnedEquals != nil {
+		m["http_error_code_returned_equals"] = aws.StringValue(c.HttpErrorCodeReturnedEquals)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenS3BucketWebsiteConfigurationRoutingRuleRedirect(r *s3.Redirect) []interface{} {
+	if r == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if r.HostName != nil {
+		m["host_name"] = aws.StringValue(r.HostName)
+	}
+
+	if r.HttpRedirectCode != nil {
+		m["http_redirect_code"] = aws.StringValue(r.HttpRedirectCode)
+	}
+
+	if r.Protocol != nil {
+		m["protocol"] = aws.StringValue(r.Protocol)
+	}
+
+	if r.ReplaceKeyWith != nil {
+		m["replace_key_with"] = aws.StringValue(r.ReplaceKeyWith)
+	}
+
+	if r.ReplaceKeyPrefixWith != nil {
+		m["replace_key_prefix_with"] = aws.StringValue(r.ReplaceKeyPrefixWith)
+	}
+
+	return []interface{}{m}
+}

--- a/internal/service/s3/bucket_website_configuration_test.go
+++ b/internal/service/s3/bucket_website_configuration_test.go
@@ -1,0 +1,651 @@
+package s3_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestAccS3BucketWebsiteConfiguration_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "index_document.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "index_document.0.suffix", "index.html"),
+					resource.TestCheckResourceAttrSet(resourceName, "website_domain"),
+					resource.TestCheckResourceAttrSet(resourceName, "website_endpoint"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucketWebsiteConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_update(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+				),
+			},
+			{
+				Config: testAccBucketWebsiteConfigurationUpdateConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "index_document.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "index_document.0.suffix", "index.html"),
+					resource.TestCheckResourceAttr(resourceName, "error_document.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "error_document.0.key", "error.html"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_Redirect(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_Redirect(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_all_requests_to.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_all_requests_to.0.host_name", "example.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_OptionalRedirection(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "routing_rule.*", map[string]string{
+						"condition.#":                        "1",
+						"condition.0.key_prefix_equals":      "docs/",
+						"redirect.#":                         "1",
+						"redirect.0.replace_key_prefix_with": "documents/",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectErrors(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "routing_rule.*", map[string]string{
+						"condition.#": "1",
+						"condition.0.http_error_code_returned_equals": "404",
+						"redirect.#":                         "1",
+						"redirect.0.replace_key_prefix_with": "report-404",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectToPage(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "routing_rule.*", map[string]string{
+						"condition.#":                   "1",
+						"condition.0.key_prefix_equals": "images/",
+						"redirect.#":                    "1",
+						"redirect.0.replace_key_with":   "errorpage.html",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_MultipleRules(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "routing_rule.*", map[string]string{
+						"condition.#":                   "1",
+						"condition.0.key_prefix_equals": "docs/",
+						"redirect.#":                    "1",
+						"redirect.0.replace_key_with":   "errorpage.html",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "routing_rule.*", map[string]string{
+						"condition.#":                   "1",
+						"condition.0.key_prefix_equals": "images/",
+						"redirect.#":                    "1",
+						"redirect.0.replace_key_with":   "errorpage.html",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketWebsiteConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRules_RedirectOnly(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectOnly(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "routing_rule.*", map[string]string{
+						"redirect.#":                  "1",
+						"redirect.0.protocol":         s3.ProtocolHttps,
+						"redirect.0.replace_key_with": "errorpage.html",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckBucketWebsiteConfigurationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_bucket_website_configuration" {
+			continue
+		}
+
+		bucket, expectedBucketOwner, err := tfs3.ParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketWebsiteInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketWebsite(input)
+
+		if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, tfs3.ErrCodeNoSuchWebsiteConfiguration) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting S3 bucket website configuration (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("S3 bucket website configuration (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBucketWebsiteConfigurationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+		bucket, expectedBucketOwner, err := tfs3.ParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketWebsiteInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketWebsite(input)
+
+		if err != nil {
+			return fmt.Errorf("error getting S3 bucket website configuration (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("S3 Bucket website configuration (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccBucketWebsiteConfigurationBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+  index_document {
+    suffix = "index.html"
+  }
+}
+`, rName)
+}
+
+func testAccBucketWebsiteConfigurationUpdateConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+`, rName)
+}
+
+func testAccBucketWebsiteConfigurationConfig_Redirect(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+  redirect_all_requests_to {
+    host_name = "example.com"
+  }
+}
+`, rName)
+}
+
+func testAccBucketWebsiteConfigurationConfig_RoutingRules_OptionalRedirection(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rule {
+    condition {
+      key_prefix_equals = "docs/"
+    }
+    redirect {
+      replace_key_prefix_with = "documents/"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectErrors(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
+		fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rule {
+    condition {
+      http_error_code_returned_equals = "404"
+    }
+    redirect {
+      replace_key_prefix_with = "report-404"
+    }
+  }
+}
+`, rName))
+}
+
+func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectToPage(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rule {
+    condition {
+      key_prefix_equals = "images/"
+    }
+    redirect {
+      replace_key_with = "errorpage.html"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rule {
+    redirect {
+      protocol         = "https"
+      replace_key_with = "errorpage.html"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccBucketWebsiteConfigurationConfig_RoutingRules_MultipleRules(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rule {
+    condition {
+      key_prefix_equals = "images/"
+    }
+    redirect {
+      replace_key_with = "errorpage.html"
+    }
+  }
+
+  routing_rule {
+    condition {
+      key_prefix_equals = "docs/"
+    }
+    redirect {
+      replace_key_with = "errorpage.html"
+    }
+  }
+}
+`, rName)
+}

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -6,5 +6,6 @@ package s3
 const (
 	ErrCodeNoSuchConfiguration                  = "NoSuchConfiguration"
 	ErrCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
+	ErrCodeNoSuchWebsiteConfiguration           = "NoSuchWebsiteConfiguration"
 	ErrCodeOperationAborted                     = "OperationAborted"
 )

--- a/internal/service/s3/id.go
+++ b/internal/service/s3/id.go
@@ -1,0 +1,41 @@
+package s3
+
+import (
+	"fmt"
+	"strings"
+)
+
+const resourceIDSeparator = ","
+
+// CreateResourceID is a generic method for creating an ID string for a bucket-related resource e.g. aws_s3_bucket_versioning.
+// The method expects a bucket name and an optional accountID.
+func CreateResourceID(bucket, expectedBucketOwner string) string {
+	if expectedBucketOwner == "" {
+		return bucket
+	}
+
+	parts := []string{bucket, expectedBucketOwner}
+	id := strings.Join(parts, resourceIDSeparator)
+
+	return id
+}
+
+// ParseResourceID is a generic method for parsing an ID string
+// for a bucket name and accountID if provided.
+func ParseResourceID(id string) (bucket, expectedBucketOwner string, err error) {
+	parts := strings.Split(id, resourceIDSeparator)
+
+	if len(parts) == 1 && parts[0] != "" {
+		bucket = parts[0]
+		return
+	}
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		bucket = parts[0]
+		expectedBucketOwner = parts[1]
+		return
+	}
+
+	err = fmt.Errorf("unexpected format for ID (%s), expected BUCKET or BUCKET%sEXPECTED_BUCKET_OWNER", id, resourceIDSeparator)
+	return
+}

--- a/internal/service/s3/id_test.go
+++ b/internal/service/s3/id_test.go
@@ -1,0 +1,62 @@
+package s3_test
+
+import (
+	"testing"
+
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestParseResourceID(t *testing.T) {
+	testCases := []struct {
+		TestName            string
+		InputID             string
+		ExpectError         bool
+		ExpectedBucket      string
+		ExpectedBucketOwner string
+	}{
+		{
+			TestName:    "empty ID",
+			InputID:     "",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect format",
+			InputID:     "test,example,123456789012",
+			ExpectError: true,
+		},
+		{
+			TestName:            "valid ID with bucket",
+			InputID:             tfs3.CreateResourceID("example", ""),
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and bucket owner",
+			InputID:             tfs3.CreateResourceID("example", "123456789012"),
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotBucket, gotExpectedBucketOwner, err := tfs3.ParseResourceID(testCase.InputID)
+
+			if err == nil && testCase.ExpectError {
+				t.Fatalf("expected error")
+			}
+
+			if err != nil && !testCase.ExpectError {
+				t.Fatalf("unexpected error")
+			}
+
+			if gotBucket != testCase.ExpectedBucket {
+				t.Errorf("got bucket %s, expected %s", gotBucket, testCase.ExpectedBucket)
+			}
+
+			if gotExpectedBucketOwner != testCase.ExpectedBucketOwner {
+				t.Errorf("got ExpectedBucketOwner %s, expected %s", gotExpectedBucketOwner, testCase.ExpectedBucketOwner)
+			}
+		})
+	}
+}

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -12,6 +12,10 @@ Provides a S3 bucket resource.
 
 -> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the [`aws_s3control_bucket`](/docs/providers/aws/r/s3control_bucket.html) resource.
 
+~> **NOTE on S3 Bucket Website Configuration:** S3 Bucket Website can be configured in either the standalone resource [`aws_s3_bucket_website_configuration`](s3_bucket_website_configuration.html.markdown)
+or with the deprecated parameter `website` in the resource `aws_s3_bucket`.
+Configuring with both will cause inconsistencies and may overwrite configuration.
+
 ## Example Usage
 
 ### Private Bucket w/ Tags
@@ -29,6 +33,9 @@ resource "aws_s3_bucket" "b" {
 ```
 
 ### Static Website Hosting
+
+-> **NOTE:** The parameter `website` is deprecated.
+Use the resource [`aws_s3_bucket_website_configuration`](s3_bucket_website_configuration.html.markdown) instead.
 
 ```terraform
 resource "aws_s3_bucket" "b" {
@@ -359,7 +366,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
-* `website` - (Optional) A website object (documented below).
+* `website` - (Optional, **Deprecated**) A website object (documented below). Use the resource [`aws_s3_bucket_website_configuration`](s3_bucket_website_configuration.html.markdown) instead.
 * `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 * `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -1,0 +1,142 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_website_configuration"
+description: |-
+  Provides an S3 bucket website configuration resource.
+---
+
+# Resource: aws_s3_bucket_website_configuration
+
+Provides an S3 bucket website configuration resource. For more information, see [Hosting Websites on S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html).
+
+## Example Usage
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "myexamplebucket"
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "example" {
+  bucket = aws_s3_bucket.example.bucket
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rule {
+    condition {
+      key_prefix_equals = "docs/"
+    }
+    redirect {
+      replace_key_prefix_with = "documents/"
+    }
+  }
+}
+```
+
+## Usage Notes
+
+~> **NOTE:** To avoid conflicts always add the following lifecycle object to the `aws_s3_bucket` resource of the source bucket.
+
+This resource implements the same features that are provided by the `website` object of the [`aws_s3_bucket` resource](s3_bucket.html.markdown). To avoid conflicts or unexpected apply results, a lifecycle configuration is needed on the `aws_s3_bucket` to ignore changes to the internal `website` object.  Failure to add the `lifecycle` configuration to the `aws_s3_bucket` will result in conflicting state results.
+
+```
+lifecycle {
+  ignore_changes = [
+    website
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required, Forces new resource) The name of the bucket.
+* `error_document` - (Optional, Conflicts with `redirect_all_requests_to`) The name of the error document for the website [detailed below](#error_document).
+* `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
+* `index_document` - (Optional, Required if `redirect_all_requests_to` is not specified) The name of the index document for the website [detailed below](#index_document).
+* `redirect_all_requests_to` - (Optional, Required if `index_document` is not specified) The redirect behavior for every request to this bucket's website endpoint [detailed below](#redirect_all_requests_to). Conflicts with `error_document`, `index_document`, and `routing_rule`.
+* `routing_rule` - (Optional, Conflicts with `redirect_all_requests_to`) List of rules that define when a redirect is applied and the redirect behavior [detailed below](#routing_rule).
+
+### error_document
+
+The `error_document` configuration block supports the following arguments:
+
+* `key` - (Required) The object key name to use when a 4XX class error occurs.
+
+### index_document
+
+The `index_document` configuration block supports the following arguments:
+
+* `suffix` - (Required) A suffix that is appended to a request that is for a directory on the website endpoint.
+For example, if the suffix is `index.html` and you make a request to `samplebucket/images/`, the data that is returned will be for the object with the key name `images/index.html`.
+The suffix must not be empty and must not include a slash character.
+
+### redirect_all_requests_to
+
+The `redirect_all_requests_to` configuration block supports the following arguments:
+
+* `host_name` - (Required) Name of the host where requests are redirected.
+* `protocol` - (Optional) Protocol to use when redirecting requests. The default is the protocol that is used in the original request. Valid values: `http`, `https`.
+
+### routing_rule
+
+The `routing_rule` configuration block supports the following arguments:
+
+* `condition` - (Optional) A configuration block for describing a condition that must be met for the specified redirect to apply [detailed below](#condition).
+* `redirect` - (Required) A configuration block for redirect information [detailed below](#redirect).
+
+### condition
+
+The `condition` configuration block supports the following arguments:
+
+* `http_error_code_returned_equals` - (Optional, Required if `key_prefix_equals` is not specified) The HTTP error code when the redirect is applied. If specified with `key_prefix_equals`, then both must be true for the redirect to be applied.
+* `key_prefix_equals` - (Optional, Required if `http_error_code_returned_equals` is not specified) The object key name prefix when the redirect is applied. If specified with `http_error_code_returned_equals`, then both must be true for the redirect to be applied.
+
+### redirect
+
+The `redirect` configuration block supports the following arguments:
+
+* `host_name` - (Optional) The host name to use in the redirect request.
+* `http_redirect_code` - (Optional) The HTTP redirect code to use on the response.
+* `protocol` - (Optional) Protocol to use when redirecting requests. The default is the protocol that is used in the original request. Valid values: `http`, `https`.
+* `replace_key_prefix_with` - (Optional, Conflicts with `replace_key_with`) The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix `docs/` (objects in the `docs/` folder) to `documents/`, you can set a `condition` block with `key_prefix_equals` set to `docs/` and in the `redirect` set `replace_key_prefix_with` to `/documents`.
+* `replace_key_with` - (Optional, Conflicts with `replace_key_prefix_with`) The specific object key to use in the redirect request. For example, redirect request to `error.html`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The `bucket` or `bucket` and `expected_bucket_owner` separated by a comma (`,`) if the latter is provided.
+* `website_domain` - The domain of the website endpoint. This is used to create Route 53 alias records.
+* `website_endpoint` - The website endpoint.
+
+## Import
+
+S3 bucket website configuration can be imported in one of two ways.
+
+If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider,
+the S3 bucket website configuration resource should be imported using the `bucket` e.g.,
+
+```
+$ terraform import aws_s3_bucket_website_configuration.example bucket-name
+```
+
+If the owner (account ID) of the source bucket differs from the account used to configure the Terraform AWS Provider,
+the S3 bucket website configuration resource should be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_website_configuration.example bucket-name,123456789012
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23106

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketWebsiteConfiguration_disappears (27.63s)
--- PASS: TestAccS3BucketWebsiteConfiguration_Redirect (31.78s)
--- PASS: TestAccS3BucketWebsiteConfiguration_basic (32.32s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_RedirectOnly (32.55s)
--- PASS: TestAccS3BucketWebsiteConfiguration_update (54.72s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules (62.65s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect (89.95s)

--- PASS: TestAccS3Bucket_Basic_forceDestroy (29.18s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (31.90s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (32.91s)
--- PASS: TestAccS3Bucket_Basic_basic (33.20s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (45.97s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (44.85s)
--- PASS: TestAccS3Bucket_Manage_objectLock (56.40s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (14.13s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (39.66s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (221.22s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (274.76s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (338.71s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (250.64s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (249.14s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (347.20s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (295.95s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (693.42s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (109.28s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (130.68s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (227.40s)
--- PASS: TestAccS3Bucket_Security_logging (179.54s)
--- PASS: TestAccS3Bucket_Security_corsDelete (97.73s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (321.74s)
--- PASS: TestAccS3Bucket_Replication_basic (648.50s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (101.02s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (178.04s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (99.96s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (213.52s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (64.76s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (152.28s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (141.48s)
--- PASS: TestAccS3Bucket_Manage_versioning (244.74s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (148.93s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (231.07s)
--- PASS: TestAccS3Bucket_Web_routingRules (205.08s)
--- PASS: TestAccS3Bucket_Security_grantToACL (203.98s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (273.57s)
--- PASS: TestAccS3Bucket_Web_redirect (447.32s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (272.74s)
--- PASS: TestAccS3Bucket_Web_simple (462.93s)
--- PASS: TestAccS3Bucket_Tags_basic (260.28s)
--- PASS: TestAccS3Bucket_Basic_generatedName (176.33s)
--- PASS: TestAccS3Bucket_Security_updateACL (188.25s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (203.11s)
--- PASS: TestAccS3Bucket_Basic_acceleration (203.20s)
--- PASS: TestAccS3Bucket_Security_policy (298.19s)
--- PASS: TestAccS3Bucket_Security_updateGrant (298.14s)
--- PASS: TestAccS3Bucket_Basic_emptyString (98.75s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (254.37s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (296.36s)
```
