### PR TITLE
r/s3_bucket_lifecycle_configuration: make `new_noncurrent_versions` arguments nullable ints to prevent drift and fix other nullable int args (`filter.object_size_greater_than` and `filter.object_size_less_than`)

### DIFF
--- a/.changelog/23441.txt
+++ b/.changelog/23441.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Correctly configure `rule.filter.object_size_greater_than` and `rule.filter.object_size_less_than` in API requests and terraform state
+```
+
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Prevent drift when `rule.noncurrent_version_expiration.newer_noncurrent_versions` or `rule.noncurrent_version_transition.newer_noncurrent_versions` is not specified
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -164,9 +164,9 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"newer_noncurrent_versions": {
-										Type:         schema.TypeInt,
+										Type:         nullable.TypeNullableInt,
 										Optional:     true,
-										ValidateFunc: validation.IntAtLeast(1),
+										ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(1),
 									},
 									"noncurrent_days": {
 										Type:         schema.TypeInt,
@@ -182,9 +182,9 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"newer_noncurrent_versions": {
-										Type:         schema.TypeInt,
+										Type:         nullable.TypeNullableInt,
 										Optional:     true,
-										ValidateFunc: validation.IntAtLeast(1),
+										ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(1),
 									},
 									"noncurrent_days": {
 										Type:         schema.TypeInt,

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -128,6 +128,151 @@ func TestAccS3BucketLifecycleConfiguration_filterWithPrefix(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_filterWithObjectSizeGreaterThanConfig(rName, date, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":                      "1",
+						"expiration.0.date":                 date,
+						"filter.#":                          "1",
+						"filter.0.object_size_greater_than": "100",
+						"id":                                rName,
+						"status":                            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_filterWithObjectSizeLessThanConfig(rName, date, 500),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":                   "1",
+						"expiration.0.date":              date,
+						"filter.#":                       "1",
+						"filter.0.object_size_less_than": "500",
+						"id":                             rName,
+						"status":                         tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_filterWithObjectSizeRangeConfig(rName, date, 500, 64000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":      "1",
+						"expiration.0.date": date,
+						"filter.#":          "1",
+						"filter.0.and.#":    "1",
+						"filter.0.and.0.object_size_greater_than": "500",
+						"filter.0.and.0.object_size_less_than":    "64000",
+						"id":                                      rName,
+						"status":                                  tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_filterWithObjectSizeRangeAndPrefixConfig(rName, date, 500, 64000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":      "1",
+						"expiration.0.date": date,
+						"filter.#":          "1",
+						"filter.0.and.#":    "1",
+						"filter.0.and.0.object_size_greater_than": "500",
+						"filter.0.and.0.object_size_less_than":    "64000",
+						"filter.0.and.0.prefix":                   rName,
+						"id":                                      rName,
+						"status":                                  tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketLifecycleConfiguration_disableRule(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
@@ -1240,4 +1385,135 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
   }
 }
 `, rName)
+}
+
+func testAccBucketLifecycleConfiguration_filterWithObjectSizeGreaterThanConfig(rName, date string, sizeGreaterThan int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = %[1]q
+
+    expiration {
+      date = %[2]q
+    }
+
+    filter {
+      object_size_greater_than = %[3]d
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName, date, sizeGreaterThan)
+}
+
+func testAccBucketLifecycleConfiguration_filterWithObjectSizeLessThanConfig(rName, date string, sizeLessThan int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = %[1]q
+
+    expiration {
+      date = %[2]q
+    }
+
+    filter {
+      object_size_less_than = %[3]d
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName, date, sizeLessThan)
+}
+
+func testAccBucketLifecycleConfiguration_filterWithObjectSizeRangeConfig(rName, date string, sizeGreaterThan, sizeLessThan int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = %[1]q
+
+    expiration {
+      date = %[2]q
+    }
+
+    filter {
+      and {
+        object_size_greater_than = %[3]d
+        object_size_less_than    = %[4]d
+      }
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName, date, sizeGreaterThan, sizeLessThan)
+}
+
+func testAccBucketLifecycleConfiguration_filterWithObjectSizeRangeAndPrefixConfig(rName, date string, sizeGreaterThan, sizeLessThan int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = %[1]q
+
+    expiration {
+      date = %[2]q
+    }
+
+    filter {
+      and {
+        object_size_greater_than = %[3]d
+        object_size_less_than    = %[4]d
+        prefix                   = %[1]q
+      }
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName, date, sizeGreaterThan, sizeLessThan)
 }

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -365,13 +365,13 @@ The `abort_incomplete_multipart_upload` configuration block supports the followi
 
 The `expiration` configuration block supports the following arguments:
 
