### PR TITLE
Add dependabot to maintainer list

### DIFF
--- a/infrastructure/repository/maintainer-list.tf
+++ b/infrastructure/repository/maintainer-list.tf
@@ -5,5 +5,5 @@
 resource "github_actions_secret" "maintainer_list" {
   repository      = "terraform-provider-aws"
   secret_name     = "MAINTAINER_LIST"
-  plaintext_value = "['anGie44', 'breathingdust', 'ewbankkit', 'gdavison', 'johnsonaj', 'justinretzolk', 'maryelizbeth', 'YakDriver', 'zhelding']"
+  plaintext_value = "['anGie44', 'breathingdust', 'dependabot[bot]', 'ewbankkit', 'gdavison', 'johnsonaj', 'justinretzolk', 'maryelizbeth', 'YakDriver', 'zhelding']"
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #23633

Output from acceptance testing: n/a, meta PR

### Information

With the recent switch to using the `MAINTAINER_LIST` repository secret, dependabot is now being tagged with `needs-triage`. This PR aims to correct that.