### PR TITLE
r/aws_ecs_service: update `propagate_tags` `enable_ecs_managed_tags` `load_balancer` and `service_registries` without destroy & recreate

### DIFF
--- a/.changelog/23600.txt
+++ b/.changelog/23600.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_service: `enable_ecs_managed_tags`, `load_balancer`, `propagate_tags` and `service_registries` can now be updated in-place
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -978,142 +978,124 @@ func flattenServiceRegistries(srs []*ecs.ServiceRegistry) []map[string]interface
 
 func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ECSConn
-	updateService := false
 
-	input := ecs.UpdateServiceInput{
-		Cluster:            aws.String(d.Get("cluster").(string)),
-		ForceNewDeployment: aws.Bool(d.Get("force_new_deployment").(bool)),
-		Service:            aws.String(d.Id()),
-	}
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &ecs.UpdateServiceInput{
+			Cluster:            aws.String(d.Get("cluster").(string)),
+			ForceNewDeployment: aws.Bool(d.Get("force_new_deployment").(bool)),
+			Service:            aws.String(d.Id()),
+		}
 
-	schedulingStrategy := d.Get("scheduling_strategy").(string)
+		schedulingStrategy := d.Get("scheduling_strategy").(string)
 
-	if schedulingStrategy == ecs.SchedulingStrategyDaemon {
-		if d.HasChange("deployment_minimum_healthy_percent") {
-			updateService = true
-			input.DeploymentConfiguration = &ecs.DeploymentConfiguration{
-				MinimumHealthyPercent: aws.Int64(int64(d.Get("deployment_minimum_healthy_percent").(int))),
+		if schedulingStrategy == ecs.SchedulingStrategyDaemon {
+			if d.HasChange("deployment_minimum_healthy_percent") {
+				input.DeploymentConfiguration = &ecs.DeploymentConfiguration{
+					MinimumHealthyPercent: aws.Int64(int64(d.Get("deployment_minimum_healthy_percent").(int))),
+				}
 			}
-		}
-	} else if schedulingStrategy == ecs.SchedulingStrategyReplica {
-		if d.HasChange("desired_count") {
-			updateService = true
-			input.DesiredCount = aws.Int64(int64(d.Get("desired_count").(int)))
-		}
-
-		if d.HasChanges("deployment_maximum_percent", "deployment_minimum_healthy_percent") {
-			updateService = true
-			input.DeploymentConfiguration = &ecs.DeploymentConfiguration{
-				MaximumPercent:        aws.Int64(int64(d.Get("deployment_maximum_percent").(int))),
-				MinimumHealthyPercent: aws.Int64(int64(d.Get("deployment_minimum_healthy_percent").(int))),
-			}
-		}
-	}
-
-	if d.HasChange("deployment_circuit_breaker") {
-		updateService = true
-
-		if input.DeploymentConfiguration == nil {
-			input.DeploymentConfiguration = &ecs.DeploymentConfiguration{}
-		}
-
-		// To remove an existing deployment circuit breaker, specify an empty object.
-		input.DeploymentConfiguration.DeploymentCircuitBreaker = &ecs.DeploymentCircuitBreaker{}
-
-		if v, ok := d.GetOk("deployment_circuit_breaker"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.DeploymentConfiguration.DeploymentCircuitBreaker = expandDeploymentCircuitBreaker(v.([]interface{})[0].(map[string]interface{}))
-		}
-	}
-
-	if d.HasChange("ordered_placement_strategy") {
-		updateService = true
-		// Reference: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html#ECS-UpdateService-request-placementStrategy
-		// To remove an existing placement strategy, specify an empty object.
-		input.PlacementStrategy = []*ecs.PlacementStrategy{}
-
-		if v, ok := d.GetOk("ordered_placement_strategy"); ok && len(v.([]interface{})) > 0 {
-			ps, err := expandPlacementStrategy(v.([]interface{}))
-
-			if err != nil {
-				return err
+		} else if schedulingStrategy == ecs.SchedulingStrategyReplica {
+			if d.HasChange("desired_count") {
+				input.DesiredCount = aws.Int64(int64(d.Get("desired_count").(int)))
 			}
 
-			input.PlacementStrategy = ps
+			if d.HasChanges("deployment_maximum_percent", "deployment_minimum_healthy_percent") {
+				input.DeploymentConfiguration = &ecs.DeploymentConfiguration{
+					MaximumPercent:        aws.Int64(int64(d.Get("deployment_maximum_percent").(int))),
+					MinimumHealthyPercent: aws.Int64(int64(d.Get("deployment_minimum_healthy_percent").(int))),
+				}
+			}
 		}
-	}
 
-	if d.HasChange("placement_constraints") {
-		updateService = true
-		// Reference: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html#ECS-UpdateService-request-placementConstraints
-		// To remove all existing placement constraints, specify an empty array.
-		input.PlacementConstraints = []*ecs.PlacementConstraint{}
-
-		if v, ok := d.Get("placement_constraints").(*schema.Set); ok && v.Len() > 0 {
-			pc, err := expandPlacementConstraints(v.List())
-
-			if err != nil {
-				return err
+		if d.HasChange("deployment_circuit_breaker") {
+			if input.DeploymentConfiguration == nil {
+				input.DeploymentConfiguration = &ecs.DeploymentConfiguration{}
 			}
 
-			input.PlacementConstraints = pc
+			// To remove an existing deployment circuit breaker, specify an empty object.
+			input.DeploymentConfiguration.DeploymentCircuitBreaker = &ecs.DeploymentCircuitBreaker{}
+
+			if v, ok := d.GetOk("deployment_circuit_breaker"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+				input.DeploymentConfiguration.DeploymentCircuitBreaker = expandDeploymentCircuitBreaker(v.([]interface{})[0].(map[string]interface{}))
+			}
 		}
-	}
 
-	if d.HasChange("platform_version") {
-		updateService = true
-		input.PlatformVersion = aws.String(d.Get("platform_version").(string))
-	}
+		if d.HasChange("ordered_placement_strategy") {
+			// Reference: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html#ECS-UpdateService-request-placementStrategy
+			// To remove an existing placement strategy, specify an empty object.
+			input.PlacementStrategy = []*ecs.PlacementStrategy{}
 
-	if d.HasChange("health_check_grace_period_seconds") {
-		updateService = true
-		input.HealthCheckGracePeriodSeconds = aws.Int64(int64(d.Get("health_check_grace_period_seconds").(int)))
-	}
+			if v, ok := d.GetOk("ordered_placement_strategy"); ok && len(v.([]interface{})) > 0 {
+				ps, err := expandPlacementStrategy(v.([]interface{}))
 
-	if d.HasChange("task_definition") {
-		updateService = true
-		input.TaskDefinition = aws.String(d.Get("task_definition").(string))
-	}
+				if err != nil {
+					return err
+				}
 
-	if d.HasChange("network_configuration") {
-		updateService = true
-		input.NetworkConfiguration = expandNetworkConfiguration(d.Get("network_configuration").([]interface{}))
-	}
+				input.PlacementStrategy = ps
+			}
+		}
 
-	if d.HasChange("capacity_provider_strategy") {
-		updateService = true
-		input.CapacityProviderStrategy = expandCapacityProviderStrategy(d.Get("capacity_provider_strategy").(*schema.Set))
-	}
+		if d.HasChange("placement_constraints") {
+			// Reference: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html#ECS-UpdateService-request-placementConstraints
+			// To remove all existing placement constraints, specify an empty array.
+			input.PlacementConstraints = []*ecs.PlacementConstraint{}
 
-	if d.HasChange("enable_execute_command") {
-		updateService = true
-		input.EnableExecuteCommand = aws.Bool(d.Get("enable_execute_command").(bool))
-	}
+			if v, ok := d.Get("placement_constraints").(*schema.Set); ok && v.Len() > 0 {
+				pc, err := expandPlacementConstraints(v.List())
 
-	if d.HasChange("enable_ecs_managed_tags") {
-		updateService = true
-		input.EnableECSManagedTags = aws.Bool(d.Get("enable_ecs_managed_tags").(bool))
-	}
+				if err != nil {
+					return err
+				}
 
-	if d.HasChange("load_balancer") {
-		updateService = true
-		input.LoadBalancers = expandLoadBalancers(d.Get("load_balancer").([]interface{}))
-	}
+				input.PlacementConstraints = pc
+			}
+		}
 
-	if d.HasChange("propagate_tags") {
-		updateService = true
-		input.PropagateTags = aws.String(d.Get("propagate_tags").(string))
-	}
+		if d.HasChange("platform_version") {
+			input.PlatformVersion = aws.String(d.Get("platform_version").(string))
+		}
 
-	if d.HasChange("service_registries") {
-		updateService = true
-		input.ServiceRegistries = expandServiceRegistries(d.Get("service_registries").([]interface{}))
-	}
+		if d.HasChange("health_check_grace_period_seconds") {
+			input.HealthCheckGracePeriodSeconds = aws.Int64(int64(d.Get("health_check_grace_period_seconds").(int)))
+		}
 
-	if updateService {
+		if d.HasChange("task_definition") {
+			input.TaskDefinition = aws.String(d.Get("task_definition").(string))
+		}
+
+		if d.HasChange("network_configuration") {
+			input.NetworkConfiguration = expandNetworkConfiguration(d.Get("network_configuration").([]interface{}))
+		}
+
+		if d.HasChange("capacity_provider_strategy") {
+			input.CapacityProviderStrategy = expandCapacityProviderStrategy(d.Get("capacity_provider_strategy").(*schema.Set))
+		}
+
+		if d.HasChange("enable_execute_command") {
+			input.EnableExecuteCommand = aws.Bool(d.Get("enable_execute_command").(bool))
+		}
+
+		if d.HasChange("enable_ecs_managed_tags") {
+			input.EnableECSManagedTags = aws.Bool(d.Get("enable_ecs_managed_tags").(bool))
+		}
+
+		if d.HasChange("load_balancer") {
+			input.LoadBalancers = expandLoadBalancers(d.Get("load_balancer").([]interface{}))
+		}
+
+		if d.HasChange("propagate_tags") {
+			input.PropagateTags = aws.String(d.Get("propagate_tags").(string))
+		}
+
+		if d.HasChange("service_registries") {
+			input.ServiceRegistries = expandServiceRegistries(d.Get("service_registries").([]interface{}))
+		}
+
 		log.Printf("[DEBUG] Updating ECS Service (%s): %s", d.Id(), input)
 		// Retry due to IAM eventual consistency
 		err := resource.Retry(tfiam.PropagationTimeout+serviceUpdateTimeout, func() *resource.RetryError {
-			_, err := conn.UpdateService(&input)
+			_, err := conn.UpdateService(input)
 
 			if err != nil {
 				if tfawserr.ErrMessageContains(err, ecs.ErrCodeInvalidParameterException, "verify that the ECS service role being passed has the proper permissions") {
@@ -1130,22 +1112,22 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if tfresource.TimedOut(err) {
-			_, err = conn.UpdateService(&input)
+			_, err = conn.UpdateService(input)
 		}
 
 		if err != nil {
 			return fmt.Errorf("error updating ECS Service (%s): %w", d.Id(), err)
 		}
-	}
 
-	if d.Get("wait_for_steady_state").(bool) {
-		cluster := ""
-		if v, ok := d.GetOk("cluster"); ok {
-			cluster = v.(string)
-		}
+		if d.Get("wait_for_steady_state").(bool) {
+			cluster := ""
+			if v, ok := d.GetOk("cluster"); ok {
+				cluster = v.(string)
+			}
 
-		if err := waitServiceStable(conn, d.Id(), cluster); err != nil {
-			return fmt.Errorf("error waiting for ECS service (%s) to become ready: %w", d.Id(), err)
+			if err := waitServiceStable(conn, d.Id(), cluster); err != nil {
+				return fmt.Errorf("error waiting for ECS service (%s) to become ready: %w", d.Id(), err)
+			}
 		}
 	}
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -107,15 +107,11 @@ func ResourceService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							ForceNew: true,
-							Optional: true,
-							Default:  ecs.DeploymentControllerTypeEcs,
-							ValidateFunc: validation.StringInSlice([]string{
-								ecs.DeploymentControllerTypeCodeDeploy,
-								ecs.DeploymentControllerTypeEcs,
-								ecs.DeploymentControllerTypeExternal,
-							}, false),
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Default:      ecs.DeploymentControllerTypeEcs,
+							ValidateFunc: validation.StringInSlice(ecs.DeploymentControllerType_Values(), false),
 						},
 					},
 				},
@@ -253,13 +249,9 @@ func ResourceService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ecs.PlacementStrategyTypeBinpack,
-								ecs.PlacementStrategyTypeRandom,
-								ecs.PlacementStrategyTypeSpread,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(ecs.PlacementStrategyType_Values(), false),
 						},
 						"field": {
 							Type:     schema.TypeString,
@@ -289,12 +281,9 @@ func ResourceService() *schema.Resource {
 							Optional: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ecs.PlacementConstraintTypeDistinctInstance,
-								ecs.PlacementConstraintTypeMemberOf,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(ecs.PlacementConstraintType_Values(), false),
 						},
 					},
 				},
@@ -313,21 +302,14 @@ func ResourceService() *schema.Resource {
 					}
 					return false
 				},
-				ValidateFunc: validation.StringInSlice([]string{
-					ecs.PropagateTagsService,
-					ecs.PropagateTagsTaskDefinition,
-					ecs.PropagateTagsNone,
-				}, false),
+				ValidateFunc: validation.StringInSlice(ecs.PropagateTags_Values(), false),
 			},
 			"scheduling_strategy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  ecs.SchedulingStrategyReplica,
-				ValidateFunc: validation.StringInSlice([]string{
-					ecs.SchedulingStrategyDaemon,
-					ecs.SchedulingStrategyReplica,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      ecs.SchedulingStrategyReplica,
+				ValidateFunc: validation.StringInSlice(ecs.SchedulingStrategy_Values(), false),
 			},
 			"service_registries": {
 				Type:     schema.TypeList,

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -316,7 +316,7 @@ func ResourceService() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					ecs.PropagateTagsService,
 					ecs.PropagateTagsTaskDefinition,
-					"",
+					ecs.PropagateTagsNone,
 				}, false),
 			},
 			"scheduling_strategy": {
@@ -1105,6 +1105,26 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("enable_execute_command") {
 		updateService = true
 		input.EnableExecuteCommand = aws.Bool(d.Get("enable_execute_command").(bool))
+	}
+
+	if d.HasChange("enable_ecs_managed_tags") {
+		updateService = true
+		input.EnableECSManagedTags = aws.Bool(d.Get("enable_ecs_managed_tags").(bool))
+	}
+
+	if d.HasChange("load_balancer") {
+		updateService = true
+		input.LoadBalancers = expandLoadBalancers(d.Get("load_balancer").([]interface{}))
+	}
+
+	if d.HasChange("propagate_tags") {
+		updateService = true
+		input.PropagateTags = aws.String(d.Get("propagate_tags").(string))
+	}
+
+	if d.HasChange("service_registries") {
+		updateService = true
+		input.ServiceRegistries = expandServiceRegistries(d.Get("service_registries").([]interface{}))
 	}
 
 	if updateService {

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -153,7 +153,6 @@ func ResourceService() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
 			},
 			"enable_execute_command": {
 				Type:     schema.TypeBool,
@@ -185,7 +184,6 @@ func ResourceService() *schema.Resource {
 			"load_balancer": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"elb_name": {
@@ -309,7 +307,6 @@ func ResourceService() *schema.Resource {
 			"propagate_tags": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if old == "NONE" && new == "" {
 						return true
@@ -335,7 +332,6 @@ func ResourceService() *schema.Resource {
 			"service_registries": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -1233,10 +1233,10 @@ func TestAccECSService_Tags_propagate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceManagedTagsConfig(rName),
+				Config: testAccServicePropagateTagsConfig(rName, "NONE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName, &third),
-					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", ecs.PropagateTagsNone),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
---
This pull request aims to take advantage of the recent updates to the ECS api to allow for updating `propagate_tags` `ecs_managed_tags` `load_balancer` and `service_registries` without requiring a new deployment of the `aws_ecs_service` resource

The associated updates to the API can be found [here](https://aws.amazon.com/about-aws/whats-new/2022/03/amazon-ecs-service-api-updating-elastic-load-balancers-service-registries-tag-propagation-ecs-managed-tags/)

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23596.
Closes #23581.

Output from acceptance testing:

```
➜ make testacc TESTS=TestAccECSService PKG=ecs                               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 4 -run='TestAccECSService'  -timeout 180m
=== RUN   TestAccECSServiceDataSource_basic
=== PAUSE TestAccECSServiceDataSource_basic
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_basicImport
=== PAUSE TestAccECSService_basicImport
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_CapacityProviderStrategy_multiple
=== PAUSE TestAccECSService_CapacityProviderStrategy_multiple
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_renamedCluster
=== PAUSE TestAccECSService_renamedCluster
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== CONT  TestAccECSServiceDataSource_basic
=== CONT  TestAccECSService_multipleTargetGroups
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
=== CONT  TestAccECSService_executeCommand
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (62.37s)
=== CONT  TestAccECSService_Tags_propagate
--- PASS: TestAccECSServiceDataSource_basic (93.59s)
=== CONT  TestAccECSService_Tags_managed
--- PASS: TestAccECSService_executeCommand (119.17s)
=== CONT  TestAccECSService_Tags_basic
--- PASS: TestAccECSService_Tags_managed (90.58s)
=== CONT  TestAccECSService_ServiceRegistries_changes
--- PASS: TestAccECSService_Tags_propagate (137.64s)
=== CONT  TestAccECSService_ServiceRegistries_container
--- PASS: TestAccECSService_Tags_basic (150.21s)
=== CONT  TestAccECSService_ServiceRegistries_basic
--- PASS: TestAccECSService_multipleTargetGroups (288.66s)
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_ServiceRegistries_container (172.31s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
--- PASS: TestAccECSService_replicaSchedulingStrategy (89.16s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (59.40s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_ServiceRegistries_basic (185.92s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSService_ServiceRegistries_changes (337.40s)
=== CONT  TestAccECSService_loadBalancerChanges
--- PASS: TestAccECSService_clusterName (87.37s)
=== CONT  TestAccECSService_deploymentCircuitBreaker
--- PASS: TestAccECSService_deploymentCircuitBreaker (88.93s)
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
--- PASS: TestAccECSService_loadBalancerChanges (136.81s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_alb (277.57s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (346.58s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (102.60s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_DeploymentValues_basic (87.84s)
=== CONT  TestAccECSService_iamRole
--- PASS: TestAccECSService_DeploymentControllerType_external (66.10s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
--- PASS: TestAccECSService_iamRole (77.24s)
=== CONT  TestAccECSService_renamedCluster
--- PASS: TestAccECSService_renamedCluster (108.51s)
=== CONT  TestAccECSService_familyAndRevision
=== CONT  TestAccECSService_CapacityProviderStrategy_multiple
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (158.46s)
--- PASS: TestAccECSService_familyAndRevision (110.28s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (316.28s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (127.89s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (409.72s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_disappears (88.38s)
=== CONT  TestAccECSService_basicImport
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (90.11s)
=== CONT  TestAccECSService_basic
--- PASS: TestAccECSService_basicImport (86.43s)
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (192.61s)
=== CONT  TestAccECSService_LaunchTypeEC2_network
--- PASS: TestAccECSService_basic (128.42s)
=== CONT  TestAccECSService_PlacementStrategy_missing
--- PASS: TestAccECSService_PlacementStrategy_missing (6.14s)
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
--- PASS: TestAccECSService_LaunchTypeEC2_network (118.99s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSService_CapacityProviderStrategy_update (357.34s)
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (195.49s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (89.57s)
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
--- PASS: TestAccECSService_PlacementConstraints_basic (131.00s)
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
--- PASS: TestAccECSService_PlacementStrategy_basic (178.71s)
=== CONT  TestAccECSService_forceNewDeployment
--- PASS: TestAccECSService_LaunchTypeFargate_basic (164.33s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (208.75s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (177.95s)
--- PASS: TestAccECSService_forceNewDeployment (126.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        1707.653s
```
