### PR TITLE
New resource for Route53 Traffic Policy and Traffic Policy Instance, datasource for Route53 Traffic Policy

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1671,6 +1671,7 @@ func Provider() *schema.Provider {
 			"aws_route53_query_log":                     route53.ResourceQueryLog(),
 			"aws_route53_record":                        route53.ResourceRecord(),
 			"aws_route53_traffic_policy":                route53.ResourceTrafficPolicy(),
+			"aws_route53_traffic_policy_instance":       route53.ResourceTrafficPolicyInstance(),
 			"aws_route53_vpc_association_authorization": route53.ResourceVPCAssociationAuthorization(),
 			"aws_route53_zone":                          route53.ResourceZone(),
 			"aws_route53_zone_association":              route53.ResourceZoneAssociation(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1669,6 +1669,7 @@ func Provider() *schema.Provider {
 			"aws_route53_key_signing_key":               route53.ResourceKeySigningKey(),
 			"aws_route53_query_log":                     route53.ResourceQueryLog(),
 			"aws_route53_record":                        route53.ResourceRecord(),
+			"aws_route53_traffic_policy":                route53.ResourceTrafficPolicy(),
 			"aws_route53_vpc_association_authorization": route53.ResourceVPCAssociationAuthorization(),
 			"aws_route53_zone":                          route53.ResourceZone(),
 			"aws_route53_zone_association":              route53.ResourceZoneAssociation(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -756,6 +756,7 @@ func Provider() *schema.Provider {
 
 			"aws_route53_delegation_set": route53.DataSourceDelegationSet(),
 			"aws_route53_zone":           route53.DataSourceZone(),
+			"aws_route53_traffic_policy": route53.DataSourceTrafficPolicy(),
 
 			"aws_route53_resolver_endpoint": route53resolver.DataSourceEndpoint(),
 			"aws_route53_resolver_rule":     route53resolver.DataSourceRule(),

--- a/internal/service/route53/find.go
+++ b/internal/service/route53/find.go
@@ -117,3 +117,31 @@ func FindTrafficPolicyById(ctx context.Context, conn *route53.Route53, trafficPo
 
 	return nil, nil
 }
+
+func FindTrafficPolicyInstanceId(ctx context.Context, conn *route53.Route53, id string) (*route53.GetTrafficPolicyInstanceOutput, error) {
+	input := &route53.GetTrafficPolicyInstanceInput{
+		Id: aws.String(id),
+	}
+
+	resp, err := conn.GetTrafficPolicyInstanceWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicyInstance) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return resp, nil
+}

--- a/internal/service/route53/status.go
+++ b/internal/service/route53/status.go
@@ -1,9 +1,12 @@
 package route53
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func statusChangeInfo(conn *route53.Route53, changeID string) resource.StateRefreshFunc {
@@ -55,5 +58,22 @@ func statusKeySigningKey(conn *route53.Route53, hostedZoneID string, name string
 		}
 
 		return keySigningKey, aws.StringValue(keySigningKey.Status), nil
+	}
+}
+
+//statusTrafficPolicyInstanceState fetches the traffic policy instance and its state
+func statusTrafficPolicyInstanceState(ctx context.Context, conn *route53.Route53, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := FindTrafficPolicyInstanceId(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "Unknown", err
+		}
+
+		return object, aws.StringValue(object.TrafficPolicyInstance.State), nil
 	}
 }

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -1,0 +1,217 @@
+package route53
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceTrafficPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceTrafficPolicyCreate,
+		ReadWithoutTimeout:   resourceTrafficPolicyRead,
+		UpdateWithoutTimeout: resourceTrafficPolicyUpdate,
+		DeleteWithoutTimeout: resourceTrafficPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("unexpected format of ID (%q), expected traffic-policy-id/traffic-policy-version", d.Id())
+				}
+				version, err := strconv.Atoi(idParts[1])
+				if err != nil {
+					return nil, fmt.Errorf("cannot convert to int: %s", idParts[1])
+				}
+				d.Set("version", version)
+				d.SetId(idParts[0])
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 512),
+			},
+			"comment": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"document": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 102400),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTrafficPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	input := &route53.CreateTrafficPolicyInput{
+		Document: aws.String(d.Get("document").(string)),
+		Name:     aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("comment"); ok {
+		input.Comment = aws.String(v.(string))
+	}
+
+	var err error
+	var output *route53.CreateTrafficPolicyOutput
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		output, err = conn.CreateTrafficPolicyWithContext(ctx, input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicy) {
+				resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateTrafficPolicyWithContext(ctx, input)
+	}
+
+	if err != nil {
+		return diag.Errorf("error creating Route53 traffic policy: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.TrafficPolicy.Id))
+
+	return resourceTrafficPolicyRead(ctx, d, meta)
+}
+
+func resourceTrafficPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	object, err := FindTrafficPolicyById(ctx, conn, d.Id())
+	if err != nil {
+		return diag.Errorf("error getting Route53 Traffic Policy %s from ListTrafficPolicies: %s", d.Get("name").(string), err)
+	}
+
+	if object == nil {
+		log.Printf("[WARN] Route53 Traffic Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	request := &route53.GetTrafficPolicyInput{
+		Id:      aws.String(d.Id()),
+		Version: object.LatestVersion,
+	}
+
+	response, err := conn.GetTrafficPolicy(request)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicy) {
+		log.Printf("[WARN] Route53 Traffic Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error getting Route53 Traffic Policy %s, version %d: %s", d.Get("name").(string), d.Get("version").(int), err)
+	}
+
+	d.Set("comment", response.TrafficPolicy.Comment)
+	d.Set("document", response.TrafficPolicy.Document)
+	d.Set("name", response.TrafficPolicy.Name)
+	d.Set("type", response.TrafficPolicy.Type)
+	d.Set("version", response.TrafficPolicy.Version)
+
+	return nil
+}
+
+func resourceTrafficPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	input := &route53.CreateTrafficPolicyVersionInput{
+		Id:       aws.String(d.Id()),
+		Document: aws.String(d.Get("document").(string)),
+	}
+
+	if d.HasChange("comment") {
+		input.Comment = aws.String(d.Get("comment").(string))
+	}
+
+	_, err := conn.CreateTrafficPolicyVersionWithContext(ctx, input)
+	if err != nil {
+		return diag.Errorf("error updating Route53 Traffic Policy: %s. %s", d.Get("name").(string), err)
+	}
+
+	return resourceTrafficPolicyRead(ctx, d, meta)
+}
+
+func resourceTrafficPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	var trafficPolicies []*route53.TrafficPolicy
+	var versionMarker *string
+
+	for allPoliciesListed := false; !allPoliciesListed; {
+		listRequest := &route53.ListTrafficPolicyVersionsInput{
+			Id: aws.String(d.Id()),
+		}
+		if versionMarker != nil {
+			listRequest.TrafficPolicyVersionMarker = versionMarker
+		}
+
+		listResponse, err := conn.ListTrafficPolicyVersionsWithContext(ctx, listRequest)
+		if err != nil {
+			return diag.Errorf("error listing Route 53 Traffic Policy versions: %v", err)
+		}
+
+		trafficPolicies = append(trafficPolicies, listResponse.TrafficPolicies...)
+
+		if aws.BoolValue(listResponse.IsTruncated) {
+			versionMarker = listResponse.TrafficPolicyVersionMarker
+		} else {
+			allPoliciesListed = true
+		}
+	}
+
+	for _, trafficPolicy := range trafficPolicies {
+		input := &route53.DeleteTrafficPolicyInput{
+			Id:      trafficPolicy.Id,
+			Version: trafficPolicy.Version,
+		}
+
+		_, err := conn.DeleteTrafficPolicyWithContext(ctx, input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicy) {
+				return nil
+			}
+
+			return diag.Errorf("error deleting Route53 Traffic Policy %s, version %d: %s", aws.StringValue(trafficPolicy.Id), aws.Int64Value(trafficPolicy.Version), err)
+		}
+	}
+	return nil
+}

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -153,16 +153,21 @@ func resourceTrafficPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 func resourceTrafficPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).Route53Conn
 
