### PR TITLE
r/aws_quicksight_user: allow custom namespaces

### DIFF
--- a/.changelog/23607.txt
+++ b/.changelog/23607.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_quicksight_user: Allow custom values for `namespace`
+```

--- a/docs/contributing/maintaining.md
+++ b/docs/contributing/maintaining.md
@@ -397,6 +397,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |
+| `QUICKSIGHT_NAMESPACE` | QuickSight namespace name for testing. |
 | `ROUTE53DOMAINS_DOMAIN_NAME` | Registered domain for Route 53 Domains testing. |
 | `SAGEMAKER_IMAGE_VERSION_BASE_IMAGE` | Sagemaker base image to use for tests. |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE` | Quota Code for Service Quotas testing (submits support case). |

--- a/internal/service/quicksight/user.go
+++ b/internal/service/quicksight/user.go
@@ -3,6 +3,7 @@ package quicksight
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,9 +61,10 @@ func ResourceUser() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  "default",
-				ValidateFunc: validation.StringInSlice([]string{
-					"default",
-				}, false),
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._-]*$`), "must contain only alphanumeric characters, hyphens, underscores, and periods"),
+				),
 			},
 
 			"session_name": {

--- a/internal/service/quicksight/user_test.go
+++ b/internal/service/quicksight/user_test.go
@@ -2,6 +2,7 @@ package quicksight_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -80,9 +81,14 @@ func TestAccQuickSightUser_withInvalidFormattedEmailStillWorks(t *testing.T) {
 }
 
 func TestAccQuickSightUser_withNamespace(t *testing.T) {
+	key := "QUICKSIGHT_NAMESPACE"
+	namespace := os.Getenv(key)
+	if namespace == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
 	var user quicksight.User
 	rName := "tfacctest" + sdkacctest.RandString(10)
-	rNamespace := "terraform"
 	resourceName := "aws_quicksight_user." + rName
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -92,10 +98,10 @@ func TestAccQuickSightUser_withNamespace(t *testing.T) {
 		CheckDestroy: testAccCheckQuickSightUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserWithNamespaceConfig(rName, rNamespace),
+				Config: testAccUserWithNamespaceConfig(rName, namespace),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQuickSightUserExists(resourceName, &user),
-					resource.TestCheckResourceAttr(resourceName, "namespace", rNamespace),
+					resource.TestCheckResourceAttr(resourceName, "namespace", namespace),
 				),
 			},
 		},

--- a/website/docs/r/quicksight_user.html.markdown
+++ b/website/docs/r/quicksight_user.html.markdown
@@ -16,6 +16,7 @@ Resource for managing QuickSight User
 resource "aws_quicksight_user" "example" {
   session_name  = "an-author"
   email         = "author@example.com"
+  namespace     = "foo"
   identity_type = "IAM"
   iam_arn       = "arn:aws:iam::123456789012:user/Example"
   user_role     = "AUTHOR"
@@ -33,7 +34,7 @@ The following arguments are supported:
 * `user_name` - (Optional) The Amazon QuickSight user name that you want to create for the user you are registering. Only valid for registering a user with `identity_type` set to `QUICKSIGHT`.
 * `aws_account_id` - (Optional) The ID for the AWS account that the user is in. Currently, you use the ID for the AWS account that contains your Amazon QuickSight account.
 * `iam_arn` - (Optional) The ARN of the IAM user or role that you are registering with Amazon QuickSight.
-* `namespace`  - (Optional) The namespace. Currently, you should set this to `default`.
+* `namespace`  - (Optional) The Amazon Quicksight namespace to create the user in. Defaults to `default`.
 * `session_name` - (Optional) The name of the IAM session to use when assuming roles that can embed QuickSight dashboards. Only valid for registering users using an assumed IAM role. Additionally, if registering multiple users using the same IAM role, each user needs to have a unique session name.
 
 ## Attributes Reference


### PR DESCRIPTION
Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21166

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccQuickSightUser_ PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightUser_'  -timeout 180m
=== RUN   TestAccQuickSightUser_basic
=== PAUSE TestAccQuickSightUser_basic
=== RUN   TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== PAUSE TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== RUN   TestAccQuickSightUser_withNamespace
=== PAUSE TestAccQuickSightUser_withNamespace
=== RUN   TestAccQuickSightUser_disappears
=== PAUSE TestAccQuickSightUser_disappears
=== CONT  TestAccQuickSightUser_basic
=== CONT  TestAccQuickSightUser_disappears
=== CONT  TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== CONT  TestAccQuickSightUser_withNamespace
--- PASS: TestAccQuickSightUser_disappears (17.41s)
--- PASS: TestAccQuickSightUser_withNamespace (18.65s)
--- PASS: TestAccQuickSightUser_basic (31.54s)
--- PASS: TestAccQuickSightUser_withInvalidFormattedEmailStillWorks (32.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 34.220s
```

Maintainer Notes:

Quicksight testing is dependent on the manual turning on/creation of an Enterprise Quicksight subscription and a Quicksight namespace with the name "terraform". If running the tests, ensure to enable an Enterprise Quicksight subscription, create a namespace named "terraform", and set region appropriately before.