### PR TITLE
Update `aws_s3_bucket_policy` import example to match example configuration

### DIFF
--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -60,5 +60,5 @@ No additional attributes are exported.
 S3 bucket policies can be imported using the bucket name, e.g.,
 
 ```
-$ terraform import aws_s3_bucket_policy.example my-bucket-name
+$ terraform import aws_s3_bucket_policy.allow_access_from_another_account my-bucket-name
 ```

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -60,5 +60,5 @@ No additional attributes are exported.
 S3 bucket policies can be imported using the bucket name, e.g.,
 
 ```
-$ terraform import aws_s3_bucket_policy.allow_access_from_another_account my-bucket-name
+$ terraform import aws_s3_bucket_policy.allow_access_from_another_account my-tf-test-bucket
 ```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #22772

Output from acceptance testing: n/a, docs

### Information

This small PR aims to clarify the example of importing an `aws_s3_bucket_policy` by way of matching the resource name to the example above it. This isn't necessary a "best practice", as there doesn't seem to be consistency in how imports are documented, but based on the linked issue felt like a worthwhile change.