### PR TITLE
revert gha release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,24 +1,15 @@
 archives:
   - files:
-      # Ensure only built binary is archived
-      - 'none*'
+      - none*
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:
   hooks:
-    - 'go mod download'
+    - go mod download
 builds:
-  - # Binary naming only required for Terraform CLI 0.12
-    binary: '{{ .ProjectName }}_v{{ .Version }}_x5'
-    env:
-      - CGO_ENABLED=0
+  - binary: '{{ .ProjectName }}_{{ .Version }}'
     flags:
       - -trimpath
-    goos:
-      - darwin
-      - freebsd
-      - linux
-      - windows
     goarch:
       - '386'
       - amd64
@@ -62,14 +53,12 @@ release:
   ids:
     - none
 signs:
-  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
-    artifacts: checksum
-    cmd: signore
-    signature: ${artifact}.sig
-  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
-    artifacts: checksum
-    cmd: signore
-    id: key-id
-    signature: ${artifact}.72D7468F.sig
-snapshot:
-  name_template: "{{ .Tag }}-next"
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script rewrites [GH-nnnn]-style references in the CHANGELOG.md file to
+# be Markdown links to the given github issues.
+#
+# This is run during releases so that the issue references in all of the
+# released items are presented as clickable links, but we can just use the
+# easy [GH-nnnn] shorthand for quickly adding items to the "Unrelease" section
+# while merging things between releases.
+
+set -e
+
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "ERROR: CHANGELOG.md not found in pwd."
+  echo "Please run this from the root of the terraform provider repository"
+  exit 1
+fi
+
+if [[ `uname` == "Darwin" ]]; then
+  echo "Using BSD sed"
+  SED="sed -i.bak -E -e"
+else
+  echo "Using GNU sed"
+  SED="sed -i.bak -r -e"
+fi
+
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-aws\/issues"
+
+$SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
+
+rm CHANGELOG.md.bak


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Description

* Revert goreleaser to previous form just in case

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
