### PR TITLE
docs: use valid example id for import statement

### DIFF
--- a/website/docs/r/api_gateway_vpc_link.html.markdown
+++ b/website/docs/r/api_gateway_vpc_link.html.markdown
@@ -54,5 +54,5 @@ In addition to all arguments above, the following attributes are exported:
 API Gateway VPC Link can be imported using the `id`, e.g.,
 
 ```
-$ terraform import aws_api_gateway_vpc_link.example <vpc_link_id>
+$ terraform import aws_api_gateway_vpc_link.example 12345abcde
 ```


### PR DESCRIPTION
The previous example import command for the `aws_api_gateway_vpc_link` did not include an id (see below). This documentation update provides an `id` in the import statement to make the behavior more explicit to unfamiliar users.

![image](https://user-images.githubusercontent.com/28688013/158044430-6d743de3-337e-4381-a9ec-4b611d49acd7.png)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

N/A