### PR TITLE
Fix broken GitHub Actions after switch to MAINTAINER_LIST

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,15 +11,18 @@ on:
       - CHANGELOG.md
   pull_request_target:
 
+env:
+  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
+
 jobs:
   changes:
-    if: github.event_name == 'pull_request_target' && !contains( secrets.MAINTAINER_LIST, github.actor)
     name: Filter Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request_target' && env.IN_MAINTAINER_LIST == 'false'
         id: filter
         with:
           filters: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,15 +7,18 @@ on:
       - 'release/**'
   pull_request_target:
 
+env:
+  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
+
 jobs:
   changes:
-    if: github.event_name == 'pull_request_target' && !contains( secrets.MAINTAINER_LIST, github.actor)
     name: Filter Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request_target' && env.IN_MAINTAINER_LIST == 'false'
         id: filter
         with:
           filters: |

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -4,12 +4,15 @@ on:
   issue_comment:
     types: [created]
 
+env:
+  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
+
 jobs:
   issue_comment_triage:
-    if: github.event_name == 'issue_comment' && !contains( secrets.MAINTAINER_LIST, github.actor)
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
+        if: github.event_name == 'issue_comment' && env.IN_MAINTAINER_LIST == 'false'
         with:
           labels: |
             stale

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -7,11 +7,11 @@ jobs:
   PermissionsCheck:
     env:
       MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
-      ALLOW_LISTED: ${{ contains( secrets.MAINTAINER_LIST, github.actor) }}
+      IN_MAINTAINER_LIST: ${{ contains( secrets.MAINTAINER_LIST, github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit
-        if: ${{ ( env.ALLOW_LISTED == 'false' ) && ( env.MAINTAINER_CAN_MODIFY == 'false' ) }}
+        if: ${{ ( env.IN_MAINTAINER_LIST == 'false' ) && ( env.MAINTAINER_CAN_MODIFY == 'false' ) }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -2,6 +2,10 @@ on:
   - pull_request_target
 
 name: Pull Request Target (All types)
+
+env:
+  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
+
 jobs:
   Labeler:
     runs-on: ubuntu-latest
@@ -18,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Apply needs-triage Label
       uses: actions/labeler@v4
-      if: github.event.action == 'opened' && !contains( secrets.MAINTAINER_LIST, github.actor)
+      if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
       with:
         configuration-path: .github/labeler-pr-needs-triage.yml
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates  #23636

Output from acceptance testing: n/a, relates to GitHub Actions

### Information

The linked Pull Request updated several GitHub Actions to use the new `MAINTAINER_LIST` secret to pull a list of users for an exclusion list. Unfortunately, this broke many of the workflows, so this PR aims to fix it.

There seems to be some inconsistencies, but the best I could tell, this is a result of using the `secrets` context in `jobs.<job-id>.if` definitions. Per the [context availability docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) this isn't supported (though it seemed to work on some Actions, so I'm still scratching my head a little).

Because of that, this PR introduces a top level `env` definition that evaluates the `contains()` block (the same way we were doing it in `jobs.<job-id>.if` previously) and then moves the conditional to `jobs.<job-id>.steps.if`, where `env` is supported.
