### PR TITLE
r/s3_bucket_replication_configuration: Add token parameter for x-amz-bucket-object-lock-token

### DIFF
--- a/.changelog/23624.txt
+++ b/.changelog/23624.txt
@@ -1,0 +1,5 @@
+```release-note:enhancement
+resource/aws_s3_bucket_replication_configuration: Add `token` field to specify
+x-amz-bucket-object-lock-token for enabling replication on object lock enabled
+buckets or enabling object lock on an existing bucket.
+```

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -38,6 +38,11 @@ func ResourceBucketReplicationConfiguration() *schema.Resource {
 				Required:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"token": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
 			"rule": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -309,6 +314,7 @@ func resourceBucketReplicationConfigurationCreate(d *schema.ResourceData, meta i
 	input := &s3.PutBucketReplicationInput{
 		Bucket:                   aws.String(bucket),
 		ReplicationConfiguration: rc,
+		Token:                    aws.String(d.Get("token").(string)),
 	}
 
 	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
@@ -385,6 +391,7 @@ func resourceBucketReplicationConfigurationUpdate(d *schema.ResourceData, meta i
 	input := &s3.PutBucketReplicationInput{
 		Bucket:                   aws.String(d.Id()),
 		ReplicationConfiguration: rc,
+		Token:                    aws.String(d.Get("token").(string)),
 	}
 
 	err := resource.Retry(propagationTimeout, func() *resource.RetryError {

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -39,9 +39,9 @@ func ResourceBucketReplicationConfiguration() *schema.Resource {
 				ValidateFunc: verify.ValidARN,
 			},
 			"token": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"rule": {
 				Type:     schema.TypeSet,
@@ -314,7 +314,10 @@ func resourceBucketReplicationConfigurationCreate(d *schema.ResourceData, meta i
 	input := &s3.PutBucketReplicationInput{
 		Bucket:                   aws.String(bucket),
 		ReplicationConfiguration: rc,
-		Token:                    aws.String(d.Get("token").(string)),
+	}
+
+	if v, ok := d.GetOk("token"); ok {
+		input.Token = aws.String(v.(string))
 	}
 
 	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
@@ -391,7 +394,10 @@ func resourceBucketReplicationConfigurationUpdate(d *schema.ResourceData, meta i
 	input := &s3.PutBucketReplicationInput{
 		Bucket:                   aws.String(d.Id()),
 		ReplicationConfiguration: rc,
-		Token:                    aws.String(d.Get("token").(string)),
+	}
+
+	if v, ok := d.GetOk("token"); ok {
+		input.Token = aws.String(v.(string))
 	}
 
 	err := resource.Retry(propagationTimeout, func() *resource.RetryError {

--- a/website/docs/r/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_replication_configuration.html.markdown
@@ -216,6 +216,8 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the source S3 bucket you want Amazon S3 to monitor.
 * `role` - (Required) The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+* `token` - (Optional) A token to allow replication to be enabled on an Object Lock-enabled bucket. You must contact AWS support for the bucket's "Object Lock token".
+For more details, see [Using S3 Object Lock with replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-managing-replication).
 * `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
 
 ### rule

--- a/website/docs/r/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_replication_configuration.html.markdown
@@ -216,9 +216,9 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the source S3 bucket you want Amazon S3 to monitor.
 * `role` - (Required) The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+* `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
 * `token` - (Optional) A token to allow replication to be enabled on an Object Lock-enabled bucket. You must contact AWS support for the bucket's "Object Lock token".
 For more details, see [Using S3 Object Lock with replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-managing-replication).
-* `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
 
 ### rule
 


### PR DESCRIPTION
This allows one to enable replication on an object-lock enabled bucket, OR enabling object lock on an existing bucket. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-managing-replication for details.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14061.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TESTS='TestAccS3BucketReplication.*' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketReplication.*'  -timeout 180m
=== RUN   TestAccS3BucketReplicationConfiguration_basic
=== PAUSE TestAccS3BucketReplicationConfiguration_basic
=== RUN   TestAccS3BucketReplicationConfiguration_disappears
=== PAUSE TestAccS3BucketReplicationConfiguration_disappears
=== RUN   TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== RUN   TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
=== RUN   TestAccS3BucketReplicationConfiguration_twoDestination
=== PAUSE TestAccS3BucketReplicationConfiguration_twoDestination
=== RUN   TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== PAUSE TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== RUN   TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== PAUSE TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== RUN   TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== PAUSE TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== RUN   TestAccS3BucketReplicationConfiguration_replicaModifications
=== PAUSE TestAccS3BucketReplicationConfiguration_replicaModifications
=== RUN   TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== RUN   TestAccS3BucketReplicationConfiguration_existingObjectReplication
    bucket_replication_configuration_test.go:714: skipping test: AWS Technical Support request required to allow ExistingObjectReplication
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
=== RUN   TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== RUN   TestAccS3BucketReplicationConfiguration_filter_andOperator
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_andOperator
=== RUN   TestAccS3BucketReplicationConfiguration_withoutPrefix
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutPrefix
=== CONT  TestAccS3BucketReplicationConfiguration_basic
=== CONT  TestAccS3BucketReplicationConfiguration_replicaModifications
=== CONT  TestAccS3BucketReplicationConfiguration_withoutPrefix
=== CONT  TestAccS3BucketReplicationConfiguration_twoDestination
=== CONT  TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== CONT  TestAccS3BucketReplicationConfiguration_filter_andOperator
=== CONT  TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== CONT  TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2
=== CONT  TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== CONT  TestAccS3BucketReplicationConfiguration_disappears
=== CONT  TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== CONT  TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== CONT  TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (59.40s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (171.63s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (305.94s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (307.00s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (307.06s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (307.94s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (309.00s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (309.10s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (309.21s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (309.21s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (309.34s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (309.42s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (331.59s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (336.38s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (336.73s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (347.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	353.025s
...
```

`make test` passed, and tested this on an ad-hoc TF module and was able to successfully enable replication on an object-lock enabled bucket. Before:

    │ Error: error creating S3 replication configuration for bucket (<redacted>): InvalidRequest: Replication configuration cannot be applied to an Object Lock enabled bucket

After:

```
aws_s3_bucket_replication_configuration.replication: Creating...
aws_s3_bucket_replication_configuration.replication: Creation complete after 1s [id=<redacted>]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
