### PR TITLE
r/s3_bucket_replication_configuration: backport recent changes in `main` and deprecate r/s3_bucket `replication_configuration`

### DIFF
--- a/.changelog/23716.txt
+++ b/.changelog/23716.txt
@@ -1,0 +1,21 @@
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Ensure both `key` and `value` arguments of the `rule.filter.tag` configuration block are correctly populated in the outgoing API request and terraform state.
+```
+
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Prevent inconsistent final plan when `rule.filter.prefix` is an empty string
+```
+
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Correctly configure empty `rule.filter` configuration block in API requests
+```
+
+```release-note:enhancement
+resource/aws_s3_bucket_replication_configuration: Add `token` field to specify
+x-amz-bucket-object-lock-token for enabling replication on object lock enabled
+buckets or enabling object lock on an existing bucket.
+```
+
+```release-note:note
+resource/aws_s3_bucket: The `replication_configuration` argument has been deprecated. Use the `aws_s3_bucket_replication_configuration` resource instead.
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -406,9 +406,10 @@ func ResourceBucket() *schema.Resource {
 			},
 
 			"replication_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:       schema.TypeList,
+				Optional:   true,
+				MaxItems:   1,
+				Deprecated: "Use the aws_s3_bucket_replication_configuration resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"role": {

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -38,6 +38,11 @@ func ResourceBucketReplicationConfiguration() *schema.Resource {
 				Required:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"token": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
 			"rule": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -303,12 +308,16 @@ func resourceBucketReplicationConfigurationCreate(d *schema.ResourceData, meta i
 
 	rc := &s3.ReplicationConfiguration{
 		Role:  aws.String(d.Get("role").(string)),
-		Rules: ExpandRules(d.Get("rule").(*schema.Set).List()),
+		Rules: ExpandReplicationRules(d.Get("rule").(*schema.Set).List()),
 	}
 
 	input := &s3.PutBucketReplicationInput{
 		Bucket:                   aws.String(bucket),
 		ReplicationConfiguration: rc,
+	}
+
+	if v, ok := d.GetOk("token"); ok {
+		input.Token = aws.String(v.(string))
 	}
 
 	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
@@ -367,7 +376,7 @@ func resourceBucketReplicationConfigurationRead(d *schema.ResourceData, meta int
 
 	d.Set("bucket", d.Id())
 	d.Set("role", r.Role)
-	if err := d.Set("rule", schema.NewSet(rulesHash, FlattenRules(r.Rules))); err != nil {
+	if err := d.Set("rule", schema.NewSet(rulesHash, FlattenReplicationRules(r.Rules))); err != nil {
 		return fmt.Errorf("error setting rule: %w", err)
 	}
 
@@ -379,12 +388,16 @@ func resourceBucketReplicationConfigurationUpdate(d *schema.ResourceData, meta i
 
 	rc := &s3.ReplicationConfiguration{
 		Role:  aws.String(d.Get("role").(string)),
-		Rules: ExpandRules(d.Get("rule").(*schema.Set).List()),
+		Rules: ExpandReplicationRules(d.Get("rule").(*schema.Set).List()),
 	}
 
 	input := &s3.PutBucketReplicationInput{
 		Bucket:                   aws.String(d.Id()),
 		ReplicationConfiguration: rc,
+	}
+
+	if v, ok := d.GetOk("token"); ok {
+		input.Token = aws.String(v.(string))
 	}
 
 	err := resource.Retry(propagationTimeout, func() *resource.RetryError {

--- a/internal/service/s3/flex_test.go
+++ b/internal/service/s3/flex_test.go
@@ -1,0 +1,71 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func TestExpandReplicationRuleFilterTag(t *testing.T) {
+	expectedKey := "TestKey1"
+	expectedValue := "TestValue1"
+
+	tagMap := map[string]interface{}{
+		"key":   expectedKey,
+		"value": expectedValue,
+	}
+
+	result := ExpandReplicationRuleFilterTag([]interface{}{tagMap})
+
+	if result == nil {
+		t.Fatalf("Expected *s3.Tag to not be nil")
+	}
+
+	if actualKey := aws.StringValue(result.Key); actualKey != expectedKey {
+		t.Fatalf("Expected key %s, got %s", expectedKey, actualKey)
+	}
+
+	if actualValue := aws.StringValue(result.Value); actualValue != expectedValue {
+		t.Fatalf("Expected value %s, got %s", expectedValue, actualValue)
+	}
+}
+
+func TestFlattenReplicationRuleFilterTag(t *testing.T) {
+	expectedKey := "TestKey1"
+	expectedValue := "TestValue1"
+
+	tag := &s3.Tag{
+		Key:   aws.String(expectedKey),
+		Value: aws.String(expectedValue),
+	}
+
+	result := FlattenReplicationRuleFilterTag(tag)
+
+	if len(result) != 1 {
+		t.Fatalf("Expected array to have exactly 1 element, got %d", len(result))
+	}
+
+	tagMap, ok := result[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected element in array to be a map[string]interface{}")
+	}
+
+	actualKey, ok := tagMap["key"].(string)
+	if !ok {
+		t.Fatal("Expected string 'key' key in the map")
+	}
+
+	if actualKey != expectedKey {
+		t.Fatalf("Expected 'key' to equal %s, got %s", expectedKey, actualKey)
+	}
+
+	actualValue, ok := tagMap["value"].(string)
+	if !ok {
+		t.Fatal("Expected string 'value' key in the map")
+	}
+
+	if actualValue != expectedValue {
+		t.Fatalf("Expected 'value' to equal %s, got %s", expectedValue, actualValue)
+	}
+}

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -40,6 +40,10 @@ Configuring with both will cause inconsistencies and may overwrite configuration
 or with the deprecated parameter `object_lock_configuration` in the resource `aws_s3_bucket`.
 Configuring with both will cause inconsistencies and may overwrite configuration.
 
+~> **NOTE on S3 Bucket Replication Configuration:** S3 Bucket Replication can be configured in either the standalone resource [`aws_s3_bucket_replicaton_configuration`](s3_bucket_replication_configuration.html)
+or with the deprecated parameter `replication_configuration` in the resource `aws_s3_bucket`.
+Configuring with both will cause inconsistencies and may overwrite configuration.
+
 ~> **NOTE on S3 Bucket Request Payment Configuration:** S3 Bucket Request Payment can be configured in either the standalone resource [`aws_s3_bucket_request_payment_configuration`](s3_bucket_request_payment_configuration.html)
 or with the deprecated parameter `request_payer` in the resource `aws_s3_bucket`.
 Configuring with both will cause inconsistencies and may overwrite configuration.
@@ -237,7 +241,8 @@ resource "aws_s3_bucket" "versioning_bucket" {
 
 ### Using replication configuration
 
-~> **NOTE:** See the [`aws_s3_bucket_replication_configuration` resource](/docs/providers/aws/r/s3_bucket_replication_configuration.html) to support bi-directional replication configuration and additional features.
+-> **NOTE:** The parameter `replication_configuration` is deprecated.
+Use the resource [`aws_s3_bucket_replication_configuration`](s3_bucket_replication_configuration.html) instead.
 
 ```terraform
 provider "aws" {
@@ -436,7 +441,8 @@ The following arguments are supported:
   Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur the costs of any data transfer.
   See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) developer guide for more information.
   Use the resource [`aws_s3_bucket_request_payment_configuration`](s3_bucket_request_payment_configuration.html) instead.
-* `replication_configuration` - (Optional) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+* `replication_configuration` - (Optional, **Deprecated**) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+  Use the resource [`aws_s3_bucket_replication_configuration`](s3_bucket_replication_configuration.html) instead.
 * `server_side_encryption_configuration` - (Optional, **Deprecated**) A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below).
   Use the resource [`aws_s3_bucket_server_side_encryption_configuration`](s3_bucket_server_side_encryption_configuration.html) instead.
 * `object_lock_enabled` - (Optional, Default:`false`, Forces new resource) Indicates whether this bucket has an Object Lock configuration enabled.

--- a/website/docs/r/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_replication_configuration.html.markdown
@@ -116,6 +116,8 @@ resource "aws_s3_bucket" "source" {
 }
 
 resource "aws_s3_bucket_acl" "source_bucket_acl" {
+  provider = aws.central
+
   bucket = aws_s3_bucket.source.id
   acl    = "private"
 }
@@ -130,6 +132,8 @@ resource "aws_s3_bucket_versioning" "source" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "replication" {
+  provider = aws.central
+
   # Must have bucket versioning enabled first
   depends_on = [aws_s3_bucket_versioning.source]
 
@@ -172,7 +176,7 @@ resource "aws_s3_bucket_versioning" "east" {
 }
 
 resource "aws_s3_bucket" "west" {
-  provider = west
+  provider = aws.west
   bucket   = "tf-test-bucket-west-12345"
 
   lifecycle {
@@ -183,7 +187,7 @@ resource "aws_s3_bucket" "west" {
 }
 
 resource "aws_s3_bucket_versioning" "west" {
-  provider = west
+  provider = aws.west
 
   bucket = aws_s3_bucket.west.id
   versioning_configuration {
@@ -211,6 +215,8 @@ resource "aws_s3_bucket_replication_configuration" "east_to_west" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "west_to_east" {
+  provider = aws.west
+
   # Must have bucket versioning enabled first
   depends_on = [aws_s3_bucket_versioning.west]
 

--- a/website/docs/r/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_replication_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an independent configuration resource for S3 bucket [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html).
 
+~> **NOTE:** S3 Buckets only support a single replication configuration. Declaring multiple `aws_s3_bucket_replication_configuration` resources to the same S3 Bucket will cause a perpetual difference in configuration.
+
 ## Example Usage
 
 ### Using replication configuration
@@ -93,20 +95,18 @@ resource "aws_iam_role_policy_attachment" "replication" {
 
 resource "aws_s3_bucket" "destination" {
   bucket = "tf-test-bucket-destination-12345"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination" {
+  bucket = aws_s3_bucket.destination.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket" "source" {
   provider = aws.central
   bucket   = "tf-test-bucket-source-12345"
-  acl      = "private"
-
-  versioning {
-    enabled = true
-  }
 
   lifecycle {
     ignore_changes = [
@@ -115,7 +115,24 @@ resource "aws_s3_bucket" "source" {
   }
 }
 
+resource "aws_s3_bucket_acl" "source_bucket_acl" {
+  bucket = aws_s3_bucket.source.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  provider = aws.central
+
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_replication_configuration" "replication" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.source]
+
   role   = aws_iam_role.replication.arn
   bucket = aws_s3_bucket.source.id
 
@@ -140,14 +157,17 @@ resource "aws_s3_bucket_replication_configuration" "replication" {
 resource "aws_s3_bucket" "east" {
   bucket = "tf-test-bucket-east-12345"
 
-  versioning {
-    enabled = true
-  }
-
   lifecycle {
     ignore_changes = [
       replication_configuration
     ]
+  }
+}
+
+resource "aws_s3_bucket_versioning" "east" {
+  bucket = aws_s3_bucket.east.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -155,10 +175,6 @@ resource "aws_s3_bucket" "west" {
   provider = west
   bucket   = "tf-test-bucket-west-12345"
 
-  versioning {
-    enabled = true
-  }
-
   lifecycle {
     ignore_changes = [
       replication_configuration
@@ -166,7 +182,19 @@ resource "aws_s3_bucket" "west" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "west" {
+  provider = west
+
+  bucket = aws_s3_bucket.west.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_replication_configuration" "east_to_west" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.east]
+
   role   = aws_iam_role.east_replication.arn
   bucket = aws_s3_bucket.east.id
 
@@ -183,6 +211,9 @@ resource "aws_s3_bucket_replication_configuration" "east_to_west" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "west_to_east" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.west]
+
   role   = aws_iam_role.west_replication.arn
   bucket = aws_s3_bucket.west.id
 
@@ -229,6 +260,8 @@ The following arguments are supported:
 * `bucket` - (Required) The name of the source S3 bucket you want Amazon S3 to monitor.
 * `role` - (Required) The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
 * `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
+* `token` - (Optional) A token to allow replication to be enabled on an Object Lock-enabled bucket. You must contact AWS support for the bucket's "Object Lock token".
+For more details, see [Using S3 Object Lock with replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-managing-replication).
 
 ### rule
 
@@ -241,9 +274,9 @@ The `rule` configuration block supports the following arguments:
 * `delete_marker_replication` - (Optional) Whether delete markers are replicated. This argument is only valid with V2 replication configurations (i.e., when `filter` is used)[documented below](#delete_marker_replication).
 * `destination` - (Required) Specifies the destination for the rule [documented below](#destination).
 * `existing_object_replication` - (Optional) Replicate existing objects in the source bucket according to the rule configurations [documented below](#existing_object_replication).
-* `filter` - (Optional, Conflicts with `prefix`) Filter that identifies subset of objects to which the replication rule applies [documented below](#filter).
+* `filter` - (Optional, Conflicts with `prefix`) Filter that identifies subset of objects to which the replication rule applies [documented below](#filter). If not specified, the `rule` will default to using `prefix`.
 * `id` - (Optional) Unique identifier for the rule. Must be less than or equal to 255 characters in length.
-* `prefix` - (Optional, Conflicts with `filter`) Object key name prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
+* `prefix` - (Optional, Conflicts with `filter`) Object key name prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length. Defaults to an empty string (`""`) if `filter` is not specified.
 * `priority` - (Optional) The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
 * `source_selection_criteria` - (Optional) Specifies special object selection criteria [documented below](#source_selection_criteria).
 * `status` - (Required) The status of the rule. Either `"Enabled"` or `"Disabled"`. The rule is ignored if status is not "Enabled".
@@ -360,7 +393,8 @@ The `existing_object_replication` configuration block supports the following arg
 
 ### filter
 
-~> **NOTE:** With the `filter` argument, you must specify exactly one of `prefix`, `tag`, or `and`.  Replication configuration V1 supports filtering based on only the `prefix` attribute. For backwards compatibility, Amazon S3 continues to support the V1 configuration.
+~> **NOTE:** The `filter` argument must be specified as either an empty configuration block (`filter {}`) to imply the rule requires no filter or with exactly one of `prefix`, `tag`, or `and`.
+Replication configuration V1 supports filtering based on only the `prefix` attribute. For backwards compatibility, Amazon S3 continues to support the V1 configuration.
 
 The `filter` configuration block supports the following arguments:
 


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23624, #23616, #23586, #23582, #23579
Relates #23106 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestExpandReplicationRuleFilterTag (0.00s)
--- PASS: TestFlattenReplicationRuleFilterTag (0.00s)

$ make testacc TESTARGS='-run=TestAccS3BucketReplicationConfiguration_' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketReplicationConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketReplicationConfiguration_basic
=== PAUSE TestAccS3BucketReplicationConfiguration_basic
=== RUN   TestAccS3BucketReplicationConfiguration_disappears
=== PAUSE TestAccS3BucketReplicationConfiguration_disappears
=== RUN   TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== RUN   TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
=== RUN   TestAccS3BucketReplicationConfiguration_twoDestination
=== PAUSE TestAccS3BucketReplicationConfiguration_twoDestination
=== RUN   TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== PAUSE TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== RUN   TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== PAUSE TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== RUN   TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== PAUSE TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== RUN   TestAccS3BucketReplicationConfiguration_replicaModifications
=== PAUSE TestAccS3BucketReplicationConfiguration_replicaModifications
=== RUN   TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== RUN   TestAccS3BucketReplicationConfiguration_existingObjectReplication
    bucket_replication_configuration_test.go:714: skipping test: AWS Technical Support request required to allow ExistingObjectReplication
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
=== RUN   TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock
=== RUN   TestAccS3BucketReplicationConfiguration_filter_emptyPrefix
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_emptyPrefix
=== RUN   TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== RUN   TestAccS3BucketReplicationConfiguration_filter_andOperator
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_andOperator
=== RUN   TestAccS3BucketReplicationConfiguration_withoutPrefix
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutPrefix
=== CONT  TestAccS3BucketReplicationConfiguration_basic
=== CONT  TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== CONT  TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock
=== CONT  TestAccS3BucketReplicationConfiguration_filter_emptyPrefix
=== CONT  TestAccS3BucketReplicationConfiguration_withoutPrefix
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (414.32s)
=== CONT  TestAccS3BucketReplicationConfiguration_filter_andOperator
--- PASS: TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock (414.37s)
=== CONT  TestAccS3BucketReplicationConfiguration_filter_tagFilter
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (414.47s)
=== CONT  TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
--- PASS: TestAccS3BucketReplicationConfiguration_filter_emptyPrefix (414.48s)
=== CONT  TestAccS3BucketReplicationConfiguration_replicaModifications
--- PASS: TestAccS3BucketReplicationConfiguration_basic (493.33s)
=== CONT  TestAccS3BucketReplicationConfiguration_replicationTimeControl
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (461.70s)
=== CONT  TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (461.69s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (391.98s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (548.14s)
=== CONT  TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (569.29s)
=== CONT  TestAccS3BucketReplicationConfiguration_twoDestination
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (582.08s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (154.76s)
=== CONT  TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (626.36s)
=== CONT  TestAccS3BucketReplicationConfiguration_disappears
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (652.58s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (673.78s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (873.28s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (203.83s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (750.47s)
```
