### PR TITLE
documentation: Updates SES documentation link

### DIFF
--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an SES domain MAIL FROM resource.
 
-~> **NOTE:** For the MAIL FROM domain to be fully usable, this resource should be paired with the [aws_ses_domain_identity resource](/docs/providers/aws/r/ses_domain_identity.html). To validate the MAIL FROM domain, a DNS MX record is required. To pass SPF checks, a DNS TXT record may also be required. See the [Amazon SES MAIL FROM documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-set.html) for more information.
+~> **NOTE:** For the MAIL FROM domain to be fully usable, this resource should be paired with the [aws_ses_domain_identity resource](/docs/providers/aws/r/ses_domain_identity.html). To validate the MAIL FROM domain, a DNS MX record is required. To pass SPF checks, a DNS TXT record may also be required. See the [Amazon SES MAIL FROM documentation](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html) for more information.
 
 ## Example Usage
 


### PR DESCRIPTION
A link in the `aws_ses_domain_mail_from` documentation was pointing to a moved URL on the AWS documentation site