### PR TITLE
Correct documentation on argument name on aws_datapipeline_pipeline_difinition

### DIFF
--- a/website/docs/r/datapipeline_pipeline_definition.html.markdown
+++ b/website/docs/r/datapipeline_pipeline_definition.html.markdown
@@ -96,10 +96,10 @@ The following arguments are optional:
 
 ### `parameter_object`
 
-* `attributes` - (Required) Configuration block for attributes of the parameter object. See below
+* `attribute` - (Required) Configuration block for attributes of the parameter object. See below
 * `id` - (Required) ID of the parameter object.
 
-### `attributes`
+### `attribute`
 
 * `key` - (Required) Field identifier.
 * `string_value` - (Required) Field value, expressed as a String.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23550

Output from acceptance testing: n/a, docs

### Information

As mentioned in the linked issue, [the correct argument](https://github.com/hashicorp/terraform-provider-aws/blob/1ddf4c774b7124b83cd032b777d5a0f291af54c1/internal/service/datapipeline/pipeline_definition.go#L36) is `attribute`, while the documentation currently has `attributes`.