### PR TITLE
aws_launch_template: fix network interface device_index of 0 being ignored

### DIFF
--- a/.changelog/23767.txt
+++ b/.changelog/23767.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_launch_template: Fix `device_index` of `0` not being set
+resource/aws_launch_template: Fix `device_index` and `network_card_index` of `0` not being set
 ```

--- a/.changelog/23767.txt
+++ b/.changelog/23767.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_launch_template: Fix `device_index` and `network_card_index` of `0` not being set
+resource/aws_launch_template: Fix `network_interfaces.device_index` and `network_interfaces.network_card_index` of `0` not being set
 ```

--- a/.changelog/23767.txt
+++ b/.changelog/23767.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_launch_template: Fix device_index of 0 not being set
+```

--- a/.changelog/23767.txt
+++ b/.changelog/23767.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_launch_template: Fix device_index of 0 not being set
+resource/aws_launch_template: Fix `device_index` of `0` not being set
 ```

--- a/internal/service/ec2/launch_template.go
+++ b/internal/service/ec2/launch_template.go
@@ -1429,7 +1429,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 		apiObject.Description = aws.String(v)
 	}
 
-	if v, ok := tfMap["device_index"].(int); ok && v != 0 {
+	if v, ok := tfMap["device_index"].(int); ok {
 		apiObject.DeviceIndex = aws.Int64(int64(v))
 	}
 

--- a/internal/service/ec2/launch_template.go
+++ b/internal/service/ec2/launch_template.go
@@ -1485,7 +1485,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 		apiObject.Ipv6Prefixes = expandIPv6PrefixSpecificationRequests(v.List())
 	}
 
-	if v, ok := tfMap["network_card_index"].(int); ok && v != 0 {
+	if v, ok := tfMap["network_card_index"].(int); ok {
 		apiObject.NetworkCardIndex = aws.Int64(int64(v))
 	}
 

--- a/internal/service/ec2/launch_template_test.go
+++ b/internal/service/ec2/launch_template_test.go
@@ -772,18 +772,28 @@ func TestAccEC2LaunchTemplate_networkInterface(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchTemplateConfig_networkInterface(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_carrier_ip_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.delete_on_termination", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.device_index", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.interface_type", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_address_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_addresses.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_prefix_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_address_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_addresses.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_prefix_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_prefixes.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.device_index", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.network_card_index", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.private_ip_address", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.security_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.subnet_id", ""),
 				),
 			},
 			{

--- a/internal/service/ec2/launch_template_test.go
+++ b/internal/service/ec2/launch_template_test.go
@@ -783,6 +783,7 @@ func TestAccEC2LaunchTemplate_networkInterface(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_prefixes.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_prefix_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.device_index", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
0 is a legal device index, moreover a launchtemplate requires a network interface with a device index of 0 to be functional

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23766

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TESTS=TestAccEC2LaunchTemplate_networkInterface PKG=ec2 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_networkInterface'  -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_networkInterface
=== PAUSE TestAccEC2LaunchTemplate_networkInterface
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceType
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceType
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== CONT  TestAccEC2LaunchTemplate_networkInterface
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceType
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceCardIndex
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (18.13s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (18.83s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (19.00s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (19.14s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (19.14s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (19.50s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceAddresses (24.70s)
--- PASS: TestAccEC2LaunchTemplate_networkInterface (24.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	27.604s
```

I tried to write a failing test (adding `resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.device_index", "0")`) but that test seemed to pass even without the change in this pr