### PR TITLE
fix #23543 Ignore suffix for domains in aws_route53_resolver_firewall_domain_list

### DIFF
--- a/.changelog/23543.txt
+++ b/.changelog/23543.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_resolver_firewall_domain_list: Ignore suffixes in the domain list.
+```

--- a/internal/service/route53resolver/firewall_domain_list.go
+++ b/internal/service/route53resolver/firewall_domain_list.go
@@ -3,6 +3,7 @@ package route53resolver
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"

--- a/internal/service/route53resolver/firewall_domain_list.go
+++ b/internal/service/route53resolver/firewall_domain_list.go
@@ -114,7 +114,11 @@ func resourceFirewallDomainListRead(d *schema.ResourceData, meta interface{}) er
 	domains := []*string{}
 
 	err = conn.ListFirewallDomainsPages(input, func(output *route53resolver.ListFirewallDomainsOutput, lastPage bool) bool {
-		domains = append(domains, output.Domains...)
+		// AWS' response contains a dot at the end, this causes the domains to never match.
+		for _, domain := range output.Domains {
+			var sanitizedDomain := strings.TrimSuffix(*domain, ".")
+			domains = append(domains, &sanitizedDomain)
+		}
 		return !lastPage
 	})
 

--- a/internal/service/route53resolver/firewall_domain_list.go
+++ b/internal/service/route53resolver/firewall_domain_list.go
@@ -114,9 +114,9 @@ func resourceFirewallDomainListRead(d *schema.ResourceData, meta interface{}) er
 	domains := []*string{}
 
 	err = conn.ListFirewallDomainsPages(input, func(output *route53resolver.ListFirewallDomainsOutput, lastPage bool) bool {
-		// AWS' response contains a dot at the end, this causes the domains to never match.
+		// AWS' response contains a trailing dot at the end, this causes the domains to never match.
 		for _, domain := range output.Domains {
-			var sanitizedDomain := strings.TrimSuffix(*domain, ".")
+			var sanitizedDomain = strings.TrimSuffix(*domain, ".")
 			domains = append(domains, &sanitizedDomain)
 		}
 		return !lastPage


### PR DESCRIPTION
Trimming trailing . that is added to all domains by AWS and causing perpetual diffs.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #23543

