### PR TITLE
r/wafv2_web_acl_logging_configuration docs: specify that any log destination needs the aws-waf-logs- prefix

### DIFF
--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -12,7 +12,7 @@ Creates a WAFv2 Web ACL Logging Configuration resource.
 
 -> **Note:** To start logging from a WAFv2 Web ACL, an Amazon Kinesis Data Firehose (e.g., [`aws_kinesis_firehose_delivery_stream` resource](/docs/providers/aws/r/kinesis_firehose_delivery_stream.html) must also be created with a PUT source (not a stream) and in the region that you are operating.
 If you are capturing logs for Amazon CloudFront, always create the firehose in US East (N. Virginia).
-Be sure to give the data firehose a name that starts with the prefix `aws-waf-logs-`.
+Be sure to give the data firehose, cloudwatch log group, and/or s3 bucket a name that starts with the prefix `aws-waf-logs-`.
 
 ## Example Usage
 


### PR DESCRIPTION
See:
- https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
- https://docs.aws.amazon.com/waf/latest/developerguide/logging-s3.html#logging-s3-naming
- https://docs.aws.amazon.com/waf/latest/developerguide/logging-kinesis.html
