### PR TITLE
Add provider infrastructure for Amazon AppIntegrations

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -50,6 +50,8 @@ service/apigatewayv2:
   - '((\*|-) ?`?|(data|resource) "?)aws_apigatewayv2_'
 service/appconfig:
   - '((\*|-) ?`?|(data|resource) "?)aws_appconfig_'
+service/appintegrations:
+  - '((\*|-) ?`?|(data|resource) "?)aws_appintegrations_'
 service/applicationautoscaling:
   - '((\*|-) ?`?|(data|resource) "?)aws_appautoscaling_'
 service/applicationdiscoveryservice:

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -80,6 +80,9 @@ service/apigatewayv2:
 service/appconfig:
   - 'internal/service/appconfig/**/*'
   - 'website/**/appconfig_*'
+service/appintegrations:
+  - 'internal/service/appintegrations/**/*'
+  - 'website/**/appintegrations_*'
 service/applicationautoscaling:
   - 'internal/service/appautoscaling/**/*'
   - 'website/**/appautoscaling_*'

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -17,6 +17,7 @@ variable "service_labels" {
     "apigatewayv2",
     "appconfig",
     "appflow",
+    "appintegrations",
     "applicationautoscaling",
     "applicationdiscoveryservice",
     "applicationinsights",

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -7,6 +7,7 @@ Access Analyzer
 Account
 Amplify Console
 AppConfig
+AppIntegrations
 AppMesh
 App Runner
 AppSync


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

API reference: https://docs.aws.amazon.com/appintegrations/latest/APIReference/API_Operations.html

Resources and Data Sources will have separate PRs

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./...  -timeout=5m
?       github.com/hashicorp/terraform-provider-aws     [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/acctest    (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/attrmap    [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/conns      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/create     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable      (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/experimental/sync  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/flex       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters 0.242s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer     0.119s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account    0.315s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        5.159s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acmpca     15.112s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        0.169s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amplify    0.151s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 2.323s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       0.992s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling     0.148s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  0.117s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appmesh    0.204s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  0.166s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    0.139s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     0.152s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        0.197s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans   0.158s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     0.292s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      0.270s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/budgets    0.139s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      0.211s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloud9     0.165s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol       0.219s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     0.189s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1.252s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2 0.207s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch        0.180s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail 0.189s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch 0.241s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs     0.220s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact       0.189s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  0.198s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codecommit 0.207s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codedeploy 0.290s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       0.485s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections        0.186s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications      0.113s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity    0.188s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 0.198s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      0.194s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    0.154s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cur        0.197s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange       0.170s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline       0.154s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   0.157s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dax        0.130s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/detective  0.151s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm 0.180s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      1.493s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dlm        0.287s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        0.204s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/docdb      0.259s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ds 0.163s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   0.934s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        19.031s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        0.164s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic  0.197s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        0.158s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        0.263s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        0.970s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        1.373s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk   0.265s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      0.328s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder  0.208s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elb        1.392s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      6.074s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        0.185s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     0.214s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/firehose   0.132s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fms        0.152s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        0.152s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   0.193s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glacier    0.193s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  0.415s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       0.403s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/grafana    0.238s
?       github.com/hashicorp/terraform-provider-aws/internal/service/greengrass [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  0.299s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        3.061s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/identitystore      0.227s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       0.458s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector  0.248s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        0.507s
?       github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics       [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/service/iotevents  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      0.159s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect       0.154s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesis    0.182s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics   0.196s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2 0.196s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo       0.145s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        1.431s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      0.144s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     0.166s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels  0.199s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager     0.150s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  0.246s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie      0.119s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie2     0.566s
?       github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect       [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert       0.204s
?       github.com/hashicorp/terraform-provider-aws/internal/service/medialive  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage       0.227s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediastore 0.226s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   0.180s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       0.426s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 0.247s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mwaa       0.189s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    0.136s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    0.296s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     0.322s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opsworks   0.231s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/organizations      1.141s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts   0.227s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint   0.196s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pricing    0.297s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/qldb       0.187s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 0.243s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ram        0.564s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2.004s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   0.490s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups     0.234s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi   0.113s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    0.660s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53domains     0.197s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig       0.163s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness   0.193s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    0.481s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 2.619s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3control  0.395s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts 0.251s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  0.237s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/schemas    0.158s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     0.451s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/securityhub        0.514s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo     0.196s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     0.293s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery   0.230s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      0.216s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        0.181s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sfn        0.164s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/shield     0.238s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/signer     0.179s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/simpledb   0.187s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        0.179s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sqs        0.103s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        0.162s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   0.192s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway     0.069s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        0.218s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/swf        0.122s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/synthetics 0.080s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite    0.076s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/transfer   0.122s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/waf        0.052s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafregional        0.052s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      0.077s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/worklink   0.051s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/workspaces 0.052s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/xray       0.051s
ok      github.com/hashicorp/terraform-provider-aws/internal/tags       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/tfresource (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/vault/sdk/helper/jsonutil  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/verify     0.058s
?       github.com/hashicorp/terraform-provider-aws/version     [no test files]

...
```
