### PR TITLE
Fix for hashicorp/terraform-provider-aws/#20452

### DIFF
--- a/internal/service/ecs/wait.go
+++ b/internal/service/ecs/wait.go
@@ -63,6 +63,7 @@ func waitCapacityProviderUpdated(conn *ecs.ECS, arn string) (*ecs.CapacityProvid
 }
 
 func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
+	var err error
 	input := &ecs.DescribeServicesInput{
 		Services: aws.StringSlice([]string{id}),
 	}
@@ -71,10 +72,12 @@ func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
 		input.Cluster = aws.String(cluster)
 	}
 
-	if err := conn.WaitUntilServicesStable(input); err != nil {
-		return err
+	for i := 0; i < 3; i++ {
+		if err := conn.WaitUntilServicesStable(input); err == nil {
+			return nil
+		}
 	}
-	return nil
+	return err
 }
 
 func waitServiceInactive(conn *ecs.ECS, id, cluster string) error {


### PR DESCRIPTION
When using `wait_for_steady_state` retry up to 3 times.

This is due to when a service is replaced there is a possibility the
service will return a status of INACTIVE as the AWS API returns the
status of the old service instead of the new one which hasn't fully
registered yet.


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20452

### Description

* for use with `wait_for_steady_state`, this retries on error
* for new resources, this will ignore the `INACTIVE` state condition during read 