### PR TITLE
fix #22727: allow any character in networkfirewall/stateful_rule/header source/destination per the api docs

### DIFF
--- a/.changelog/22727.txt
+++ b/.changelog/22727.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_networkfirewall_rule_group: Allow any character in `source` and `destination` `definition` arguments as per the AWS API docs
+resource/aws_networkfirewall_rule_group: Allow any character in `source` and `destination` `rule_group.rules_source.stateful_rule.header` arguments as per the AWS API docs
 ```

--- a/.changelog/22727.txt
+++ b/.changelog/22727.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_networkfirewall_rule_group: Allow any character in `source` and 'destination' `definition` as per the AWS API docs
+```

--- a/.changelog/22727.txt
+++ b/.changelog/22727.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_networkfirewall_rule_group: Allow any character in `source` and 'destination' `definition` as per the AWS API docs
+resource/aws_networkfirewall_rule_group: Allow any character in `source` and `destination` `definition` arguments as per the AWS API docs
 ```

--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -185,7 +185,6 @@ func ResourceRuleGroup() *schema.Resource {
 															"destination": {
 																Type:     schema.TypeString,
 																Required: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
 															},
 															"destination_port": {
 																Type:     schema.TypeString,
@@ -204,7 +203,6 @@ func ResourceRuleGroup() *schema.Resource {
 															"source": {
 																Type:     schema.TypeString,
 																Required: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
 															},
 															"source_port": {
 																Type:     schema.TypeString,

--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -185,10 +185,7 @@ func ResourceRuleGroup() *schema.Resource {
 															"destination": {
 																Type:     schema.TypeString,
 																Required: true,
-																ValidateFunc: validation.Any(
-																	verify.ValidIPv4CIDRNetworkAddress,
-																	validation.StringInSlice([]string{networkfirewall.StatefulRuleDirectionAny}, false),
-																),
+																Elem:     &schema.Schema{Type: schema.TypeString},
 															},
 															"destination_port": {
 																Type:     schema.TypeString,
@@ -207,10 +204,7 @@ func ResourceRuleGroup() *schema.Resource {
 															"source": {
 																Type:     schema.TypeString,
 																Required: true,
-																ValidateFunc: validation.Any(
-																	verify.ValidIPv4CIDRNetworkAddress,
-																	validation.StringInSlice([]string{networkfirewall.StatefulRuleDirectionAny}, false),
-																),
+																Elem:     &schema.Schema{Type: schema.TypeString},
 															},
 															"source_port": {
 																Type:     schema.TypeString,


### PR DESCRIPTION
This allows the use of ip_sets for source and destination

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22727
