### PR TITLE
Correct AWS documentation link in aws_ec2_transit_gateway_vpc_attachments

### DIFF
--- a/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
@@ -45,5 +45,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `ids` A list of all attachments ids matching filter, you can retrieve more information about the attachment using the data [aws_ec2_transit_gateway_vpc_attachment][2] getting it by identifier
 
-[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-transit-gateway-attachments.html
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayVpcAttachments.html 
 [2]: https://www.terraform.io/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html

--- a/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
@@ -45,5 +45,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `ids` A list of all attachments ids matching filter, you can retrieve more information about the attachment using the data [aws_ec2_transit_gateway_vpc_attachment][2] getting it by identifier
 
-[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayVpcAttachments.html 
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayVpcAttachments.html
 [2]: https://www.terraform.io/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23425

Output from acceptance testing: n/a, docs

### Information

The documentation previously linked to the AWS document for `describe-transit-gateway-attachments`. This PR updates the link to the API documentation for `DescribeTransitGatewayVpcAttachments` (the call that's used in the underlying resource), to more accurately reflect the list of filter names.
