### PR TITLE
d/aws_ec2_transit_gateway_connect_peer: Add missing `arn` attribute

### DIFF
--- a/internal/service/ec2/transit_gateway_connect_peer_data_source.go
+++ b/internal/service/ec2/transit_gateway_connect_peer_data_source.go
@@ -20,6 +20,10 @@ func DataSourceTransitGatewayConnectPeer() *schema.Resource {
 		ReadWithoutTimeout: dataSourceTransitGatewayConnectPeerRead,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"bgp_asn": {
 				Type:     schema.TypeString,
 				Computed: true,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13251.

```
=== RUN   TestAccEC2TransitGatewayDataSource_serial/ConnectPeer/Filter
------- Stderr: -------
panic: Invalid address to set: []string{"arn"}
goroutine 5332 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc006761e80, {0x8e110a9, 0x3}, {0x6deeac0, 0xc00137dcc0})
  /var/lib/teamcity/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource_data.go:230 +0x2a5
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.dataSourceTransitGatewayConnectPeerRead({0x68, 0x80}, 0xc006761e80, {0x7ae5440, 0xc001115500})
  /opt/teamcity-agent/work/87cd0779df5e20c9/internal/service/ec2/transit_gateway_connect_peer_data_source.go:84 +0x570
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x8e145c6, {0x9ed8938, 0xc002bfe200}, 0xc006762c60, {0x7ae5440, 0xc001115500})
  /var/lib/teamcity/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:353 +0x87
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc0003befc0, {0x9ed8938, 0xc002bfe200}, 0xc006760980, {0x7ae5440, 0xc001115500})
  /var/lib/teamcity/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:569 +0xf7
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc0029965e8, {0x9ed8938, 0xc002bfe200}, 0xc002574220)
  /var/lib/teamcity/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/grpc_provider.go:1133 +0x3a8
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc0029ba280, {0x9ed89e0, 0xc006762090}, 0xc000da00a0)
  /var/lib/teamcity/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:478 +0x37b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x8bbd020, 0xc0029ba280}, {0x9ed89e0, 0xc006762090}, 0xc00217c060, 0x0)
  /var/lib/teamcity/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0029bc000, {0x9fd6b28, 0xc001f51680}, 0xc001036000, 0xc002998d80, 0xf7c4810, 0x0)
  /var/lib/teamcity/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0xc8f
google.golang.org/grpc.(*Server).handleStream(0xc0029bc000, {0x9fd6b28, 0xc001f51680}, 0xc001036000, 0x0)
  /var/lib/teamcity/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
  /var/lib/teamcity/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
  /var/lib/teamcity/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x294
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEC2TransitGatewayDataSource_serial/ConnectPeer/Filter PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2TransitGatewayDataSource_serial/ConnectPeer/Filter'  -timeout 180m
=== RUN   TestAccEC2TransitGatewayDataSource_serial
=== RUN   TestAccEC2TransitGatewayDataSource_serial/ConnectPeer
=== RUN   TestAccEC2TransitGatewayDataSource_serial/ConnectPeer/Filter
--- PASS: TestAccEC2TransitGatewayDataSource_serial (775.37s)
    --- PASS: TestAccEC2TransitGatewayDataSource_serial/ConnectPeer (775.37s)
        --- PASS: TestAccEC2TransitGatewayDataSource_serial/ConnectPeer/Filter (775.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	779.293s
```