-* `date` - (Optional) The date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.
+* `date` - (Optional) The date the object is to be moved or deleted. Should be in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
 * `days` - (Optional) The lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer.
 * `expired_object_delete_marker` - (Optional, Conflicts with `date` and `days`) Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to `true`, the delete marker will be expired; if set to `false` the policy takes no action.
 
 ### filter
 
-~> **NOTE:** The `filter` configuration block must have exactly one of `prefix`, `tag`, or `and` specified.
+~> **NOTE:** The `filter` configuration block must have exactly one of `prefix`, `tag`, `and`, `object_size_greater_than` or `object_size_less_than` specified.
 
 The `filter` configuration block supports the following arguments:
 
@@ -392,7 +392,7 @@ The `noncurrent_version_expiration` configuration block supports the following a
 
 The `noncurrent_version_transition` configuration block supports the following arguments:
 
-* `newer_noncurrent_versions` - (Optional) The number of noncurrent versions Amazon S3 will retain.
+* `newer_noncurrent_versions` - (Optional) The number of noncurrent versions Amazon S3 will retain. Must be a non-zero positive integer.
 * `noncurrent_days` - (Optional) The number of days an object is noncurrent before Amazon S3 can perform the associated action.
 * `storage_class` - (Required) The class of storage used to store the object. Valid Values: `GLACIER`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `DEEP_ARCHIVE`, `GLACIER_IR`.
 
@@ -402,7 +402,7 @@ The `transition` configuration block supports the following arguments:
 
 ~> **Note:** Only one of `date` or `days` should be specified. If neither are specified, the `transition` will default to 0 `days`.
 
-* `date` - (Optional, Conflicts with `days`) The date objects are transitioned to the specified storage class. The date value must be in ISO 8601 format and set to midnight UTC e.g. `2023-01-13T00:00:00Z`.
+* `date` - (Optional, Conflicts with `days`) The date objects are transitioned to the specified storage class. The date value must be in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) and set to midnight UTC e.g. `2023-01-13T00:00:00Z`.
 * `days` - (Optional, Conflicts with `date`) The number of days after creation when objects are transitioned to the specified storage class. The value must be a positive integer. If both `days` and `date` are not specified, defaults to `0`. Valid values depend on `storage_class`, see [Transition objects using Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html) for more details.
 * `storage_class` - The class of storage used to store the object. Valid Values: `GLACIER`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `DEEP_ARCHIVE`, `GLACIER_IR`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23375
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23575

