### PR TITLE
d/aws_ecrpublic_authorization_token

### DIFF
--- a/.changelog/23535.txt
+++ b/.changelog/23535.txt
@@ -1,0 +1,3 @@
+```new-data-source
+aws_ecrpublic_authorization_token
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -580,6 +580,8 @@ func Provider() *schema.Provider {
 			"aws_ecr_image":               ecr.DataSourceImage(),
 			"aws_ecr_repository":          ecr.DataSourceRepository(),
 
+			"aws_ecrpublic_authorization_token": ecrpublic.DataSourceAuthorizationToken(),
+
 			"aws_ecs_cluster":              ecs.DataSourceCluster(),
 			"aws_ecs_container_definition": ecs.DataSourceContainerDefinition(),
 			"aws_ecs_service":              ecs.DataSourceService(),

--- a/internal/service/ecrpublic/authorization_token_data_source.go
+++ b/internal/service/ecrpublic/authorization_token_data_source.go
@@ -1,0 +1,72 @@
+package ecrpublic
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecrpublic"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceAuthorizationToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAuthorizationTokenRead,
+
+		Schema: map[string]*schema.Schema{
+			"authorization_token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"expires_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceAuthorizationTokenRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ECRPublicConn
+	params := &ecrpublic.GetAuthorizationTokenInput{}
+	log.Printf("[DEBUG] Getting Public ECR authorization token")
+	out, err := conn.GetAuthorizationToken(params)
+	if err != nil {
+		return fmt.Errorf("error getting Public ECR authorization token: %w", err)
+	}
+	log.Printf("[DEBUG] Received Public ECR AuthorizationData %v", out.AuthorizationData)
+	authorizationData := out.AuthorizationData
+	authorizationToken := aws.StringValue(authorizationData.AuthorizationToken)
+	expiresAt := aws.TimeValue(authorizationData.ExpiresAt).Format(time.RFC3339)
+	authBytes, err := base64.URLEncoding.DecodeString(authorizationToken)
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("error decoding Public ECR authorization token: %w", err)
+	}
+	basicAuthorization := strings.Split(string(authBytes), ":")
+	if len(basicAuthorization) != 2 {
+		return fmt.Errorf("unknown Public ECR authorization token format")
+	}
+	userName := basicAuthorization[0]
+	password := basicAuthorization[1]
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("authorization_token", authorizationToken)
+	d.Set("expires_at", expiresAt)
+	d.Set("user_name", userName)
+	d.Set("password", password)
+	return nil
+}

--- a/internal/service/ecrpublic/authorization_token_data_source_test.go
+++ b/internal/service/ecrpublic/authorization_token_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccECRPublicAuthorizationTokenDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ecrpublic_authorization_token.repo"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:   func() { acctest.PreCheck(t) },
+		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, ecr.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/service/ecrpublic/authorization_token_data_source_test.go
+++ b/internal/service/ecrpublic/authorization_token_data_source_test.go
@@ -1,0 +1,36 @@
+package ecrpublic_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccECRPublicAuthorizationTokenDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_ecrpublic_authorization_token.repo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, ecr.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAuthorizationTokenBasicDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorization_token"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expires_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "user_name"),
+					resource.TestMatchResourceAttr(dataSourceName, "user_name", regexp.MustCompile(`AWS`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "password"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckAuthorizationTokenBasicDataSourceConfig = `
+data "aws_ecrpublic_authorization_token" "repo" {}
+`

--- a/website/docs/d/ecrpublic_authorization_token.html.markdown
+++ b/website/docs/d/ecrpublic_authorization_token.html.markdown
@@ -1,0 +1,28 @@
+---
+subcategory: "ECR"
+layout: "aws"
+page_title: "AWS: aws_ecrpublic_authorization_token"
+description: |-
+    Provides details about a Public ECR Authorization Token
+---
+
+# Data Source: aws_ecrpublic_authorization_token
+
+The Public ECR Authorization Token data source allows the authorization token, token expiration date, user name and password to be retrieved for a Public ECR repository.
+
+## Example Usage
+
+```terraform
+data "aws_ecrpublic_authorization_token" "token" {
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `authorization_token` - Temporary IAM authentication credentials to access the ECR repository encoded in base64 in the form of `user_name:password`.
+* `expires_at` - The time in UTC RFC3339 format when the authorization token expires.
+* `id` - Region of the authorization token.
+* `password` - Password decoded from the authorization token.
+* `user_name` - User name decoded from the authorization token.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23534 

Output from acceptance testing:

```
$ make testacc TESTS=TestAccECRPublic PKG=ecrpublic 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecrpublic/... -v -count 1 -parallel 20 -run='TestAccECRPublic'  -timeout 180m
=== RUN   TestAccECRPublicAuthorizationTokenDataSource_basic
--- PASS: TestAccECRPublicAuthorizationTokenDataSource_basic (11.45s)
=== RUN   TestAccECRPublicRepositoryPolicy_basic
=== PAUSE TestAccECRPublicRepositoryPolicy_basic
=== RUN   TestAccECRPublicRepositoryPolicy_disappears
=== PAUSE TestAccECRPublicRepositoryPolicy_disappears
=== RUN   TestAccECRPublicRepositoryPolicy_Disappears_repository
=== PAUSE TestAccECRPublicRepositoryPolicy_Disappears_repository
=== RUN   TestAccECRPublicRepositoryPolicy_iam
=== PAUSE TestAccECRPublicRepositoryPolicy_iam
=== RUN   TestAccECRPublicRepository_basic
=== PAUSE TestAccECRPublicRepository_basic
=== RUN   TestAccECRPublicRepository_CatalogData_aboutText
=== PAUSE TestAccECRPublicRepository_CatalogData_aboutText
=== RUN   TestAccECRPublicRepository_CatalogData_architectures
=== PAUSE TestAccECRPublicRepository_CatalogData_architectures
=== RUN   TestAccECRPublicRepository_CatalogData_description
=== PAUSE TestAccECRPublicRepository_CatalogData_description
=== RUN   TestAccECRPublicRepository_CatalogData_operatingSystems
=== PAUSE TestAccECRPublicRepository_CatalogData_operatingSystems
=== RUN   TestAccECRPublicRepository_CatalogData_usageText
=== PAUSE TestAccECRPublicRepository_CatalogData_usageText
=== RUN   TestAccECRPublicRepository_CatalogData_logoImageBlob
=== PAUSE TestAccECRPublicRepository_CatalogData_logoImageBlob
=== RUN   TestAccECRPublicRepository_Basic_forceDestroy
=== PAUSE TestAccECRPublicRepository_Basic_forceDestroy
=== RUN   TestAccECRPublicRepository_disappears
=== PAUSE TestAccECRPublicRepository_disappears
=== CONT  TestAccECRPublicRepositoryPolicy_basic
=== CONT  TestAccECRPublicRepository_CatalogData_description
=== CONT  TestAccECRPublicRepository_basic
=== CONT  TestAccECRPublicRepository_CatalogData_logoImageBlob
=== CONT  TestAccECRPublicRepository_CatalogData_usageText
=== CONT  TestAccECRPublicRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRPublicRepositoryPolicy_iam
=== CONT  TestAccECRPublicRepository_CatalogData_aboutText
=== CONT  TestAccECRPublicRepository_CatalogData_architectures
=== CONT  TestAccECRPublicRepository_Basic_forceDestroy
=== CONT  TestAccECRPublicRepositoryPolicy_disappears
=== CONT  TestAccECRPublicRepository_disappears
=== CONT  TestAccECRPublicRepository_CatalogData_operatingSystems
--- PASS: TestAccECRPublicRepository_disappears (17.85s)
--- PASS: TestAccECRPublicRepositoryPolicy_Disappears_repository (17.91s)
--- PASS: TestAccECRPublicRepositoryPolicy_disappears (20.21s)
--- PASS: TestAccECRPublicRepository_Basic_forceDestroy (23.21s)
--- PASS: TestAccECRPublicRepository_CatalogData_logoImageBlob (23.21s)
--- PASS: TestAccECRPublicRepository_basic (23.28s)
--- PASS: TestAccECRPublicRepository_CatalogData_usageText (34.27s)
--- PASS: TestAccECRPublicRepository_CatalogData_description (34.43s)
--- PASS: TestAccECRPublicRepository_CatalogData_operatingSystems (34.96s)
--- PASS: TestAccECRPublicRepository_CatalogData_aboutText (35.01s)
--- PASS: TestAccECRPublicRepository_CatalogData_architectures (35.05s)
--- PASS: TestAccECRPublicRepositoryPolicy_basic (35.28s)
--- PASS: TestAccECRPublicRepositoryPolicy_iam (40.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic  55.311s

...
```
