### PR TITLE
r/s3_bucket_acl: backport support of pre-2018 naming for buckets in `us-east-1`

### DIFF
--- a/.changelog/23679.txt
+++ b/.changelog/23679.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_acl: Support resource import for S3 bucket names consisting of uppercase letters, underscores, and a maximum of 255 characters
+```

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -458,17 +458,19 @@ func BucketACLCreateResourceID(bucket, expectedBucketOwner, acl string) string {
 // BucketACLParseResourceID is a method for parsing the ID string
 // for the bucket name, accountID, and ACL if provided.
 func BucketACLParseResourceID(id string) (string, string, string, error) {
-	// For only  bucket name in the ID  e.g. bucket
-	// ~> Bucket names can consist of only lowercase letters, numbers, dots, and hyphens; Max 63 characters
-	bucketRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63}$`)
+	// For only bucket name in the ID  e.g. my-bucket or My_Bucket
+	// ~> On or after 3/1/2018: Bucket names can consist of only lowercase letters, numbers, dots, and hyphens; Max 63 characters
+	// ~> Before 3/1/2018: Bucket names could consist of uppercase letters and underscores if in us-east-1; Max 255 characters
+	// Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+	bucketRegex := regexp.MustCompile(`^([a-z0-9.-]{1,63}|[a-zA-Z0-9.\-_]{1,255})$`)
 	// For bucket and accountID in the ID e.g. bucket,123456789101
 	// ~> Account IDs must consist of 12 digits
-	bucketAndOwnerRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63},\d{12}$`)
+	bucketAndOwnerRegex := regexp.MustCompile(`^([a-z0-9.-]{1,63}|[a-zA-Z0-9.\-_]{1,255}),\d{12}$`)
 	// For bucket and ACL in the ID e.g. bucket,public-read
 	// ~> (Canned) ACL values include: private, public-read, public-read-write, authenticated-read, aws-exec-read, and log-delivery-write
-	bucketAndAclRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63},[a-z-]+$`)
+	bucketAndAclRegex := regexp.MustCompile(`^([a-z0-9.-]{1,63}|[a-zA-Z0-9.\-_]{1,255}),[a-z-]+$`)
 	// For bucket, accountID, and ACL in the ID e.g. bucket,123456789101,public-read
-	bucketOwnerAclRegex := regexp.MustCompile(`^[a-z0-9.-]{1,63},\d{12},[a-z-]+$`)
+	bucketOwnerAclRegex := regexp.MustCompile(`^([a-z0-9.-]{1,63}|[a-zA-Z0-9.\-_]{1,255}),\d{12},[a-z-]+$`)
 
 	// Bucket name ONLY
 	if bucketRegex.MatchString(id) {

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -133,6 +133,90 @@ func TestBucketACLParseResourceID(t *testing.T) {
 			ExpectedBucket:      "my-example.bucket.4000",
 			ExpectedBucketOwner: "123456789012",
 		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1)", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("Example", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "Example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) that has underscores", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example_Bucket", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "My_Example_Bucket",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) that has underscore, dot, and hyphens", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example-Bucket.local", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "My_Example-Bucket.local",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) that has underscore, dots, hyphen, and numbers", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example-Bucket.4000", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "My_Example-Bucket.4000",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) and acl", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("Example", "", s3.BucketCannedACLPrivate),
+			ExpectedACL:         s3.BucketCannedACLPrivate,
+			ExpectedBucket:      "Example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) and acl that has underscores", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example_Bucket", "", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "My_Example_Bucket",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) that has underscore, dot, hyphen, and number and acl that has hyphens", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example-Bucket.4000", "", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "My_Example-Bucket.4000",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) and bucket owner", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("Example", "123456789012", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "Example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) that has underscore, dot, hyphen, and number and bucket owner", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example-Bucket.4000", "123456789012", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "My_Example-Bucket.4000",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1), bucket owner, and acl", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("Example", "123456789012", s3.BucketCannedACLPrivate),
+			ExpectedACL:         s3.BucketCannedACLPrivate,
+			ExpectedBucket:      "Example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1), bucket owner, and acl that has hyphens", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("Example", "123456789012", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "Example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket (pre-2018, us-east-1) that has underscore, dot, hyphen, and numbers, bucket owner, and acl that has hyphens", //lintignore:AWSAT003
+			InputID:             tfs3.BucketACLCreateResourceID("My_Example-bucket.4000", "123456789012", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "My_Example-bucket.4000",
+			ExpectedBucketOwner: "123456789012",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23676

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAcl_disappears (23.25s)
--- PASS: TestAccS3BucketAcl_basic (35.16s)
--- PASS: TestAccS3BucketAcl_migrate_aclNoChange (58.03s)
--- PASS: TestAccS3BucketAcl_migrate_grantsNoChange (58.25s)
--- PASS: TestAccS3BucketAcl_grantToACL (58.32s)
--- PASS: TestAccS3BucketAcl_migrate_aclWithChange (58.69s)
--- PASS: TestAccS3BucketAcl_updateACL (58.96s)
--- PASS: TestAccS3BucketAcl_ACLToGrant (59.44s)
--- PASS: TestAccS3BucketAcl_migrate_grantsWithChange (61.21s)
--- PASS: TestAccS3BucketAcl_updateGrant (61.50s)

--- PASS: TestBucketACLParseResourceID (0.05s)
    --- PASS: TestBucketACLParseResourceID/empty_ID (0.00s)
    --- PASS: TestBucketACLParseResourceID/incorrect_bucket_and_account_ID_format_with_slash_separator (0.00s)
    --- PASS: TestBucketACLParseResourceID/incorrect_bucket,_account_ID,_and_ACL_format_with_slash_separators (0.00s)
    --- PASS: TestBucketACLParseResourceID/incorrect_bucket,_account_ID,_and_ACL_format_with_mixed_separators (0.00s)
    --- PASS: TestBucketACLParseResourceID/incorrect_bucket,_ACL,_and_account_ID_format (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_that_has_dot_and_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_that_has_dots,_hyphen,_and_numbers (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_and_acl (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_and_acl_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_that_has_dot,_hyphen,_and_number_and_acl_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_and_bucket_owner (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_that_has_dot,_hyphen,_and_number_and_bucket_owner (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket,_bucket_owner,_and_acl (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket,_bucket_owner,_and_acl_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_that_has_dot,_hyphen,_and_numbers,_bucket_owner,_and_acl_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1) (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_that_has_underscores (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_that_has_underscore,_dot,_and_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_that_has_underscore,_dots,_hyphen,_and_numbers (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_and_acl (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_and_acl_that_has_underscores (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_that_has_underscore,_dot,_hyphen,_and_number_and_acl_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_and_bucket_owner (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_that_has_underscore,_dot,_hyphen,_and_number_and_bucket_owner (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1),_bucket_owner,_and_acl (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1),_bucket_owner,_and_acl_that_has_hyphens (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_(pre-2018,_us-east-1)_that_has_underscore,_dot,_hyphen,_and_numbers,_bucket_owner,_and_acl_that_has_hyphens (0.00s)
PASS
```
