### PR TITLE
F secretsmanager rotation 22969

### DIFF
--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -137,7 +137,16 @@ func ResourceSecret() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"automatically_after_days": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Computed: true,
+						},
+						"duration": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"schedule_expression": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -334,6 +343,7 @@ func resourceSecretRead(d *schema.ResourceData, meta interface{}) error {
 	if aws.BoolValue(output.RotationEnabled) {
 		d.Set("rotation_lambda_arn", output.RotationLambdaARN)
 		if err := d.Set("rotation_rules", flattenSecretsManagerRotationRules(output.RotationRules)); err != nil {
+			log.Printf("[ERROR] OTHER FILE DUMMY")
 			return fmt.Errorf("error setting rotation_rules: %w", err)
 		}
 	} else {

--- a/internal/service/secretsmanager/secret_rotation_data_source.go
+++ b/internal/service/secretsmanager/secret_rotation_data_source.go
@@ -36,7 +36,16 @@ func DataSourceSecretRotation() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"automatically_after_days": {
 							Type:     schema.TypeInt,
-							Computed: true,
+							Optional: true,
+						},
+						"duration": {
+							Type:     schema.TypeString,
+							Default:  "0",
+							Optional: true,
+						},
+						"schedule_expression": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -28,7 +28,7 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creating secret rotation resource
 			{
-				Config: testAccSecretRotationConfig(rName, 7),
+				Config: testAccSecretRotationConfigAutomatic(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretRotationExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -50,6 +50,72 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 					),
 				},
 			*/
+			// Test importing secret rotation
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretRotation_rate(t *testing.T) {
+	var secret secretsmanager.DescribeSecretOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_rotation.test"
+	lambdaFunctionResourceName := "aws_lambda_function.test1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, secretsmanager.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSecretRotationDestroy,
+		Steps: []resource.TestStep{
+			// Test creating secret rotation resource with daily rate schedule expression
+			{
+				Config: testAccSecretRotationConfigRate(rName, 14),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretRotationExists(resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.schedule_expression", "rate(14 days)"),
+				),
+			},
+			// Test importing secret rotation
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretRotation_cron(t *testing.T) {
+	var secret secretsmanager.DescribeSecretOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_rotation.test"
+	lambdaFunctionResourceName := "aws_lambda_function.test1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, secretsmanager.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSecretRotationDestroy,
+		Steps: []resource.TestStep{
+			// Test creating secret rotation resource with daily rate schedule expression
+			{
+				Config: testAccSecretRotationConfigCron(rName, "cron(0 2 L * ? *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretRotationExists(resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.schedule_expression", "cron(0 2 L * ? *)"),
+				),
+			},
 			// Test importing secret rotation
 			{
 				ResourceName:      resourceName,
@@ -121,7 +187,7 @@ func testAccCheckSecretRotationExists(resourceName string, secret *secretsmanage
 	}
 }
 
-func testAccSecretRotationConfig(rName string, automaticallyAfterDays int) string {
+func testAccSecretRotationConfigAutomatic(rName string, automaticallyAfterDays int) string {
 	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
 # Not a real rotation function
 resource "aws_lambda_function" "test1" {
@@ -170,4 +236,108 @@ resource "aws_secretsmanager_secret_rotation" "test" {
   depends_on = [aws_lambda_permission.test1]
 }
 `, rName, automaticallyAfterDays)
+}
+
+func testAccSecretRotationConfigRate(rName string, dayRate int) string {
+	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
+# Not a real rotation function
+resource "aws_lambda_function" "test1" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-1"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_lambda_permission" "test1" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test1.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
+}
+
+# Not a real rotation function
+resource "aws_lambda_function" "test2" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-2"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_lambda_permission" "test2" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test2.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager2"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = "%[1]s"
+}
+
+resource "aws_secretsmanager_secret_rotation" "test" {
+  secret_id           = aws_secretsmanager_secret.test.id
+  rotation_lambda_arn = aws_lambda_function.test1.arn
+
+  rotation_rules {
+    schedule_expression 	 = "rate(%[2]d days)"
+	automatically_after_days = 0
+  }
+
+  depends_on = [aws_lambda_permission.test1]
+}
+`, rName, dayRate)
+}
+
+func testAccSecretRotationConfigCron(rName string, cron string) string {
+	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
+# Not a real rotation function
+resource "aws_lambda_function" "test1" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-1"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_lambda_permission" "test1" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test1.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
+}
+
+# Not a real rotation function
+resource "aws_lambda_function" "test2" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-2"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_lambda_permission" "test2" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test2.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager2"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = "%[1]s"
+}
+
+resource "aws_secretsmanager_secret_rotation" "test" {
+  secret_id           = aws_secretsmanager_secret.test.id
+  rotation_lambda_arn = aws_lambda_function.test1.arn
+
+  rotation_rules {
+    schedule_expression 	 = "%[2]s"
+	duration				 = "2h"
+  }
+
+  depends_on = [aws_lambda_permission.test1]
+}
+`, rName, cron)
 }

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -74,13 +74,13 @@ func TestAccSecretsManagerSecretRotation_rate(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creating secret rotation resource with daily rate schedule expression
 			{
-				Config: testAccSecretRotationConfigRate(rName, 14),
+				Config: testAccSecretRotationConfigRate(rName, 90),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretRotationExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.schedule_expression", "rate(14 days)"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.schedule_expression", "rate(90 days)"),
 				),
 			},
 			// Test importing secret rotation
@@ -282,7 +282,6 @@ resource "aws_secretsmanager_secret_rotation" "test" {
 
   rotation_rules {
     schedule_expression 	 = "rate(%[2]d days)"
-	automatically_after_days = 0
   }
 
   depends_on = [aws_lambda_permission.test1]
@@ -334,7 +333,6 @@ resource "aws_secretsmanager_secret_rotation" "test" {
 
   rotation_rules {
     schedule_expression 	 = "%[2]s"
-	duration				 = "2h"
   }
 
   depends_on = [aws_lambda_permission.test1]

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -281,7 +281,7 @@ resource "aws_secretsmanager_secret_rotation" "test" {
   rotation_lambda_arn = aws_lambda_function.test1.arn
 
   rotation_rules {
-    schedule_expression 	 = "rate(%[2]d days)"
+    schedule_expression = "rate(%[2]d days)"
   }
 
   depends_on = [aws_lambda_permission.test1]
@@ -332,7 +332,7 @@ resource "aws_secretsmanager_secret_rotation" "test" {
   rotation_lambda_arn = aws_lambda_function.test1.arn
 
   rotation_rules {
-    schedule_expression 	 = "%[2]s"
+    schedule_expression = "%[2]s"
   }
 
   depends_on = [aws_lambda_permission.test1]

--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -26,6 +26,7 @@ resource "aws_secretsmanager_secret_rotation" "example" {
 ```
 
 ### Rate Expression
+
 ```terraform
 resource "aws_secretsmanager_secret_rotation" "example" {
   secret_id           = aws_secretsmanager_secret.example.id
@@ -71,8 +72,8 @@ The following arguments are supported:
 
 * `automatically_after_days` - (Optional) Specifies the number of days between automatic scheduled rotations of the secret.
 * `schedule_expression` - (Optional) A rate or cron expression specifying when rotations of the secret should occur.  
-** `rate` - a rate expression - for example, 'rate(20 days)'.  
-** `cron` - a cron expression detailing when rotation should occur.  
+`rate` - a rate expression - for example, 'rate(20 days)'.  
+`cron` - a cron expression detailing when rotation should occur.  
 * `duration` - (Optional) Can only be used with a schedule expression.  Used to shorten the window in which AWS will execute the rotation.
 
 You must supply one of 'automatically_after_days' or 'schedule_expression' when defining secrets rotation.  

--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -25,6 +25,30 @@ resource "aws_secretsmanager_secret_rotation" "example" {
 }
 ```
 
+### Rate Expression
+```terraform
+resource "aws_secretsmanager_secret_rotation" "example" {
+  secret_id           = aws_secretsmanager_secret.example.id
+  rotation_lambda_arn = aws_lambda_function.example.arn
+
+  rotation_rules {
+    schedule_expression = "rate(14 days)"
+  }
+}
+```
+
+### Cron Expression With 2 Hour Duration
+```terraform
+resource "aws_secretsmanager_secret_rotation" "example" {
+  secret_id           = aws_secretsmanager_secret.example.id
+  rotation_lambda_arn = aws_lambda_function.example.arn
+
+  rotation_rules {
+    schedule_expression = "cron(0 2 L * ? *)"
+    duration            = 2
+  }
+}
+```
 ### Rotation Configuration
 
 To enable automatic secret rotation, the Secrets Manager service requires usage of a Lambda function. The [Rotate Secrets section in the Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html) provides additional information about deploying a prebuilt Lambda functions for supported credential rotation (e.g., RDS) or deploying a custom Lambda function.
@@ -43,7 +67,15 @@ The following arguments are supported:
 
 ### rotation_rules
 
-* `automatically_after_days` - (Required) Specifies the number of days between automatic scheduled rotations of the secret.
+* `automatically_after_days` - (Optional) Specifies the number of days between automatic scheduled rotations of the secret.
+* `schedule_expression` - (Optional) A rate or cron expression  specifying when rotations of the secret should occur.  
+** `rate` - a rate expression - for example, 'rate(20 days)'.  
+** `cron` - a cron expression detailing when rotation should occur.  
+* `duration` - (Optional) Can only be used with a schedule expression.  Used to shorten the window in which AWS will execute the rotation (the default is 24 hours).
+
+You must supply one of 'automatically_after_days' or 'schedule_expression' when defining secrets rotation.  
+
+Please refer to [Schedule expressions in Secrets Manager rotation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotate-secrets_schedule.html) for more details.
 
 ## Attributes Reference
 
@@ -52,6 +84,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Amazon Resource Name (ARN) of the secret.
 * `arn` - Amazon Resource Name (ARN) of the secret.
 * `rotation_enabled` - Specifies whether automatic rotation is enabled for this secret.
+* `automatically_after_days` - Due to the way the AWS API works this attribute will be calculated even when a schedule expression is used.
 
 ## Import
 

--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -38,6 +38,7 @@ resource "aws_secretsmanager_secret_rotation" "example" {
 ```
 
 ### Cron Expression With 2 Hour Duration
+
 ```terraform
 resource "aws_secretsmanager_secret_rotation" "example" {
   secret_id           = aws_secretsmanager_secret.example.id
@@ -49,6 +50,7 @@ resource "aws_secretsmanager_secret_rotation" "example" {
   }
 }
 ```
+
 ### Rotation Configuration
 
 To enable automatic secret rotation, the Secrets Manager service requires usage of a Lambda function. The [Rotate Secrets section in the Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html) provides additional information about deploying a prebuilt Lambda functions for supported credential rotation (e.g., RDS) or deploying a custom Lambda function.

--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -68,10 +68,10 @@ The following arguments are supported:
 ### rotation_rules
 
 * `automatically_after_days` - (Optional) Specifies the number of days between automatic scheduled rotations of the secret.
-* `schedule_expression` - (Optional) A rate or cron expression  specifying when rotations of the secret should occur.  
+* `schedule_expression` - (Optional) A rate or cron expression specifying when rotations of the secret should occur.  
 ** `rate` - a rate expression - for example, 'rate(20 days)'.  
 ** `cron` - a cron expression detailing when rotation should occur.  
-* `duration` - (Optional) Can only be used with a schedule expression.  Used to shorten the window in which AWS will execute the rotation (the default is 24 hours).
+* `duration` - (Optional) Can only be used with a schedule expression.  Used to shorten the window in which AWS will execute the rotation.
 
 You must supply one of 'automatically_after_days' or 'schedule_expression' when defining secrets rotation.  
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22969 

Output from acceptance testing:

```
$  make testacc PKG=secretsmanager                                                                                                                                                                                                                                                                                                                                                          <aws:default>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 20   -timeout 180m
=== RUN   TestValidSecretName
--- PASS: TestValidSecretName (0.00s)
=== RUN   TestValidSecretNamePrefix
--- PASS: TestValidSecretNamePrefix (0.00s)
=== RUN   TestAccSecretsManagerSecretDataSource_basic
=== PAUSE TestAccSecretsManagerSecretDataSource_basic
=== RUN   TestAccSecretsManagerSecretDataSource_arn
=== PAUSE TestAccSecretsManagerSecretDataSource_arn
=== RUN   TestAccSecretsManagerSecretDataSource_name
=== PAUSE TestAccSecretsManagerSecretDataSource_name
=== RUN   TestAccSecretsManagerSecretDataSource_policy
=== PAUSE TestAccSecretsManagerSecretDataSource_policy
=== RUN   TestAccSecretsManagerSecretPolicy_basic
=== PAUSE TestAccSecretsManagerSecretPolicy_basic
=== RUN   TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== PAUSE TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== RUN   TestAccSecretsManagerSecretPolicy_disappears
=== PAUSE TestAccSecretsManagerSecretPolicy_disappears
=== RUN   TestAccSecretsManagerSecretRotationDataSource_basic
=== PAUSE TestAccSecretsManagerSecretRotationDataSource_basic
=== RUN   TestAccSecretsManagerSecretRotation_basic
=== PAUSE TestAccSecretsManagerSecretRotation_basic
=== RUN   TestAccSecretsManagerSecretRotation_rate
=== PAUSE TestAccSecretsManagerSecretRotation_rate
=== RUN   TestAccSecretsManagerSecretRotation_cron
=== PAUSE TestAccSecretsManagerSecretRotation_cron
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== RUN   TestAccSecretsManagerSecret_withNamePrefix
=== PAUSE TestAccSecretsManagerSecret_withNamePrefix
=== RUN   TestAccSecretsManagerSecret_description
=== PAUSE TestAccSecretsManagerSecret_description
=== RUN   TestAccSecretsManagerSecret_basicReplica
=== PAUSE TestAccSecretsManagerSecret_basicReplica
=== RUN   TestAccSecretsManagerSecret_overwriteReplica
=== PAUSE TestAccSecretsManagerSecret_overwriteReplica
=== RUN   TestAccSecretsManagerSecret_kmsKeyID
=== PAUSE TestAccSecretsManagerSecret_kmsKeyID
=== RUN   TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== PAUSE TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== RUN   TestAccSecretsManagerSecret_rotationLambdaARN
=== PAUSE TestAccSecretsManagerSecret_rotationLambdaARN
=== RUN   TestAccSecretsManagerSecret_rotationRules
=== PAUSE TestAccSecretsManagerSecret_rotationRules
=== RUN   TestAccSecretsManagerSecret_tags
=== PAUSE TestAccSecretsManagerSecret_tags
=== RUN   TestAccSecretsManagerSecret_policy
=== PAUSE TestAccSecretsManagerSecret_policy
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionID
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionID
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionStage
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionStage
=== RUN   TestAccSecretsManagerSecretVersion_basicString
=== PAUSE TestAccSecretsManagerSecretVersion_basicString
=== RUN   TestAccSecretsManagerSecretVersion_base64Binary
=== PAUSE TestAccSecretsManagerSecretVersion_base64Binary
=== RUN   TestAccSecretsManagerSecretVersion_versionStages
=== PAUSE TestAccSecretsManagerSecretVersion_versionStages
=== CONT  TestAccSecretsManagerSecretDataSource_basic
=== CONT  TestAccSecretsManagerSecret_basicReplica
=== CONT  TestAccSecretsManagerSecretRotationDataSource_basic
=== CONT  TestAccSecretsManagerSecret_description
=== CONT  TestAccSecretsManagerSecret_withNamePrefix
=== CONT  TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecretRotation_cron
=== CONT  TestAccSecretsManagerSecretRotation_rate
=== CONT  TestAccSecretsManagerSecretVersion_versionStages
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionStage
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionID
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretDataSource_name
=== CONT  TestAccSecretsManagerSecretDataSource_policy
=== CONT  TestAccSecretsManagerSecretPolicy_basic
=== CONT  TestAccSecretsManagerSecretRotation_basic
=== CONT  TestAccSecretsManagerSecret_policy
=== CONT  TestAccSecretsManagerSecretVersion_base64Binary
=== CONT  TestAccSecretsManagerSecretVersion_basicString
=== CONT  TestAccSecretsManagerSecret_rotationLambdaARN
=== CONT  TestAccSecretsManagerSecret_tags
--- PASS: TestAccSecretsManagerSecretDataSource_basic (248.23s)
--- PASS: TestAccSecretsManagerSecretDataSource_policy (457.80s)
=== CONT  TestAccSecretsManagerSecret_rotationRules
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionID (458.28s)
=== CONT  TestAccSecretsManagerSecretPolicy_disappears
--- PASS: TestAccSecretsManagerSecretDataSource_name (459.32s)
=== CONT  TestAccSecretsManagerSecretPolicy_blockPublicPolicy
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionStage (459.45s)
=== CONT  TestAccSecretsManagerSecretDataSource_arn
--- PASS: TestAccSecretsManagerSecret_basicReplica (464.00s)
=== CONT  TestAccSecretsManagerSecret_kmsKeyID
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (494.81s)
=== CONT  TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
--- PASS: TestAccSecretsManagerSecretRotationDataSource_basic (530.33s)
=== CONT  TestAccSecretsManagerSecret_overwriteReplica
--- PASS: TestAccSecretsManagerSecret_basic (575.36s)
--- PASS: TestAccSecretsManagerSecret_withNamePrefix (580.43s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (582.51s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (583.77s)
--- PASS: TestAccSecretsManagerSecretRotation_rate (601.06s)
--- PASS: TestAccSecretsManagerSecretRotation_basic (616.40s)
--- PASS: TestAccSecretsManagerSecretRotation_cron (628.80s)
--- PASS: TestAccSecretsManagerSecretDataSource_arn (324.23s)
--- PASS: TestAccSecretsManagerSecret_description (793.77s)
--- PASS: TestAccSecretsManagerSecretPolicy_basic (797.19s)
--- PASS: TestAccSecretsManagerSecretPolicy_disappears (339.37s)
--- PASS: TestAccSecretsManagerSecret_rotationLambdaARN (826.05s)
--- PASS: TestAccSecretsManagerSecret_policy (880.37s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (921.10s)
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (458.74s)
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (490.77s)
--- PASS: TestAccSecretsManagerSecret_rotationRules (503.74s)
--- PASS: TestAccSecretsManagerSecret_overwriteReplica (483.86s)
--- PASS: TestAccSecretsManagerSecretPolicy_blockPublicPolicy (558.11s)
--- PASS: TestAccSecretsManagerSecret_tags (777.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     1043.826s

...
```
