### PR TITLE
fix "*" key policy in aws_route53_key_signing_key example

### DIFF
--- a/website/docs/r/route53_key_signing_key.html.markdown
+++ b/website/docs/r/route53_key_signing_key.html.markdown
@@ -17,6 +17,8 @@ provider "aws" {
   region = "us-east-1"
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "example" {
   customer_master_key_spec = "ECC_NIST_P256"
   deletion_window_in_days  = 7
@@ -35,6 +37,14 @@ resource "aws_kms_key" "example" {
         }
         Sid      = "Allow Route 53 DNSSEC Service",
         Resource = "*"
+        Condition = {
+            StringEquals = {
+                "aws:SourceAccount" = "${data.aws_caller_identity.current.account_id}"
+            }
+            ArnLike = {
+                "aws:SourceArn" = "arn:aws:route53:::hostedzone/*"
+            }
+        }
       },
       {
         Action = "kms:CreateGrant",
@@ -54,10 +64,10 @@ resource "aws_kms_key" "example" {
         Action = "kms:*"
         Effect = "Allow"
         Principal = {
-          AWS = "*"
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         }
         Resource = "*"
-        Sid      = "IAM User Permissions"
+        Sid      = "Enable IAM User Permissions"
       },
     ]
     Version = "2012-10-17"

--- a/website/docs/r/route53_key_signing_key.html.markdown
+++ b/website/docs/r/route53_key_signing_key.html.markdown
@@ -38,12 +38,12 @@ resource "aws_kms_key" "example" {
         Sid      = "Allow Route 53 DNSSEC Service",
         Resource = "*"
         Condition = {
-            StringEquals = {
-                "aws:SourceAccount" = "${data.aws_caller_identity.current.account_id}"
-            }
-            ArnLike = {
-                "aws:SourceArn" = "arn:aws:route53:::hostedzone/*"
-            }
+          StringEquals = {
+            "aws:SourceAccount" = "${data.aws_caller_identity.current.account_id}"
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:route53:::hostedzone/*"
+          }
         }
       },
       {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing: n/a

### Information

The example policy in the docs uses a Principal of `AWS = "*"` and this is generally accepted as a bad practice. There's a special warning the the [AWS Docs](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html) about this:

>  Do not set the Principal to an asterisk (*) in any key policy statement that allows permissions unless you use conditions to limit the key policy. An asterisk gives every identity in every AWS account permission to use the KMS key, unless another policy statement explicitly denies it. Users in other AWS accounts just need corresponding IAM permissions in their own accounts to use the KMS key.

This request modified the policy to mimic what the Console would create for manual KSK creation. It limits the the use of the KMS Key to the specific account, and adds conditions for Route53 as well.
