### PR TITLE
[WIP] Feature help for OperationPreferences in StackSetInstances

### DIFF
--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -178,13 +178,8 @@ func resourceStackSetInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		input.ParameterOverrides = expandParameters(v.(map[string]interface{}))
 	}
 
-	// if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-	// 	input.OperationPreferences = expandCloudFormationOperationPreferences(v.([]interface{}))
-	// 	return fmt.Errorf("%+v", v)
-	// }
-
 	if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.OperationPreferences = testprefs(d)
+		input.OperationPreferences = expandCloudFormationOperationPreferences(d)
 	}
 
 	log.Printf("[DEBUG] Creating CloudFormation StackSet Instance: %s", input)
@@ -326,7 +321,7 @@ func resourceStackSetInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.OperationPreferences = testprefs(d)
+			input.OperationPreferences = expandCloudFormationOperationPreferences(d)
 		}
 
 		log.Printf("[DEBUG] Updating CloudFormation StackSet Instance: %s", input)
@@ -408,45 +403,7 @@ func expandCloudFormationDeploymentTargets(l []interface{}) *cloudformation.Depl
 	return dt
 }
 
-func expandCloudFormationOperationPreferences(l []interface{}) *cloudformation.StackSetOperationPreferences {
-	if len(l) == 0 {
-		return nil
-	}
-
-	m := l[0].(map[string]interface{})
-
-	operationPreferences := &cloudformation.StackSetOperationPreferences{
-		// FailureToleranceCount: aws.Int64(int64(m["failure_tolerance_count"].(int))),
-		// FailureTolerancePercentage: aws.Int64(int64(m["failure_tolerance_percentage"].(int))),
-		// MaxConcurrentCount: aws.Int64(int64(m["max_concurrent_count"].(int))),
-		// MaxConcurrentPercentage:    aws.Int64(int64(m["max_concurrent_percentage"].(int))),
-		// RegionConcurrencyType: aws.String(m["region_concurrency_type"].(string)),
-	}
-
-	if v, ok := m["failure_tolerance_count"]; ok && v != -1 {
-		operationPreferences.FailureToleranceCount = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := m["failure_tolerance_percentage"]; ok && v != -1 {
-		operationPreferences.FailureTolerancePercentage = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := m["max_concurrent_count"]; ok && v != -1 {
-		operationPreferences.MaxConcurrentCount = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := m["max_concurrent_percentage"]; ok && v != -1 {
-		operationPreferences.MaxConcurrentPercentage = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := m["region_order"].(*schema.Set); ok && v.Len() > 0 {
-		operationPreferences.RegionOrder = flex.ExpandStringSet(v)
-	}
-
-	return operationPreferences
-}
-
-func testprefs(d *schema.ResourceData) *cloudformation.StackSetOperationPreferences {
+func expandCloudFormationOperationPreferences(d *schema.ResourceData) *cloudformation.StackSetOperationPreferences {
 
 	operationPreferences := &cloudformation.StackSetOperationPreferences{}
 

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -75,30 +75,26 @@ func ResourceStackSetInstance() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"failure_tolerance_count": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							// Default:       -1,
+							Type:          schema.TypeInt,
+							Optional:      true,
 							ValidateFunc:  validation.IntAtLeast(0),
 							ConflictsWith: []string{"operation_preferences.failure_tolerance_percentage"},
 						},
 						"failure_tolerance_percentage": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							// Default:       -1,
+							Type:          schema.TypeInt,
+							Optional:      true,
 							ValidateFunc:  validation.IntBetween(0, 100),
 							ConflictsWith: []string{"operation_preferences.failure_tolerance_count"},
 						},
 						"max_concurrent_count": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							// Default:       -1,
+							Type:          schema.TypeInt,
+							Optional:      true,
 							ValidateFunc:  validation.IntAtLeast(1),
 							ConflictsWith: []string{"operation_preferences.max_concurrent_percentage"},
 						},
 						"max_concurrent_percentage": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							// Default:       -1,
+							Type:          schema.TypeInt,
+							Optional:      true,
 							ValidateFunc:  validation.IntBetween(1, 100),
 							ConflictsWith: []string{"operation_preferences.max_concurrent_count"},
 						},
@@ -304,7 +300,7 @@ func resourceStackSetInstanceRead(d *schema.ResourceData, meta interface{}) erro
 func resourceStackSetInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).CloudFormationConn
 
-	if d.HasChanges("deployment_targets", "parameter_overrides") {
+	if d.HasChanges("deployment_targets", "parameter_overrides", "operation_preferences") {
 		stackSetName, accountID, region, err := StackSetInstanceParseResourceID(d.Id())
 
 		if err != nil {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Greetings! I am attempting to thread the needle to help add support for OperationPreferences called out in the following issues: https://github.com/hashicorp/terraform-provider-aws/issues/21307 & https://github.com/hashicorp/terraform-provider-aws/issues/18490

Help would be greatly appreciated for the following sections:
1. How are you supposed to deal with the 0 value conflicting with validation?

I attempted to follow examples in the code for expanding values out of the config, when I convert and pass the interface like other pieces of the code [Example](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/cloudformation/stack_set_instance.go#L121), I have no way to verify whether the `0` value thats being passed was explicit or not. If there is no default value and the user hasn't configured that parameter, I don't understand why it's getting set to a 0 value. This then breaks during validation `ValidateFunc:  validation.IntBetween(1, 100),`. 

My first attempt involved [mirroring "deployment_targets"](https://github.com/Popsiclestick/terraform-provider-aws/blob/stack-set-instances-operation-preferences/internal/service/cloudformation/stack_set_instance.go#L185-L188). But whenever I checked for `ok` or `v != nil` in [expandCloudFormationOperationPreferences](https://github.com/Popsiclestick/terraform-provider-aws/blob/stack-set-instances-operation-preferences/internal/service/cloudformation/stack_set_instance.go#L415-L451) the value was set to a `0`. Later I attempted experimenting with `-1` as I saw other pieces of the code doing this.

[Second attempt](https://github.com/Popsiclestick/terraform-provider-aws/blob/stack-set-instances-operation-preferences/internal/service/cloudformation/stack_set_instance.go#L453-L477) I just went an passed ResourceData down so I could grab the underlying values. This appears to work.

It's been a bit since I've written Go and I am uncertain if `GetOk` is doing some kind of reflection which is changing the value? Help would be greatly appreciated in determining whats going on or if I missed something. Thank you very much! 


