### PR TITLE
Simplify `autoremove_labels` GitHub Action

### DIFF
--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -1,18 +1,18 @@
 name: Autoremove Labels
+
 on:
   issues:
     types: [closed]
   pull_request_target:
     types: [closed]
+
 jobs:
-  remove-labels:
+  RemoveTriagingLabelsFromClosedIssueOrPR:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        labels: ['needs-triage', 'waiting-response']
     steps:
-      - name: Remove ${{ matrix.labels }} label
+      - name: Remove triaging labels from closed issues and PRs
         uses: actions-ecosystem/action-remove-labels@v1
-        if: contains(github.event.*.labels.*.name, matrix.labels)
         with:
-          labels: ${{ matrix.labels }}
+          labels: |
+            needs-triage
+            waiting-response


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
n/a
```

### Information

Previously, the Action used to automatically remove labels would fail if a particular label was not applied to a closing issue/PR. That behavior has changed, so there no longer needs to be a `strategy.matrix`, which made the Action run as multiple steps. Also took the opportunity to rename the job to be a bit more descriptive.