### PR TITLE
resource/aws_amplify_app: update `repository` attribute in place

### DIFF
--- a/.changelog/23517.txt
+++ b/.changelog/23517.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_app: Allow `repository` to be updated in-place
+```

--- a/internal/service/amplify/amplify_test.go
+++ b/internal/service/amplify/amplify_test.go
@@ -55,7 +55,7 @@ func TestAccAmplify_serial(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					tc(t)
 					// Explicitly sleep between tests.
-					time.Sleep(15 * time.Second)
+					time.Sleep(5 * time.Second)
 				})
 			}
 		})

--- a/internal/service/amplify/amplify_test.go
+++ b/internal/service/amplify/amplify_test.go
@@ -55,7 +55,7 @@ func TestAccAmplify_serial(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					tc(t)
 					// Explicitly sleep between tests.
-					time.Sleep(5 * time.Second)
+					time.Sleep(15 * time.Second)
 				})
 			}
 		})

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -306,7 +306,6 @@ func ResourceApp() *schema.Resource {
 			"repository": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1000),
 			},
 

--- a/internal/service/amplify/app_test.go
+++ b/internal/service/amplify/app_test.go
@@ -23,7 +23,7 @@ func testAccApp_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -70,7 +70,7 @@ func testAccApp_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -93,7 +93,7 @@ func testAccApp_Tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -140,7 +140,7 @@ func testAccApp_AutoBranchCreationConfig(t *testing.T) {
 
 	credentials := base64.StdEncoding.EncodeToString([]byte("username1:password1"))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -236,7 +236,7 @@ func testAccApp_BasicAuthCredentials(t *testing.T) {
 	credentials1 := base64.StdEncoding.EncodeToString([]byte("username1:password1"))
 	credentials2 := base64.StdEncoding.EncodeToString([]byte("username2:password2"))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -281,7 +281,7 @@ func testAccApp_BuildSpec(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -323,7 +323,7 @@ func testAccApp_CustomRules(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -373,7 +373,7 @@ func testAccApp_Description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -416,7 +416,7 @@ func testAccApp_EnvironmentVariables(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -462,7 +462,7 @@ func testAccApp_IAMServiceRole(t *testing.T) {
 	iamRole1ResourceName := "aws_iam_role.test1"
 	iamRole2ResourceName := "aws_iam_role.test2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -505,7 +505,7 @@ func testAccApp_Name(t *testing.T) {
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -551,7 +551,7 @@ func testAccApp_Repository(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/amplify/backend_environment_test.go
+++ b/internal/service/amplify/backend_environment_test.go
@@ -22,7 +22,7 @@ func testAccBackendEnvironment_basic(t *testing.T) {
 
 	environmentName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -54,7 +54,7 @@ func testAccBackendEnvironment_disappears(t *testing.T) {
 
 	environmentName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -79,7 +79,7 @@ func testAccBackendEnvironment_DeploymentArtifacts_StackName(t *testing.T) {
 
 	environmentName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/amplify/branch_test.go
+++ b/internal/service/amplify/branch_test.go
@@ -21,7 +21,7 @@ func testAccBranch_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -68,7 +68,7 @@ func testAccBranch_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -91,7 +91,7 @@ func testAccBranch_Tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -139,7 +139,7 @@ func testAccBranch_BasicAuthCredentials(t *testing.T) {
 	credentials1 := base64.StdEncoding.EncodeToString([]byte("username1:password1"))
 	credentials2 := base64.StdEncoding.EncodeToString([]byte("username2:password2"))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -184,7 +184,7 @@ func testAccBranch_EnvironmentVariables(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -231,7 +231,7 @@ func testAccBranch_OptionalArguments(t *testing.T) {
 	backendEnvironment1ResourceName := "aws_amplify_backend_environment.test1"
 	backendEnvironment2ResourceName := "aws_amplify_backend_environment.test2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -27,7 +27,7 @@ func testAccDomainAssociation_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_domain_association.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -68,7 +68,7 @@ func testAccDomainAssociation_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_domain_association.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -97,7 +97,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_domain_association.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/amplify/webhook_test.go
+++ b/internal/service/amplify/webhook_test.go
@@ -20,7 +20,7 @@ func testAccWebhook_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_webhook.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -50,7 +50,7 @@ func testAccWebhook_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_webhook.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,
@@ -73,7 +73,7 @@ func testAccWebhook_update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_webhook.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, amplify.EndpointsID),
 		Providers:    acctest.Providers,


### PR DESCRIPTION
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes an issue where an `aws_amplify_app` will be destroyed and recreated when modifying the `repository` attribute instead of being updated in place.

Closes #23499

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ TF_ACC=1 go test  ./internal/service/amplify -run=TestAccAmplify_serial  -v -count 1 -parallel 1   -timeout 180m
=== RUN   TestAccAmplify_serial
=== RUN   TestAccAmplify_serial/App
=== RUN   TestAccAmplify_serial/App/Tags
=== PAUSE TestAccAmplify_serial/App/Tags
=== RUN   TestAccAmplify_serial/App/AutoBranchCreationConfig
=== PAUSE TestAccAmplify_serial/App/AutoBranchCreationConfig
=== RUN   TestAccAmplify_serial/App/BuildSpec
=== PAUSE TestAccAmplify_serial/App/BuildSpec
=== RUN   TestAccAmplify_serial/App/CustomRules
=== PAUSE TestAccAmplify_serial/App/CustomRules
=== RUN   TestAccAmplify_serial/App/IamServiceRole
=== PAUSE TestAccAmplify_serial/App/IamServiceRole
=== RUN   TestAccAmplify_serial/App/Repository
=== PAUSE TestAccAmplify_serial/App/Repository
=== RUN   TestAccAmplify_serial/App/basic
=== PAUSE TestAccAmplify_serial/App/basic
=== RUN   TestAccAmplify_serial/App/disappears
=== PAUSE TestAccAmplify_serial/App/disappears
=== RUN   TestAccAmplify_serial/App/BasicAuthCredentials
=== PAUSE TestAccAmplify_serial/App/BasicAuthCredentials
=== RUN   TestAccAmplify_serial/App/Description
=== PAUSE TestAccAmplify_serial/App/Description
=== RUN   TestAccAmplify_serial/App/EnvironmentVariables
=== PAUSE TestAccAmplify_serial/App/EnvironmentVariables
=== RUN   TestAccAmplify_serial/App/Name
=== PAUSE TestAccAmplify_serial/App/Name
=== CONT  TestAccAmplify_serial/App/Tags
=== CONT  TestAccAmplify_serial/App/basic
=== CONT  TestAccAmplify_serial/App/Name
=== CONT  TestAccAmplify_serial/App/EnvironmentVariables
=== CONT  TestAccAmplify_serial/App/Description
=== CONT  TestAccAmplify_serial/App/BasicAuthCredentials
=== CONT  TestAccAmplify_serial/App/disappears
=== CONT  TestAccAmplify_serial/App/CustomRules
=== CONT  TestAccAmplify_serial/App/Repository
=== CONT  TestAccAmplify_serial/App/IamServiceRole
=== CONT  TestAccAmplify_serial/App/BuildSpec
=== CONT  TestAccAmplify_serial/App/AutoBranchCreationConfig
=== RUN   TestAccAmplify_serial/BackendEnvironment
=== RUN   TestAccAmplify_serial/BackendEnvironment/basic
=== PAUSE TestAccAmplify_serial/BackendEnvironment/basic
=== RUN   TestAccAmplify_serial/BackendEnvironment/disappears
=== PAUSE TestAccAmplify_serial/BackendEnvironment/disappears
=== RUN   TestAccAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName
=== PAUSE TestAccAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName
=== CONT  TestAccAmplify_serial/BackendEnvironment/basic
=== CONT  TestAccAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName
=== CONT  TestAccAmplify_serial/BackendEnvironment/disappears
=== RUN   TestAccAmplify_serial/Branch
=== RUN   TestAccAmplify_serial/Branch/disappears
=== PAUSE TestAccAmplify_serial/Branch/disappears
=== RUN   TestAccAmplify_serial/Branch/Tags
=== PAUSE TestAccAmplify_serial/Branch/Tags
=== RUN   TestAccAmplify_serial/Branch/BasicAuthCredentials
=== PAUSE TestAccAmplify_serial/Branch/BasicAuthCredentials
=== RUN   TestAccAmplify_serial/Branch/EnvironmentVariables
=== PAUSE TestAccAmplify_serial/Branch/EnvironmentVariables
=== RUN   TestAccAmplify_serial/Branch/OptionalArguments
=== PAUSE TestAccAmplify_serial/Branch/OptionalArguments
=== RUN   TestAccAmplify_serial/Branch/basic
=== PAUSE TestAccAmplify_serial/Branch/basic
=== CONT  TestAccAmplify_serial/Branch/disappears
=== CONT  TestAccAmplify_serial/Branch/EnvironmentVariables
=== CONT  TestAccAmplify_serial/Branch/basic
=== CONT  TestAccAmplify_serial/Branch/OptionalArguments
=== CONT  TestAccAmplify_serial/Branch/Tags
=== CONT  TestAccAmplify_serial/Branch/BasicAuthCredentials
=== RUN   TestAccAmplify_serial/DomainAssociation
=== RUN   TestAccAmplify_serial/DomainAssociation/basic
    domain_association_test.go:23: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/disappears
    domain_association_test.go:64: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/update
    domain_association_test.go:93: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/Webhook
=== RUN   TestAccAmplify_serial/Webhook/basic
=== PAUSE TestAccAmplify_serial/Webhook/basic
=== RUN   TestAccAmplify_serial/Webhook/disappears
=== PAUSE TestAccAmplify_serial/Webhook/disappears
=== RUN   TestAccAmplify_serial/Webhook/update
=== PAUSE TestAccAmplify_serial/Webhook/update
=== CONT  TestAccAmplify_serial/Webhook/basic
=== CONT  TestAccAmplify_serial/Webhook/update
    webhook_test.go:76: Step 1/3 error: Error running apply: exit status 1

        Error: error creating Amplify App (tf-acc-test-4386902220289407518): BadRequestException: Rate exceeded while calling CreateApp, please slow down or try again later.

          with aws_amplify_app.test,
          on terraform_plugin_test.tf line 2, in resource "aws_amplify_app" "test":
           2: resource "aws_amplify_app" "test" {

=== CONT  TestAccAmplify_serial/Webhook/disappears
    webhook_test.go:53: Step 1/1 error: Error running apply: exit status 1

        Error: error creating Amplify App (tf-acc-test-1096456474378132208): BadRequestException: Rate exceeded while calling CreateApp, please slow down or try again later.

          with aws_amplify_app.test,
          on terraform_plugin_test.tf line 2, in resource "aws_amplify_app" "test":
           2: resource "aws_amplify_app" "test" {

--- FAIL: TestAccAmplify_serial (1122.73s)
    --- PASS: TestAccAmplify_serial/App (0.00s)
        --- PASS: TestAccAmplify_serial/App/Tags (65.36s)
        --- PASS: TestAccAmplify_serial/App/basic (27.76s)
        --- PASS: TestAccAmplify_serial/App/Name (53.18s)
        --- PASS: TestAccAmplify_serial/App/EnvironmentVariables (58.72s)
        --- PASS: TestAccAmplify_serial/App/Description (61.79s)
        --- PASS: TestAccAmplify_serial/App/BasicAuthCredentials (58.67s)
        --- PASS: TestAccAmplify_serial/App/disappears (22.47s)
        --- PASS: TestAccAmplify_serial/App/CustomRules (58.59s)
        --- PASS: TestAccAmplify_serial/App/Repository (31.26s)
        --- PASS: TestAccAmplify_serial/App/IamServiceRole (65.89s)
        --- PASS: TestAccAmplify_serial/App/BuildSpec (55.02s)
        --- PASS: TestAccAmplify_serial/App/AutoBranchCreationConfig (73.07s)
    --- PASS: TestAccAmplify_serial/BackendEnvironment (0.00s)
        --- PASS: TestAccAmplify_serial/BackendEnvironment/basic (38.35s)
        --- PASS: TestAccAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName (32.86s)
        --- PASS: TestAccAmplify_serial/BackendEnvironment/disappears (28.11s)
    --- PASS: TestAccAmplify_serial/Branch (0.01s)
        --- PASS: TestAccAmplify_serial/Branch/disappears (29.48s)
        --- PASS: TestAccAmplify_serial/Branch/EnvironmentVariables (63.82s)
        --- PASS: TestAccAmplify_serial/Branch/basic (34.52s)
        --- PASS: TestAccAmplify_serial/Branch/OptionalArguments (54.60s)
        --- PASS: TestAccAmplify_serial/Branch/Tags (63.49s)
        --- PASS: TestAccAmplify_serial/Branch/BasicAuthCredentials (62.29s)
    --- PASS: TestAccAmplify_serial/DomainAssociation (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/basic (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/disappears (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/update (0.00s)
    --- FAIL: TestAccAmplify_serial/Webhook (0.00s)
        --- PASS: TestAccAmplify_serial/Webhook/basic (68.84s)
        --- FAIL: TestAccAmplify_serial/Webhook/update (7.54s)
        --- FAIL: TestAccAmplify_serial/Webhook/disappears (7.02s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	1124.325s
FAIL
```
Some tests fail due to rate limits somehow, however the relevant tests (repository related) pass.


