### PR TITLE
docs/s3_bucket_object_lock_configuration: add missing details on choosing import syntax

### DIFF
--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -109,13 +109,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-S3 bucket Object Lock configuration can be imported using the `bucket` e.g.,
+S3 bucket Object Lock configuration can be imported in one of two ways.
+
+If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider,
+the S3 bucket Object Lock configuration resource should be imported using the `bucket` e.g.,
 
 ```
 $ terraform import aws_s3_bucket_object_lock_configuration.example bucket-name
 ```
 
-In addition, S3 bucket Object Lock configuration can be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+If the owner (account ID) of the source bucket differs from the account used to configure the Terraform AWS Provider,
+the S3 bucket Object Lock configuration resource should be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
 
 ```
 $ terraform import aws_s3_bucket_object_lock_configuration.example bucket-name,123456789012


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23420

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