-	input := &route53.CreateTrafficPolicyVersionInput{
-		Id:       aws.String(d.Id()),
-		Document: aws.String(d.Get("document").(string)),
+	object, err := FindTrafficPolicyById(ctx, conn, d.Id())
+	if err != nil {
+		return diag.Errorf("error getting Route53 Traffic Policy %s from ListTrafficPolicies: %s", d.Get("name").(string), err)
+	}
+
+	input := &route53.UpdateTrafficPolicyCommentInput{
+		Id:      aws.String(d.Id()),
+		Version: object.LatestVersion,
 	}
 
 	if d.HasChange("comment") {
 		input.Comment = aws.String(d.Get("comment").(string))
 	}
 
-	_, err := conn.CreateTrafficPolicyVersionWithContext(ctx, input)
+	_, err = conn.UpdateTrafficPolicyCommentWithContext(ctx, input)
 	if err != nil {
 		return diag.Errorf("error updating Route53 Traffic Policy: %s. %s", d.Get("name").(string), err)
 	}

--- a/internal/service/route53/traffic_policy_data_source.go
+++ b/internal/service/route53/traffic_policy_data_source.go
@@ -1,0 +1,73 @@
+package route53
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceTrafficPolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourcePolicyRead,
+		Schema: map[string]*schema.Schema{
+			"traffic_policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"document": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	object, err := FindTrafficPolicyById(ctx, conn, d.Get("traffic_policy_id").(string))
+	if err != nil {
+		return diag.Errorf("error getting Route53 Traffic Policy %s from ListTrafficPolicies: %s", d.Get("name").(string), err)
+	}
+
+	request := &route53.GetTrafficPolicyInput{
+		Id:      object.Id,
+		Version: object.LatestVersion,
+	}
+
+	response, err := conn.GetTrafficPolicy(request)
+
+	if err != nil {
+		return diag.Errorf("error getting Route53 Traffic Policy %s: %s", d.Get("name").(string), err)
+	}
+
+	d.Set("comment", response.TrafficPolicy.Comment)
+	d.Set("document", response.TrafficPolicy.Document)
+	d.Set("name", response.TrafficPolicy.Name)
+	d.Set("type", response.TrafficPolicy.Type)
+	d.Set("version", response.TrafficPolicy.Version)
+
+	d.SetId(aws.StringValue(response.TrafficPolicy.Id))
+
+	return nil
+}

--- a/internal/service/route53/traffic_policy_data_source_test.go
+++ b/internal/service/route53/traffic_policy_data_source_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/aws/aws-sdk-go/service/route53"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccDataPipelinePipelineDataSource_basic(t *testing.T) {
+func TestAccTrafficPolicyDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_route53_traffic_policy.test"
 	resourceName := "aws_route53_traffic_policy.test"
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
@@ -19,10 +19,10 @@ func TestAccDataPipelinePipelineDataSource_basic(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckTrafficPolicyDestroy,
-		ErrorCheck:        acctest.ErrorCheck(t, datapipeline.EndpointsID),
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataPipelinePipelineDataSourceConfig(rName),
+				Config: testAccTrafficPolicyDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "traffic_policy_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
@@ -36,7 +36,7 @@ func TestAccDataPipelinePipelineDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDataPipelinePipelineDataSourceConfig(name string) string {
+func testAccTrafficPolicyDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_traffic_policy" "test" {
   name     = %[1]q

--- a/internal/service/route53/traffic_policy_data_source_test.go
+++ b/internal/service/route53/traffic_policy_data_source_test.go
@@ -1,0 +1,62 @@
+package route53_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDataPipelinePipelineDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_route53_traffic_policy.test"
+	resourceName := "aws_route53_traffic_policy.test"
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrafficPolicyDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, datapipeline.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPipelinePipelineDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "traffic_policy_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "comment", resourceName, "comment"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "document", resourceName, "document"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataPipelinePipelineDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_traffic_policy" "test" {
+  name     = %[1]q
+  document = <<-EOT
+{
+    "AWSPolicyFormatVersion":"2015-10-01",
+    "RecordType":"A",
+    "Endpoints":{
+        "endpoint-start-NkPh":{
+            "Type":"value",
+            "Value":"10.0.0.1"
+        }
+    },
+    "StartEndpoint":"endpoint-start-NkPh"
+}
+EOT
+}
+
+data "aws_route53_traffic_policy" "test" {
+  traffic_policy_id = aws_route53_traffic_policy.test.id
+}
+`, name)
+}

--- a/internal/service/route53/traffic_policy_instance.go
+++ b/internal/service/route53/traffic_policy_instance.go
@@ -1,0 +1,186 @@
+package route53
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceTrafficPolicyInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceTrafficPolicyInstanceCreate,
+		ReadWithoutTimeout:   resourceTrafficPolicyInstanceRead,
+		UpdateWithoutTimeout: resourceTrafficPolicyInstanceUpdate,
+		DeleteWithoutTimeout: resourceTrafficPolicyInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"hosted_zone_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+				StateFunc: func(v interface{}) string {
+					value := strings.TrimSuffix(v.(string), ".")
+					return strings.ToLower(value)
+				},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"traffic_policy_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 36),
+			},
+			"traffic_policy_version": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 1000),
+			},
+			"ttl": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtMost(2147483647),
+			},
+		},
+	}
+}
+
+func resourceTrafficPolicyInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	input := &route53.CreateTrafficPolicyInstanceInput{
+		HostedZoneId:         aws.String(d.Get("hosted_zone_id").(string)),
+		Name:                 aws.String(d.Get("name").(string)),
+		TrafficPolicyId:      aws.String(d.Get("traffic_policy_id").(string)),
+		TrafficPolicyVersion: aws.Int64(int64(d.Get("traffic_policy_version").(int))),
+		TTL:                  aws.Int64(int64(d.Get("ttl").(int))),
+	}
+
+	var err error
+	var output *route53.CreateTrafficPolicyInstanceOutput
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		output, err = conn.CreateTrafficPolicyInstanceWithContext(ctx, input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicyInstance) {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateTrafficPolicyInstanceWithContext(ctx, input)
+	}
+	if err != nil {
+		return diag.Errorf("error creating Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	if _, err = waitTrafficPolicyInstanceStateApplied(ctx, conn, aws.StringValue(output.TrafficPolicyInstance.Id)); err != nil {
+		return diag.Errorf("error waiting for Route53 Traffic Policy Instance (%s) to be Applied: %s", d.Id(), err)
+	}
+
+	d.SetId(aws.StringValue(output.TrafficPolicyInstance.Id))
+
+	return resourceTrafficPolicyInstanceRead(ctx, d, meta)
+}
+
+func resourceTrafficPolicyInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	input := &route53.GetTrafficPolicyInstanceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	output, err := conn.GetTrafficPolicyInstanceWithContext(ctx, input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicyInstance) {
+		log.Printf("[WARN] Route53 Traffic Policy Instance (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error reading Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	d.Set("hosted_zone_id", output.TrafficPolicyInstance.HostedZoneId)
+	d.Set("message", output.TrafficPolicyInstance.Message)
+	d.Set("name", strings.TrimSuffix(aws.StringValue(output.TrafficPolicyInstance.Name), "."))
+	d.Set("state", output.TrafficPolicyInstance.State)
+	d.Set("traffic_policy_id", output.TrafficPolicyInstance.TrafficPolicyId)
+	d.Set("traffic_policy_version", output.TrafficPolicyInstance.TrafficPolicyVersion)
+	d.Set("ttl", output.TrafficPolicyInstance.TTL)
+
+	return nil
+}
+
+func resourceTrafficPolicyInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	input := &route53.UpdateTrafficPolicyInstanceInput{
+		Id:                   aws.String(d.Id()),
+		TrafficPolicyId:      aws.String(d.Get("traffic_policy_id").(string)),
+		TrafficPolicyVersion: aws.Int64(int64(d.Get("traffic_policy_version").(int))),
+		TTL:                  aws.Int64(int64(d.Get("ttl").(int))),
+	}
+
+	_, err := conn.UpdateTrafficPolicyInstanceWithContext(ctx, input)
+	if err != nil {
+		return diag.Errorf("error updating Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	return resourceTrafficPolicyInstanceRead(ctx, d, meta)
+}
+
+func resourceTrafficPolicyInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Route53Conn
+
+	input := &route53.DeleteTrafficPolicyInstanceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteTrafficPolicyInstanceWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicyInstance) {
+			return nil
+		}
+		return diag.Errorf("error deleting Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	if _, err = waitTrafficPolicyInstanceStateDeleted(ctx, conn, d.Id()); err != nil {
+		if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicyInstance) {
+			return nil
+		}
+		return diag.Errorf("error waiting for Route53 Traffic Policy Instance (%s) to be Deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/route53/traffic_policy_instance_test.go
+++ b/internal/service/route53/traffic_policy_instance_test.go
@@ -1,0 +1,201 @@
+package route53_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfrouter53 "github.com/hashicorp/terraform-provider-aws/internal/service/route53"
+)
+
+func TestAccTrafficPolicyInstance_basic(t *testing.T) {
+	var output route53.GetTrafficPolicyInstanceOutput
+	resourceName := "aws_route53_traffic_policy_instance.test"
+
+	zoneName := acctest.RandomDomainName()
+	rName := fmt.Sprintf("%s_%s", sdkacctest.RandString(5), zoneName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRoute53TrafficPolicyInstanceDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyInstanceConfig(zoneName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyInstanceExists(resourceName, &output),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTrafficPolicyInstance_disappears(t *testing.T) {
+	var output route53.GetTrafficPolicyInstanceOutput
+	resourceName := "aws_route53_traffic_policy_instance.test"
+
+	zoneName := acctest.RandomDomainName()
+	rName := fmt.Sprintf("%s_%s", sdkacctest.RandString(5), zoneName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRoute53TrafficPolicyInstanceDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyInstanceConfig(zoneName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyInstanceExists(resourceName, &output),
+					acctest.CheckResourceDisappears(acctest.Provider, tfrouter53.ResourceTrafficPolicyInstance(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccTrafficPolicyInstance_complete(t *testing.T) {
+	var output route53.GetTrafficPolicyInstanceOutput
+	resourceName := "aws_route53_traffic_policy_instance.test"
+
+	zoneName := acctest.RandomDomainName()
+	rName := fmt.Sprintf("%s_%s", sdkacctest.RandString(5), zoneName)
+	rNameUpdated := fmt.Sprintf("%s_%s", sdkacctest.RandString(5), zoneName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRoute53TrafficPolicyInstanceDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyInstanceConfig(zoneName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyInstanceExists(resourceName, &output),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				Config: testAccTrafficPolicyInstanceConfig(zoneName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyInstanceExists(resourceName, &output),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTrafficPolicyInstanceExists(resourceName string, output *route53.GetTrafficPolicyInstanceOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Route53Conn
+
+		input := &route53.GetTrafficPolicyInstanceInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.GetTrafficPolicyInstanceWithContext(context.Background(), input)
+
+		if err != nil {
+			return fmt.Errorf("problem checking for traffic policy instance existence: %w", err)
+		}
+
+		if resp == nil {
+			return fmt.Errorf("traffic policy instance %q does not exist", rs.Primary.ID)
+		}
+
+		output = resp
+
+		return nil
+	}
+}
+
+func testAccCheckRoute53TrafficPolicyInstanceDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_traffic_policy_instance" {
+			continue
+		}
+
+		input := &route53.GetTrafficPolicyInstanceInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.GetTrafficPolicyInstanceWithContext(context.Background(), input)
+		if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicyInstance) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Route53 Traffic Policy Instance %s : %w", rs.Primary.Attributes["name"], err)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error during check if traffic policy instance still exists, %#v", err)
+		}
+		if resp != nil {
+			return fmt.Errorf("traffic Policy instance still exists")
+		}
+	}
+	return nil
+}
+
+func testAccTrafficPolicyInstanceConfig(zoneName, instanceName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = %[1]q
+}
+
+resource "aws_route53_traffic_policy" "test" {
+  name     = aws_route53_zone.test.name
+  document = <<-EOT
+{
+    "AWSPolicyFormatVersion":"2015-10-01",
+    "RecordType":"A",
+    "Endpoints":{
+        "endpoint-start-NkPh":{
+            "Type":"value",
+            "Value":"10.0.0.1"
+        }
+    },
+    "StartEndpoint":"endpoint-start-NkPh"
+}
+EOT
+}
+
+resource "aws_route53_traffic_policy_instance" "test" {
+  hosted_zone_id         = aws_route53_zone.test.zone_id
+  name                   = %[2]q
+  traffic_policy_id      = aws_route53_traffic_policy.test.id
+  traffic_policy_version = aws_route53_traffic_policy.test.version
+  ttl                    = 360
+}
+`, zoneName, instanceName)
+}

--- a/internal/service/route53/traffic_policy_test.go
+++ b/internal/service/route53/traffic_policy_test.go
@@ -1,0 +1,223 @@
+package route53_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfroute53 "github.com/hashicorp/terraform-provider-aws/internal/service/route53"
+)
+
+func TestAccTrafficPolicy_basic(t *testing.T) {
+	var output route53.TrafficPolicySummary
+	resourceName := "aws_route53_traffic_policy.test"
+	rName := fmt.Sprintf("tf-route53-traffic-policy-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrafficPolicyDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyExists(resourceName, &output),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccTrafficPolicyImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTrafficPolicy_disappears(t *testing.T) {
+	var output route53.TrafficPolicySummary
+	resourceName := "aws_route53_traffic_policy.test"
+	rName := fmt.Sprintf("tf-route53-traffic-policy-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrafficPolicyDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyExists(resourceName, &output),
+					testAccCheckTrafficPolicyDisappears(&output),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccTrafficPolicy_complete(t *testing.T) {
+	var output route53.TrafficPolicySummary
+	resourceName := "aws_route53_traffic_policy.test"
+	rName := fmt.Sprintf("tf-route53-traffic-policy-%s", sdkacctest.RandString(5))
+	comment := `comment`
+	commentUpdated := `comment updated`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrafficPolicyDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyConfigComplete(rName, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyExists(resourceName, &output),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				Config: testAccTrafficPolicyConfigComplete(rName, commentUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyExists(resourceName, &output),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentUpdated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccTrafficPolicyImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTrafficPolicyExists(resourceName string, trafficPolicy *route53.TrafficPolicySummary) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Route53Conn
+
+		resp, err := tfroute53.FindTrafficPolicyById(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("problem checking for traffic policy existence: %w", err)
+		}
+
+		if resp == nil {
+			return fmt.Errorf("traffic policy %q does not exist", rs.Primary.ID)
+		}
+
+		*trafficPolicy = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckTrafficPolicyDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_traffic_policy" {
+			continue
+		}
+
+		resp, err := tfroute53.FindTrafficPolicyById(context.Background(), conn, rs.Primary.ID)
+		if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchTrafficPolicy) || resp == nil {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error during check if traffic policy still exists, %#v", err)
+		}
+		if resp != nil {
+			return fmt.Errorf("traffic Policy still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckTrafficPolicyDisappears(trafficPolicy *route53.TrafficPolicySummary) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Route53Conn
+
+		input := &route53.DeleteTrafficPolicyInput{
+			Id:      trafficPolicy.Id,
+			Version: trafficPolicy.LatestVersion,
+		}
+
+		_, err := conn.DeleteTrafficPolicyWithContext(context.Background(), input)
+
+		return err
+	}
+}
+
+func testAccTrafficPolicyImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["id"], rs.Primary.Attributes["version"]), nil
+	}
+}
+
+func testAccTrafficPolicyConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_traffic_policy" "test" {
+  name     = %[1]q
+  document = <<-EOT
+{
+    "AWSPolicyFormatVersion":"2015-10-01",
+    "RecordType":"A",
+    "Endpoints":{
+        "endpoint-start-NkPh":{
+            "Type":"value",
+            "Value":"10.0.0.1"
+        }
+    },
+    "StartEndpoint":"endpoint-start-NkPh"
+}
+EOT
+}
+`, name)
+}
+
+func testAccTrafficPolicyConfigComplete(name, comment string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_traffic_policy" "test" {
+  name     = %[1]q
+  comment  = %[2]q
+  document = <<-EOT
+{
+    "AWSPolicyFormatVersion":"2015-10-01",
+    "RecordType":"A",
+    "Endpoints":{
+        "endpoint-start-NkPh":{
+            "Type":"value",
+            "Value":"10.0.0.1"
+        }
+    },
+    "StartEndpoint":"endpoint-start-NkPh"
+}
+EOT
+}
+`, name, comment)
+}

