### PR TITLE
r/s3_bucket_lifecycle_configuration: backport fix; support the default filtering used in v3.x of the s3 bucket resource

### DIFF
--- a/.changelog/23750.txt
+++ b/.changelog/23750.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_lifecycle_configuration: Support empty string filtering (default behavior of the `aws_s3_bucket.lifecycle_rule` parameter in provider versions prior to v4.0)
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -91,7 +91,12 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 						"filter": {
 							Type:     schema.TypeList,
 							Optional: true,
-							MaxItems: 1,
+							// If neither the filter block nor the prefix parameter in the rule are specified,
+							// we apply the Default behavior from v3.x of the provider (Filter with empty string Prefix),
+							// which will thus return a Filter in the GetBucketLifecycleConfiguration request and
+							// require diff suppression.
+							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"and": {

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -36,7 +36,8 @@ func TestAccS3BucketLifecycleConfiguration_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"expiration.#":      "1",
 						"expiration.0.days": "365",
-						"filter.#":          "0",
+						"filter.#":          "1",
+						"filter.0.prefix":   "",
 						"id":                rName,
 						"status":            tfs3.LifecycleRuleStatusEnabled,
 					}),
@@ -360,6 +361,37 @@ func TestAccS3BucketLifecycleConfiguration_multipleRules(t *testing.T) {
 						"filter.0.prefix":   "tmp/",
 						"status":            tfs3.LifecycleRuleStatusEnabled,
 					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23730
+func TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_MultipleRules_noFilterOrPrefixConfig(rName, s3.ReplicationRuleStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.filter.0.prefix", ""),
 				),
 			},
 			{
@@ -1335,6 +1367,43 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
   }
 }
 `, rName, date)
+}
+
+func testAccBucketLifecycleConfiguration_MultipleRules_noFilterOrPrefixConfig(rName, status string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id     = "%[1]s-1"
+    status = %[2]q
+    expiration {
+      days = 365
+    }
+  }
+  rule {
+    id     = "%[1]s-2"
+    status = %[2]q
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+`, rName, status)
 }
 
 func testAccBucketLifecycleConfiguration_nonCurrentVersionExpirationConfig(rName string) string {

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -431,6 +431,19 @@ func ExpandLifecycleRules(l []interface{}) ([]*s3.LifecycleRule, error) {
 			result.Filter = ExpandLifecycleRuleFilter(v)
 		}
 
+		if v, ok := tfMap["prefix"].(string); ok && result.Filter == nil {
+			// If neither the filter block nor the prefix are specified,
+			// apply the Default behavior from v3.x of the provider;
+			// otherwise, set the prefix as specified in Terraform.
+			if v == "" {
+				result.SetFilter(&s3.LifecycleRuleFilter{
+					Prefix: aws.String(v),
+				})
+			} else {
+				result.Prefix = aws.String(v)
+			}
+		}
+
 		if v, ok := tfMap["id"].(string); ok {
 			result.ID = aws.String(v)
 		}
@@ -441,10 +454,6 @@ func ExpandLifecycleRules(l []interface{}) ([]*s3.LifecycleRule, error) {
 
 		if v, ok := tfMap["noncurrent_version_transition"].(*schema.Set); ok && v.Len() > 0 {
 			result.NoncurrentVersionTransitions = ExpandLifecycleRuleNoncurrentVersionTransitions(v.List())
-		}
-
-		if v, ok := tfMap["prefix"].(string); ok && result.Filter == nil {
-			result.Prefix = aws.String(v)
 		}
 
 		if v, ok := tfMap["status"].(string); ok && v != "" {

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -22,6 +22,24 @@ For more information see the Amazon S3 User Guide on [`Lifecycle Configuration E
 
 ## Example Usage
 
+### With neither a filter nor prefix specified
+
+The Lifecycle rule applies to a subset of objects based on the key name prefix (`""`).
+
+This configuration is intended to replicate the default behavior of the `lifecycle_rule`
+parameter in the Terraform AWS Provider `aws_s3_bucket` resource prior to `v4.0`.
+
+```terraform
+resource "aws_s3_bucket_lifecycle_configuration" "example" {
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    id = "rule-1"
+    # ... other transition/expiration actions ...
+    status = "Enabled"
+  }
+}
+```
+
 ### Specifying an empty filter
 
 The Lifecycle rule applies to all objects in the bucket.
@@ -371,7 +389,12 @@ The following arguments are supported:
 
 ### rule
 
-~> **NOTE:** The `filter` argument, while Optional, is required if the `rule` configuration block does not contain a `prefix`. Since `prefix` is deprecated by Amazon S3 and will be removed in the next major version of the Terraform AWS Provider, we recommend users specify `filter`.
+~> **NOTE:** The `filter` argument, while Optional, is required if the `rule` configuration block does not contain a `prefix` **and** you intend to override the default behavior of setting the rule to filter objects with the empty string prefix (`""`).
+Since `prefix` is deprecated by Amazon S3 and will be removed in the next major version of the Terraform AWS Provider, we recommend users either specify `filter` or leave both `filter` and `prefix` unspecified.
+
+~> **NOTE:** A rule cannot be updated from having a filter (via either the `rule.filter` parameter or when neither `rule.filter` and `rule.prefix` are specified) to only having a prefix via the `rule.prefix` parameter.
+
+~> **NOTE** Terraform cannot distinguish a difference between configurations that use `rule.filter {}` and configurations that neither use `rule.filter` nor `rule.prefix`, so a rule cannot be updated from applying to all objects in the bucket via `rule.filter {}` to applying to a subset of objects based on the key prefix `""` and vice versa.
 
 The `rule` configuration block supports the following arguments:
 
@@ -401,7 +424,7 @@ The `expiration` configuration block supports the following arguments:
 
 ### filter
 
-~> **NOTE:** The `filter` configuration block must have exactly one of `prefix`, `tag`, `and`, `object_size_greater_than` or `object_size_less_than` specified.
+~> **NOTE:** The `filter` configuration block must either be specified as the empty configuration block (`filter {}`) or with exactly one of `prefix`, `tag`, `and`, `object_size_greater_than` or `object_size_less_than` specified.
 
 The `filter` configuration block supports the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/23746
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23730

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccS3BucketLifecycleConfiguration_' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketLifecycleConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_disappears
=== PAUSE TestAccS3BucketLifecycleConfiguration_disappears
=== RUN   TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_disableRule
=== PAUSE TestAccS3BucketLifecycleConfiguration_disableRule
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== RUN   TestAccS3BucketLifecycleConfiguration_prefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_prefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== RUN   TestAccS3BucketLifecycleConfiguration_remove
=== PAUSE TestAccS3BucketLifecycleConfiguration_remove
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (205.41s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
=== CONT  TestAccS3BucketLifecycleConfiguration_prefix
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (205.45s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (205.51s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (205.53s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (205.56s)
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (201.33s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (201.25s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (201.30s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== CONT  TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (201.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (358.73s)
=== CONT  TestAccS3BucketLifecycleConfiguration_remove
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (205.71s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (210.13s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_withChange
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (210.25s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_remove (91.30s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (286.12s)
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (199.65s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (207.92s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (199.41s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (199.17s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (286.14s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (62.08s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (200.98s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (210.26s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (201.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (289.54s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (352.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	1321.424s
```
