### PR TITLE
r/s3_bucket_versioning: support disabled versioning i.e. unversioned buckets

### DIFF
--- a/.changelog/23723.txt
+++ b/.changelog/23723.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_versioning: Add missing support for `Disabled` bucket versioning
+```

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -58,12 +59,32 @@ func ResourceBucketVersioning() *schema.Resource {
 						"status": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice(s3.BucketVersioningStatus_Values(), false),
+							ValidateFunc: validation.StringInSlice(BucketVersioningStatus_Values(), false),
 						},
 					},
 				},
 			},
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				// This CustomizeDiff acts as a plan-time validation to prevent MalformedXML errors
+				// when updating bucket versioning to "Disabled" on existing resources
+				// as it's not supported by the AWS S3 API.
+				if diff.Id() == "" || !diff.HasChange("versioning_configuration.0.status") {
+					return nil
+				}
+
+				oldStatusRaw, newStatusRaw := diff.GetChange("versioning_configuration.0.status")
+				oldStatus, newStatus := oldStatusRaw.(string), newStatusRaw.(string)
+
+				if newStatus == BucketVersioningStatusDisabled && (oldStatus == s3.BucketVersioningStatusEnabled || oldStatus == s3.BucketVersioningStatusSuspended) {
+					return fmt.Errorf("versioning_configuration.status cannot be updated from '%s' to '%s'", oldStatus, newStatus)
+				}
+
+				return nil
+			},
+		),
 	}
 }
 
@@ -73,25 +94,35 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 	bucket := d.Get("bucket").(string)
 	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
 
-	input := &s3.PutBucketVersioningInput{
-		Bucket:                  aws.String(bucket),
-		VersioningConfiguration: expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{})),
-	}
+	versioningConfiguration := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{}))
 
-	if expectedBucketOwner != "" {
-		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-	}
+	// To support migration from v3 to v4 of the provider, we need to support
+	// versioning resources that represent unversioned S3 buckets as was previously
+	// supported within the aws_s3_bucket resource of the 3.x version of the provider.
+	// Thus, we essentially bring existing bucket versioning into adoption.
+	if aws.StringValue(versioningConfiguration.Status) != BucketVersioningStatusDisabled {
+		input := &s3.PutBucketVersioningInput{
+			Bucket:                  aws.String(bucket),
+			VersioningConfiguration: versioningConfiguration,
+		}
 
-	if v, ok := d.GetOk("mfa"); ok {
-		input.MFA = aws.String(v.(string))
-	}
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
 
-	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.PutBucketVersioningWithContext(ctx, input)
-	})
+		if v, ok := d.GetOk("mfa"); ok {
+			input.MFA = aws.String(v.(string))
+		}
 
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating S3 bucket versioning for %s: %w", bucket, err))
+		_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+			return conn.PutBucketVersioningWithContext(ctx, input)
+		})
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error creating S3 bucket versioning for %s: %w", bucket, err))
+		}
+	} else {
+		log.Printf("[DEBUG] Creating S3 bucket versioning for unversioned bucket: %s", bucket)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -166,6 +197,11 @@ func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).S3Conn
 
+	if v := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{})); v != nil && aws.StringValue(v.Status) == BucketVersioningStatusDisabled {
+		log.Printf("[DEBUG] Removing S3 bucket versioning for unversioned bucket (%s) from state", d.Id())
+		return nil
+	}
+
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -238,6 +274,9 @@ func flattenBucketVersioningConfiguration(config *s3.GetBucketVersioningOutput) 
 
 	if config.Status != nil {
 		m["status"] = aws.StringValue(config.Status)
+	} else {
+		// Bucket Versioning by default is disabled but not set in the config struct's Status field
+		m["status"] = BucketVersioningStatusDisabled
 	}
 
 	return []interface{}{m}

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -2,6 +2,7 @@ package s3_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -134,6 +135,155 @@ func TestAccS3BucketVersioning_MFADelete(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketVersioning_Status_disabled(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketVersioningDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, tfs3.BucketVersioningStatusDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", tfs3.BucketVersioningStatusDisabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_Status_disabledToEnabled(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketVersioningDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, tfs3.BucketVersioningStatusDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", tfs3.BucketVersioningStatusDisabled),
+				),
+			},
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, s3.BucketVersioningStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusEnabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_Status_disabledToSuspended(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketVersioningDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, tfs3.BucketVersioningStatusDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", tfs3.BucketVersioningStatusDisabled),
+				),
+			},
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, s3.BucketVersioningStatusSuspended),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusSuspended),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_Status_enabledToDisabled(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketVersioningDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, s3.BucketVersioningStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusEnabled),
+				),
+			},
+			{
+				Config:      testAccBucketVersioningBasicConfig(rName, tfs3.BucketVersioningStatusDisabled),
+				ExpectError: regexp.MustCompile(`versioning_configuration.status cannot be updated from 'Enabled' to 'Disabled'`),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_Status_suspendedToDisabled(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketVersioningDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, s3.BucketVersioningStatusSuspended),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusSuspended),
+				),
+			},
+			{
+				Config:      testAccBucketVersioningBasicConfig(rName, tfs3.BucketVersioningStatusDisabled),
+				ExpectError: regexp.MustCompile(`versioning_configuration.status cannot be updated from 'Suspended' to 'Disabled'`),
+			},
+		},
+	})
+}
+
 func testAccCheckBucketVersioningDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
 
@@ -156,7 +306,7 @@ func testAccCheckBucketVersioningDestroy(s *terraform.State) error {
 			return fmt.Errorf("error getting S3 bucket versioning (%s): %w", rs.Primary.ID, err)
 		}
 
-		if output != nil && aws.StringValue(output.Status) != s3.BucketVersioningStatusSuspended {
+		if output != nil && aws.StringValue(output.Status) == s3.ReplicationRuleStatusEnabled {
 			return fmt.Errorf("S3 bucket versioning (%s) still exists", rs.Primary.ID)
 		}
 	}

--- a/internal/service/s3/enum.go
+++ b/internal/service/s3/enum.go
@@ -11,6 +11,8 @@ const (
 	BucketCannedACLExecRead         = "aws-exec-read"
 	BucketCannedACLLogDeliveryWrite = "log-delivery-write"
 
+	BucketVersioningStatusDisabled = "Disabled"
+
 	LifecycleRuleStatusEnabled  = "Enabled"
 	LifecycleRuleStatusDisabled = "Disabled"
 )
@@ -19,6 +21,12 @@ func BucketCannedACL_Values() []string {
 	result := s3.BucketCannedACL_Values()
 	result = appendUniqueString(result, BucketCannedACLExecRead)
 	result = appendUniqueString(result, BucketCannedACLLogDeliveryWrite)
+	return result
+}
+
+func BucketVersioningStatus_Values() []string {
+	result := s3.BucketVersioningStatus_Values()
+	result = appendUniqueString(result, BucketVersioningStatusDisabled)
 	return result
 }
 

--- a/internal/service/s3/status.go
+++ b/internal/service/s3/status.go
@@ -85,6 +85,10 @@ func bucketVersioningStatus(ctx context.Context, conn *s3.S3, bucket, expectedBu
 			}
 		}
 
+		if output.Status == nil {
+			return output, BucketVersioningStatusDisabled, nil
+		}
+
 		return output, aws.StringValue(output.Status), nil
 	}
 }

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -46,7 +46,7 @@ func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, 
 func waitForBucketVersioningStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string) (*s3.GetBucketVersioningOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{""},
-		Target:                    []string{s3.BucketVersioningStatusEnabled, s3.BucketVersioningStatusSuspended},
+		Target:                    []string{s3.BucketVersioningStatusEnabled, s3.BucketVersioningStatusSuspended, BucketVersioningStatusDisabled},
 		Refresh:                   bucketVersioningStatus(ctx, conn, bucket, expectedBucketOwner),
 		Timeout:                   bucketVersioningStableTimeout,
 		ContinuousTargetOccurence: 3,

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -1304,7 +1304,9 @@ Switch your Terraform configuration to the [`aws_s3_bucket_versioning` resource]
 
 ~> **NOTE:** As `aws_s3_bucket_versioning` is a separate resource, any S3 objects for which versioning is important (_e.g._, a truststore for mutual TLS authentication) must implicitly or explicitly depend on the `aws_s3_bucket_versioning` resource. Otherwise, the S3 objects may be created before versioning has been set. [See below](#ensure-objects-depend-on-versioning) for an example. Also note that AWS recommends waiting 15 minutes after enabling versioning on a bucket before putting or deleting objects in/from the bucket.
 
-For example, given this previous configuration:
+#### Buckets With Versioning Enabled
+
+Given this previous configuration:
 
 ```terraform
 resource "aws_s3_bucket" "example" {
@@ -1346,6 +1348,114 @@ resource "aws_s3_bucket_versioning" "example" {
   }
 }
 ```
+
+Run `terraform import` on each new resource, _e.g._,
+
+```shell
+$ terraform import aws_s3_bucket_versioning.example yournamehere
+aws_s3_bucket_versioning.example: Importing from ID "yournamehere"...
+aws_s3_bucket_versioning.example: Import prepared!
+  Prepared aws_s3_bucket_versioning for import
+aws_s3_bucket_versioning.example: Refreshing state... [id=yournamehere]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+#### Buckets With Versioning Disabled or Suspended
+
+Depending on the version of the Terraform AWS Provider you are migrating from, the interpretation of `versioning.enabled = false`
+in your `aws_s3_bucket` resource will differ and thus the migration to the `aws_s3_bucket_versioning` resource will also differ as follows.
+
+If you are migrating from the Terraform AWS Provider `v3.70.0` or later:
+
+* For new S3 buckets, `enabled = false` is synonymous to `Disabled`.
+* For existing S3 buckets, `enabled = false` is synonymous to `Suspended`.
+
+If you are migrating from an earlier version of the Terraform AWS Provider:
+
+* For both new and existing S3 buckets, `enabled = false` is synonymous to `Suspended`.
+
+Given this previous configuration :
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "yournamehere"
+
+  # ... other configuration ...
+  versioning {
+    enabled = false
+  }
+}
+```
+
+You will get the following error after upgrading:
+
+```
+│ Error: Value for unconfigurable attribute
+│
+│   with aws_s3_bucket.example,
+│   on main.tf line 1, in resource "aws_s3_bucket" "example":
+│    1: resource "aws_s3_bucket" "example" {
+│
+│ Can't configure a value for "versioning": its value will be decided automatically based on the result of applying this configuration.
+```
+
+Since `versioning` is now read only, update your configuration to use the `aws_s3_bucket_versioning`
+resource and remove `versioning` and its nested arguments in the `aws_s3_bucket` resource.
+
+* If migrating from Terraform AWS Provider `v3.70.0` or later and bucket versioning was never enabled:
+
+  ```terraform
+  resource "aws_s3_bucket" "example" {
+    bucket = "yournamehere"
+  
+    # ... other configuration ...
+  }
+  
+  resource "aws_s3_bucket_versioning" "example" {
+    bucket = aws_s3_bucket.example.id
+    versioning_configuration {
+      status = "Disabled"
+    }
+  }
+  ```
+
+* If migrating from Terraform AWS Provider `v3.70.0` or later and bucket versioning was enabled at one point:
+
+  ```terraform
+  resource "aws_s3_bucket" "example" {
+    bucket = "yournamehere"
+  
+    # ... other configuration ...
+  }
+  
+  resource "aws_s3_bucket_versioning" "example" {
+    bucket = aws_s3_bucket.example.id
+    versioning_configuration {
+      status = "Suspended"
+    }
+  }
+  ```
+  
+* If migrating from an earlier version of Terraform AWS Provider:
+
+  ```terraform
+  resource "aws_s3_bucket" "example" {
+    bucket = "yournamehere"
+  
+    # ... other configuration ...
+  }
+  
+  resource "aws_s3_bucket_versioning" "example" {
+    bucket = aws_s3_bucket.example.id
+    versioning_configuration {
+      status = "Suspended"
+    }
+  }
+  ```
 
 Run `terraform import` on each new resource, _e.g._,
 

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -9,12 +9,16 @@ description: |-
 # Resource: aws_s3_bucket_versioning
 
 Provides a resource for controlling versioning on an S3 bucket.
-Deleting this resource will suspend versioning on the associated S3 bucket.
+Deleting this resource will either suspend versioning on the associated S3 bucket or
+simply remove the resource from Terraform state if the associated S3 bucket is unversioned.
+
 For more information, see [How S3 versioning works](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html).
 
 ~> **NOTE:** If you are enabling versioning on the bucket for the first time, AWS recommends that you wait for 15 minutes after enabling versioning before issuing write operations (PUT or DELETE) on objects in the bucket.
 
 ## Example Usage
+
+### With Versioning Enabled
 
 ```terraform
 resource "aws_s3_bucket" "example" {
@@ -30,6 +34,26 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
   bucket = aws_s3_bucket.example.id
   versioning_configuration {
     status = "Enabled"
+  }
+}
+```
+
+### With Versioning Disabled
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "example-bucket"
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.example.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "versioning_example" {
+  bucket = aws_s3_bucket.example.id
+  versioning_configuration {
+    status = "Disabled"
   }
 }
 ```
@@ -73,9 +97,12 @@ The following arguments are supported:
 
 ### versioning_configuration
 
+~> **Note:** While the `versioning_configuration.status` parameter supports `Disabled`, this value is only intended for _creating_ or _importing_ resources that correspond to unversioned S3 buckets.
+Updating the value from `Enabled` or `Suspended` to `Disabled` will result in errors as the AWS S3 API does not support returning buckets to an unversioned state.
+
 The `versioning_configuration` configuration block supports the following arguments:
 
-* `status` - (Required) The versioning state of the bucket. Valid values: `Enabled` or `Suspended`.
+* `status` - (Required) The versioning state of the bucket. Valid values: `Enabled`, `Suspended`, or `Disabled`. `Disabled` should only be used when creating or importing resources that correspond to unversioned S3 buckets.
 * `mfa_delete` - (Optional) Specifies whether MFA delete is enabled in the bucket versioning configuration. Valid values: `Enabled` or `Disabled`.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23718

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketVersioning_disappears (27.36s)
--- PASS: TestAccS3BucketVersioning_Status_disabled (28.38s)
--- PASS: TestAccS3BucketVersioning_basic (31.13s)
--- PASS: TestAccS3BucketVersioning_MFADelete (31.16s)
--- PASS: TestAccS3BucketVersioning_Status_suspendedToDisabled (32.19s)
--- PASS: TestAccS3BucketVersioning_Status_enabledToDisabled (32.51s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToSuspended (47.90s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToEnabled (50.36s)
--- PASS: TestAccS3BucketVersioning_update (69.02s)
```
