### PR TITLE
r/ssm_maintenance_window_task - allow not setting `targets`

### DIFF
--- a/.changelog/23756.txt
+++ b/.changelog/23756.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_ssm_maintenance_window_task: Add `arn` and `window_task_id` attributes.
+```
+
+```release-note:enhancement
+resource/aws_ssm_maintenance_window_task: Add `cutoff_behavior` argument.
+```
+
+```release-note:bug
+resource/aws_ssm_maintenance_window_task: Allow creating a window taks without targets.
+```

--- a/internal/service/ssm/maintenance_window_task.go
+++ b/internal/service/ssm/maintenance_window_task.go
@@ -793,12 +793,16 @@ func resourceMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta interface{
 		params.ServiceRoleArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("max_errors"); ok {
-		params.MaxErrors = aws.String(v.(string))
+	if d.HasChange("max_errors") {
+		if v, ok := d.GetOk("max_errors"); ok {
+			params.MaxErrors = aws.String(v.(string))
+		}
 	}
 
-	if v, ok := d.GetOk("max_concurrency"); ok {
-		params.MaxConcurrency = aws.String(v.(string))
+	if d.HasChange("max_concurrency") {
+		if v, ok := d.GetOk("max_concurrency"); ok {
+			params.MaxConcurrency = aws.String(v.(string))
+		}
 	}
 
 	if v, ok := d.GetOk("targets"); ok {

--- a/internal/service/ssm/maintenance_window_task.go
+++ b/internal/service/ssm/maintenance_window_task.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -28,21 +29,37 @@ func ResourceMaintenanceWindowTask() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"window_task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"window_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
+			"cutoff_behavior": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ssm.MaintenanceWindowTaskCutoffBehavior_Values(), false),
+			},
+
 			"max_concurrency": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`), "must be a number without leading zeros or a percentage between 1% and 100% without leading zeros and ending with the percentage symbol"),
 			},
 
 			"max_errors": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`), "must be zero, a number without leading zeros, or a percentage between 1% and 100% without leading zeros and ending with the percentage symbol"),
 			},
 
@@ -656,11 +673,21 @@ func resourceMaintenanceWindowTaskCreate(d *schema.ResourceData, meta interface{
 	log.Printf("[INFO] Registering SSM Maintenance Window Task")
 
 	params := &ssm.RegisterTaskWithMaintenanceWindowInput{
-		WindowId:       aws.String(d.Get("window_id").(string)),
-		MaxConcurrency: aws.String(d.Get("max_concurrency").(string)),
-		MaxErrors:      aws.String(d.Get("max_errors").(string)),
-		TaskType:       aws.String(d.Get("task_type").(string)),
-		TaskArn:        aws.String(d.Get("task_arn").(string)),
+		WindowId: aws.String(d.Get("window_id").(string)),
+		TaskType: aws.String(d.Get("task_type").(string)),
+		TaskArn:  aws.String(d.Get("task_arn").(string)),
+	}
+
+	if v, ok := d.GetOk("max_errors"); ok {
+		params.MaxErrors = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_concurrency"); ok {
+		params.MaxConcurrency = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("cutoff_behavior"); ok {
+		params.CutoffBehavior = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("targets"); ok {
@@ -715,7 +742,9 @@ func resourceMaintenanceWindowTaskRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error getting Maintenance Window (%s) Task (%s): %s", windowID, d.Id(), err)
 	}
 
+	windowTaskID := aws.StringValue(resp.WindowTaskId)
 	d.Set("window_id", resp.WindowId)
+	d.Set("window_task_id", windowTaskID)
 	d.Set("max_concurrency", resp.MaxConcurrency)
 	d.Set("max_errors", resp.MaxErrors)
 	d.Set("task_type", resp.TaskType)
@@ -724,6 +753,7 @@ func resourceMaintenanceWindowTaskRead(d *schema.ResourceData, meta interface{})
 	d.Set("priority", resp.Priority)
 	d.Set("name", resp.Name)
 	d.Set("description", resp.Description)
+	d.Set("cutoff_behavior", resp.CutoffBehavior)
 
 	if resp.TaskInvocationParameters != nil {
 		if err := d.Set("task_invocation_parameters", flattenTaskInvocationParameters(resp.TaskInvocationParameters)); err != nil {
@@ -735,6 +765,15 @@ func resourceMaintenanceWindowTaskRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting targets error: %#v", err)
 	}
 
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ssm",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("windowtask/%s", windowTaskID),
+	}.String()
+	d.Set("arn", arn)
+
 	return nil
 }
 
@@ -743,18 +782,31 @@ func resourceMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta interface{
 	windowID := d.Get("window_id").(string)
 
 	params := &ssm.UpdateMaintenanceWindowTaskInput{
-		Priority:       aws.Int64(int64(d.Get("priority").(int))),
-		WindowId:       aws.String(windowID),
-		WindowTaskId:   aws.String(d.Id()),
-		MaxConcurrency: aws.String(d.Get("max_concurrency").(string)),
-		MaxErrors:      aws.String(d.Get("max_errors").(string)),
-		TaskArn:        aws.String(d.Get("task_arn").(string)),
-		Targets:        expandTargets(d.Get("targets").([]interface{})),
-		Replace:        aws.Bool(true),
+		Priority:     aws.Int64(int64(d.Get("priority").(int))),
+		WindowId:     aws.String(windowID),
+		WindowTaskId: aws.String(d.Id()),
+		TaskArn:      aws.String(d.Get("task_arn").(string)),
+		Replace:      aws.Bool(true),
 	}
 
 	if v, ok := d.GetOk("service_role_arn"); ok {
 		params.ServiceRoleArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_errors"); ok {
+		params.MaxErrors = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_concurrency"); ok {
+		params.MaxConcurrency = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("targets"); ok {
+		params.Targets = expandTargets(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("cutoff_behavior"); ok {
+		params.CutoffBehavior = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("name"); ok {

--- a/internal/service/ssm/maintenance_window_task.go
+++ b/internal/service/ssm/maintenance_window_task.go
@@ -793,20 +793,19 @@ func resourceMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta interface{
 		params.ServiceRoleArn = aws.String(v.(string))
 	}
 
-	if d.HasChange("max_errors") {
-		if v, ok := d.GetOk("max_errors"); ok {
-			params.MaxErrors = aws.String(v.(string))
-		}
+	if v, ok := d.GetOk("max_errors"); ok {
+		params.MaxErrors = aws.String(v.(string))
 	}
 
-	if d.HasChange("max_concurrency") {
-		if v, ok := d.GetOk("max_concurrency"); ok {
-			params.MaxConcurrency = aws.String(v.(string))
-		}
+	if v, ok := d.GetOk("max_concurrency"); ok {
+		params.MaxConcurrency = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("targets"); ok {
 		params.Targets = expandTargets(v.([]interface{}))
+	} else {
+		params.MaxConcurrency = nil
+		params.MaxErrors = nil
 	}
 
 	if v, ok := d.GetOk("cutoff_behavior"); ok {

--- a/internal/service/ssm/maintenance_window_task_test.go
+++ b/internal/service/ssm/maintenance_window_task_test.go
@@ -31,13 +31,16 @@ func TestAccSSMMaintenanceWindowTask_basic(t *testing.T) {
 				Config: testAccMaintenanceWindowTaskBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMaintenanceWindowTaskExists(resourceName, &before),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexp.MustCompile(`windowtask/.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "window_task_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "window_id", "aws_ssm_maintenance_window.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
 				),
 			},
 			{
 				Config: testAccMaintenanceWindowTaskBasicUpdateConfig(rName, "test description", "RUN_COMMAND", "AWS-InstallPowerShellModule", 3, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMaintenanceWindowTaskExists(resourceName, &after),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexp.MustCompile(`windowtask/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("maintenance-window-task-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "task_type", "RUN_COMMAND"),
@@ -73,6 +76,7 @@ func TestAccSSMMaintenanceWindowTask_noTarget(t *testing.T) {
 				Config: testAccMaintenanceWindowTaskNoTargetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMaintenanceWindowTaskExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "0"),
 				),
 			},
 			{

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -134,14 +134,15 @@ resource "aws_ssm_maintenance_window_task" "example" {
 The following arguments are supported:
 
 * `window_id` - (Required) The Id of the maintenance window to register the task with.
-* `max_concurrency` - (Required) The maximum number of targets this task can be run for in parallel.
-* `max_errors` - (Required) The maximum number of errors allowed before this task stops being scheduled.
+* `max_concurrency` - (Optional) The maximum number of targets this task can be run for in parallel.
+* `max_errors` - (Optional) The maximum number of errors allowed before this task stops being scheduled.
+* `cutoff_behavior` - (Optional) Indicates whether tasks should continue to run after the cutoff time specified in the maintenance windows is reached. Valid values are `CONTINUE_TASK` and `CANCEL_TASK`.
 * `task_type` - (Required) The type of task being registered. Valid values: `AUTOMATION`, `LAMBDA`, `RUN_COMMAND` or `STEP_FUNCTIONS`.
 * `task_arn` - (Required) The ARN of the task to execute.
 * `service_role_arn` - (Optional) The role that should be assumed when executing the task. If a role is not provided, Systems Manager uses your account's service-linked role. If no service-linked role for Systems Manager exists in your account, it is created for you.
 * `name` - (Optional) The name of the maintenance window task.
 * `description` - (Optional) The description of the maintenance window task.
-* `targets` - (Required) The targets (either instances or window target ids). Instances are specified using Key=InstanceIds,Values=instanceid1,instanceid2. Window target ids are specified using Key=WindowTargetIds,Values=window target id1, window target id2.
+* `targets` - (Optional) The targets (either instances or window target ids). Instances are specified using Key=InstanceIds,Values=instanceid1,instanceid2. Window target ids are specified using Key=WindowTargetIds,Values=window target id1, window target id2.
 * `priority` - (Optional) The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.
 * `task_invocation_parameters` - (Optional) Configuration block with parameters for task execution.
 
@@ -201,7 +202,9 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the maintenance window task.
 * `id` - The ID of the maintenance window task.
+* `window_task_id` - The ID of the maintenance window task.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20090
Closes #19396

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSSMMaintenanceWindowTask_ PKG=ssm

--- PASS: TestAccSSMMaintenanceWindowTask_disappears (37.91s)
--- PASS: TestAccSSMMaintenanceWindowTask_noRole (38.52s)
--- PASS: TestAccSSMMaintenanceWindowTask_emptyNotification (38.69s)
--- PASS: TestAccSSMMaintenanceWindowTask_noTarget (42.96s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters (43.02s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters (57.72s)
--- PASS: TestAccSSMMaintenanceWindowTask_cutoff (63.79s)
--- PASS: TestAccSSMMaintenanceWindowTask_updateForcesNewResource (67.72s)
--- PASS: TestAccSSMMaintenanceWindowTask_description (68.20s)
--- PASS: TestAccSSMMaintenanceWindowTask_basic (68.45s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters (75.11s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters (75.12s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch (90.59s)
```
