### PR TITLE
fix #23485: Remove limit for number of domains in aws_route53_resolver_firewall_domain_list

### DIFF
--- a/.changelog/23485.txt
+++ b/.changelog/23485.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_resolver_firewall_domain_list: Remove limit for number of `domains`.
+```

--- a/internal/service/route53resolver/firewall_domain_list.go
+++ b/internal/service/route53resolver/firewall_domain_list.go
@@ -42,7 +42,6 @@ func ResourceFirewallDomainList() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				MinItems: 0,
-				MaxItems: 255,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 


### PR DESCRIPTION
Removing limit for number of domains defined in aws_route53_resolver_firewall_domain_list per [API Docs](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_UpdateFirewallDomains.html#API_route53resolver_UpdateFirewallDomains_RequestSyntax)

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #23485

