### PR TITLE
r/athena_workgroup - add `acl_configuration` and `expected_bucket_owner` args

### DIFF
--- a/.changelog/23748.txt
+++ b/.changelog/23748.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_athena_workgroup: Add `acl_configuration` and `expected_bucket_owner` arguments
+resource/aws_athena_workgroup: Add `acl_configuration` and `expected_bucket_owner` arguments to the `configuration.result_configuration` block
 ```

--- a/.changelog/23748.txt
+++ b/.changelog/23748.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_athena_workgroup: Add `acl_configuration` and `expected_bucket_owner` arguments
+```

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -543,6 +543,14 @@ func flattenAthenaWorkGroupResultConfiguration(resultConfiguration *athena.Resul
 		"output_location":          aws.StringValue(resultConfiguration.OutputLocation),
 	}
 
+	if resultConfiguration.ExpectedBucketOwner != nil {
+		m["expected_bucket_owner"] = aws.StringValue(resultConfiguration.ExpectedBucketOwner)
+	}
+
+	if resultConfiguration.AclConfiguration != nil {
+		m["acl_configuration"] = flattenAthenaWorkGroupAclConfiguration(resultConfiguration.AclConfiguration)
+	}
+
 	return []interface{}{m}
 }
 
@@ -554,6 +562,18 @@ func flattenAthenaWorkGroupEncryptionConfiguration(encryptionConfiguration *athe
 	m := map[string]interface{}{
 		"encryption_option": aws.StringValue(encryptionConfiguration.EncryptionOption),
 		"kms_key_arn":       aws.StringValue(encryptionConfiguration.KmsKey),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenAthenaWorkGroupAclConfiguration(aclConfig *athena.AclConfiguration) []interface{} {
+	if aclConfig == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"s3_acl_option": aws.StringValue(aclConfig.S3AclOption),
 	}
 
 	return []interface{}{m}

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -440,6 +440,10 @@ func expandAthenaWorkGroupResultConfiguration(l []interface{}) *athena.ResultCon
 		resultConfiguration.ExpectedBucketOwner = aws.String(v)
 	}
 
+	if v, ok := m["acl_configuration"]; ok {
+		resultConfiguration.AclConfiguration = expandAthenaResultConfigurationAclConfig(v.([]interface{}))
+	}
+
 	return resultConfiguration
 }
 
@@ -468,6 +472,12 @@ func expandAthenaWorkGroupResultConfigurationUpdates(l []interface{}) *athena.Re
 		resultConfigurationUpdates.ExpectedBucketOwner = aws.String(v)
 	} else {
 		resultConfigurationUpdates.RemoveExpectedBucketOwner = aws.Bool(true)
+	}
+
+	if v, ok := m["acl_configuration"]; ok {
+		resultConfigurationUpdates.AclConfiguration = expandAthenaResultConfigurationAclConfig(v.([]interface{}))
+	} else {
+		resultConfigurationUpdates.RemoveAclConfiguration = aws.Bool(true)
 	}
 
 	return resultConfigurationUpdates

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -828,9 +828,9 @@ resource "aws_athena_workgroup" "test" {
     result_configuration {
       acl_configuration {
         s3_acl_option = "BUCKET_OWNER_FULL_CONTROL"
-	  }
+      }
     }
-  }  
+  }
 }
 `, rName)
 }

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
 )
 
 func TestAccAthenaWorkGroup_basic(t *testing.T) {
@@ -68,7 +69,7 @@ func TestAccAthenaWorkGroup_disappears(t *testing.T) {
 				Config: testAccAthenaWorkGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkGroupExists(resourceName, &workgroup1),
-					testAccCheckWorkGroupDisappears(&workgroup1),
+					acctest.CheckResourceDisappears(acctest.Provider, tfathena.ResourceWorkGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -664,20 +665,6 @@ func testAccCheckWorkGroupExists(name string, workgroup *athena.WorkGroup) resou
 		*workgroup = *output.WorkGroup
 
 		return nil
-	}
-}
-
-func testAccCheckWorkGroupDisappears(workgroup *athena.WorkGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn
-
-		input := &athena.DeleteWorkGroupInput{
-			WorkGroup: workgroup.Name,
-		}
-
-		_, err := conn.DeleteWorkGroup(input)
-
-		return err
 	}
 }
 

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 
 * `encryption_configuration` - (Optional) Configuration block with encryption settings. See [Encryption Configuration](#encryption-configuration) below.
 * `acl_configuration` - (Optional) Indicates that an Amazon S3 canned ACL should be set to control ownership of stored query results. See [ACL Configuration](#acl-configuration) below.
+* `expected_bucket_owner` - (Optional) The AWS account ID that you expect to be the owner of the Amazon S3 bucket.
 * `output_location` - (Optional) The location in Amazon S3 where your query results are stored, such as `s3://path/to/query/bucket/`. For more information, see [Queries and Query Result Files](https://docs.aws.amazon.com/athena/latest/ug/querying.html).
 
 ##### ACL Configuration

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -43,33 +43,30 @@ The following arguments are supported:
 * `tags` - (Optional) Key-value map of resource tags for the workgroup. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional) The option to delete the workgroup and its contents even if the workgroup contains any named queries.
 
