### PR TITLE
r/s3_bucket_replication_configuration: backport  update rule to a TypeList and mark `rule.id` as Computed and `rule.prefix` as Deprecated

### DIFF
--- a/.changelog/23737.txt
+++ b/.changelog/23737.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Set `rule.id` as Computed to prevent drift when the value is not configured
+```
+
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Change `rule` configuration block to list instead of set
+```
+
+```release-note:note:
+resource/aws_s3_bucket_replication_configuration: The `rule.prefix` parameter has been deprecated. Use the `rule.filter` parameter instead.
+```

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -540,6 +540,46 @@ func TestAccS3BucketReplicationConfiguration_replicaModifications(t *testing.T) 
 	})
 }
 
+// TestAccS3BucketReplicationConfiguration_withoutId ensures a configuration with a Computed
+// rule.id does not result in a non-empty plan
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23690
+func TestAccS3BucketReplicationConfiguration_withoutId(t *testing.T) {
+	resourceName := "aws_s3_bucket_replication_configuration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dstBucketResourceName := "aws_s3_bucket.destination"
+	iamRoleResourceName := "aws_iam_role.test"
+
+	// record the initialized providers so that we can use them to check for the instances in each region
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      acctest.CheckWithProviders(testAccCheckBucketReplicationConfigurationDestroy, &providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketReplicationConfiguration_prefix_withoutIdConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketReplicationConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "role", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "rule.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.prefix", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.status", s3.ReplicationRuleStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "rule.0.destination.0.bucket", dstBucketResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // StorageClass issue: https://github.com/hashicorp/terraform/issues/10909
 func TestAccS3BucketReplicationConfiguration_withoutStorageClass(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -835,9 +875,12 @@ func TestAccS3BucketReplicationConfiguration_filter_emptyPrefix(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName: resourceName,
+				ImportState:  true,
+				// The "rule" parameter as a TypeList will have a nil value
+				// if prefix was specified as an empty string, which was used as workaround
+				// when the parameter was a TypeSet
+				ImportStateVerifyIgnore: []string{"rule.0.filter.0.prefix"},
 			},
 		},
 	})
@@ -948,6 +991,47 @@ func TestAccS3BucketReplicationConfiguration_filter_andOperator(t *testing.T) {
 						"destination.#":                      "1",
 					}),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "rule.*.destination.0.bucket", dstBucketResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccS3BucketReplicationConfiguration_filter_withoutId ensures a configuration with a Computed
