### PR TITLE
Correct key_pair_id argument name in aws_key_pair data source

### DIFF
--- a/website/docs/d/key_pair.html.markdown
+++ b/website/docs/d/key_pair.html.markdown
@@ -42,7 +42,7 @@ The arguments of this data source act as filters for querying the available
 Key Pairs. The given filters must match exactly one Key Pair
 whose data will be exported as attributes.
 
-* `key_id` - (Optional) The Key Pair ID.
+* `key_pair_id` - (Optional) The Key Pair ID.
 * `key_name` - (Optional) The Key Pair name.
 * `filter` -  (Optional) Custom filter block as described below.
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #23711

Output from acceptance testing: n/a, docs

### Information

The `aws_key_pair` data source incorrectly lists an argument as `key_id`, where [it is actually](https://github.com/hashicorp/terraform-provider-aws/blob/dca16597d0ecd04d69e622ad8cced3db81f9769f/internal/service/ec2/key_pair_data_source.go#L33) `key_pair_id`. This PR corrects the argument name.
