### PR TITLE
d/ssm_document - dont generate `arn` for aws managed docs

### DIFF
--- a/.changelog/23757.txt
+++ b/.changelog/23757.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_ssm_document: Support `TEXT` `document_format`
+```
+
+```release-note:bug
+data-source/aws_ssm_document: Dont generate `arn` for AWS managed docs.
+```

--- a/internal/service/ssm/document_data_source.go
+++ b/internal/service/ssm/document_data_source.go
@@ -3,6 +3,7 @@ package ssm
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -25,13 +26,10 @@ func DataSourceDocument() *schema.Resource {
 				Computed: true,
 			},
 			"document_format": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ssm.DocumentFormatJson,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.DocumentFormatJson,
-					ssm.DocumentFormatYaml,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ssm.DocumentFormatJson,
+				ValidateFunc: validation.StringInSlice(ssm.DocumentFormat_Values(), false),
 			},
 			"document_type": {
 				Type:     schema.TypeString,
@@ -52,10 +50,8 @@ func DataSourceDocument() *schema.Resource {
 func dataDocumentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SSMConn
 
-	name := d.Get("name").(string)
-
 	docInput := &ssm.GetDocumentInput{
-		Name:           aws.String(name),
+		Name:           aws.String(d.Get("name").(string)),
 		DocumentFormat: aws.String(d.Get("document_format").(string)),
 	}
 
@@ -70,18 +66,24 @@ func dataDocumentRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading SSM Document: %w", err)
 	}
 
-	d.SetId(aws.StringValue(resp.Name))
+	name := aws.StringValue(resp.Name)
 
-	arn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Service:   "ssm",
-		Region:    meta.(*conns.AWSClient).Region,
-		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("document/%s", aws.StringValue(resp.Name)),
-	}.String()
+	d.SetId(name)
 
-	d.Set("arn", arn)
-	d.Set("name", resp.Name)
+	if !strings.HasPrefix(name, "AWS-") {
+		arn := arn.ARN{
+			Partition: meta.(*conns.AWSClient).Partition,
+			Service:   "ssm",
+			Region:    meta.(*conns.AWSClient).Region,
+			AccountID: meta.(*conns.AWSClient).AccountID,
+			Resource:  fmt.Sprintf("document/%s", name),
+		}.String()
+		d.Set("arn", arn)
+	} else {
+		d.Set("arn", name)
+	}
+
+	d.Set("name", name)
 	d.Set("content", resp.Content)
 	d.Set("document_version", resp.DocumentVersion)
 	d.Set("document_format", resp.DocumentFormat)

--- a/internal/service/ssm/document_data_source_test.go
+++ b/internal/service/ssm/document_data_source_test.go
@@ -45,7 +45,26 @@ func TestAccSSMDocumentDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDocumentDataSourceConfig(name string, documentFormat string) string {
+func TestAccSSMDocumentDataSource_awsManaged(t *testing.T) {
+	resourceName := "data.aws_ssm_document.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, ssm.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDocumentDataSourceAWSManagedDocumentConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "AWS-StartEC2Instance"),
+					resource.TestCheckResourceAttr(resourceName, "arn", "AWS-StartEC2Instance"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDocumentDataSourceConfig(name, documentFormat string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
   name          = "%s"
@@ -77,4 +96,12 @@ data "aws_ssm_document" "test" {
   document_format = "%s"
 }
 `, name, documentFormat)
+}
+
+func testAccCheckDocumentDataSourceAWSManagedDocumentConfig() string {
+	return `
+data "aws_ssm_document" "test" {
+  name = "AWS-StartEC2Instance"
+}
+`
 }

--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -40,13 +40,13 @@ data "aws_ssm_document" "test" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Systems Manager document.
-* `document_format` - (Optional) Returns the document in the specified format. The document format can be either JSON or YAML. JSON is the default format.
+* `document_format` - (Optional) Returns the document in the specified format. The document format can be either `JSON`, `YAML` and `TEXT`. JSON is the default format.
 * `document_version` - (Optional) The document version for which you want information.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the document.
+* `arn` - The ARN of the document. If the document is an AWS managed document, this value will be set to the name of the document instead.
 * `content` - The contents of the document.
 * `document_type` - The type of the document.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19674

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSSMDocumentDataSource_ PKG=ssm

--- PASS: TestAccSSMDocumentDataSource_awsManaged (23.03s)
--- PASS: TestAccSSMDocumentDataSource_basic (52.19s)
```
