### PR TITLE
r/imagebuilder_image_recipe: Fix regression with Windows base images

### DIFF
--- a/.changelog/23580.txt
+++ b/.changelog/23580.txt
@@ -1,3 +1,3 @@
-```release-note: bug
+```release-note:bug
 resource/aws_image_builder_image_recipe: Fix regression in 4.3.0 whereby Windows-based images wouldn't build because of the newly introduced `systems_manager_agent.uninstall_after_build` argument.
 ```

--- a/.changelog/23580.txt
+++ b/.changelog/23580.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+resource/aws_image_builder_image_recipe: Fix regression in 4.3.0 whereby Windows-based images wouldn't build because of the newly introduced `systems_manager_agent.uninstall_after_build` argument.
+```

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -265,14 +265,10 @@ func resourceImageRecipeCreate(d *schema.ResourceData, meta interface{}) error {
 		input.ParentImage = aws.String(v.(string))
 	}
 
-	input.AdditionalInstanceConfiguration = &imagebuilder.AdditionalInstanceConfiguration{
-		SystemsManagerAgent: &imagebuilder.SystemsManagerAgent{
-			UninstallAfterBuild: aws.Bool(false),
-		},
-	}
-
 	if v, ok := d.GetOk("systems_manager_agent"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.AdditionalInstanceConfiguration.SystemsManagerAgent = expandSystemsManagerAgent(v.([]interface{})[0].(map[string]interface{}))
+		input.AdditionalInstanceConfiguration = &imagebuilder.AdditionalInstanceConfiguration{
+			SystemsManagerAgent: expandSystemsManagerAgent(v.([]interface{})[0].(map[string]interface{})),
+		}
 	}
 
 	if len(tags) > 0 {
@@ -280,6 +276,9 @@ func resourceImageRecipeCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("user_data_base64"); ok {
+		if input.AdditionalInstanceConfiguration == nil {
+			input.AdditionalInstanceConfiguration = &imagebuilder.AdditionalInstanceConfiguration{}
+		}
 		input.AdditionalInstanceConfiguration.UserDataOverride = aws.String(v.(string))
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23568.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/23293.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22159.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

The new regression test correctly catches the bug I introduced:
```
$ make testacc TESTS=TestAccImageBuilderImageRecipe_WindowsBaseImage PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipe_WindowsBaseImage'  -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_WindowsBaseImage
=== PAUSE TestAccImageBuilderImageRecipe_WindowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_WindowsBaseImage
    image_recipe_test.go:629: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating Image Builder Image Recipe: InvalidParameterCombinationException: The value supplied for parameter 'parentImage' and 'systemsManagerAgent' is not valid. Image Builder does not support configuring the SSM Agent on Windows.
        
          with aws_imagebuilder_image_recipe.test,
          on terraform_plugin_test.tf line 26, in resource "aws_imagebuilder_image_recipe" "test":
          26: resource "aws_imagebuilder_image_recipe" "test" {
        
--- FAIL: TestAccImageBuilderImageRecipe_WindowsBaseImage (18.68s)
```

And after my fix:

```
$ make testacc TESTS=TestAccImageBuilderImageRecipe_WindowsBaseImage PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipe_WindowsBaseImage'  -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_WindowsBaseImage
=== PAUSE TestAccImageBuilderImageRecipe_WindowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_WindowsBaseImage
--- PASS: TestAccImageBuilderImageRecipe_WindowsBaseImage (36.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	36.265s
```

And finally, the full suite still passes:

```
$ make testacc TESTS=TestAccImageBuilderImageRecipe_ PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipe_'  -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_disappears
=== PAUSE TestAccImageBuilderImageRecipe_disappears
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderImageRecipe_component
=== PAUSE TestAccImageBuilderImageRecipe_component
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== RUN   TestAccImageBuilderImageRecipe_description
=== PAUSE TestAccImageBuilderImageRecipe_description
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImageRecipe_workingDirectory
=== PAUSE TestAccImageBuilderImageRecipe_workingDirectory
=== RUN   TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageBuilderImageRecipe_systemsManagerAgent
=== PAUSE TestAccImageBuilderImageRecipe_systemsManagerAgent
=== RUN   TestAccImageBuilderImageRecipe_userDataBase64
=== PAUSE TestAccImageBuilderImageRecipe_userDataBase64
=== RUN   TestAccImageBuilderImageRecipe_WindowsBaseImage
=== PAUSE TestAccImageBuilderImageRecipe_WindowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_basic
=== CONT  TestAccImageBuilderImageRecipe_tags
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageBuilderImageRecipe_systemsManagerAgent
=== CONT  TestAccImageBuilderImageRecipe_WindowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== CONT  TestAccImageBuilderImageRecipe_workingDirectory
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
=== CONT  TestAccImageBuilderImageRecipe_component
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== CONT  TestAccImageBuilderImageRecipe_userDataBase64
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== CONT  TestAccImageBuilderImageRecipe_description
=== CONT  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (62.07s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (76.30s)
=== CONT  TestAccImageBuilderImageRecipe_disappears
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (79.44s)
--- PASS: TestAccImageBuilderImageRecipe_WindowsBaseImage (82.92s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (85.09s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (86.07s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (86.13s)
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (89.15s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (89.16s)
--- PASS: TestAccImageBuilderImageRecipe_description (89.36s)
--- PASS: TestAccImageBuilderImageRecipe_systemsManagerAgent (90.38s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (92.54s)
--- PASS: TestAccImageBuilderImageRecipe_basic (92.58s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (92.70s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (92.79s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (92.80s)
--- PASS: TestAccImageBuilderImageRecipe_component (93.80s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (100.09s)
--- PASS: TestAccImageBuilderImageRecipe_disappears (40.68s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (55.62s)
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (134.54s)
--- PASS: TestAccImageBuilderImageRecipe_tags (143.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	143.360s
```