### PR TITLE
dms/endpoint: Fix bug where KMS key ignored

### DIFF
--- a/.changelog/23444.txt
+++ b/.changelog/23444.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dms_endpoint: Fix bug where KMS key was ignored for DynamoDB, OpenSearch, Kafka, Kinesis, Oracle, Postgres, and S3 engines.
+resource/aws_dms_endpoint: Fix bug where KMS key was ignored for DynamoDB, OpenSearch, Kafka, Kinesis, Oracle, PostgreSQL, and S3 engines.
 ```

--- a/.changelog/23444.txt
+++ b/.changelog/23444.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_endpoint: Fix bug where KMS key was ignored for DynamoDB, OpenSearch, Kafka, Kinesis, Oracle, Postgres, and S3 engines.
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -601,6 +601,24 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		Tags:               Tags(tags.IgnoreAWS()),
 	}
 
+	if v, ok := d.GetOk("certificate_arn"); ok {
+		request.CertificateArn = aws.String(v.(string))
+	}
+
+	// Send ExtraConnectionAttributes in the API request for all resource types
+	// per https://github.com/hashicorp/terraform-provider-aws/issues/8009
+	if v, ok := d.GetOk("extra_connection_attributes"); ok {
+		request.ExtraConnectionAttributes = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok {
+		request.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ssl_mode"); ok {
+		request.SslMode = aws.String(v.(string))
+	}
+
 	switch d.Get("engine_name").(string) {
 	case engineNameDynamoDB:
 		request.DynamoDbSettings = &dms.DynamoDbSettings{
@@ -697,24 +715,6 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("database_name"); ok {
 			request.DatabaseName = aws.String(v.(string))
 		}
-	}
-
-	if v, ok := d.GetOk("kms_key_arn"); ok {
-		request.KmsKeyId = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("certificate_arn"); ok {
-		request.CertificateArn = aws.String(v.(string))
-	}
-
-	// Send ExtraConnectionAttributes in the API request for all resource types
-	// per https://github.com/hashicorp/terraform-provider-aws/issues/8009
-	if v, ok := d.GetOk("extra_connection_attributes"); ok {
-		request.ExtraConnectionAttributes = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("ssl_mode"); ok {
-		request.SslMode = aws.String(v.(string))
 	}
 
 	log.Println("[DEBUG] DMS create endpoint:", request)

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -697,10 +697,10 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("database_name"); ok {
 			request.DatabaseName = aws.String(v.(string))
 		}
+	}
 
-		if v, ok := d.GetOk("kms_key_arn"); ok {
-			request.KmsKeyId = aws.String(v.(string))
-		}
+	if v, ok := d.GetOk("kms_key_arn"); ok {
+		request.KmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("certificate_arn"); ok {

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDMSEndpoint_basic(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -56,7 +56,7 @@ func TestAccDMSEndpoint_basic(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_S3_basic(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -113,7 +113,7 @@ func TestAccDMSEndpoint_S3_basic(t *testing.T) {
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8009
 func TestAccDMSEndpoint_S3_extraConnectionAttributes(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -140,7 +140,7 @@ func TestAccDMSEndpoint_S3_extraConnectionAttributes(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_dynamoDB(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -434,7 +434,7 @@ func TestAccDMSEndpoint_kinesis(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_MongoDB_basic(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -464,7 +464,7 @@ func TestAccDMSEndpoint_MongoDB_basic(t *testing.T) {
 // configured fields and extra_connection_attributes now set in the resource
 // per https://github.com/hashicorp/terraform-provider-aws/issues/8009
 func TestAccDMSEndpoint_MongoDB_update(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -509,7 +509,7 @@ func TestAccDMSEndpoint_MongoDB_update(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_Oracle_basic(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -536,7 +536,7 @@ func TestAccDMSEndpoint_Oracle_basic(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_Oracle_secretID(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -562,7 +562,7 @@ func TestAccDMSEndpoint_Oracle_secretID(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_Oracle_update(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -602,7 +602,7 @@ func TestAccDMSEndpoint_Oracle_update(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_PostgreSQL_basic(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -629,7 +629,7 @@ func TestAccDMSEndpoint_PostgreSQL_basic(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_PostgreSQL_secretID(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -655,7 +655,7 @@ func TestAccDMSEndpoint_PostgreSQL_secretID(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_PostgreSQL_update(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -717,7 +717,7 @@ func TestAccDMSEndpoint_PostgreSQL_kmsKey(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_docDB(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -757,7 +757,7 @@ func TestAccDMSEndpoint_docDB(t *testing.T) {
 }
 
 func TestAccDMSEndpoint_db2(t *testing.T) {
-	resourceName := "aws_dms_endpoint.dms_endpoint"
+	resourceName := "aws_dms_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -854,7 +854,7 @@ func testAccCheckEndpointExists(n string) resource.TestCheckFunc {
 
 func testAccEndpointConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   database_name               = "tf-test-dms-db"
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
@@ -878,7 +878,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_basicUpdate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   database_name               = "tf-test-dms-db-updated"
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
@@ -904,7 +904,7 @@ func testAccEndpointConfig_dynamoDB(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id         = %[1]q
   endpoint_type       = "target"
   engine_name         = "dynamodb"
@@ -970,7 +970,7 @@ func testAccEndpointConfig_dynamoDBUpdate(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id         = %[1]q
   endpoint_type       = "target"
   engine_name         = "dynamodb"
@@ -1034,7 +1034,7 @@ func testAccEndpointConfig_s3(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "target"
   engine_name                 = "s3"
@@ -1114,7 +1114,7 @@ func testAccEndpointConfig_s3ExtraConnectionAttributes(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "target"
   engine_name                 = "s3"
@@ -1192,7 +1192,7 @@ func testAccEndpointConfig_s3Config(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "target"
   engine_name                 = "s3"
@@ -1547,7 +1547,7 @@ data "aws_kms_alias" "dms" {
   name = "alias/aws/dms"
 }
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
   engine_name                 = "mongodb"
@@ -1584,7 +1584,7 @@ data "aws_kms_alias" "dms" {
   name = "alias/aws/dms"
 }
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
   engine_name                 = "mongodb"
@@ -1615,7 +1615,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_oracle(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
   engine_name                 = "oracle"
@@ -1638,7 +1638,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_oracleUpdate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
   engine_name                 = "oracle"
@@ -1709,7 +1709,7 @@ resource "aws_iam_role_policy" "test" {
 EOF
 }
 
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                     = %[1]q
   endpoint_type                   = "source"
   engine_name                     = "oracle"
@@ -1731,7 +1731,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_postgreSQL(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
   engine_name                 = "postgres"
@@ -1754,7 +1754,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_postgreSQLUpdate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
   engine_name                 = "postgres"
@@ -1824,7 +1824,7 @@ resource "aws_iam_role_policy" "test" {
 }
 EOF
 }
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   endpoint_id                     = %[1]q
   endpoint_type                   = "source"
   engine_name                     = "postgres"
@@ -1846,7 +1846,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_docDB(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   database_name               = "tf-test-dms-db"
   endpoint_id                 = %[1]q
   endpoint_type               = "target"
@@ -1870,7 +1870,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_docDBUpdate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   database_name               = "tf-test-dms-db-updated"
   endpoint_id                 = %[1]q
   endpoint_type               = "target"
@@ -1894,7 +1894,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_db2(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   database_name               = "tf-test-dms-db"
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
@@ -1918,7 +1918,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
 func testAccEndpointConfig_db2Update(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_dms_endpoint" "dms_endpoint" {
+resource "aws_dms_endpoint" "test" {
   database_name               = "tf-test-dms-db-updated"
   endpoint_id                 = %[1]q
   endpoint_type               = "source"

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1961,7 +1961,7 @@ resource "aws_dms_endpoint" "test" {
   kms_key_arn                 = aws_kms_key.test.arn
 
   tags = {
-    Name   = %[1]q
+    Name = %[1]q
   }
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23143
Relates #19040

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccDMSEndpoint PKG=dms 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint'  -timeout 180m
--- PASS: TestAccDMSEndpoint_MongoDB_basic (35.44s)
--- PASS: TestAccDMSEndpoint_Oracle_secretID (36.88s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_secretID (36.97s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_kmsKey (39.08s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (39.87s)
--- PASS: TestAccDMSEndpoint_Oracle_basic (40.46s)
--- PASS: TestAccDMSEndpoint_docDB (44.71s)
--- PASS: TestAccDMSEndpoint_db2 (44.90s)
--- PASS: TestAccDMSEndpoint_Oracle_update (45.01s)
--- PASS: TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage (46.87s)
--- PASS: TestAccDMSEndpoint_OpenSearch_errorRetryDuration (46.98s)
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (46.98s)
--- PASS: TestAccDMSEndpoint_S3_extraConnectionAttributes (46.98s)
--- PASS: TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes (47.24s)
--- PASS: TestAccDMSEndpoint_kafka (57.16s)
--- PASS: TestAccDMSEndpoint_basic (57.18s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_update (57.51s)
--- PASS: TestAccDMSEndpoint_dynamoDB (59.68s)
--- PASS: TestAccDMSEndpoint_MongoDB_update (59.91s)
--- PASS: TestAccDMSEndpoint_kinesis (77.51s)
--- PASS: TestAccDMSEndpoint_S3_basic (54.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	91.495s
```
