### PR TITLE
resource/aws_s3_bucket_accelerate_configuration: Backport resource `aws_s3_bucket_request_payment_configuration`

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1596,6 +1596,7 @@ func Provider() *schema.Provider {
 			"aws_s3_bucket_policy":                            s3.ResourceBucketPolicy(),
 			"aws_s3_bucket_public_access_block":               s3.ResourceBucketPublicAccessBlock(),
 			"aws_s3_bucket_replication_configuration":         s3.ResourceBucketReplicationConfiguration(),
+			"aws_s3_bucket_request_payment_configuration":     s3.ResourceBucketRequestPaymentConfiguration(),
 			"aws_s3_object_copy":                              s3.ResourceObjectCopy(),
 
 			"aws_s3_access_point":                             s3control.ResourceAccessPoint(),

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -391,6 +391,7 @@ func ResourceBucket() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
+				Deprecated:   "Use the aws_s3_bucket_request_payment_configuration resource instead",
 				ValidateFunc: validation.StringInSlice(s3.Payer_Values(), false),
 			},
 

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -1,0 +1,175 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceBucketRequestPaymentConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBucketRequestPaymentConfigurationCreate,
+		ReadContext:   resourceBucketRequestPaymentConfigurationRead,
+		UpdateContext: resourceBucketRequestPaymentConfigurationUpdate,
+		DeleteContext: resourceBucketRequestPaymentConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 63),
+			},
+			"expected_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"payer": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(s3.Payer_Values(), false),
+			},
+		},
+	}
+}
+
+func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket := d.Get("bucket").(string)
+	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
+
+	input := &s3.PutBucketRequestPaymentInput{
+		Bucket: aws.String(bucket),
+		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
+			Payer: aws.String(d.Get("payer").(string)),
+		},
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.PutBucketRequestPaymentWithContext(ctx, input)
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating S3 bucket (%s) request payment configuration: %w", bucket, err))
+	}
+
+	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
+
+	return resourceBucketRequestPaymentConfigurationRead(ctx, d, meta)
+}
+
+func resourceBucketRequestPaymentConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.GetBucketRequestPaymentInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	output, err := conn.GetBucketRequestPaymentWithContext(ctx, input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket Request Payment Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if output == nil {
+		return diag.FromErr(fmt.Errorf("error reading S3 bucket request payment configuration (%s): empty output", d.Id()))
+	}
+
+	d.Set("bucket", bucket)
+	d.Set("expected_bucket_owner", expectedBucketOwner)
+	d.Set("payer", output.Payer)
+
+	return nil
+}
+
+func resourceBucketRequestPaymentConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.PutBucketRequestPaymentInput{
+		Bucket: aws.String(bucket),
+		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
+			Payer: aws.String(d.Get("payer").(string)),
+		},
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	_, err = conn.PutBucketRequestPaymentWithContext(ctx, input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating S3 bucket request payment configuration (%s): %w", d.Id(), err))
+	}
+
+	return resourceBucketRequestPaymentConfigurationRead(ctx, d, meta)
+}
+
+func resourceBucketRequestPaymentConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.PutBucketRequestPaymentInput{
+		Bucket: aws.String(bucket),
+		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
+			// To remove a configuration, it is equivalent to disabling
+			// "Requester Pays" in the console; thus, we reset "Payer" back to "BucketOwner"
+			Payer: aws.String(s3.PayerBucketOwner),
+		},
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	_, err = conn.PutBucketRequestPaymentWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting S3 bucket request payment configuration (%s): %w", d.Id(), err))
+	}
+
+	return nil
+}

