### PR TITLE
resource/aws_synthetics_canrany: Add environment variables to run config

### DIFF
--- a/.changelog/23574.txt
+++ b/.changelog/23574.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_synthetics_canary: Add optional `environment variables` to `run_config`.
+resource/aws_synthetics_canary: Add optional `environment_variables` to `run_config`.
 ```

--- a/.changelog/23574.txt
+++ b/.changelog/23574.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_synthetics_canary: Add optional `environment variables` to `run_config`.
+```

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -390,16 +390,13 @@ func resourceCanaryRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting vpc config: %w", err)
 	}
 
-	// get environment variables since they are not available on describe
-	envVars := make(map[string]*string)
+	// get environment variables since they a
+	runConfig := &synthetics.CanaryRunConfigInput{}
 	if v, ok := d.GetOk("run_config"); ok {
-		runConfig := expandCanaryRunConfig(v.([]interface{}))
-		for k, v := range runConfig.EnvironmentVariables {
-			envVars[k] = v
-		}
+		runConfig = expandCanaryRunConfig(v.([]interface{}))
 	}
 
-	if err := d.Set("run_config", flattenCanaryRunConfig(canary.RunConfig, envVars)); err != nil {
+	if err := d.Set("run_config", flattenCanaryRunConfig(canary.RunConfig, runConfig.EnvironmentVariables)); err != nil {
 		return fmt.Errorf("error setting run config: %w", err)
 	}
 

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -390,7 +390,6 @@ func resourceCanaryRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting vpc config: %w", err)
 	}
 