### Description
* handling of `filter.object_size_greater_than` and `filter.object_size_less_than` arguments is updated to account for their `nullable.TypeNullableInt` types
* `new_noncurrent_versions` in `filter.noncurrent_version_expiration` and `filter.noncurrent_version_transition` are updated to `nullable.TypeNullableInt` type to prevent diff when the API sends back null 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (194.52s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (196.10s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (196.13s)
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (196.23s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (196.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (194.36s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (194.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (194.28s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (328.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (328.60s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (192.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (192.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (202.84s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (192.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (192.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (195.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (205.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (54.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (275.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (191.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (273.22s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (273.17s)
```

To validate the example given in #23375:

1. terraform apply
```
Terraform will perform the following actions:

  # aws_s3_bucket.example will be created
  + resource "aws_s3_bucket" "example" {
      + acceleration_status                  = (known after apply)
      + acl                                  = (known after apply)
      + arn                                  = (known after apply)
      + bucket                               = "aws-provider-issue-23375"
      + bucket_domain_name                   = (known after apply)
      + bucket_regional_domain_name          = (known after apply)
      + cors_rule                            = (known after apply)
      + force_destroy                        = false
      + grant                                = (known after apply)
      + hosted_zone_id                       = (known after apply)
      + id                                   = (known after apply)
      + lifecycle_rule                       = (known after apply)
      + logging                              = (known after apply)
      + policy                               = (known after apply)
      + region                               = (known after apply)
      + replication_configuration            = (known after apply)
      + request_payer                        = (known after apply)
      + server_side_encryption_configuration = (known after apply)
      + tags_all                             = (known after apply)
      + versioning                           = (known after apply)
      + website                              = (known after apply)
      + website_domain                       = (known after apply)
      + website_endpoint                     = (known after apply)

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)
          + rule                = (known after apply)
        }
    }

  # aws_s3_bucket_lifecycle_configuration.example will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "example" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + id     = "rule"
          + status = "Enabled"

          + expiration {
              + date                         = "2024-01-01T00:00:00Z"
              + days                         = 0
              + expired_object_delete_marker = (known after apply)
            }

          + filter {
            }

          + noncurrent_version_transition {
              + noncurrent_days = 120
              + storage_class   = "GLACIER"
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + lifecycle = (known after apply)
aws_s3_bucket.example: Creating...
aws_s3_bucket.example: Creation complete after 2s [id=aws-provider-issue-23375]
aws_s3_bucket_lifecycle_configuration.example: Creating...
aws_s3_bucket_lifecycle_configuration.example: Still creating... [10s elapsed]
aws_s3_bucket_lifecycle_configuration.example: Still creating... [20s elapsed]
aws_s3_bucket_lifecycle_configuration.example: Still creating... [30s elapsed]
aws_s3_bucket_lifecycle_configuration.example: Creation complete after 32s [id=aws-provider-issue-23375]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

lifecycle = [
  {
    "abort_incomplete_multipart_upload" = []
    "expiration" = [
      {
        "date" = "2024-01-01T00:00:00Z"
        "days" = 0
        "expired_object_delete_marker" = false
      },
    ]
    "filter" = [
      {
        "and" = []
        "object_size_greater_than" = null
        "object_size_less_than" = null
        "prefix" = null
        "tag" = []
      },
    ]
    "id" = "rule"
    "noncurrent_version_expiration" = []
    "noncurrent_version_transition" = [
      {
        "newer_noncurrent_versions" = ""
        "noncurrent_days" = 120
        "storage_class" = "GLACIER"
      },
    ]
    "prefix" = ""
    "status" = "Enabled"
    "transition" = []
  },
]
```
2. terraform apply --> no change needed for `rule.noncurrent_version_transition.newer_noncurrent_versions` when previously terraform was trying to update `null` -> `0`
```
aws_s3_bucket.example: Refreshing state... [id=aws-provider-issue-23375]
aws_s3_bucket_lifecycle_configuration.example: Refreshing state... [id=aws-provider-issue-23375]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # aws_s3_bucket.example has changed
  ~ resource "aws_s3_bucket" "example" {
        id                                   = "aws-provider-issue-23375"
      ~ lifecycle_rule                       = [
          + {
              + abort_incomplete_multipart_upload_days = 0
              + enabled                                = true
              + expiration                             = [
                  + {
                      + date                         = "2024-01-01"
                      + days                         = 0
                      + expired_object_delete_marker = false
                    },
                ]
              + id                                     = "rule"
              + noncurrent_version_expiration          = []
              + noncurrent_version_transition          = [
                  + {
                      + days          = 120
                      + storage_class = "GLACIER"
                    },
                ]
              + prefix                                 = ""
              + tags                                   = {}
              + transition                             = []
            },
        ]
      + tags                                 = {}
        # (17 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or
respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

No changes. Your infrastructure matches the configuration.

Your configuration already matches the changes detected above. If you'd like to update the Terraform state to match, create and apply a refresh-only plan:
  terraform apply -refresh-only

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

lifecycle = [
  {
    "abort_incomplete_multipart_upload" = []
    "expiration" = [
      {
        "date" = "2024-01-01T00:00:00Z"
        "days" = 0
        "expired_object_delete_marker" = false
      },
    ]
    "filter" = [
      {
        "and" = []
        "object_size_greater_than" = null
        "object_size_less_than" = null
        "prefix" = null
        "tag" = []
      },
    ]
    "id" = "rule"
    "noncurrent_version_expiration" = []
    "noncurrent_version_transition" = [
      {
        "newer_noncurrent_versions" = ""
        "noncurrent_days" = 120
        "storage_class" = "GLACIER"
      },
    ]
    "prefix" = ""
    "status" = "Enabled"
    "transition" = []
  },
]
```

