### PR TITLE
Additional fixes for GitHub Actions after MAINTAINER_LIST switch

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,14 +1,19 @@
+name: Issue triage
+
 on:
   issues:
     types: [opened]
-name: Issue triage
+
+env:
+  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
+
 jobs:
   markIssuesForTriage:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Apply Issue needs-triage Label
-      if: github.event.action == 'opened' && !contains( secrets.MAINTAINER_LIST, github.actor)
+      if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
       uses: github/issue-labeler@v2.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,14 +1,19 @@
+name: Pull Request Project Automation
+
 on:
   pull_request_target:
     types: [opened, ready_for_review]
-name: Pull Request Project Automation
+
+env:
+  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
+
 jobs:
   WorkingBoardReview:
     runs-on: ubuntu-latest
     steps:
     - name: Move team PRs to Review column
       uses: alex-page/github-project-automation-plus@v0.8.1
-      if: contains( secrets.MAINTAINER_LIST, github.actor) && github.event.pull_request.draft == false
+      if: env.IN_MAINTAINER_LIST == 'true' && github.event.pull_request.draft == false
       with:
         project: AWS Provider Working Board
         column: Open Maintainer PR


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #23640
Relates #23636

Output from acceptance testing:

```
n/a
```

### Information

These are an additional GitHub Actions that were impacted by the malformed syntax of #23636 that were not caught in the fixes included in #23640. Applying same fixes as before.