### PR TITLE
Fix aws_launch_template metadata_options default values

### DIFF
--- a/internal/service/ec2/launch_template.go
+++ b/internal/service/ec2/launch_template.go
@@ -386,7 +386,7 @@ func ResourceLaunchTemplate() *schema.Resource {
 						"http_endpoint": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled,
 							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateInstanceMetadataEndpointState_Values(), false),
 						},
 						"http_protocol_ipv6": {
@@ -398,13 +398,13 @@ func ResourceLaunchTemplate() *schema.Resource {
 						"http_tokens": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      ec2.LaunchTemplateHttpTokensStateOptional,
 							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateHttpTokensState_Values(), false),
 						},
 						"http_put_response_hop_limit": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      "1",
 							ValidateFunc: validation.IntBetween(1, 64),
 						},
 						"instance_metadata_tags": {

--- a/internal/service/ec2/launch_template_test.go
+++ b/internal/service/ec2/launch_template_test.go
@@ -1178,6 +1178,23 @@ func TestAccEC2LaunchTemplate_metadataOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccLaunchTemplateConfig_metadataOptionsDefaults(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccLaunchTemplateConfig_metadataOptionsInstanceTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
@@ -2282,6 +2299,15 @@ resource "aws_launch_template" "test" {
     http_put_response_hop_limit = 2
     http_protocol_ipv6          = "enabled"
   }
+}
+`, rName)
+}
+
+func testAccLaunchTemplateConfig_metadataOptionsDefaults(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+  metadata_options {}
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #23174

Same PR as https://github.com/hashicorp/terraform-provider-aws/pull/23213. I had to recreate the PR because the previous one was closed automatically after I messed up my fork. I reran the test.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccEC2LaunchTemplate_metadataOptions PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_metadataOptions'  -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (156.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        159.667s
...
```
