### PR TITLE
rd/aws_imagebuilder_image - add support for container_recipe_arn

### DIFF
--- a/.changelog/23647.txt
+++ b/.changelog/23647.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image: Add `container_recipe_arn` argument
+```

--- a/.changelog/23647.txt
+++ b/.changelog/23647.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_imagebuilder_image: Add `container_recipe_arn` argument
 ```
+
+```release-note:enhancement
+data-source/aws_imagebuilder_image: Add `container_recipe_arn` attribute
+```

--- a/internal/service/imagebuilder/image.go
+++ b/internal/service/imagebuilder/image.go
@@ -39,6 +39,13 @@ func ResourceImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"container_recipe_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^arn:aws[^:]*:imagebuilder:[^:]+:(?:\d{12}|aws):container-recipe/[a-z0-9-_]+/\d+\.\d+\.\d+$`), "valid container recipe ARN must be provided"),
+				ExactlyOneOf: []string{"container_recipe_arn", "image_recipe_arn"},
+			},
 			"distribution_configuration_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -53,9 +60,10 @@ func ResourceImage() *schema.Resource {
 			},
 			"image_recipe_arn": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^arn:aws[^:]*:imagebuilder:[^:]+:(?:\d{12}|aws):image-recipe/[a-z0-9-_]+/\d+\.\d+\.\d+$`), "valid image recipe ARN must be provided"),
+				ExactlyOneOf: []string{"container_recipe_arn", "image_recipe_arn"},
 			},
 			"image_tests_configuration": {
 				Type:     schema.TypeList,
@@ -157,6 +165,10 @@ func resourceImageCreate(d *schema.ResourceData, meta interface{}) error {
 		EnhancedImageMetadataEnabled: aws.Bool(d.Get("enhanced_image_metadata_enabled").(bool)),
 	}
 
+	if v, ok := d.GetOk("container_recipe_arn"); ok {
+		input.ContainerRecipeArn = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("distribution_configuration_arn"); ok {
 		input.DistributionConfigurationArn = aws.String(v.(string))
 	}
@@ -225,6 +237,10 @@ func resourceImageRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("arn", image.Arn)
 	d.Set("date_created", image.DateCreated)
+
+	if image.ContainerRecipe != nil {
+		d.Set("container_recipe_arn", image.ContainerRecipe.Arn)
+	}
 
 	if image.DistributionConfiguration != nil {
 		d.Set("distribution_configuration_arn", image.DistributionConfiguration.Arn)

--- a/internal/service/imagebuilder/image_data_source.go
+++ b/internal/service/imagebuilder/image_data_source.go
@@ -25,6 +25,10 @@ func DataSourceImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"container_recipe_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"date_created": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -150,6 +154,10 @@ func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("build_version_arn", image.Arn)
 	d.Set("date_created", image.DateCreated)
+
+	if image.ContainerRecipe != nil {
+		d.Set("container_recipe_arn", image.ContainerRecipe.Arn)
+	}
 
 	if image.DistributionConfiguration != nil {
 		d.Set("distribution_configuration_arn", image.DistributionConfiguration.Arn)

--- a/internal/service/imagebuilder/image_data_source_test.go
+++ b/internal/service/imagebuilder/image_data_source_test.go
@@ -78,6 +78,28 @@ func TestAccImageBuilderImageDataSource_ARN_self(t *testing.T) {
 	})
 }
 
+func TestAccImageBuilderImageDataSource_ARN_containerRecipeARN(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_imagebuilder_image.test"
+	resourceName := "aws_imagebuilder_image.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageARNContainerRecipeARNDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "container_recipe_arn", resourceName, "container_recipe_arn"),
+				),
+			},
+		},
+	})
+}
+
 func testAccImageARNDataSourceConfig() string {
 	return `
 data "aws_partition" "current" {}
