### PR TITLE
resource/aws_s3_bucket: Add top-level `object_lock_enabled` parameter

### DIFF
--- a/.changelog/23556.txt
+++ b/.changelog/23556.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add top-level `object_lock_enabled` parameter
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -592,6 +592,14 @@ func ResourceBucket() *schema.Resource {
 				},
 			},
 
+			"object_lock_enabled": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true, // Can be removed when object_lock_configuration.0.object_lock_enabled is removed
+				ForceNew:      true,
+				ConflictsWith: []string{"object_lock_configuration.0.object_lock_enabled"},
+			},
+
 			"object_lock_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -601,9 +609,10 @@ func ResourceBucket() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"object_lock_enabled": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice(s3.ObjectLockEnabled_Values(), false),
+							Deprecated:   "Use the top-level parameter object_lock_enabled instead",
 						},
 
 						"rule": {
@@ -670,7 +679,8 @@ func resourceBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] S3 bucket create: %s", bucket)
 
 	req := &s3.CreateBucketInput{
-		Bucket: aws.String(bucket),
+		Bucket:                     aws.String(bucket),
+		ObjectLockEnabledForBucket: aws.Bool(d.Get("object_lock_enabled").(bool)),
 	}
 
 	awsRegion := meta.(*conns.AWSClient).Region
@@ -697,9 +707,8 @@ func resourceBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateBucket(req)
 		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "OperationAborted" {
-				return resource.RetryableError(
-					fmt.Errorf("Error creating S3 bucket %s, retrying: %s", bucket, err))
+			if awsErr.Code() == ErrCodeOperationAborted {
+				return resource.RetryableError(fmt.Errorf("Error creating S3 bucket %s, retrying: %w", bucket, err))
 			}
 		}
 		if err != nil {
@@ -1151,11 +1160,13 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[WARN] Unable to read S3 bucket (%s) Object Lock Configuration: %s", d.Id(), err)
 	}
 
