### PR TITLE
feat: Add App Config Feature Flag type

### DIFF
--- a/.changelog/23719.txt
+++ b/.changelog/23719.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_configuration_profile: Add `type` argument
+```

--- a/.changelog/23719.txt
+++ b/.changelog/23719.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_configuration_profile: Add `type` argument
+resource/aws_configuration_profile: Add `type` argument to support [AWS AppConfig Feature Flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/)
 ```

--- a/internal/service/appconfig/configuration_profile.go
+++ b/internal/service/appconfig/configuration_profile.go
@@ -63,6 +63,12 @@ func ResourceConfigurationProfile() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "AWS.Freeform",
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z\.]+`), ""),
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"validator": {
@@ -119,6 +125,10 @@ func resourceConfigurationProfileCreate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("validator"); ok && v.(*schema.Set).Len() > 0 {
 		input.Validators = expandAppconfigValidators(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		input.Type = aws.String(v.(string))
 	}
 
 	profile, err := conn.CreateConfigurationProfile(input)

--- a/internal/service/appconfig/configuration_profile_test.go
+++ b/internal/service/appconfig/configuration_profile_test.go
@@ -31,13 +31,14 @@ func TestAccAppConfigConfigurationProfile_basic(t *testing.T) {
 				Config: testAccConfigurationProfileNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationProfileExists(resourceName),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "appconfig", regexp.MustCompile(`application/[a-z0-9]{4,7}/configurationprofile/[a-z0-9]{4,7}`)),
 					resource.TestCheckResourceAttrPair(resourceName, "application_id", appResourceName, "id"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "appconfig", regexp.MustCompile(`application/[a-z0-9]{4,7}/configurationprofile/[a-z0-9]{4,7}`)),
 					resource.TestMatchResourceAttr(resourceName, "configuration_profile_id", regexp.MustCompile(`[a-z0-9]{4,7}`)),
 					resource.TestCheckResourceAttr(resourceName, "location_uri", "hosted"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "validator.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "AWS.Freeform"),
+					resource.TestCheckResourceAttr(resourceName, "validator.#", "0"),
 				),
 			},
 			{

--- a/internal/service/appconfig/enum.go
+++ b/internal/service/appconfig/enum.go
@@ -1,0 +1,13 @@
+package appconfig
+
+const (
+	ConfigurationProfileTypeAWSAppConfigFeatureFlags = "AWS.AppConfig.FeatureFlags"
+	ConfigurationProfileTypeAWSFreeform              = "AWS.Freeform"
+)
+
+func ConfigurationProfileType_Values() []string {
+	return []string{
+		ConfigurationProfileTypeAWSAppConfigFeatureFlags,
+		ConfigurationProfileTypeAWSFreeform,
+	}
+}

--- a/website/docs/r/appconfig_configuration_profile.html.markdown
+++ b/website/docs/r/appconfig_configuration_profile.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `retrieval_role_arn` - (Optional) The ARN of an IAM role with permission to access the configuration at the specified `location_uri`. A retrieval role ARN is not required for configurations stored in the AWS AppConfig `hosted` configuration store. It is required for all other sources that store your configuration.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `validator` - (Optional) A set of methods for validating the configuration. Maximum of 2. See [Validator](#validator) below for more details.
+* `type` - (Optional) The type of the configuration profile. This will default to `AWS.Freeform`.
 
 ### Validator
 

--- a/website/docs/r/appconfig_configuration_profile.html.markdown
+++ b/website/docs/r/appconfig_configuration_profile.html.markdown
@@ -40,8 +40,8 @@ The following arguments are supported:
 * `description` - (Optional) The description of the configuration profile. Can be at most 1024 characters.
 * `retrieval_role_arn` - (Optional) The ARN of an IAM role with permission to access the configuration at the specified `location_uri`. A retrieval role ARN is not required for configurations stored in the AWS AppConfig `hosted` configuration store. It is required for all other sources that store your configuration.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `type` - (Optional) The type of configurations contained in the profile. Valid values: `AWS.AppConfig.FeatureFlags` and `AWS.Freeform`.  Default: `AWS.Freeform`.
 * `validator` - (Optional) A set of methods for validating the configuration. Maximum of 2. See [Validator](#validator) below for more details.
-* `type` - (Optional) The type of the configuration profile. This will default to `AWS.Freeform`.
 
 ### Validator
 

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -39,26 +39,26 @@ resource "aws_appconfig_hosted_configuration_version" "example" {
   content_type             = "application/json"
 
   content = jsonencode({
-    flags: {
-      foo: {
-        name: "foo",
-        _deprecation: {
-          "status": "planned"
+    flags : {
+      foo : {
+        name : "foo",
+        _deprecation : {
+          "status" : "planned"
         }
       }
-      bar: {
-        name: "bar",
+      bar : {
+        name : "bar",
       }
     }
-    values: {
-      foo: {
-        enabled: "true",
+    values : {
+      foo : {
+        enabled : "true",
       }
-      bar: {
-        enabled: "true",
+      bar : {
+        enabled : "true",
       }
     }
-    version: "1"
+    version : "1"
   })
 }
 ```

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -10,18 +10,54 @@ description: |-
 
 Provides an AppConfig Hosted Configuration Version resource.
 
