### PR TITLE
docs/internet_gateway: update vpc_id to optional

### DIFF
--- a/website/docs/r/internet_gateway.html.markdown
+++ b/website/docs/r/internet_gateway.html.markdown
@@ -26,7 +26,7 @@ resource "aws_internet_gateway" "gw" {
 
 The following arguments are supported:
 
-* `vpc_id` - (Optional) The VPC ID to create in.  See the [aws_internet_gateway_attachment](/providers/hashicorp/aws/latest/docs/resources/internet_gateway_attachment) resource to attach an Internet Gateway to a VPC.
+* `vpc_id` - (Optional) The VPC ID to create in.  See the [aws_internet_gateway_attachment](internet_gateway_attachment.html) resource for an alternate way to attach an Internet Gateway to a VPC.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 -> **Note:** It's recommended to denote that the AWS Instance or Elastic IP depends on the Internet Gateway. For example:

--- a/website/docs/r/internet_gateway.html.markdown
+++ b/website/docs/r/internet_gateway.html.markdown
@@ -26,7 +26,7 @@ resource "aws_internet_gateway" "gw" {
 
 The following arguments are supported:
 
-* `vpc_id` - (Required) The VPC ID to create in.
+* `vpc_id` - (Optional) The VPC ID to create in.  See the [aws_internet_gateway_attachment](/providers/hashicorp/aws/latest/docs/resources/internet_gateway_attachment) resource to attach an Internet Gateway to a VPC.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 -> **Note:** It's recommended to denote that the AWS Instance or Elastic IP depends on the Internet Gateway. For example:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16386

Updating the docs for `aws_internet_gateway` to note the `vpc_id` is optional now since `aws_internet_gateway_attachment` can be used.