### PR TITLE
aws_kms_key: Increased Timeout on Tag and Description Propagation waiter

### DIFF
--- a/.changelog/23593.txt
+++ b/.changelog/23593.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_kms_key: Increase `description` and `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+```
+
+```release-note:bug
+resource/aws_kms_external_key: Increase `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+```
+
+```release-note:bug
+resource/aws_kms_replica_key: Increase `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+```
+
+```release-note:bug
+resource/aws_kms_replica_external_key: Increase `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+```

--- a/.changelog/23593.txt
+++ b/.changelog/23593.txt
@@ -3,13 +3,13 @@ resource/aws_kms_key: Increase `description` and `tags` eventual consistency tim
 ```
 
 ```release-note:bug
-resource/aws_kms_external_key: Increase `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+resource/aws_kms_external_key: Increase `tags` eventual consistency timeout from 5 minutes to 10 minutes
 ```
 
 ```release-note:bug
-resource/aws_kms_replica_key: Increase `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+resource/aws_kms_replica_key: Increase `tags` eventual consistency timeout from 5 minutes to 10 minutes
 ```
 
 ```release-note:bug
-resource/aws_kms_replica_external_key: Increase `tags` eventual consistency timeouts from 5 minutes to 10 minutes
+resource/aws_kms_replica_external_key: Increase `tags` eventual consistency timeout from 5 minutes to 10 minutes
 ```

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -18,12 +18,12 @@ const (
 	KeyStatePendingDeletionTimeout = 20 * time.Minute
 
 	KeyDeletedTimeout                = 20 * time.Minute
-	KeyDescriptionPropagationTimeout = 5 * time.Minute
+	KeyDescriptionPropagationTimeout = 10 * time.Minute
 	KeyMaterialImportedTimeout       = 10 * time.Minute
 	KeyPolicyPropagationTimeout      = 5 * time.Minute
 	KeyRotationUpdatedTimeout        = 10 * time.Minute
 	KeyStatePropagationTimeout       = 20 * time.Minute
-	KeyTagsPropagationTimeout        = 5 * time.Minute
+	KeyTagsPropagationTimeout        = 10 * time.Minute
 	KeyValidToPropagationTimeout     = 5 * time.Minute
 
 	PropagationTimeout = 2 * time.Minute


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Our team has noticed that Amazon sometimes takes longer than the current timeout value to update tags or descriptions on a kms key resource.

A re run of terraform apply always shows the value was properly updated.

Increasing the time out value on these two waiters to allow the provider a little more time before timing out.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23592
Closes #23136

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccKMSKey_' PKG_NAME=internal/service/kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSKey_ -timeout 180m
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== RUN   TestAccKMSKey_disappears
=== PAUSE TestAccKMSKey_disappears
=== RUN   TestAccKMSKey_multiRegion
=== PAUSE TestAccKMSKey_multiRegion
=== RUN   TestAccKMSKey_asymmetricKey
=== PAUSE TestAccKMSKey_asymmetricKey
=== RUN   TestAccKMSKey_Policy_basic
=== PAUSE TestAccKMSKey_Policy_basic
=== RUN   TestAccKMSKey_Policy_bypass
=== PAUSE TestAccKMSKey_Policy_bypass
=== RUN   TestAccKMSKey_Policy_bypassUpdate
=== PAUSE TestAccKMSKey_Policy_bypassUpdate
=== RUN   TestAccKMSKey_Policy_iamRole
=== PAUSE TestAccKMSKey_Policy_iamRole
=== RUN   TestAccKMSKey_Policy_iamRoleOrder
=== PAUSE TestAccKMSKey_Policy_iamRoleOrder
=== RUN   TestAccKMSKey_Policy_iamServiceLinkedRole
=== PAUSE TestAccKMSKey_Policy_iamServiceLinkedRole
=== RUN   TestAccKMSKey_Policy_booleanCondition
=== PAUSE TestAccKMSKey_Policy_booleanCondition
=== RUN   TestAccKMSKey_isEnabled
=== PAUSE TestAccKMSKey_isEnabled
=== RUN   TestAccKMSKey_tags
=== PAUSE TestAccKMSKey_tags
=== CONT  TestAccKMSKey_basic
=== CONT  TestAccKMSKey_Policy_iamRole
=== CONT  TestAccKMSKey_tags
=== CONT  TestAccKMSKey_isEnabled
=== CONT  TestAccKMSKey_Policy_booleanCondition
=== CONT  TestAccKMSKey_Policy_iamServiceLinkedRole
=== CONT  TestAccKMSKey_Policy_iamRoleOrder
=== CONT  TestAccKMSKey_Policy_bypassUpdate
=== CONT  TestAccKMSKey_multiRegion
=== CONT  TestAccKMSKey_asymmetricKey
=== CONT  TestAccKMSKey_Policy_basic
=== CONT  TestAccKMSKey_Policy_bypass
=== CONT  TestAccKMSKey_disappears
--- PASS: TestAccKMSKey_asymmetricKey (57.97s)
--- PASS: TestAccKMSKey_disappears (72.10s)
--- PASS: TestAccKMSKey_multiRegion (75.10s)
--- PASS: TestAccKMSKey_basic (82.69s)
--- PASS: TestAccKMSKey_Policy_iamRole (86.24s)
--- PASS: TestAccKMSKey_Policy_booleanCondition (88.47s)
--- PASS: TestAccKMSKey_Policy_bypassUpdate (94.98s)
--- PASS: TestAccKMSKey_Policy_basic (103.03s)
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (105.78s)
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (125.06s)
--- PASS: TestAccKMSKey_tags (130.92s)
--- PASS: TestAccKMSKey_Policy_bypass (181.69s)
--- PASS: TestAccKMSKey_isEnabled (191.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        198.001s

...
```

### Changelog
```release-note:bug
resource/aws_kms_key: Increased Timeout on Tag and Description Propagation waiter
```