-### configuration Argument Reference
-
-The `configuration` configuration block supports the following arguments:
+### Configuration
 
 * `bytes_scanned_cutoff_per_query` - (Optional) Integer for the upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan. Must be at least `10485760`.
 * `enforce_workgroup_configuration` - (Optional) Boolean whether the settings for the workgroup override client-side settings. For more information, see [Workgroup Settings Override Client-Side Settings](https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html). Defaults to `true`.
-* `engine_version` - (Optional) Configuration block for the Athena Engine Versioning. For more information, see [Athena Engine Versioning](https://docs.aws.amazon.com/athena/latest/ug/engine-versions.html). Documented below.
+* `engine_version` - (Optional) Configuration block for the Athena Engine Versioning. For more information, see [Athena Engine Versioning](https://docs.aws.amazon.com/athena/latest/ug/engine-versions.html). See [Engine Version](#engine-version) below.
 * `publish_cloudwatch_metrics_enabled` - (Optional) Boolean whether Amazon CloudWatch metrics are enabled for the workgroup. Defaults to `true`.
-* `result_configuration` - (Optional) Configuration block with result settings. Documented below.
+* `result_configuration` - (Optional) Configuration block with result settings. See [Result Configuration](#result-configuration) below.
 * `requester_pays_enabled` - (Optional) If set to true , allows members assigned to a workgroup to reference Amazon S3 Requester Pays buckets in queries. If set to false , workgroup members cannot query data from Requester Pays buckets, and queries that retrieve data from Requester Pays buckets cause an error. The default is false . For more information about Requester Pays buckets, see [Requester Pays Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) in the Amazon Simple Storage Service Developer Guide.
 
-#### engine_version Argument Reference
-
-The `engine_version` configuration block within the `configuration` supports the following arguments:
+#### Engine Version
 
 * `selected_engine_version` - (Optional) The requested engine version. Defaults to `AUTO`.
 
-#### result_configuration Argument Reference
+#### Result Configuration
 
-The `result_configuration` configuration block within the `configuration` supports the following arguments:
-
-* `encryption_configuration` - (Optional) Configuration block with encryption settings. Documented below.
+* `encryption_configuration` - (Optional) Configuration block with encryption settings. See [Encryption Configuration](#encryption-configuration) below.
+* `acl_configuration` - (Optional) Indicates that an Amazon S3 canned ACL should be set to control ownership of stored query results. See [ACL Configuration](#acl-configuration) below.
 * `output_location` - (Optional) The location in Amazon S3 where your query results are stored, such as `s3://path/to/query/bucket/`. For more information, see [Queries and Query Result Files](https://docs.aws.amazon.com/athena/latest/ug/querying.html).
 
-##### encryption_configuration Argument Reference
+##### ACL Configuration
 
-The `encryption_configuration` configuration block within the `result_configuration` of the `configuration` supports the following arguments:
+* `s3_acl_option` - (Required) The Amazon S3 canned ACL that Athena should specify when storing query results. Valid value is `BUCKET_OWNER_FULL_CONTROL`.
+
+##### Encryption Configuration
 
 * `encryption_option` - (Required) Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (`SSE_S3`), server-side encryption with KMS-managed keys (`SSE_KMS`), or client-side encryption with KMS-managed keys (`CSE_KMS`) is used. If a query runs in a workgroup and the workgroup overrides client-side settings, then the workgroup's setting for encryption is used. It specifies whether query results must be encrypted, for all queries that run in this workgroup.
 * `kms_key_arn` - (Optional) For `SSE_KMS` and `CSE_KMS`, this is the KMS key Amazon Resource Name (ARN).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAthenaWorkGroup_ PKG=athena
--- PASS: TestAccAthenaWorkGroup_disappears (28.99s)
--- PASS: TestAccAthenaWorkGroup_aclConfig (35.61s)
--- PASS: TestAccAthenaWorkGroup_basic (38.28s)
--- PASS: TestAccAthenaWorkGroup_ResultEncryption_sseS3 (38.35s)
--- PASS: TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery (58.18s)
--- PASS: TestAccAthenaWorkGroup_forceDestroy (58.39s)
--- PASS: TestAccAthenaWorkGroup_description (60.73s)
--- PASS: TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled (61.05s)
--- PASS: TestAccAthenaWorkGroup_enforceWorkGroup (61.32s)
--- PASS: TestAccAthenaWorkGroup_requesterPaysEnabled (61.37s)
--- PASS: TestAccAthenaWorkGroup_ResultEncryption_kms (66.23s)
--- PASS: TestAccAthenaWorkGroup_tags (81.81s)
--- PASS: TestAccAthenaWorkGroup_configurationEngineVersion (82.46s)
--- PASS: TestAccAthenaWorkGroup_state (82.72s)
--- PASS: TestAccAthenaWorkGroup_Result_outputLocation (85.23s)
--- PASS: TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy (85.48s)
```
