### PR TITLE
Route 53 Domains available only in `us-east-1`

### DIFF
--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1265,7 +1265,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		return nil, diag.Errorf("error creating AWS SDK v1 session: %s", err)
 	}
 
-	accountID, Partition, err := awsbase.GetAwsAccountIDAndPartition(ctx, cfg, &awsbaseConfig)
+	accountID, partition, err := awsbase.GetAwsAccountIDAndPartition(ctx, cfg, &awsbaseConfig)
 	if err != nil {
 		return nil, diag.Errorf("error retrieving account details: %s", err)
 	}
@@ -1496,7 +1496,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		OpsWorksConn:                      opsworks.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[OpsWorks])})),
 		OrganizationsConn:                 organizations.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Organizations])})),
 		OutpostsConn:                      outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Outposts])})),
-		Partition:                         Partition,
+		Partition:                         partition,
 		PersonalizeConn:                   personalize.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Personalize])})),
 		PersonalizeEventsConn:             personalizeevents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PersonalizeEvents])})),
 		PersonalizeRuntimeConn:            personalizeruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PersonalizeRuntime])})),
@@ -1524,7 +1524,8 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		Route53DomainsConn: route53domains.NewFromConfig(cfg, func(o *route53domains.Options) {
 			if endpoint := c.Endpoints[Route53Domains]; endpoint != "" {
 				o.EndpointResolver = route53domains.EndpointResolverFromURL(endpoint)
-			} else {
+			} else if partition == endpoints.AwsPartitionID {
+				// Route 53 Domains is only available in AWS Commercial us-east-1 Region.
 				o.Region = endpoints.UsEast1RegionID
 			}
 		}),
@@ -1624,7 +1625,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	client.S3ConnURICleaningDisabled = s3.New(sess.Copy(s3Config))
 
 	// Force "global" services to correct regions
-	switch Partition {
+	switch partition {
 	case endpoints.AwsPartitionID:
 		globalAcceleratorConfig.Region = aws.String(endpoints.UsWest2RegionID)
 		route53Config.Region = aws.String(endpoints.UsEast1RegionID)

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1524,6 +1524,8 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		Route53DomainsConn: route53domains.NewFromConfig(cfg, func(o *route53domains.Options) {
 			if endpoint := c.Endpoints[Route53Domains]; endpoint != "" {
 				o.EndpointResolver = route53domains.EndpointResolverFromURL(endpoint)
+			} else {
+				o.Region = endpoints.UsEast1RegionID
 			}
 		}),
 		Route53RecoveryControlConfigConn: route53recoverycontrolconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Route53RecoveryControlConfig])})),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23639.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% ROUTE53DOMAINS_DOMAIN_NAME=terraform-provider-aws-acctest-acm.com make testacc TESTS=TestAccRoute53Domains_serial/RegisteredDomain/tags PKG=route53domains
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53domains/... -v -count 1 -parallel 20 -run='TestAccRoute53Domains_serial/RegisteredDomain/tags'  -timeout 180m
=== RUN   TestAccRoute53Domains_serial
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/tags
--- PASS: TestAccRoute53Domains_serial (32.97s)
    --- PASS: TestAccRoute53Domains_serial/RegisteredDomain (32.97s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/tags (32.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	36.827s
```