@@ -197,6 +219,137 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 resource "aws_imagebuilder_image" "test" {
   image_recipe_arn                 = aws_imagebuilder_image_recipe.test.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
+}
+
+data "aws_imagebuilder_image" "test" {
+  arn = aws_imagebuilder_image.test.arn
+}
+`, rName)
+}
+
+func testAccImageARNContainerRecipeARNDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  ingress {
+    from_port = 0
+    protocol  = -1
+    self      = true
+    to_port   = 0
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.test.id
+}
+
+resource "aws_iam_role" "test" {
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+      Sid = ""
+    }]
+  })
+  name = %[1]q
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonSSMManagedInstanceCore" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_role_policy_attachment" "EC2InstanceProfileForImageBuilderECRContainerBuilds" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = aws_iam_role.test.name
+  role = aws_iam_role.test.name
+
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
+    aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds
+  ]
+}
+
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+
+data "aws_imagebuilder_component" "update-linux" {
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.0"
+}
+
+resource "aws_imagebuilder_container_recipe" "test" {
+  component {
+    component_arn = data.aws_imagebuilder_component.update-linux.arn
+  }
+
+  dockerfile_template_data = <<EOF
+FROM {{{ imagebuilder:parentImage }}}
+{{{ imagebuilder:environments }}}
+{{{ imagebuilder:components }}}
+EOF
+
+  name           = %[1]q
+  container_type = "DOCKER"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-latest/x.x.x"
+  version        = "1.0.0"
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+  security_group_ids    = [aws_default_security_group.test.id]
+  subnet_id             = aws_subnet.test.id
+
+  depends_on = [aws_default_route_table.test]
+}
+
+resource "aws_imagebuilder_image" "test" {
+  container_recipe_arn             = aws_imagebuilder_container_recipe.test.arn
   infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
 }
 

--- a/internal/service/imagebuilder/image_test.go
+++ b/internal/service/imagebuilder/image_test.go
@@ -599,7 +599,8 @@ resource "aws_iam_instance_profile" "test" {
   role = aws_iam_role.test.name
 
   depends_on = [
-    aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds,
+	aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
+    aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds
   ]
 }
 

--- a/internal/service/imagebuilder/image_test.go
+++ b/internal/service/imagebuilder/image_test.go
@@ -33,6 +33,7 @@ func TestAccImageBuilderImage_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "imagebuilder", regexp.MustCompile(fmt.Sprintf("image/%s/1.0.0/[1-9][0-9]*", rName))),
+					resource.TestCheckNoResourceAttr(resourceName, "container_recipe_arn"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "date_created"),
 					resource.TestCheckNoResourceAttr(resourceName, "distribution_configuration_arn"),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_image_metadata_enabled", "true"),
@@ -225,6 +226,28 @@ func TestAccImageBuilderImage_tags(t *testing.T) {
 					testAccCheckImageExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderImage_containerRecipeARN(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_image.test"
+	containerRecipeResourceName := "aws_imagebuilder_container_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageContainerRecipeARNConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "container_recipe_arn", containerRecipeResourceName, "arn"),
 				),
 			},
 		},
@@ -497,4 +520,131 @@ resource "aws_imagebuilder_image" "test" {
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccImageContainerRecipeARNConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  ingress {
+    from_port = 0
+    protocol  = -1
+    self      = true
+    to_port   = 0
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.test.id
+}
+
+resource "aws_iam_role" "test" {
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+      Sid = ""
+    }]
+  })
+  name = %[1]q
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonSSMManagedInstanceCore" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_role_policy_attachment" "EC2InstanceProfileForImageBuilderECRContainerBuilds" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = aws_iam_role.test.name
+  role = aws_iam_role.test.name
+
+  depends_on = [
+    aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds,
+  ]
+}
+
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+
+data "aws_imagebuilder_component" "update-linux" {
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.0"
+}
+
+resource "aws_imagebuilder_container_recipe" "test" {
+  component {
+    component_arn = data.aws_imagebuilder_component.update-linux.arn
+  }
+
+  dockerfile_template_data = <<EOF
+FROM {{{ imagebuilder:parentImage }}}
+{{{ imagebuilder:environments }}}
+{{{ imagebuilder:components }}}
+EOF
+
+  name           = %[1]q
+  container_type = "DOCKER"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-latest/x.x.x"
+  version        = "1.0.0"
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  instance_types        = ["t2.micro"]
+  name                  = %[1]q
+  security_group_ids    = [aws_default_security_group.test.id]
+  subnet_id             = aws_subnet.test.id
+
+  depends_on = [aws_default_route_table.test]
+}
+
+resource "aws_imagebuilder_image" "test" {
+  container_recipe_arn             = aws_imagebuilder_container_recipe.test.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
+}
+`, rName)
 }

