### PR TITLE
GitHub Action - Add regressions to To Do column of working board

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -33,3 +33,13 @@ jobs:
           message: |
             :warning: The following pull request has been labeled as a regression:
             https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+  AddToWorkingBoard:
+    if: ${{ github.event.label.name == 'regression' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add regressions to To Do column
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: AWS Provider Working Board
+          column: To Do
+          repo-token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Output from acceptance testing: n/a, relates to GitHub Actions for the repo

### Information

This PR introduces an expansion to the current regressions action to automatically add issues and PRs labelled with `regression` to the To Do column of the AWS Provider Working Board.