--- a/website/docs/d/route53_traffic_policy.html.markdown
+++ b/website/docs/d/route53_traffic_policy.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "Route53"
+layout: "aws"
+page_title: "AWS: aws_route53_zone"
+description: |-
+    Provides details about a specific Route 53 Hosted Zone
+---
+
+# Data Source: aws_route53_zone
+
+`aws_route53_zone` provides details about a specific Route 53 Hosted Zone.
+
+This data source allows to find a Hosted Zone ID given Hosted Zone name and certain search criteria.
+
+## Example Usage
+
+The following example shows how to get a Hosted Zone from its name and from this data how to create a Record Set.
+
+
+```terraform
+resource "aws_route53_traffic_policy" "example" {
+  name     = "example"
+  comment  = "example comment"
+  document = <<EOF
+{
+  "AWSPolicyFormatVersion": "2015-10-01",
+  "RecordType": "A",
+  "Endpoints": {
+    "endpoint-start-NkPh": {
+      "Type": "value",
+      "Value": "10.0.0.2"
+    }
+  },
+  "StartEndpoint": "endpoint-start-NkPh"
+}
+EOF
+}
+
+
+data "aws_route53_traffic_policy" "example" {
+  traffic_policy_id = aws_route53_traffic_policy.test.id
+}
+```
+
+## Argument Reference
+
+* `traffic_policy_id` - (Required) ID of the traffic policy.
+
+## Attributes Reference
+
+The following attribute is additionally exported:
+
+* `id` - ID of the traffic policy
+* `comment` - Comment for the traffic policy.
+* `document` - Policy document. This is a JSON formatted string. For more information about building Route53 traffic policy documents, see the [AWS Route53 Traffic Policy document format](https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html)
+* `name` - Name of the traffic policy.
+* `type` - DNS type of the resource record sets that Amazon Route 53 creates when you use a traffic policy to create a traffic policy instance.
+* `version` - Version number of the traffic policy. This value is automatically incremented by AWS after each update of this resource.