--- a/internal/service/s3/bucket_request_payment_configuration_test.go
+++ b/internal/service/s3/bucket_request_payment_configuration_test.go
@@ -1,0 +1,199 @@
+package s3_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestAccS3BucketRequestPaymentConfiguration_Basic_BucketOwner(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_request_payment_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketRequestPaymentConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketRequestPaymentConfigurationBasicConfig(rName, s3.PayerBucketOwner),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketRequestPaymentConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "payer", s3.PayerBucketOwner),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketRequestPaymentConfiguration_Basic_Requester(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_request_payment_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketRequestPaymentConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketRequestPaymentConfigurationBasicConfig(rName, s3.PayerRequester),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketRequestPaymentConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "payer", s3.PayerRequester),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketRequestPaymentConfiguration_update(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_request_payment_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketRequestPaymentConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketRequestPaymentConfigurationBasicConfig(rName, s3.PayerRequester),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketRequestPaymentConfigurationExists(resourceName),
+				),
+			},
+			{
+				Config: testAccBucketRequestPaymentConfigurationBasicConfig(rName, s3.PayerBucketOwner),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketRequestPaymentConfigurationExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketRequestPaymentConfigurationBasicConfig(rName, s3.PayerRequester),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketRequestPaymentConfigurationExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBucketRequestPaymentConfigurationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_bucket_request_payment_configuration" {
+			continue
+		}
+
+		bucket, expectedBucketOwner, err := tfs3.ParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketRequestPaymentInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketRequestPayment(input)
+
+		if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting S3 bucket request payment configuration (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil && aws.StringValue(output.Payer) != s3.PayerBucketOwner {
+			return fmt.Errorf("S3 bucket request payment configuration (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBucketRequestPaymentConfigurationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+		bucket, expectedBucketOwner, err := tfs3.ParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketRequestPaymentInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketRequestPayment(input)
+
+		if err != nil {
+			return fmt.Errorf("error getting S3 bucket request payment configuration (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("S3 Bucket request payment configuration (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccBucketRequestPaymentConfigurationBasicConfig(rName, payer string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_request_payment_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+  payer  = %[2]q
+}
+`, rName, payer)
+}

--- a/internal/service/s3/id.go
+++ b/internal/service/s3/id.go
@@ -1,0 +1,41 @@
+package s3
+
+import (
+	"fmt"
+	"strings"
+)
+
+const resourceIDSeparator = ","
+
+// CreateResourceID is a generic method for creating an ID string for a bucket-related resource e.g. aws_s3_bucket_versioning.
+// The method expects a bucket name and an optional accountID.
+func CreateResourceID(bucket, expectedBucketOwner string) string {
+	if expectedBucketOwner == "" {
+		return bucket
+	}
+
+	parts := []string{bucket, expectedBucketOwner}
+	id := strings.Join(parts, resourceIDSeparator)
+
+	return id
+}
+
+// ParseResourceID is a generic method for parsing an ID string
+// for a bucket name and accountID if provided.
+func ParseResourceID(id string) (bucket, expectedBucketOwner string, err error) {
+	parts := strings.Split(id, resourceIDSeparator)
+
+	if len(parts) == 1 && parts[0] != "" {
+		bucket = parts[0]
+		return
+	}
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		bucket = parts[0]
+		expectedBucketOwner = parts[1]
+		return
+	}
+
+	err = fmt.Errorf("unexpected format for ID (%s), expected BUCKET or BUCKET%sEXPECTED_BUCKET_OWNER", id, resourceIDSeparator)
+	return
+}

--- a/internal/service/s3/id_test.go
+++ b/internal/service/s3/id_test.go
@@ -1,0 +1,62 @@
+package s3_test
+
+import (
+	"testing"
+
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestParseResourceID(t *testing.T) {
+	testCases := []struct {
+		TestName            string
+		InputID             string
+		ExpectError         bool
+		ExpectedBucket      string
+		ExpectedBucketOwner string
+	}{
+		{
+			TestName:    "empty ID",
+			InputID:     "",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect format",
+			InputID:     "test,example,123456789012",
+			ExpectError: true,
+		},
+		{
+			TestName:            "valid ID with bucket",
+			InputID:             tfs3.CreateResourceID("example", ""),
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and bucket owner",
+			InputID:             tfs3.CreateResourceID("example", "123456789012"),
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotBucket, gotExpectedBucketOwner, err := tfs3.ParseResourceID(testCase.InputID)
+
+			if err == nil && testCase.ExpectError {
+				t.Fatalf("expected error")
+			}
+
+			if err != nil && !testCase.ExpectError {
+				t.Fatalf("unexpected error")
+			}
+
+			if gotBucket != testCase.ExpectedBucket {
+				t.Errorf("got bucket %s, expected %s", gotBucket, testCase.ExpectedBucket)
+			}
+
+			if gotExpectedBucketOwner != testCase.ExpectedBucketOwner {
+				t.Errorf("got ExpectedBucketOwner %s, expected %s", gotExpectedBucketOwner, testCase.ExpectedBucketOwner)
+			}
+		})
+	}
+}

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -12,6 +12,10 @@ Provides a S3 bucket resource.
 
 -> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the [`aws_s3control_bucket`](/docs/providers/aws/r/s3control_bucket.html) resource.
 
+~> **NOTE on S3 Bucket Request Payment Configuration:** S3 Bucket Request Payment can be configured in either the standalone resource [`aws_s3_bucket_request_payment_configuration`](s3_bucket_request_payment_configuration.html)
+or with the deprecated parameter `request_payer` in the resource `aws_s3_bucket`.
+Configuring with both will cause inconsistencies and may overwrite configuration.
+
 ## Example Usage
 
 ### Private Bucket w/ Tags
@@ -365,10 +369,10 @@ The following arguments are supported:
 * `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 * `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 * `acceleration_status` - (Optional) Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
-* `request_payer` - (Optional) Specifies who should bear the cost of Amazon S3 data transfer.
-Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
-the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
-developer guide for more information.
+* `request_payer` - (Optional, **Deprecated**) Specifies who should bear the cost of Amazon S3 data transfer.
+  Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
+  See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
+  Use the resource [`aws_s3_bucket_request_payment_configuration`](s3_bucket_request_payment_configuration.html) instead.
 * `replication_configuration` - (Optional) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 * `server_side_encryption_configuration` - (Optional) A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 * `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)

--- a/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_request_payment_configuration"
+description: |-
+  Provides an S3 bucket request payment configuration resource.
+---
+
+# Resource: aws_s3_bucket_request_payment_configuration
+
+Provides an S3 bucket request payment configuration resource. For more information, see [Requester Pays Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html).
+
+~> **NOTE:** Destroying an `aws_s3_bucket_request_payment_configuration` resource resets the bucket's `payer` to the S3 default: the bucket owner.
+
+## Example Usage
+
+```terraform
+resource "aws_s3_bucket_request_payment_configuration" "example" {
+  bucket = aws_s3_bucket.example.bucket
+  payer  = "Requester"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required, Forces new resource) The name of the bucket.
+* `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
+* `payer` - (Required) Specifies who pays for the download and request fees. Valid values: `BucketOwner`, `Requester`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The `bucket` or `bucket` and `expected_bucket_owner` separated by a comma (`,`) if the latter is provided.
+
+## Import
+
+S3 bucket request payment configuration can be imported using the `bucket` e.g.,
+
+```
+$ terraform import aws_s3_bucket_request_payment_configuration.example bucket-name
+```
+
+In addition, S3 bucket request payment configuration can be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_request_payment_configuration.example bucket-name,123456789012
+```


### PR DESCRIPTION
Adds resource `aws_s3_bucket_request_payment_configuration` and deprecates `request_payer` in `aws_s3_bucket`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=s3 TESTS='TestAccS3Bucket_|TestAccS3BucketRequestPaymentConfiguration_'

--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (114.44s)
--- PASS: TestAccS3Bucket_Security_corsDelete (174.86s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (181.72s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (224.00s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (224.93s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (225.31s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (226.55s)
--- PASS: TestAccS3BucketRequestPaymentConfiguration_Basic_BucketOwner (231.60s)
--- PASS: TestAccS3Bucket_Security_logging (245.75s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (281.92s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (284.95s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (286.10s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (287.32s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (136.17s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (207.85s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (342.54s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (355.11s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (188.55s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (196.29s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (198.68s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (202.40s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (163.44s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (466.72s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (491.14s)
--- PASS: TestAccS3Bucket_Web_simple (521.05s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (521.75s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (202.56s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (211.48s)
--- PASS: TestAccS3Bucket_Security_grantToACL (323.29s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (360.11s)
--- PASS: TestAccS3Bucket_Manage_versioning (416.94s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (340.47s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (279.34s)
--- PASS: TestAccS3Bucket_Web_routingRules (372.65s)
--- PASS: TestAccS3Bucket_Tags_basic (205.41s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (285.85s)
--- PASS: TestAccS3Bucket_Basic_emptyString (186.61s)
--- PASS: TestAccS3Bucket_Basic_basic (190.10s)
--- PASS: TestAccS3Bucket_Security_updateGrant (471.83s)
--- PASS: TestAccS3Bucket_Manage_objectLock (343.20s)
--- PASS: TestAccS3Bucket_Security_updateACL (331.32s)
--- PASS: TestAccS3BucketRequestPaymentConfiguration_Basic_Requester (162.59s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (318.63s)
--- PASS: TestAccS3Bucket_Web_redirect (471.92s)
--- PASS: TestAccS3Bucket_Replication_basic (796.63s)
--- PASS: TestAccS3Bucket_Basic_acceleration (305.53s)
--- PASS: TestAccS3Bucket_Basic_generatedName (143.09s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (227.08s)
--- PASS: TestAccS3Bucket_Security_policy (334.14s)
--- PASS: TestAccS3BucketRequestPaymentConfiguration_update (278.32s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (372.38s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (493.06s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (301.49s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (545.34s)
```
