### PR TITLE
Support source_db_instance_automated_backups_arn when restoring aws_db_instance to point in time

### DIFF
--- a/.changelog/23649.txt
+++ b/.changelog/23649.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Add source_db_instance_automated_backups_arn to restore_to_point_in_time
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -405,6 +405,11 @@ func ResourceInstance() *schema.Resource {
 							Optional: true,
 						},
 
+						"source_db_instance_automated_backups_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"use_latest_restorable_time": {
 							Type:          schema.TypeBool,
 							Optional:      true,
@@ -1989,6 +1994,10 @@ func expandRestoreToPointInTime(l []interface{}) *rds.RestoreDBInstanceToPointIn
 
 	if v, ok := tfMap["source_dbi_resource_id"].(string); ok && v != "" {
 		input.SourceDbiResourceId = aws.String(v)
+	}
+
+	if v, ok := tfMap["source_db_instance_automated_backups_arn"].(string); ok && v != "" {
+		input.SourceDBInstanceAutomatedBackupsArn = aws.String(v)
 	}
 
 	if v, ok := tfMap["use_latest_restorable_time"].(bool); ok && v {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -225,8 +225,10 @@ This setting does not apply to `aurora-mysql` or `aurora-postgresql` DB engines.
 The `restore_to_point_in_time` block supports the following arguments:
 
 * `restore_time` - (Optional) The date and time to restore from. Value must be a time in Universal Coordinated Time (UTC) format and must be before the latest restorable time for the DB instance. Cannot be specified with `use_latest_restorable_time`.
-* `source_db_instance_identifier` - (Optional) The identifier of the source DB instance from which to restore. Must match the identifier of an existing DB instance. Required if `source_dbi_resource_id` is not specified.
-* `source_dbi_resource_id` - (Optional) The resource ID of the source DB instance from which to restore. Required if `source_db_instance_identifier` is not specified.
+* `source_db_instance_identifier` - (Optional) The identifier of the source DB instance from which to restore. Must match the identifier of an existing DB instance. One of `source_db_instance_identifier`, `source_dbi_resource_id`, `source_db_instance_automated_backups_arn` must be specified.
+* `source_dbi_resource_id` - (Optional) The resource ID of the source DB instance from which to restore. One of `source_db_instance_identifier`, `source_dbi_resource_id`, `source_db_instance_automated_backups_arn` must be specified.
+* `source_db_instance_automated_backups_arn` - (Optional) The resource ID of the source DB instance from which to restore. One of `source_db_instance_identifier`, `source_dbi_resource_id`, `source_db_instance_automated_backups_arn` must be specified.
+
 * `use_latest_restorable_time` - (Optional) A boolean value that indicates whether the DB instance is restored from the latest backup time. Defaults to `false`. Cannot be specified with `restore_time`.
 
 ### S3 Import Options


### PR DESCRIPTION
This is required when restoring a cross region automated backup: the source db instance does not in that region, so specifying `source_db_instance_identifier` or `source_dbi_resource_id` results in a DBInstanceNotFound error.

I have not added a test for this change, the main reason being that I wasn't sure how to get the input required (the arn of an automated backup), as it's not part of the attributes exported by an aws_db_instance, not is there currently a data source for getting these. Adding such a data source is probably beyond my skill at the moment unfortunately

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

