### PR TITLE
data-source/aws_eks_node_group: Add `taints` attribute

### DIFF
--- a/.changelog/23452.txt
+++ b/.changelog/23452.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_eks_node_group: Add `taints` attribute
+```

--- a/internal/service/eks/node_group_data_source.go
+++ b/internal/service/eks/node_group_data_source.go
@@ -127,6 +127,26 @@ func DataSourceNodeGroup() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"tags": tftags.TagsSchemaComputed(),
+			"taints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"effect": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -184,6 +204,10 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	if err := d.Set("tags", KeyValueTags(nodeGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	if err := d.Set("taints", flattenEksTaints(nodeGroup.Taints)); err != nil {
+		return diag.Errorf("error setting taint: %s", err)
 	}
 
 	d.Set("version", nodeGroup.Version)

--- a/internal/service/eks/node_group_data_source_test.go
+++ b/internal/service/eks/node_group_data_source_test.go
@@ -48,6 +48,7 @@ func TestAccEKSNodeGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceResourceName, "status"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.#", dataSourceResourceName, "subnet_ids.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids", dataSourceResourceName, "subnet_ids"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "taints.#", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceResourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(resourceName, "version", dataSourceResourceName, "version"),
 				),

--- a/website/docs/d/eks_node_group.html.markdown
+++ b/website/docs/d/eks_node_group.html.markdown
@@ -47,5 +47,9 @@ data "aws_eks_node_group" "example" {
     * `min_size` - Minimum number of worker nodes.
 * `status` - Status of the EKS Node Group.
 * `subnet_ids` – Identifiers of EC2 Subnets to associate with the EKS Node Group.
+* `taints` - List of objects containing information about taints applied to the nodes in the EKS Node Group.
+    * `key` - The key of the taint.
+    * `value` - The value of the taint.
+    * `effect` - The effect of the taint.
 * `tags` - Key-value map of resource tags.
 * `version` – Kubernetes version.


### PR DESCRIPTION
Adds the `taints` attribute to the `aws_eks_node_group` data source. It was added to the resource in https://github.com/hashicorp/terraform-provider-aws/pull/19482 but is missing from the data source.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEKSNodeGroupDataSource PKG=eks

=== RUN   TestAccEKSNodeGroupDataSource_basic
        --- PASS: TestAccEKSNodeGroupDataSource_basic (1384.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        1386.654s
...
```