--- a/internal/service/imagebuilder/image_test.go
+++ b/internal/service/imagebuilder/image_test.go
@@ -599,7 +599,7 @@ resource "aws_iam_instance_profile" "test" {
   role = aws_iam_role.test.name
 
   depends_on = [
-	aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
+    aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
     aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds
   ]
 }
@@ -635,7 +635,6 @@ EOF
 
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
-  instance_types        = ["t2.micro"]
   name                  = %[1]q
   security_group_ids    = [aws_default_security_group.test.id]
   subnet_id             = aws_subnet.test.id

--- a/website/docs/d/imagebuilder_image.html.markdown
+++ b/website/docs/d/imagebuilder_image.html.markdown
@@ -29,10 +29,11 @@ data "aws_imagebuilder_image" "example" {
 In addition to all arguments above, the following attributes are exported:
 
 * `build_version_arn` - Build version Amazon Resource Name (ARN) of the image. This will always have the `#.#.#/#` suffix.
+* `container_recipe_arn` - Amazon Resource Name (ARN) of the container recipe.
 * `date_created` - Date the image was created.
 * `distribution_configuration_arn` - Amazon Resource Name (ARN) of the Image Builder Distribution Configuration.
 * `enhanced_image_metadata_enabled` - Whether additional information about the image being created is collected.
-* `image_recipe_arn` - Amazon Resource Name (ARN) of the Image Builder Infrastructure Recipe.
+* `image_recipe_arn` - Amazon Resource Name (ARN) of the image recipe.
 * `image_tests_configuration` - List of an object with image tests configuration.
     * `image_tests_enabled` - Whether image tests are enabled.
     * `timeout_minutes` - Number of minutes before image tests time out.

--- a/website/docs/r/imagebuilder_image.html.markdown
+++ b/website/docs/r/imagebuilder_image.html.markdown
@@ -24,13 +24,14 @@ resource "aws_imagebuilder_image" "example" {
 
 The following arguments are required:
 
-* `image_recipe_arn` - (Required) Amazon Resource Name (ARN) of the Image Builder Infrastructure Recipe.
 * `infrastructure_configuration_arn` - (Required) Amazon Resource Name (ARN) of the Image Builder Infrastructure Configuration.
 
 The following arguments are optional:
 
+* `container_recipe_arn` - (Optional) - Amazon Resource Name (ARN) of the container recipe.
 * `distribution_configuration_arn` - (Optional) Amazon Resource Name (ARN) of the Image Builder Distribution Configuration.
 * `enhanced_image_metadata_enabled` - (Optional) Whether additional information about the image being created is collected. Defaults to `true`.
+* `image_recipe_arn` - (Optional) Amazon Resource Name (ARN) of the image recipe.
 * `image_tests_configuration` - (Optional) Configuration block with image tests configuration. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags for the Image Builder Image. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23380.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS="TestAccImageBuilderImage_containerRecipeARN" PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImage_containerRecipeARN'  -timeout 180m
=== RUN   TestAccImageBuilderImage_containerRecipeARN
=== PAUSE TestAccImageBuilderImage_containerRecipeARN
=== CONT  TestAccImageBuilderImage_containerRecipeARN
--- PASS: TestAccImageBuilderImage_containerRecipeARN (666.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       668.203s
```
```
make testacc TESTS="TestAccImageBuilderImageDataSource_ARN_containerRecipeARN" PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageDataSource_ARN_containerRecipeARN'  -timeout 180m
=== RUN   TestAccImageBuilderImageDataSource_ARN_containerRecipeARN
=== PAUSE TestAccImageBuilderImageDataSource_ARN_containerRecipeARN
=== CONT  TestAccImageBuilderImageDataSource_ARN_containerRecipeARN
--- PASS: TestAccImageBuilderImageDataSource_ARN_containerRecipeARN (549.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       551.440s
```