-## Example Usage
+## Example Usage Freeform
 
 ```terraform
 resource "aws_appconfig_hosted_configuration_version" "example" {
   application_id           = aws_appconfig_application.example.id
   configuration_profile_id = aws_appconfig_configuration_profile.example.configuration_profile_id
-  description              = "Example Hosted Configuration Version"
+  description              = "Example Freeform Hosted Configuration Version"
   content_type             = "application/json"
 
   content = jsonencode({
-    foo = "bar"
+    foo            = "bar",
+    fruit          = ["apple", "pear", "orange"],
+    isThingEnabled = true
   })
+}
+```
+
+## Example Usage Feature Flag
+
+```terraform
+resource "aws_appconfig_hosted_configuration_version" "example" {
+  application_id           = aws_appconfig_application.example.id
+  configuration_profile_id = aws_appconfig_configuration_profile.example.configuration_profile_id
+  description              = "Example Freeform Hosted Configuration Version"
+  content_type             = "application/json"
+
+  content = jsonencode({
+      flags: {
+        foo: {
+          name: "foo",
+          _deprecation: {
+              "status": "planned"
+          }
+        }
+        bar: {
+          name: "bar",
+        }
+      }
+      values: {
+        foo: {
+          enabled: "true",
+        }
+        bar: {
+          enabled: "true",
+        }
+      }
+      version: "1"
+    })
 }
 ```
 

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -39,27 +39,27 @@ resource "aws_appconfig_hosted_configuration_version" "example" {
   content_type             = "application/json"
 
   content = jsonencode({
-      flags: {
-        foo: {
-          name: "foo",
-          _deprecation: {
-              "status": "planned"
-          }
-        }
-        bar: {
-          name: "bar",
+    flags: {
+      foo: {
+        name: "foo",
+        _deprecation: {
+          "status": "planned"
         }
       }
-      values: {
-        foo: {
-          enabled: "true",
-        }
-        bar: {
-          enabled: "true",
-        }
+      bar: {
+        name: "bar",
       }
-      version: "1"
-    })
+    }
+    values: {
+      foo: {
+        enabled: "true",
+      }
+      bar: {
+        enabled: "true",
+      }
+    }
+    version: "1"
+  })
 }
 ```
 

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -10,7 +10,9 @@ description: |-
 
 Provides an AppConfig Hosted Configuration Version resource.
 
-## Example Usage Freeform
+## Example Usage
+
+### Freeform
 
 ```terraform
 resource "aws_appconfig_hosted_configuration_version" "example" {
@@ -27,7 +29,7 @@ resource "aws_appconfig_hosted_configuration_version" "example" {
 }
 ```
 
-## Example Usage Feature Flag
+### Feature Flags
 
 ```terraform
 resource "aws_appconfig_hosted_configuration_version" "example" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

Feature Flags in App Config are now GA, https://aws.amazon.com/about-aws/whats-new/2022/03/aws-appconfig-feature-flags/

This Pull Request exposes the ability to set the Configuration Profile type to either Free Form, or Feature Flag, as per the AWS API docs, https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/API_CreateConfigurationProfile.html#appconfig-CreateConfigurationProfile-request-Type

I've marked the default value to be FreeForm. Whilst this isn't explicitly documented on AWS, this is the observed behaviour from creating an App Config Profile without setting this value. Using this default maintains backwards compatibility. The validation function uses the regex function documented by AWS

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23720

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