--- a/website/docs/r/route53_traffic_policy.html.markdown
+++ b/website/docs/r/route53_traffic_policy.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Route53"
+layout: "aws"
+page_title: "AWS: aws_route53_traffic_policy"
+description: |-
+    Manages a Route53 Traffic Policy
+---
+
+# Resource: aws_route53_traffic_policy
+
+Manages a Route53 Traffic Policy.
+
+## Example Usage
+
+```terraform
+resource "aws_route53_traffic_policy" "example" {
+  name     = "example"
+  comment  = "example comment"
+  document = <<EOF
+{
+  "AWSPolicyFormatVersion": "2015-10-01",
+  "RecordType": "A",
+  "Endpoints": {
+    "endpoint-start-NkPh": {
+      "Type": "value",
+      "Value": "10.0.0.2"
+    }
+  },
+  "StartEndpoint": "endpoint-start-NkPh"
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the traffic policy.
+* `document` - (Required) Policy document. This is a JSON formatted string. For more information about building Route53 traffic policy documents, see the [AWS Route53 Traffic Policy document format](https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html)
+
+The following arguments are optional:
+
+* `comment` - (Optional) Comment for the traffic policy.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the traffic policy
+* `type` - DNS type of the resource record sets that Amazon Route 53 creates when you use a traffic policy to create a traffic policy instance.
+* `version` - Version number of the traffic policy. This value is automatically incremented by AWS after each update of this resource.
+
+
+## Import
+
+Route53 Traffic Policy can be imported using the `id` and `version`, e.g.
+
+```
+$ terraform import aws_route53_traffic_policy.example 01a52019-d16f-422a-ae72-c306d2b6df7e/1
+```

--- a/website/docs/r/route53_traffic_policy_instance.html.markdown
+++ b/website/docs/r/route53_traffic_policy_instance.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Route53"
+layout: "aws"
+page_title: "AWS: aws_route53_traffic_policy_instance"
+description: |-
+    Provides a Route53 traffic policy instance resource.
+---
+
+# Resource: aws_route53_traffic_policy_instance
+
+Provides a Route53 traffic policy instance resource.
+
+## Example Usage
+
+```terraform
+resource "aws_route53_traffic_policy_instance" "test" {
+  name                   = "test.example.com"
+  traffic_policy_id      = "b3gb108f-ea6f-45a5-baab-9d112d8b4037"
+  traffic_policy_version = 1
+  hosted_zone_id         = "Z033120931TAQO548OGJC"
+  ttl                    = 360
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Domain name for which Amazon Route 53 responds to DNS queries by using the resource record sets that Route 53 creates for this traffic policy instance.
+* `traffic_policy_id` - (Required) ID of the traffic policy that you want to use to create resource record sets in the specified hosted zone.
+* `traffic_policy_version` - (Required) Version of the traffic policy
+* `hosted_zone_id` - (Required) ID of the hosted zone that you want Amazon Route 53 to create resource record sets in by using the configuration in a traffic policy.
+* `ttl` - (Required) TTL that you want Amazon Route 53 to assign to all the resource record sets that it creates in the specified hosted zone.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of traffic policy instance.
+* `message` - If `state` is `Failed`, an explanation of the reason for the failure. If `state` is another value, `message` is empty. .
+* `state` - State of a policy traffic instance.
+
+## Import
+
+Route53 traffic policy instance can be imported using its id.
+
+```
+$ terraform import aws_route53_traffic_policy_instance.test df579d9a-6396-410e-ac22-e7ad60cf9e7e
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->
 - Added a new resource, doc and tests for [Route53 Traffic Policy](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateTrafficPolicy.html) called `aws_route53_traffic_policy` 
 - Added a new datasource, doc and tests for  [Route53 Traffic Policy](https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetTrafficPolicy.html) called `aws_route53_traffic_policy` 
 - Added a new resource, doc and tests for  [Route53 Traffic Policy Instance](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateTrafficPolicyInstance.html) called `aws_route53_traffic_policy_instance` 
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11256

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Resource Route 53 Traffic Policy 
```
$ make testacc TESTARGS='-run=TestAccTrafficPolicy_' PKG=route53      [16:55:52]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20  -run=TestAccTrafficPolicy_ -timeout 180m
=== RUN   TestAccTrafficPolicy_basic
=== PAUSE TestAccTrafficPolicy_basic
=== RUN   TestAccTrafficPolicy_disappears
=== PAUSE TestAccTrafficPolicy_disappears
=== RUN   TestAccTrafficPolicy_complete
=== PAUSE TestAccTrafficPolicy_complete
=== CONT  TestAccTrafficPolicy_basic
=== CONT  TestAccTrafficPolicy_complete
=== CONT  TestAccTrafficPolicy_disappears
--- PASS: TestAccTrafficPolicy_disappears (14.30s)
--- PASS: TestAccTrafficPolicy_basic (19.19s)
--- PASS: TestAccTrafficPolicy_complete (30.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    33.095s
```


Datasource Route 53 Traffic Policy 
```
$ make testacc TESTARGS='-run=TestAccTrafficPolicyDataSource_' PKG=route53                  [17:02:14]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20  -run=TestAccTrafficPolicyDataSource_ -timeout 180m
=== RUN   TestAccTrafficPolicyDataSource_basic
=== PAUSE TestAccTrafficPolicyDataSource_basic
=== CONT  TestAccTrafficPolicyDataSource_basic
--- PASS: TestAccTrafficPolicyDataSource_basic (16.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    19.308s

```

Resource Route 53 Traffic Policy Instance
```
$ make testacc TESTARGS='-run=TestAccTrafficPolicyInstance_' PKG=route53                    [17:04:52]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20  -run=TestAccTrafficPolicyInstance_ -timeout 180m
=== RUN   TestAccTrafficPolicyInstance_basic
=== PAUSE TestAccTrafficPolicyInstance_basic
=== RUN   TestAccTrafficPolicyInstance_disappears
=== PAUSE TestAccTrafficPolicyInstance_disappears
=== RUN   TestAccTrafficPolicyInstance_complete
=== PAUSE TestAccTrafficPolicyInstance_complete
=== CONT  TestAccTrafficPolicyInstance_basic
=== CONT  TestAccTrafficPolicyInstance_complete
=== CONT  TestAccTrafficPolicyInstance_disappears
--- PASS: TestAccTrafficPolicyInstance_disappears (116.59s)
--- PASS: TestAccTrafficPolicyInstance_basic (128.91s)
--- PASS: TestAccTrafficPolicyInstance_complete (211.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    214.002s


```