### PR TITLE
account/alternate_contact: Fix eventual consistency

### DIFF
--- a/.changelog/23516.txt
+++ b/.changelog/23516.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_account_alternate_contact: Improve eventual consistency handling to avoid "no resource found" on updates
+```
+
+```release-note:enhancement
+resource/aws_account_alternate_contact: Add configurable timeouts
+```

--- a/internal/service/account/alternate_contact.go
+++ b/internal/service/account/alternate_contact.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/account"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -27,6 +26,12 @@ func ResourceAlternateContact() *schema.Resource {
 		DeleteContext: resourceAlternateContactDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(alternateContactCreateTimeout),
+			Update: schema.DefaultTimeout(alternateContactUpdateTimeout),
+			Delete: schema.DefaultTimeout(alternateContactDeleteTimeout),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -93,6 +98,10 @@ func resourceAlternateContactCreate(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId(id)
 
+	if _, err := waitAlternateContactCreated(ctx, conn, accountID, contactType, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for Account Alternate Contact (%s) create: %s", d.Id(), err)
+	}
+
 	return resourceAlternateContactRead(ctx, d, meta)
 }
 
@@ -136,12 +145,17 @@ func resourceAlternateContactUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	email := d.Get("email_address").(string)
+	name := d.Get("name").(string)
+	phone := d.Get("phone_number").(string)
+	title := d.Get("title").(string)
+
 	input := &account.PutAlternateContactInput{
 		AlternateContactType: aws.String(contactType),
-		EmailAddress:         aws.String(d.Get("email_address").(string)),
-		Name:                 aws.String(d.Get("name").(string)),
-		PhoneNumber:          aws.String(d.Get("phone_number").(string)),
-		Title:                aws.String(d.Get("title").(string)),
+		EmailAddress:         aws.String(email),
+		Name:                 aws.String(name),
+		PhoneNumber:          aws.String(phone),
+		Title:                aws.String(title),
 	}
 
 	if accountID != "" {
@@ -153,6 +167,10 @@ func resourceAlternateContactUpdate(ctx context.Context, d *schema.ResourceData,
 
 	if err != nil {
 		return diag.Errorf("error updating Account Alternate Contact (%s): %s", d.Id(), err)
+	}
+
+	if err := waitAlternateContactUpdated(ctx, conn, accountID, contactType, email, name, phone, title, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("error waiting for Account Alternate Contact (%s) update: %s", d.Id(), err)
 	}
 
 	return resourceAlternateContactRead(ctx, d, meta)
@@ -186,36 +204,11 @@ func resourceAlternateContactDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error deleting Account Alternate Contact (%s): %s", d.Id(), err)
 	}
 
+	if err := waitAlternateContactDeleted(ctx, conn, accountID, contactType, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for Account Alternate Contact (%s) delete: %s", d.Id(), err)
+	}
+
 	return nil
-}
-
-func FindAlternateContactByAccountIDAndContactType(ctx context.Context, conn *account.Account, accountID, contactType string) (*account.AlternateContact, error) {
-	input := &account.GetAlternateContactInput{
-		AlternateContactType: aws.String(contactType),
-	}
-
-	if accountID != "" {
-		input.AccountId = aws.String(accountID)
-	}
-
-	output, err := conn.GetAlternateContactWithContext(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, account.ErrCodeResourceNotFoundException) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if output == nil || output.AlternateContact == nil {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	return output.AlternateContact, nil
 }
 
 const alternateContactResourceIDSeparator = "/"

--- a/internal/service/account/find.go
+++ b/internal/service/account/find.go
@@ -1,0 +1,40 @@
+package account
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/account"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func FindAlternateContactByAccountIDAndContactType(ctx context.Context, conn *account.Account, accountID, contactType string) (*account.AlternateContact, error) {
+	input := &account.GetAlternateContactInput{
+		AlternateContactType: aws.String(contactType),
+	}
+
+	if accountID != "" {
+		input.AccountId = aws.String(accountID)
+	}
+
+	output, err := conn.GetAlternateContactWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, account.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.AlternateContact == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.AlternateContact, nil
+}

--- a/internal/service/account/status.go
+++ b/internal/service/account/status.go
@@ -1,0 +1,56 @@
+package account
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/account"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+const (
+	statusFound      = "FOUND"
+	statusNotFound   = "NOT_FOUND"
+	statusUpdated    = "UPDATED"
+	statusNotUpdated = "NOT_UPDATED"
+)
+
+func statusAlternateContact(ctx context.Context, conn *account.Account, accountID, contactType string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindAlternateContactByAccountIDAndContactType(ctx, conn, accountID, contactType)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, statusFound, nil
+	}
+}
+
+func statusAlternateContactUpdate(ctx context.Context, conn *account.Account, accountID, contactType, email, name, phone, title string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindAlternateContactByAccountIDAndContactType(ctx, conn, accountID, contactType)
+
+		if tfresource.NotFound(err) {
+			return nil, statusNotFound, nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if email == aws.StringValue(output.EmailAddress) &&
+			name == aws.StringValue(output.Name) &&
+			phone == aws.StringValue(output.PhoneNumber) &&
+			title == aws.StringValue(output.Title) {
+			return output, statusUpdated, nil
+		}
+
+		return output, statusNotUpdated, nil
+	}
+}

--- a/internal/service/account/status.go
+++ b/internal/service/account/status.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	statusFound      = "FOUND"
-	statusNotFound   = "NOT_FOUND"
 	statusUpdated    = "UPDATED"
 	statusNotUpdated = "NOT_UPDATED"
 )
@@ -37,7 +36,7 @@ func statusAlternateContactUpdate(ctx context.Context, conn *account.Account, ac
 		output, err := FindAlternateContactByAccountIDAndContactType(ctx, conn, accountID, contactType)
 
 		if tfresource.NotFound(err) {
-			return nil, statusNotFound, nil
+			return nil, "", nil
 		}
 
 		if err != nil {

--- a/internal/service/account/wait.go
+++ b/internal/service/account/wait.go
@@ -16,7 +16,7 @@ const (
 
 func waitAlternateContactCreated(ctx context.Context, conn *account.Account, accountID, contactType string, timeout time.Duration) (*account.AlternateContact, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{statusNotFound},
+		Pending:                   []string{},
 		Target:                    []string{statusFound},
 		Refresh:                   statusAlternateContact(ctx, conn, accountID, contactType),
 		Timeout:                   timeout,
@@ -35,7 +35,7 @@ func waitAlternateContactCreated(ctx context.Context, conn *account.Account, acc
 
 func waitAlternateContactUpdated(ctx context.Context, conn *account.Account, accountID, contactType, email, name, phone, title string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{statusNotFound, statusNotUpdated},
+		Pending:                   []string{statusNotUpdated},
 		Target:                    []string{statusUpdated},
 		Refresh:                   statusAlternateContactUpdate(ctx, conn, accountID, contactType, email, name, phone, title),
 		Timeout:                   timeout,

--- a/internal/service/account/wait.go
+++ b/internal/service/account/wait.go
@@ -1,0 +1,62 @@
+package account
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/account"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	alternateContactCreateTimeout = 5 * time.Minute
+	alternateContactUpdateTimeout = 5 * time.Minute
+	alternateContactDeleteTimeout = 5 * time.Minute
+)
+
+func waitAlternateContactCreated(ctx context.Context, conn *account.Account, accountID, contactType string, timeout time.Duration) (*account.AlternateContact, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{statusNotFound},
+		Target:                    []string{statusFound},
+		Refresh:                   statusAlternateContact(ctx, conn, accountID, contactType),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*account.AlternateContact); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitAlternateContactUpdated(ctx context.Context, conn *account.Account, accountID, contactType, email, name, phone, title string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{statusNotFound, statusNotUpdated},
+		Target:                    []string{statusUpdated},
+		Refresh:                   statusAlternateContactUpdate(ctx, conn, accountID, contactType, email, name, phone, title),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitAlternateContactDeleted(ctx context.Context, conn *account.Account, accountID, contactType string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{statusFound},
+		Target:  []string{},
+		Refresh: statusAlternateContact(ctx, conn, accountID, contactType),
+		Timeout: timeout,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}

--- a/website/docs/r/account_alternate_contact.html.markdown
+++ b/website/docs/r/account_alternate_contact.html.markdown
@@ -39,6 +39,15 @@ The following arguments are supported:
 
 No additional attributes are exported.
 
+## Timeouts
+
+`aws_account_alternate_contact` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+- `create` - (Default `5 minutes`)
+- `update` - (Default `5 minutes`)
+- `delete` - (Default `5 minutes`)
+
 ## Import
 
 The Alternate Contact for the current account can be imported using the `alternate_contact_type`, e.g.,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22186

Output from acceptance testing:


```console
% make testacc TESTS=TestAccAccountAlternateContact_ PKG=account 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/account/... -v -count 1 -parallel 20 -run='TestAccAccountAlternateContact_'  -timeout 180m
--- PASS: TestAccAccountAlternateContact_basic (34.16s)
--- PASS: TestAccAccountAlternateContact_disappears (13.84s)
--- SKIP: TestAccAccountAlternateContact_accountID (0.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	50.459s
```
