### PR TITLE
github/workflows/release: Use output var in commit message and add release date to changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           run: |
             CHANGELOG_FILE_NAME="CHANGELOG.md"
             PREVIOUS_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
-            TAG=${PREVIOUS_RELEASE_TAG:1}
            
             # Add Release Date
             RELEASE_DATE=`date +%B' '%e', '%Y`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,23 @@ jobs:
           run: |
             CHANGELOG_FILE_NAME="CHANGELOG.md"
             PREVIOUS_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
+            TAG=${PREVIOUS_RELEASE_TAG:1}
+           
+            # Add Release Date
+            RELEASE_DATE=`date +%B' '%e', '%Y`
+            sed -i -e "1 s/Unreleased/$RELEASE_DATE/" $CHANGELOG_FILE_NAME           
+            
+            # Prepend next release line
             echo Previous release is: $PREVIOUS_RELEASE_TAG
-
+            
             NEW_RELEASE_LINE=$(echo $PREVIOUS_RELEASE_TAG | awk -F. '{
                 $1 = substr($1,2)
                 $2 += 1
-                printf("%s.%01d.%s\n\n", $1, $2, $3);
+                printf("%s.%01d.0\n\n", $1, $2);
             }')
-
+            
             echo New minor version is: v$NEW_RELEASE_LINE
-
+            
             echo -e "## $NEW_RELEASE_LINE (Unreleased)\n$(cat $CHANGELOG_FILE_NAME)" > $CHANGELOG_FILE_NAME
             
             echo ::set-output name=prev_release_tag::$PREVIOUS_RELEASE_TAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
           with:
             fetch-depth: 0
             ref: main
-        - run: |
+        - name: Update Changelog Header
+          id: changelog
+          run: |
             CHANGELOG_FILE_NAME="CHANGELOG.md"
             PREVIOUS_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
             echo Previous release is: $PREVIOUS_RELEASE_TAG
@@ -71,9 +73,11 @@ jobs:
             echo New minor version is: v$NEW_RELEASE_LINE
 
             echo -e "## $NEW_RELEASE_LINE (Unreleased)\n$(cat $CHANGELOG_FILE_NAME)" > $CHANGELOG_FILE_NAME
+            
+            echo ::set-output name=prev_release_tag::$PREVIOUS_RELEASE_TAG
         - run: |
               git config --local user.email changelogbot@hashicorp.com
               git config --local user.name changelogbot
               git add CHANGELOG.md
-              git commit -m "Update CHANGELOG.md after ${{ github.event.release.tag_name }}" 
+              git commit -m "Update CHANGELOG.md after ${{ steps.changelog.outputs.prev_release_tag }}" 
               git push


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
### Description
* Latest release shows the commit version without the tag b/c it's no longer available in the github event triggered

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
