### PR TITLE
r/s3_bucket_replication_configuration: correctly expand and flatten `rule.filter.tag`

### DIFF
--- a/.changelog/23579.txt
+++ b/.changelog/23579.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Ensure both `key` and `value` arguments of the `rule.filter.tag` configuration block are correctly populated in the outgoing API request and terraform state.
+```

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -303,7 +303,7 @@ func resourceBucketReplicationConfigurationCreate(d *schema.ResourceData, meta i
 
 	rc := &s3.ReplicationConfiguration{
 		Role:  aws.String(d.Get("role").(string)),
-		Rules: ExpandRules(d.Get("rule").(*schema.Set).List()),
+		Rules: ExpandReplicationRules(d.Get("rule").(*schema.Set).List()),
 	}
 
 	input := &s3.PutBucketReplicationInput{
@@ -367,7 +367,7 @@ func resourceBucketReplicationConfigurationRead(d *schema.ResourceData, meta int
 
 	d.Set("bucket", d.Id())
 	d.Set("role", r.Role)
-	if err := d.Set("rule", schema.NewSet(rulesHash, FlattenRules(r.Rules))); err != nil {
+	if err := d.Set("rule", schema.NewSet(rulesHash, FlattenReplicationRules(r.Rules))); err != nil {
 		return fmt.Errorf("error setting rule: %w", err)
 	}
 
@@ -379,7 +379,7 @@ func resourceBucketReplicationConfigurationUpdate(d *schema.ResourceData, meta i
 
 	rc := &s3.ReplicationConfiguration{
 		Role:  aws.String(d.Get("role").(string)),
-		Rules: ExpandRules(d.Get("rule").(*schema.Set).List()),
+		Rules: ExpandReplicationRules(d.Get("rule").(*schema.Set).List()),
 	}
 
 	input := &s3.PutBucketReplicationInput{

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -10,7 +10,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-func ExpandAccessControlTranslation(l []interface{}) *s3.AccessControlTranslation {
+func ExpandReplicationRuleDestinationAccessControlTranslation(l []interface{}) *s3.AccessControlTranslation {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -30,7 +30,7 @@ func ExpandAccessControlTranslation(l []interface{}) *s3.AccessControlTranslatio
 	return result
 }
 
-func ExpandEncryptionConfiguration(l []interface{}) *s3.EncryptionConfiguration {
+func ExpandReplicationRuleDestinationEncryptionConfiguration(l []interface{}) *s3.EncryptionConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -50,7 +50,7 @@ func ExpandEncryptionConfiguration(l []interface{}) *s3.EncryptionConfiguration 
 	return result
 }
 
-func ExpandDeleteMarkerReplication(l []interface{}) *s3.DeleteMarkerReplication {
+func ExpandReplicationRuleDeleteMarkerReplication(l []interface{}) *s3.DeleteMarkerReplication {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -70,7 +70,7 @@ func ExpandDeleteMarkerReplication(l []interface{}) *s3.DeleteMarkerReplication 
 	return result
 }
 
-func ExpandDestination(l []interface{}) *s3.Destination {
+func ExpandReplicationRuleDestination(l []interface{}) *s3.Destination {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -84,7 +84,7 @@ func ExpandDestination(l []interface{}) *s3.Destination {
 	result := &s3.Destination{}
 
 	if v, ok := tfMap["access_control_translation"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.AccessControlTranslation = ExpandAccessControlTranslation(v)
+		result.AccessControlTranslation = ExpandReplicationRuleDestinationAccessControlTranslation(v)
 	}
 
 	if v, ok := tfMap["account"].(string); ok && v != "" {
@@ -96,15 +96,15 @@ func ExpandDestination(l []interface{}) *s3.Destination {
 	}
 
 	if v, ok := tfMap["encryption_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.EncryptionConfiguration = ExpandEncryptionConfiguration(v)
+		result.EncryptionConfiguration = ExpandReplicationRuleDestinationEncryptionConfiguration(v)
 	}
 
 	if v, ok := tfMap["metrics"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.Metrics = ExpandMetrics(v)
+		result.Metrics = ExpandReplicationRuleDestinationMetrics(v)
 	}
 
 	if v, ok := tfMap["replication_time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.ReplicationTime = ExpandReplicationTime(v)
+		result.ReplicationTime = ExpandReplicationRuleDestinationReplicationTime(v)
 	}
 
 	if v, ok := tfMap["storage_class"].(string); ok && v != "" {
@@ -114,7 +114,7 @@ func ExpandDestination(l []interface{}) *s3.Destination {
 	return result
 }
 
-func ExpandExistingObjectReplication(l []interface{}) *s3.ExistingObjectReplication {
+func ExpandReplicationRuleExistingObjectReplication(l []interface{}) *s3.ExistingObjectReplication {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -134,7 +134,7 @@ func ExpandExistingObjectReplication(l []interface{}) *s3.ExistingObjectReplicat
 	return result
 }
 
-func ExpandFilter(l []interface{}) *s3.ReplicationRuleFilter {
+func ExpandReplicationRuleFilter(l []interface{}) *s3.ReplicationRuleFilter {
 	if len(l) == 0 {
 		return nil
 	}
@@ -151,14 +151,11 @@ func ExpandFilter(l []interface{}) *s3.ReplicationRuleFilter {
 	tfMap := l[0].(map[string]interface{})
 
 	if v, ok := tfMap["and"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.And = ExpandReplicationRuleAndOperator(v)
+		result.And = ExpandReplicationRuleFilterAndOperator(v)
 	}
 
 	if v, ok := tfMap["tag"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		tags := Tags(tftags.New(v[0]).IgnoreAWS())
-		if len(tags) > 0 {
-			result.Tag = tags[0]
-		}
+		result.Tag = ExpandReplicationRuleFilterTag(v)
 	}
 
 	// Per AWS S3 API, "A Filter must have exactly one of Prefix, Tag, or And specified";
@@ -465,7 +462,7 @@ func ExpandLifecycleRules(l []interface{}) ([]*s3.LifecycleRule, error) {
 	return results, nil
 }
 
-func ExpandMetrics(l []interface{}) *s3.Metrics {
+func ExpandReplicationRuleDestinationMetrics(l []interface{}) *s3.Metrics {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -479,7 +476,7 @@ func ExpandMetrics(l []interface{}) *s3.Metrics {
 	result := &s3.Metrics{}
 
 	if v, ok := tfMap["event_threshold"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.EventThreshold = ExpandReplicationTimeValue(v)
+		result.EventThreshold = ExpandReplicationRuleDestinationReplicationTimeValue(v)
 	}
 
 	if v, ok := tfMap["status"].(string); ok && v != "" {
@@ -489,7 +486,7 @@ func ExpandMetrics(l []interface{}) *s3.Metrics {
 	return result
 }
 
-func ExpandReplicationRuleAndOperator(l []interface{}) *s3.ReplicationRuleAndOperator {
+func ExpandReplicationRuleFilterAndOperator(l []interface{}) *s3.ReplicationRuleAndOperator {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -516,7 +513,7 @@ func ExpandReplicationRuleAndOperator(l []interface{}) *s3.ReplicationRuleAndOpe
 	return result
 }
 
-func ExpandReplicationTime(l []interface{}) *s3.ReplicationTime {
+func ExpandReplicationRuleDestinationReplicationTime(l []interface{}) *s3.ReplicationTime {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -534,13 +531,13 @@ func ExpandReplicationTime(l []interface{}) *s3.ReplicationTime {
 	}
 
 	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.Time = ExpandReplicationTimeValue(v)
+		result.Time = ExpandReplicationRuleDestinationReplicationTimeValue(v)
 	}
 
 	return result
 }
 
-func ExpandReplicationTimeValue(l []interface{}) *s3.ReplicationTimeValue {
+func ExpandReplicationRuleDestinationReplicationTimeValue(l []interface{}) *s3.ReplicationTimeValue {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -560,7 +557,7 @@ func ExpandReplicationTimeValue(l []interface{}) *s3.ReplicationTimeValue {
 	return result
 }
 
-func ExpandReplicaModifications(l []interface{}) *s3.ReplicaModifications {
+func ExpandSourceSelectionCriteriaReplicaModifications(l []interface{}) *s3.ReplicaModifications {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -580,7 +577,7 @@ func ExpandReplicaModifications(l []interface{}) *s3.ReplicaModifications {
 	return result
 }
 
-func ExpandRules(l []interface{}) []*s3.ReplicationRule {
+func ExpandReplicationRules(l []interface{}) []*s3.ReplicationRule {
 	var rules []*s3.ReplicationRule
 
 	for _, tfMapRaw := range l {
@@ -591,15 +588,15 @@ func ExpandRules(l []interface{}) []*s3.ReplicationRule {
 		rule := &s3.ReplicationRule{}
 
 		if v, ok := tfMap["delete_marker_replication"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			rule.DeleteMarkerReplication = ExpandDeleteMarkerReplication(v)
+			rule.DeleteMarkerReplication = ExpandReplicationRuleDeleteMarkerReplication(v)
 		}
 
 		if v, ok := tfMap["destination"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			rule.Destination = ExpandDestination(v)
+			rule.Destination = ExpandReplicationRuleDestination(v)
 		}
 
 		if v, ok := tfMap["existing_object_replication"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			rule.ExistingObjectReplication = ExpandExistingObjectReplication(v)
+			rule.ExistingObjectReplication = ExpandReplicationRuleExistingObjectReplication(v)
 		}
 
 		if v, ok := tfMap["id"].(string); ok && v != "" {
@@ -607,7 +604,7 @@ func ExpandRules(l []interface{}) []*s3.ReplicationRule {
 		}
 
 		if v, ok := tfMap["source_selection_criteria"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			rule.SourceSelectionCriteria = ExpandSourceSelectionCriteria(v)
+			rule.SourceSelectionCriteria = ExpandReplicationRuleSourceSelectionCriteria(v)
 		}
 
 		if v, ok := tfMap["status"].(string); ok && v != "" {
@@ -619,7 +616,7 @@ func ExpandRules(l []interface{}) []*s3.ReplicationRule {
 		// by expanding the "filter" array even if the first element is nil.
 		if v, ok := tfMap["filter"].([]interface{}); ok && len(v) > 0 {
 			// XML schema V2
-			rule.Filter = ExpandFilter(v)
+			rule.Filter = ExpandReplicationRuleFilter(v)
 			rule.Priority = aws.Int64(int64(tfMap["priority"].(int)))
 		} else {
 			// XML schema V1
@@ -632,7 +629,7 @@ func ExpandRules(l []interface{}) []*s3.ReplicationRule {
 	return rules
 }
 
-func ExpandSourceSelectionCriteria(l []interface{}) *s3.SourceSelectionCriteria {
+func ExpandReplicationRuleSourceSelectionCriteria(l []interface{}) *s3.SourceSelectionCriteria {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -646,17 +643,17 @@ func ExpandSourceSelectionCriteria(l []interface{}) *s3.SourceSelectionCriteria 
 	result := &s3.SourceSelectionCriteria{}
 
 	if v, ok := tfMap["replica_modifications"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.ReplicaModifications = ExpandReplicaModifications(v)
+		result.ReplicaModifications = ExpandSourceSelectionCriteriaReplicaModifications(v)
 	}
 
 	if v, ok := tfMap["sse_kms_encrypted_objects"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.SseKmsEncryptedObjects = ExpandSseKmsEncryptedObjects(v)
+		result.SseKmsEncryptedObjects = ExpandSourceSelectionCriteriaSseKmsEncryptedObjects(v)
 	}
 
 	return result
 }
 
-func ExpandSseKmsEncryptedObjects(l []interface{}) *s3.SseKmsEncryptedObjects {
+func ExpandSourceSelectionCriteriaSseKmsEncryptedObjects(l []interface{}) *s3.SseKmsEncryptedObjects {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -676,7 +673,7 @@ func ExpandSseKmsEncryptedObjects(l []interface{}) *s3.SseKmsEncryptedObjects {
 	return result
 }
 
-func ExpandTag(l []interface{}) *s3.Tag {
+func ExpandReplicationRuleFilterTag(l []interface{}) *s3.Tag {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -700,7 +697,7 @@ func ExpandTag(l []interface{}) *s3.Tag {
 	return result
 }
 
-func FlattenAccessControlTranslation(act *s3.AccessControlTranslation) []interface{} {
+func FlattenReplicationRuleDestinationAccessControlTranslation(act *s3.AccessControlTranslation) []interface{} {
 	if act == nil {
 		return []interface{}{}
 	}
@@ -714,7 +711,7 @@ func FlattenAccessControlTranslation(act *s3.AccessControlTranslation) []interfa
 	return []interface{}{m}
 }
 
-func FlattenEncryptionConfiguration(ec *s3.EncryptionConfiguration) []interface{} {
+func FlattenReplicationRuleDestinationEncryptionConfiguration(ec *s3.EncryptionConfiguration) []interface{} {
 	if ec == nil {
 		return []interface{}{}
 	}
@@ -728,7 +725,7 @@ func FlattenEncryptionConfiguration(ec *s3.EncryptionConfiguration) []interface{
 	return []interface{}{m}
 }
 
-func FlattenDeleteMarkerReplication(dmr *s3.DeleteMarkerReplication) []interface{} {
+func FlattenReplicationRuleDeleteMarkerReplication(dmr *s3.DeleteMarkerReplication) []interface{} {
 	if dmr == nil {
 		return []interface{}{}
 	}
@@ -742,7 +739,7 @@ func FlattenDeleteMarkerReplication(dmr *s3.DeleteMarkerReplication) []interface
 	return []interface{}{m}
 }
 
-func FlattenDestination(dest *s3.Destination) []interface{} {
+func FlattenReplicationRuleDestination(dest *s3.Destination) []interface{} {
 	if dest == nil {
 		return []interface{}{}
 	}
@@ -750,7 +747,7 @@ func FlattenDestination(dest *s3.Destination) []interface{} {
 	m := make(map[string]interface{})
 
 	if dest.AccessControlTranslation != nil {
-		m["access_control_translation"] = FlattenAccessControlTranslation(dest.AccessControlTranslation)
+		m["access_control_translation"] = FlattenReplicationRuleDestinationAccessControlTranslation(dest.AccessControlTranslation)
 	}
 
 	if dest.Account != nil {
@@ -762,15 +759,15 @@ func FlattenDestination(dest *s3.Destination) []interface{} {
 	}
 
 	if dest.EncryptionConfiguration != nil {
-		m["encryption_configuration"] = FlattenEncryptionConfiguration(dest.EncryptionConfiguration)
+		m["encryption_configuration"] = FlattenReplicationRuleDestinationEncryptionConfiguration(dest.EncryptionConfiguration)
 	}
 
 	if dest.Metrics != nil {
-		m["metrics"] = FlattenMetrics(dest.Metrics)
+		m["metrics"] = FlattenReplicationRuleDestinationMetrics(dest.Metrics)
 	}
 
 	if dest.ReplicationTime != nil {
-		m["replication_time"] = FlattenReplicationTime(dest.ReplicationTime)
+		m["replication_time"] = FlattenReplicationRuleDestinationReplicationTime(dest.ReplicationTime)
 	}
 
 	if dest.StorageClass != nil {
@@ -780,7 +777,7 @@ func FlattenDestination(dest *s3.Destination) []interface{} {
 	return []interface{}{m}
 }
 
-func FlattenExistingObjectReplication(eor *s3.ExistingObjectReplication) []interface{} {
+func FlattenReplicationRuleExistingObjectReplication(eor *s3.ExistingObjectReplication) []interface{} {
 	if eor == nil {
 		return []interface{}{}
 	}
@@ -794,7 +791,7 @@ func FlattenExistingObjectReplication(eor *s3.ExistingObjectReplication) []inter
 	return []interface{}{m}
 }
 
-func FlattenFilter(filter *s3.ReplicationRuleFilter) []interface{} {
+func FlattenReplicationRuleFilter(filter *s3.ReplicationRuleFilter) []interface{} {
 	if filter == nil {
 		return []interface{}{}
 	}
@@ -802,7 +799,7 @@ func FlattenFilter(filter *s3.ReplicationRuleFilter) []interface{} {
 	m := make(map[string]interface{})
 
 	if filter.And != nil {
-		m["and"] = FlattenReplicationRuleAndOperator(filter.And)
+		m["and"] = FlattenReplicationRuleFilterAndOperator(filter.And)
 	}
 
 	if filter.Prefix != nil {
@@ -810,8 +807,7 @@ func FlattenFilter(filter *s3.ReplicationRuleFilter) []interface{} {
 	}
 
 	if filter.Tag != nil {
-		tag := KeyValueTags([]*s3.Tag{filter.Tag}).IgnoreAWS().Map()
-		m["tag"] = []interface{}{tag}
+		m["tag"] = FlattenReplicationRuleFilterTag(filter.Tag)
 	}
 
 	return []interface{}{m}
@@ -1065,7 +1061,7 @@ func FlattenLifecycleRuleTransitions(transitions []*s3.Transition) []interface{}
 	return results
 }
 
-func FlattenMetrics(metrics *s3.Metrics) []interface{} {
+func FlattenReplicationRuleDestinationMetrics(metrics *s3.Metrics) []interface{} {
 	if metrics == nil {
 		return []interface{}{}
 	}
@@ -1073,7 +1069,7 @@ func FlattenMetrics(metrics *s3.Metrics) []interface{} {
 	m := make(map[string]interface{})
 
 	if metrics.EventThreshold != nil {
-		m["event_threshold"] = FlattenReplicationTimeValue(metrics.EventThreshold)
+		m["event_threshold"] = FlattenReplicationRuleDestinationReplicationTimeValue(metrics.EventThreshold)
 	}
 
 	if metrics.Status != nil {
@@ -1083,7 +1079,7 @@ func FlattenMetrics(metrics *s3.Metrics) []interface{} {
 	return []interface{}{m}
 }
 
-func FlattenReplicationTime(rt *s3.ReplicationTime) []interface{} {
+func FlattenReplicationRuleDestinationReplicationTime(rt *s3.ReplicationTime) []interface{} {
 	if rt == nil {
 		return []interface{}{}
 	}
@@ -1095,14 +1091,14 @@ func FlattenReplicationTime(rt *s3.ReplicationTime) []interface{} {
 	}
 
 	if rt.Time != nil {
-		m["time"] = FlattenReplicationTimeValue(rt.Time)
+		m["time"] = FlattenReplicationRuleDestinationReplicationTimeValue(rt.Time)
 	}
 
 	return []interface{}{m}
 
 }
 
-func FlattenReplicationTimeValue(rtv *s3.ReplicationTimeValue) []interface{} {
+func FlattenReplicationRuleDestinationReplicationTimeValue(rtv *s3.ReplicationTimeValue) []interface{} {
 	if rtv == nil {
 		return []interface{}{}
 	}
@@ -1116,7 +1112,7 @@ func FlattenReplicationTimeValue(rtv *s3.ReplicationTimeValue) []interface{} {
 	return []interface{}{m}
 }
 
-func FlattenRules(rules []*s3.ReplicationRule) []interface{} {
+func FlattenReplicationRules(rules []*s3.ReplicationRule) []interface{} {
 	if len(rules) == 0 {
 		return []interface{}{}
 	}
@@ -1131,19 +1127,19 @@ func FlattenRules(rules []*s3.ReplicationRule) []interface{} {
 		m := make(map[string]interface{})
 
 		if rule.DeleteMarkerReplication != nil {
-			m["delete_marker_replication"] = FlattenDeleteMarkerReplication(rule.DeleteMarkerReplication)
+			m["delete_marker_replication"] = FlattenReplicationRuleDeleteMarkerReplication(rule.DeleteMarkerReplication)
 		}
 
 		if rule.Destination != nil {
-			m["destination"] = FlattenDestination(rule.Destination)
+			m["destination"] = FlattenReplicationRuleDestination(rule.Destination)
 		}
 
 		if rule.ExistingObjectReplication != nil {
-			m["existing_object_replication"] = FlattenExistingObjectReplication(rule.ExistingObjectReplication)
+			m["existing_object_replication"] = FlattenReplicationRuleExistingObjectReplication(rule.ExistingObjectReplication)
 		}
 
 		if rule.Filter != nil {
-			m["filter"] = FlattenFilter(rule.Filter)
+			m["filter"] = FlattenReplicationRuleFilter(rule.Filter)
 		}
 
 		if rule.ID != nil {
@@ -1159,7 +1155,7 @@ func FlattenRules(rules []*s3.ReplicationRule) []interface{} {
 		}
 
 		if rule.SourceSelectionCriteria != nil {
-			m["source_selection_criteria"] = FlattenSourceSelectionCriteria(rule.SourceSelectionCriteria)
+			m["source_selection_criteria"] = FlattenReplicationRuleSourceSelectionCriteria(rule.SourceSelectionCriteria)
 		}
 
 		if rule.Status != nil {
@@ -1172,7 +1168,7 @@ func FlattenRules(rules []*s3.ReplicationRule) []interface{} {
 	return results
 }
 
-func FlattenReplicaModifications(rc *s3.ReplicaModifications) []interface{} {
+func FlattenSourceSelectionCriteriaReplicaModifications(rc *s3.ReplicaModifications) []interface{} {
 	if rc == nil {
 		return []interface{}{}
 	}
@@ -1186,7 +1182,7 @@ func FlattenReplicaModifications(rc *s3.ReplicaModifications) []interface{} {
 	return []interface{}{m}
 }
 
-func FlattenReplicationRuleAndOperator(op *s3.ReplicationRuleAndOperator) []interface{} {
+func FlattenReplicationRuleFilterAndOperator(op *s3.ReplicationRuleAndOperator) []interface{} {
 	if op == nil {
 		return []interface{}{}
 	}
@@ -1205,7 +1201,26 @@ func FlattenReplicationRuleAndOperator(op *s3.ReplicationRuleAndOperator) []inte
 
 }
 
-func FlattenSourceSelectionCriteria(ssc *s3.SourceSelectionCriteria) []interface{} {
+func FlattenReplicationRuleFilterTag(tag *s3.Tag) []interface{} {
+	if tag == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if tag.Key != nil {
+		m["key"] = aws.StringValue(tag.Key)
+	}
+
+	if tag.Value != nil {
+		m["value"] = aws.StringValue(tag.Value)
+	}
+
+	return []interface{}{m}
+
+}
+
+func FlattenReplicationRuleSourceSelectionCriteria(ssc *s3.SourceSelectionCriteria) []interface{} {
 	if ssc == nil {
 		return []interface{}{}
 	}
@@ -1213,17 +1228,17 @@ func FlattenSourceSelectionCriteria(ssc *s3.SourceSelectionCriteria) []interface
 	m := make(map[string]interface{})
 
 	if ssc.ReplicaModifications != nil {
-		m["replica_modifications"] = FlattenReplicaModifications(ssc.ReplicaModifications)
+		m["replica_modifications"] = FlattenSourceSelectionCriteriaReplicaModifications(ssc.ReplicaModifications)
 	}
 
 	if ssc.SseKmsEncryptedObjects != nil {
-		m["sse_kms_encrypted_objects"] = FlattenSseKmsEncryptedObjects(ssc.SseKmsEncryptedObjects)
+		m["sse_kms_encrypted_objects"] = FlattenSourceSelectionCriteriaSseKmsEncryptedObjects(ssc.SseKmsEncryptedObjects)
 	}
 
 	return []interface{}{m}
 }
 
-func FlattenSseKmsEncryptedObjects(objects *s3.SseKmsEncryptedObjects) []interface{} {
+func FlattenSourceSelectionCriteriaSseKmsEncryptedObjects(objects *s3.SseKmsEncryptedObjects) []interface{} {
 	if objects == nil {
 		return []interface{}{}
 	}

--- a/internal/service/s3/flex_test.go
+++ b/internal/service/s3/flex_test.go
@@ -1,0 +1,71 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func TestExpandReplicationRuleFilterTag(t *testing.T) {
+	expectedKey := "TestKey1"
+	expectedValue := "TestValue1"
+
+	tagMap := map[string]interface{}{
+		"key":   expectedKey,
+		"value": expectedValue,
+	}
+
+	result := ExpandReplicationRuleFilterTag([]interface{}{tagMap})
+
+	if result == nil {
+		t.Fatalf("Expected *s3.Tag to not be nil")
+	}
+
+	if actualKey := aws.StringValue(result.Key); actualKey != expectedKey {
+		t.Fatalf("Expected key %s, got %s", expectedKey, actualKey)
+	}
+
+	if actualValue := aws.StringValue(result.Value); actualValue != expectedValue {
+		t.Fatalf("Expected value %s, got %s", expectedValue, actualValue)
+	}
+}
+
+func TestFlattenReplicationRuleFilterTag(t *testing.T) {
+	expectedKey := "TestKey1"
+	expectedValue := "TestValue1"
+
+	tag := &s3.Tag{
+		Key:   aws.String(expectedKey),
+		Value: aws.String(expectedValue),
+	}
+
+	result := FlattenReplicationRuleFilterTag(tag)
+
+	if len(result) != 1 {
+		t.Fatalf("Expected array to have exactly 1 element, got %d", len(result))
+	}
+
+	tagMap, ok := result[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected element in array to be a map[string]interface{}")
+	}
+
+	actualKey, ok := tagMap["key"].(string)
+	if !ok {
+		t.Fatal("Expected string 'key' key in the map")
+	}
+
+	if actualKey != expectedKey {
+		t.Fatalf("Expected 'key' to equal %s, got %s", expectedKey, actualKey)
+	}
+
+	actualValue, ok := tagMap["value"].(string)
+	if !ok {
+		t.Fatal("Expected string 'value' key in the map")
+	}
+
+	if actualValue != expectedValue {
+		t.Fatalf("Expected 'value' to equal %s, got %s", expectedValue, actualValue)
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23571

### Description
* This fix is similar to #23252 such that the expand/flatten methods were not correctly reading the tag key. 
* Method names in s3/flex.go are also updated to reflect they are part of the `ReplicationRule` as functionality is very similar to LifecycleRule
* An acceptance already exists to check for the `filter.tag` configuration so unit tests are added to validate the expected behavior

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestExpandReplicationRuleFilterTag (0.00s)
--- PASS: TestFlattenReplicationRuleFilterTag (0.00s)

--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (145.70s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (270.43s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (270.45s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (271.31s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (309.12s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (266.91s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (269.86s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (269.90s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (291.52s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (290.52s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (25.35s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (276.45s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (268.43s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (278.24s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (268.02s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (309.89s)

--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (194.19s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (194.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (194.67s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (205.31s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (284.21s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (193.93s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (194.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (192.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (273.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (191.61s)
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (191.81s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (201.80s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (192.32s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (191.96s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (53.09s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (335.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (270.98s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (326.36s)
```

Confirmed in console with configuration of #23571:
<img width="1268" alt="Screen Shot 2022-03-08 at 3 27 36 PM" src="https://user-images.githubusercontent.com/13805595/157319398-34a0136a-e850-46d3-bffa-f2465adaca4d.png">