-	if output, ok := resp.(*s3.GetObjectLockConfigurationOutput); ok {
+	if output, ok := resp.(*s3.GetObjectLockConfigurationOutput); ok && output.ObjectLockConfiguration != nil {
+		d.Set("object_lock_enabled", aws.StringValue(output.ObjectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled)
 		if err := d.Set("object_lock_configuration", flattenS3ObjectLockConfiguration(output.ObjectLockConfiguration)); err != nil {
 			return fmt.Errorf("error setting object_lock_configuration: %w", err)
 		}
 	} else {
+		d.Set("object_lock_enabled", false)
 		d.Set("object_lock_configuration", nil)
 	}
 

--- a/internal/service/s3/bucket_object_data_source_test.go
+++ b/internal/service/s3/bucket_object_data_source_test.go
@@ -592,9 +592,7 @@ func testAccBucketObjectDataSourceConfig_objectLockLegalHoldOff(randInt int) str
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -626,9 +624,7 @@ func testAccBucketObjectDataSourceConfig_objectLockLegalHoldOn(randInt int, reta
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {

--- a/internal/service/s3/bucket_object_lock_configuration_test.go
+++ b/internal/service/s3/bucket_object_lock_configuration_test.go
@@ -186,9 +186,7 @@ func testAccBucketObjectLockConfigurationBasicConfig(bucketName string) string {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "test" {
@@ -209,9 +207,7 @@ func testAccBucketObjectLockConfigurationUpdateConfig(bucketName string) string 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "test" {

--- a/internal/service/s3/bucket_object_test.go
+++ b/internal/service/s3/bucket_object_test.go
@@ -1912,9 +1912,7 @@ func testAccBucketObjectConfig_noObjectLockLegalHold(rName string, content strin
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -1941,9 +1939,7 @@ func testAccBucketObjectConfig_withObjectLockLegalHold(rName string, content, le
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -1971,9 +1967,7 @@ func testAccBucketObjectConfig_noObjectLockRetention(rName string, content strin
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -2000,9 +1994,7 @@ func testAccBucketObjectConfig_withObjectLockRetention(rName string, content, re
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -454,6 +454,33 @@ func TestAccS3Bucket_Manage_objectLock_deprecatedEnabled(t *testing.T) {
 	})
 }
 
+func TestAccS3Bucket_Manage_objectLock_migrate(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectLockEnabledNoDefaultRetention_deprecatedEnabled(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", s3.ObjectLockEnabledEnabled),
+				),
+			},
+			{
+				Config:   testAccObjectLockEnabledNoDefaultRetention(bucketName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccS3Bucket_Manage_objectLockWithVersioning(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.test"

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -1370,9 +1370,7 @@ resource "aws_s3_bucket" "bucket" {
   bucket        = "%s"
   force_destroy = true
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_acl" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -64,6 +64,8 @@ func TestAccS3Bucket_Basic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "0"),
 				),
 			},
 			{
@@ -406,8 +408,39 @@ func TestAccS3Bucket_Manage_objectLock(t *testing.T) {
 				Config: testAccObjectLockEnabledNoDefaultRetention(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", s3.ObjectLockEnabledEnabled),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccS3Bucket_Manage_objectLock_deprecatedEnabled(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectLockEnabledNoDefaultRetention_deprecatedEnabled(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", s3.ObjectLockEnabledEnabled),
 					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.#", "0"),
 				),
 			},
@@ -435,8 +468,38 @@ func TestAccS3Bucket_Manage_objectLockWithVersioning(t *testing.T) {
 				Config: testAccBucketConfig_objectLockEnabledWithVersioning(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", s3.ObjectLockEnabledEnabled),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_objectLockEnabledWithVersioning_deprecatedEnabled(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", s3.ObjectLockEnabledEnabled),
 				),
 			},
 			{
@@ -1222,6 +1285,16 @@ func testAccObjectLockEnabledNoDefaultRetention(bucketName string) string {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
+  object_lock_enabled = true
+}
+`, bucketName)
+}
+
+func testAccObjectLockEnabledNoDefaultRetention_deprecatedEnabled(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
@@ -1230,6 +1303,29 @@ resource "aws_s3_bucket" "test" {
 }
 
 func testAccBucketConfig_objectLockEnabledWithVersioning(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+
+  object_lock_enabled = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+`, bucketName)
+}
+
+func testAccBucketConfig_objectLockEnabledWithVersioning_deprecatedEnabled(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q

--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -621,9 +621,7 @@ func testAccObjectDataSourceConfig_objectLockLegalHoldOff(randInt int) string {
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "object_bucket" {
@@ -653,9 +651,7 @@ func testAccObjectDataSourceConfig_objectLockLegalHoldOn(randInt int, retainUnti
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "object_bucket" {

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -1896,9 +1896,7 @@ func testAccObjectConfig_noObjectLockLegalHold(rName string, content string) str
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -1923,9 +1921,7 @@ func testAccObjectConfig_withObjectLockLegalHold(rName string, content, legalHol
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -1951,9 +1947,7 @@ func testAccObjectConfig_noObjectLockRetention(rName string, content string) str
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -1978,9 +1972,7 @@ func testAccObjectConfig_withObjectLockRetention(rName string, content, retainUn
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_versioning" "test" {

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -937,9 +937,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "yournamehere"
 
   # ... other configuration ...
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "example" {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -60,7 +60,7 @@ See the [`aws_s3_bucket_lifecycle_configuration` resource](s3_bucket_lifecycle_c
 ### Using object lock configuration
 
 The `object_lock_configuration.rule` argument is read-only as of version 4.0 of the Terraform AWS Provider.
-To **enable** Object Lock on a **new** bucket, use the `object_lock_configuration.object_lock_enabled` argument in **this** resource. See [Object Lock Configuration](#object-lock-configuration) below for details.
+To **enable** Object Lock on a **new** bucket, use the `object_lock_enabled` argument in **this** resource. See [Object Lock Configuration](#object-lock-configuration) below for details.
 To configure the default retention rule of the Object Lock configuration, see the [`aws_s3_bucket_object_lock_configuration` resource](s3_bucket_object_lock_configuration.html.markdown) for configuration details.
 To **enable** Object Lock on an **existing** bucket, please contact AWS Support and refer to the [Object lock configuration for an existing bucket](s3_bucket_object_lock_configuration.html.markdown#object-lock-configuration-for-an-existing-bucket) example for more details.
 
@@ -86,6 +86,7 @@ The following arguments are supported:
 * `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+* `object_lock_enabled` - (Optional, Default:`false`, Forces new resource) Indicates whether this bucket has an Object Lock configuration enabled.
 * `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See [Object Lock Configuration](#object-lock-configuration) below.
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
@@ -98,7 +99,7 @@ To configure the default retention rule of the Object Lock configuration, see th
 
 The `object_lock_configuration` configuration block supports the following argument:
 
-* `object_lock_enabled` - (Required) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
+* `object_lock_enabled` - (Optional, **Deprecated**) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`. Use the top-level argument `object_lock_enabled` instead.
 
 ## Attributes Reference
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -100,9 +100,7 @@ resource "aws_s3_bucket_object" "example" {
 resource "aws_s3_bucket" "examplebucket" {
   bucket = "examplebuckettftest"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_acl" "example" {

--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -22,9 +22,7 @@ If you want to **enable** Object Lock for an **existing** bucket, contact AWS Su
 resource "aws_s3_bucket" "example" {
   bucket = "mybucket"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "example" {

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -98,9 +98,7 @@ resource "aws_s3_object" "example" {
 resource "aws_s3_bucket" "examplebucket" {
   bucket = "examplebuckettftest"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_acl" "example" {


### PR DESCRIPTION
Adds top-level `object_lock_enabled` parameter to `aws_s3_bucket` and deprecates `object_lock_configuration.object_lock_enabled`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23549

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=s3 TESTS='TestAccS3Bucket_|TestAccS3BucketObject_|TestAccS3BucketObjectDataSource_|TestAccS3Object_|TestAccS3ObjectDataSource_'

--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (170.67s)
--- PASS: TestAccS3BucketObjectDataSource_basic (188.71s)
--- PASS: TestAccS3Object_objectBucketKeyEnabled (190.64s)
--- PASS: TestAccS3Object_defaultBucketSSE (196.46s)
--- PASS: TestAccS3Object_bucketBucketKeyEnabled (198.22s)
--- SKIP: TestAccS3Object_nonVersioned (0.00s)
--- PASS: TestAccS3Object_sse (244.58s)
--- PASS: TestAccS3BucketObject_sse (254.45s)
--- PASS: TestAccS3Object_kms (255.85s)
--- PASS: TestAccS3Object_ignoreTags (337.50s)
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithOn (351.01s)
--- PASS: TestAccS3ObjectDataSource_allParams (197.22s)
--- PASS: TestAccS3ObjectDataSource_bucketKeyEnabled (196.90s)
--- PASS: TestAccS3ObjectDataSource_kmsEncrypted (194.07s)
--- PASS: TestAccS3ObjectDataSource_readableBody (195.66s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithNone (506.35s)
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithNone (506.70s)
--- PASS: TestAccS3Object_updatesWithVersioningViaAccessPoint (351.02s)
--- PASS: TestAccS3Object_metadata (534.27s)
--- PASS: TestAccS3ObjectDataSource_basicViaAccessPoint (200.78s)
--- PASS: TestAccS3Object_updateSameFile (348.66s)
--- PASS: TestAccS3Object_acl (548.57s)
--- PASS: TestAccS3ObjectDataSource_basic (198.60s)
--- PASS: TestAccS3Object_updatesWithVersioning (410.63s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (206.34s)
--- PASS: TestAccS3Object_updates (408.33s)
--- PASS: TestAccS3Object_noNameNoKey (83.07s)
--- PASS: TestAccS3Object_tagsMultipleSlashes (636.75s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (197.20s)
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (645.02s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (197.56s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithSet (656.26s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (252.12s)
--- PASS: TestAccS3Object_tags (707.15s)
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (712.03s)
--- PASS: TestAccS3ObjectDataSource_objectLockLegalHoldOff (195.70s)
--- PASS: TestAccS3Object_withContentCharacteristics (189.98s)
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (244.88s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (247.76s)
--- PASS: TestAccS3Bucket_Manage_objectLock (243.50s)
--- PASS: TestAccS3Object_empty (243.10s)
--- PASS: TestAccS3Object_contentBase64 (180.41s)
--- PASS: TestAccS3ObjectDataSource_singleSlashAsKey (178.18s)
--- PASS: TestAccS3Object_source (240.37s)
--- PASS: TestAccS3ObjectDataSource_objectLockLegalHoldOn (182.78s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (179.10s)
--- PASS: TestAccS3Object_storageClass (828.13s)
--- PASS: TestAccS3Bucket_Basic_generatedName (230.63s)
--- SKIP: TestAccS3BucketObject_nonVersioned (0.00s)
--- PASS: TestAccS3Object_etagEncryption (229.89s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (224.72s)
--- PASS: TestAccS3Object_content (225.57s)
--- PASS: TestAccS3ObjectDataSource_multipleSlashes (310.51s)
--- PASS: TestAccS3Bucket_Tags_basic (228.77s)
--- PASS: TestAccS3ObjectDataSource_leadingSlash (310.81s)
--- PASS: TestAccS3BucketObject_source (225.66s)
--- PASS: TestAccS3Object_sourceHashTrigger (362.09s)
--- PASS: TestAccS3BucketObject_kms (225.10s)
--- PASS: TestAccS3Bucket_Basic_emptyString (225.31s)
--- PASS: TestAccS3BucketObject_noNameNoKey (67.40s)
--- PASS: TestAccS3Bucket_Basic_basic (223.41s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (171.37s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (170.21s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (311.70s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (306.17s)
--- PASS: TestAccS3BucketObject_updateSameFile (311.23s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (178.09s)
--- PASS: TestAccS3BucketObject_contentBase64 (172.33s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (362.27s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (173.43s)
--- PASS: TestAccS3BucketObject_ignoreTags (316.13s)
--- PASS: TestAccS3BucketObject_empty (223.10s)
--- PASS: TestAccS3BucketObject_etagEncryption (224.69s)
--- PASS: TestAccS3BucketObject_updates (364.70s)
--- PASS: TestAccS3BucketObject_content (227.55s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (176.07s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (354.41s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (301.93s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (302.85s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (171.22s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (168.23s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (171.02s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (159.25s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (607.39s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (289.81s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (643.39s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (138.39s)
--- PASS: TestAccS3BucketObjectDataSource_allParams (133.47s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (383.18s)
--- PASS: TestAccS3BucketObject_metadata (411.04s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (457.52s)
--- PASS: TestAccS3BucketObject_acl (361.93s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (318.26s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (447.38s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (396.65s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (431.82s)
--- PASS: TestAccS3BucketObject_tags (420.48s)
--- PASS: TestAccS3BucketObject_storageClass (447.42s)
```