+// rule.id does not result in a non-empty plan.
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23690
+func TestAccS3BucketReplicationConfiguration_filter_withoutId(t *testing.T) {
+	resourceName := "aws_s3_bucket_replication_configuration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dstBucketResourceName := "aws_s3_bucket.destination"
+	iamRoleResourceName := "aws_iam_role.test"
+
+	// record the initialized providers so that we can use them to check for the instances in each region
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      acctest.CheckWithProviders(testAccCheckBucketReplicationConfigurationDestroy, &providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketReplicationConfiguration_filter_withoutIdConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketReplicationConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "role", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "rule.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.status", s3.ReplicationRuleStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.delete_marker_replication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "rule.0.destination.0.bucket", dstBucketResourceName, "arn"),
 				),
 			},
 			{
@@ -1123,6 +1207,49 @@ resource "aws_s3_bucket_replication_configuration" "test" {
     }
   }
 }`, storageClass)
+}
+
+func testAccBucketReplicationConfiguration_prefix_withoutIdConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBucketReplicationConfigurationBase(rName), `
+resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_versioning.destination
+  ]
+  bucket = aws_s3_bucket.source.id
+  role   = aws_iam_role.test.arn
+  rule {
+    prefix = "foo"
+    status = "Enabled"
+    destination {
+      bucket = aws_s3_bucket.destination.arn
+    }
+  }
+}`)
+}
+
+func testAccBucketReplicationConfiguration_filter_withoutIdConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBucketReplicationConfigurationBase(rName), `
+resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_versioning.destination
+  ]
+  bucket = aws_s3_bucket.source.id
+  role   = aws_iam_role.test.arn
+  rule {
+    filter {}
+    status = "Enabled"
+    delete_marker_replication {
+      status = "Disabled"
+    }
+    destination {
+      bucket = aws_s3_bucket.destination.arn
+    }
+  }
+}`)
 }
 
 func testAccBucketReplicationConfigurationRTC(rName string) string {

--- a/website/docs/r/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_replication_configuration.html.markdown
@@ -141,8 +141,12 @@ resource "aws_s3_bucket_replication_configuration" "replication" {
   bucket = aws_s3_bucket.source.id
 
   rule {
-    id     = "foobar"
-    prefix = "foo"
+    id = "foobar"
+
+    filter {
+      prefix = "foo"
+    }
+
     status = "Enabled"
 
     destination {
@@ -203,8 +207,12 @@ resource "aws_s3_bucket_replication_configuration" "east_to_west" {
   bucket = aws_s3_bucket.east.id
 
   rule {
-    id     = "foobar"
-    prefix = "foo"
+    id = "foobar"
+
+    filter {
+      prefix = "foo"
+    }
+
     status = "Enabled"
 
     destination {
@@ -224,8 +232,12 @@ resource "aws_s3_bucket_replication_configuration" "west_to_east" {
   bucket = aws_s3_bucket.west.id
 
   rule {
-    id     = "foobar"
-    prefix = "foo"
+    id = "foobar"
+
+    filter {
+      prefix = "foo"
+    }
+
     status = "Enabled"
 
     destination {
@@ -265,7 +277,7 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the source S3 bucket you want Amazon S3 to monitor.
 * `role` - (Required) The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
-* `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
+* `rule` - (Required) List of configuration blocks describing the rules managing the replication [documented below](#rule).
 * `token` - (Optional) A token to allow replication to be enabled on an Object Lock-enabled bucket. You must contact AWS support for the bucket's "Object Lock token".
 For more details, see [Using S3 Object Lock with replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-managing-replication).
 
@@ -282,7 +294,7 @@ The `rule` configuration block supports the following arguments:
 * `existing_object_replication` - (Optional) Replicate existing objects in the source bucket according to the rule configurations [documented below](#existing_object_replication).
 * `filter` - (Optional, Conflicts with `prefix`) Filter that identifies subset of objects to which the replication rule applies [documented below](#filter). If not specified, the `rule` will default to using `prefix`.
 * `id` - (Optional) Unique identifier for the rule. Must be less than or equal to 255 characters in length.
-* `prefix` - (Optional, Conflicts with `filter`) Object key name prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length. Defaults to an empty string (`""`) if `filter` is not specified.
+* `prefix` - (Optional, Conflicts with `filter`, **Deprecated**) Object key name prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length. Defaults to an empty string (`""`) if `filter` is not specified.
 * `priority` - (Optional) The priority associated with the rule. Priority should only be set if `filter` is configured. If not provided, defaults to `0`. Priority must be unique between multiple rules.
 * `source_selection_criteria` - (Optional) Specifies special object selection criteria [documented below](#source_selection_criteria).
 * `status` - (Required) The status of the rule. Either `"Enabled"` or `"Disabled"`. The rule is ignored if status is not "Enabled".


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/23703
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23487
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23690

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccS3BucketReplicationConfiguration_' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketReplicationConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketReplicationConfiguration_basic
=== PAUSE TestAccS3BucketReplicationConfiguration_basic
=== RUN   TestAccS3BucketReplicationConfiguration_disappears
=== PAUSE TestAccS3BucketReplicationConfiguration_disappears
=== RUN   TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
=== RUN   TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
=== RUN   TestAccS3BucketReplicationConfiguration_twoDestination
=== PAUSE TestAccS3BucketReplicationConfiguration_twoDestination
=== RUN   TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== PAUSE TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== RUN   TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== PAUSE TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
=== RUN   TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== PAUSE TestAccS3BucketReplicationConfiguration_replicationTimeControl
=== RUN   TestAccS3BucketReplicationConfiguration_replicaModifications
=== PAUSE TestAccS3BucketReplicationConfiguration_replicaModifications
=== RUN   TestAccS3BucketReplicationConfiguration_withoutId
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutId
=== RUN   TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
=== RUN   TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== PAUSE TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== RUN   TestAccS3BucketReplicationConfiguration_existingObjectReplication
    bucket_replication_configuration_test.go:754: skipping test: AWS Technical Support request required to allow ExistingObjectReplication
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
=== RUN   TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock
=== RUN   TestAccS3BucketReplicationConfiguration_filter_emptyPrefix
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_emptyPrefix
=== RUN   TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_tagFilter
=== RUN   TestAccS3BucketReplicationConfiguration_filter_andOperator
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_andOperator
=== RUN   TestAccS3BucketReplicationConfiguration_filter_withoutId
=== PAUSE TestAccS3BucketReplicationConfiguration_filter_withoutId
=== RUN   TestAccS3BucketReplicationConfiguration_withoutPrefix
=== PAUSE TestAccS3BucketReplicationConfiguration_withoutPrefix
=== CONT  TestAccS3BucketReplicationConfiguration_basic
=== CONT  TestAccS3BucketReplicationConfiguration_withoutStorageClass
=== CONT  TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation
=== CONT  TestAccS3BucketReplicationConfiguration_withoutId
=== CONT  TestAccS3BucketReplicationConfiguration_filter_emptyPrefix
--- PASS: TestAccS3BucketReplicationConfiguration_filter_emptyPrefix (444.83s)
=== CONT  TestAccS3BucketReplicationConfiguration_replicaModifications
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (504.94s)
=== CONT  TestAccS3BucketReplicationConfiguration_replicationTimeControl
--- PASS: TestAccS3BucketReplicationConfiguration_withoutId (504.94s)
=== CONT  TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (620.04s)
=== CONT  TestAccS3BucketReplicationConfiguration_withoutPrefix
--- PASS: TestAccS3BucketReplicationConfiguration_basic (634.75s)
=== CONT  TestAccS3BucketReplicationConfiguration_filter_andOperator
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (408.95s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
=== CONT  TestAccS3BucketReplicationConfiguration_filter_withoutId
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (469.07s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (470.20s)
=== CONT  TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (587.67s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (500.12s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2
--- PASS: TestAccS3BucketReplicationConfiguration_filter_withoutId (377.48s)
=== CONT  TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (427.12s)
=== CONT  TestAccS3BucketReplicationConfiguration_filter_tagFilter
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (302.20s)
=== CONT  TestAccS3BucketReplicationConfiguration_disappears
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (116.44s)
=== CONT  TestAccS3BucketReplicationConfiguration_twoDestination
--- PASS: TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock (425.78s)
=== CONT  TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (393.42s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (441.23s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (398.93s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (411.45s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (423.75s)
PASS
```