-	// get environment variables since they a
 	runConfig := &synthetics.CanaryRunConfigInput{}
 	if v, ok := d.GetOk("run_config"); ok {
 		runConfig = expandCanaryRunConfig(v.([]interface{}))
@@ -715,7 +714,7 @@ func expandCanaryRunConfig(l []interface{}) *synthetics.CanaryRunConfigInput {
 	}
 
 	if vars, ok := m["environment_variables"].(map[string]interface{}); ok && len(vars) > 0 {
-		codeConfig.EnvironmentVariables = flex.ExpandStringMap(ev)
+		codeConfig.EnvironmentVariables = flex.ExpandStringMap(vars)
 	}
 
 	return codeConfig

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -736,7 +736,7 @@ func flattenCanaryRunConfig(canaryCodeOut *synthetics.CanaryRunConfigOutput, env
 		"active_tracing":     aws.BoolValue(canaryCodeOut.ActiveTracing),
 	}
 
-	if v := envVars; v != nil {
+	if envVars != nil {
 		m["environment_variables"] = aws.StringValueMap(envVars)
 	}
 

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -714,12 +714,8 @@ func expandCanaryRunConfig(l []interface{}) *synthetics.CanaryRunConfigInput {
 		codeConfig.ActiveTracing = aws.Bool(v)
 	}
 
-	if vars, ok := m["environment_variables"].(map[string]interface{}); ok {
-		ev := make(map[string]string)
-		for k, v := range vars {
-			ev[k] = v.(string)
-		}
-		codeConfig.EnvironmentVariables = aws.StringMap(ev)
+	if vars, ok := m["environment_variables"].(map[string]interface{}); ok && len(vars) > 0 {
+		codeConfig.EnvironmentVariables = flex.ExpandStringMap(ev)
 	}
 
 	return codeConfig

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -319,6 +319,7 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.foo", "bar"),
 				),
 			},
 			{
@@ -761,7 +762,10 @@ resource "aws_synthetics_canary" "test" {
   }
 
   run_config {
-    timeout_in_seconds = 60
+    timeout_in_seconds    = 60
+	environment_variables = {
+		foo = "bar"
+	}
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -319,14 +319,14 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "60"),
-					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test1", "result1"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zip_file", "start_canary"},
+				ImportStateVerifyIgnore: []string{"zip_file", "start_canary", "run_config.0.environment_variables"},
 			},
 			{
 				Config: testAccCanaryRun2Config(rName),
@@ -334,6 +334,7 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 					testAccCheckCanaryExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "960"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test2", "result2"),
 				),
 			},
 			{
@@ -764,7 +765,7 @@ resource "aws_synthetics_canary" "test" {
   run_config {
     timeout_in_seconds    = 60
 	environment_variables = {
-		foo = "bar"
+		test1 = "result1"
 	}
   }
 
@@ -790,6 +791,10 @@ resource "aws_synthetics_canary" "test" {
   run_config {
     timeout_in_seconds = 120
     memory_in_mb       = 960
+	environment_variables = {
+		test1  = "result1"
+		test2 = "result2"
+	}
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -764,9 +764,8 @@ resource "aws_synthetics_canary" "test" {
 
   run_config {
     timeout_in_seconds = 60
-	
     environment_variables = {
-        test1 = "result1"
+      test1 = "result1"
     }
   }
 
@@ -792,10 +791,9 @@ resource "aws_synthetics_canary" "test" {
   run_config {
     timeout_in_seconds = 120
     memory_in_mb       = 960
-	
     environment_variables = {
-        test1  = "result1"
-        test2  = "result2"
+      test1 = "result1"
+      test2 = "result2"
     }
   }
 

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -789,11 +789,11 @@ resource "aws_synthetics_canary" "test" {
   }
 
   run_config {
-    timeout_in_seconds = 120
-    memory_in_mb       = 960
+    timeout_in_seconds    = 120
+    memory_in_mb          = 960
 	environment_variables = {
 		test1  = "result1"
-		test2 = "result2"
+		test2  = "result2"
 	}
   }
 

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -763,10 +763,11 @@ resource "aws_synthetics_canary" "test" {
   }
 
   run_config {
-    timeout_in_seconds    = 60
-	environment_variables = {
-		test1 = "result1"
-	}
+    timeout_in_seconds = 60
+	
+    environment_variables = {
+        test1 = "result1"
+    }
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
@@ -789,12 +790,13 @@ resource "aws_synthetics_canary" "test" {
   }
 
   run_config {
-    timeout_in_seconds    = 120
-    memory_in_mb          = 960
-	environment_variables = {
-		test1  = "result1"
-		test2  = "result2"
-	}
+    timeout_in_seconds = 120
+    memory_in_mb       = 960
+	
+    environment_variables = {
+        test1  = "result1"
+        test2  = "result2"
+    }
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -391,6 +391,49 @@ func TestAccSyntheticsCanary_runTracing(t *testing.T) {
 	})
 }
 
+func TestAccSyntheticsCanary_runEnvironmentVariables(t *testing.T) {
+	var conf synthetics.Canary
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	resourceName := "aws_synthetics_canary.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, synthetics.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckCanaryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCanaryRunEnvVariables1Config(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test1", "result1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zip_file", "start_canary", "run_config.0.environment_variables"},
+			},
+			{
+				Config: testAccCanaryRunEnvVariables2Config(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test1", "result1"),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test2", "result2"),
+				),
+			},
+			{
+				Config: testAccCanaryRunEnvVariables3Config(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckNoResourceAttr(resourceName, "run_config.0.environment_variables"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSyntheticsCanary_vpc(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -764,9 +807,6 @@ resource "aws_synthetics_canary" "test" {
 
   run_config {
     timeout_in_seconds = 60
-    environment_variables = {
-      test1 = "result1"
-    }
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
@@ -791,10 +831,6 @@ resource "aws_synthetics_canary" "test" {
   run_config {
     timeout_in_seconds = 120
     memory_in_mb       = 960
-    environment_variables = {
-      test1 = "result1"
-      test2 = "result2"
-    }
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
@@ -824,6 +860,76 @@ resource "aws_synthetics_canary" "test" {
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
 }
 `, rName, tracing))
+}
+
+func testAccCanaryRunEnvVariables1Config(rName string) string {
+	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
+resource "aws_synthetics_canary" "test" {
+  name                 = %[1]q
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  execution_role_arn   = aws_iam_role.test.arn
+  handler              = "exports.handler"
+  zip_file             = "test-fixtures/lambdatest.zip"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
+
+  schedule {
+    expression = "rate(0 minute)"
+  }
+
+  run_config {
+    environment_variables = {
+	  test1 = "result1"
+	}
+  }
+
+  depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccCanaryRunEnvVariables2Config(rName string) string {
+	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
+resource "aws_synthetics_canary" "test" {
+  name                 = %[1]q
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  execution_role_arn   = aws_iam_role.test.arn
+  handler              = "exports.handler"
+  zip_file             = "test-fixtures/lambdatest.zip"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
+
+  schedule {
+    expression = "rate(0 minute)"
+  }
+
+  run_config {
+    environment_variables = {
+	  test1 = "result1"
+      test2 = "result2"
+	}
+  }
+
+  depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccCanaryRunEnvVariables3Config(rName string) string {
+	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
+resource "aws_synthetics_canary" "test" {
+  name                 = %[1]q
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  execution_role_arn   = aws_iam_role.test.arn
+  handler              = "exports.handler"
+  zip_file             = "test-fixtures/lambdatest.zip"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
+
+  schedule {
+    expression = "rate(0 minute)"
+  }
+
+  depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
+}
+`, rName))
 }
 
 func testAccCanaryBasicConfig(rName string) string {

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -319,14 +319,13 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "60"),
-					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test1", "result1"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zip_file", "start_canary", "run_config.0.environment_variables"},
+				ImportStateVerifyIgnore: []string{"zip_file", "start_canary"},
 			},
 			{
 				Config: testAccCanaryRun2Config(rName),
@@ -334,7 +333,6 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 					testAccCheckCanaryExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "960"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "120"),
-					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test2", "result2"),
 				),
 			},
 			{
@@ -424,7 +422,7 @@ func TestAccSyntheticsCanary_runEnvironmentVariables(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCanaryRunEnvVariables3Config(rName),
+				Config: testAccCanaryBasicConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(resourceName, &conf),
 					resource.TestCheckNoResourceAttr(resourceName, "run_config.0.environment_variables"),
@@ -878,8 +876,8 @@ resource "aws_synthetics_canary" "test" {
 
   run_config {
     environment_variables = {
-	  test1 = "result1"
-	}
+      test1 = "result1"
+    }
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
@@ -903,28 +901,9 @@ resource "aws_synthetics_canary" "test" {
 
   run_config {
     environment_variables = {
-	  test1 = "result1"
+      test1 = "result1"
       test2 = "result2"
-	}
-  }
-
-  depends_on = [aws_iam_role.test, aws_iam_role_policy.test]
-}
-`, rName))
-}
-
-func testAccCanaryRunEnvVariables3Config(rName string) string {
-	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
-resource "aws_synthetics_canary" "test" {
-  name                 = %[1]q
-  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
-  execution_role_arn   = aws_iam_role.test.arn
-  handler              = "exports.handler"
-  zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
-
-  schedule {
-    expression = "rate(0 minute)"
+    }
   }
 
   depends_on = [aws_iam_role.test, aws_iam_role_policy.test]

--- a/website/docs/r/synthetics_canary.html.markdown
+++ b/website/docs/r/synthetics_canary.html.markdown
@@ -73,6 +73,7 @@ The following arguments are optional:
 * `timeout_in_seconds` - (Optional) Number of seconds the canary is allowed to run before it must stop. If you omit this field, the frequency of the canary is used, up to a maximum of 840 (14 minutes).
 * `memory_in_mb` - (Optional) Maximum amount of memory available to the canary while it is running, in MB. The value you specify must be a multiple of 64.
 * `active_tracing` - (Optional) Whether this canary is to use active AWS X-Ray tracing when it runs. You can enable active tracing only for canaries that use version syn-nodejs-2.0 or later for their canary runtime.
+* `environment_variables` - (Optional) Map of environment variables that are accessible from the canary during execution. Please see [AWS Docs](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime) for variables reserved for Lambda.
 
 ### vpc_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Closes #17948

Output from acceptance testing:

```
$ make testacc TESTS=TestAccSyntheticsCanary_run PKG=synthetics

=== RUN   TestAccSyntheticsCanary_runtimeVersion
=== PAUSE TestAccSyntheticsCanary_runtimeVersion
=== RUN   TestAccSyntheticsCanary_run
=== PAUSE TestAccSyntheticsCanary_run
=== RUN   TestAccSyntheticsCanary_runTracing
=== PAUSE TestAccSyntheticsCanary_runTracing
=== RUN   TestAccSyntheticsCanary_runEnvironmentVariables
=== PAUSE TestAccSyntheticsCanary_runEnvironmentVariables
=== CONT  TestAccSyntheticsCanary_runtimeVersion
=== CONT  TestAccSyntheticsCanary_runTracing
=== CONT  TestAccSyntheticsCanary_runEnvironmentVariables
=== CONT  TestAccSyntheticsCanary_run
--- PASS: TestAccSyntheticsCanary_runtimeVersion (94.30s)
--- PASS: TestAccSyntheticsCanary_runTracing (94.37s)
--- PASS: TestAccSyntheticsCanary_run (128.28s)
--- PASS: TestAccSyntheticsCanary_runEnvironmentVariables (179.27s)
PASS

```
