### PR TITLE
Create MAINTAINER_LIST secret for GitHub Actions

### DIFF
--- a/infrastructure/repository/maintainer-list.tf
+++ b/infrastructure/repository/maintainer-list.tf
@@ -1,0 +1,9 @@
+// A list of maintainers to be used as an "allow list" for various GitHub Actions.
+// This allows us to make various "exceptions" for maintainers, such as automatically
+// removing the `needs-triage` label from new Issues and Pull Requests
+//
+resource "github_actions_secret" "maintainer_list" {
+  repository      = "github-actions-test"
+  secret_name     = "MAINTAINER_LIST"
+  plaintext_value = "['anGie44', 'breathingdust', 'ewbankkit', 'gdavison', 'johnsonaj', 'justinretzolk', 'maryelizbeth', 'YakDriver', 'zhelding']"
+}

--- a/infrastructure/repository/maintainer-list.tf
+++ b/infrastructure/repository/maintainer-list.tf
@@ -3,7 +3,7 @@
 // removing the `needs-triage` label from new Issues and Pull Requests
 //
 resource "github_actions_secret" "maintainer_list" {
-  repository      = "github-actions-test"
+  repository      = "terraform-provider-aws"
   secret_name     = "MAINTAINER_LIST"
   plaintext_value = "['anGie44', 'breathingdust', 'ewbankkit', 'gdavison', 'johnsonaj', 'justinretzolk', 'maryelizbeth', 'YakDriver', 'zhelding']"
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing: n/a, this PR is a meta-PR for the repo

### Information

Currently, there's several places where we employ a list to conditionally execute certain portions of certain GitHub Actions:

- [Issue Comment Created Triage](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/issue-comment-created.yml#L9)
- [Issue Triage](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/issues.yml#L11)
- [Pull Request Project Automation](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/project.yml#L11)
- [CHANGELOG Checks](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/changelog.yml#L16)
- [Check Maintainer Edit Permissions](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/maintainer-edit.yml#L10)
- [NeedsTriageLabeler](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/pull_requests.yml#L21)
- [Dependency Checks](https://github.com/hashicorp/terraform-provider-aws/blob/ccc60a8423bcbd96ba92a988851c0b75b67185c6/.github/workflows/dependencies.yml#L12)

Given that this list is in multiple places, it's easy for it to become stale/out of date, or for the list to be updated in one place, but not the others. This PR introduces a new GitHub Actions Secret called `MAINTAINER_LIST` to help centralize the list, managed by Terraform so that it's significantly easier to be updated.

Once this PR is merged, the associated Actions will need to be updated in a separate PR (#23636). The syntax will be as follows, for example:

Previously:

```yaml
      if: github.event.action == 'opened' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding", "johnsonaj"]'), github.actor)
```

After this PR:

```yaml
      if: github.event.action == 'opened' && !contains( secrets.MAINTAINER_LIST, github.actor)
```