### PR TITLE
fix(kafka): remove diff supress on configuration_info in msk_cluster

### DIFF
--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -160,10 +160,9 @@ func ResourceCluster() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
 			"configuration_info": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				MaxItems:         1,
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"arn": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17484 and #23662

In my last PR #23662 I fixed the diff on the `aws_msk_configuration` resource, however the issue described in #17484 is still persisting, means `aws_msk_cluster ` still not get refreshed once the configuration revision referenced is switched to `(known after apply)`, I saw that that the `DiffSuppressFunc` seems to cause that, once removed it works as expected.

I didn't figure out what`verify.SuppressMissingOptionalConfigurationBlock` is intended for in this case.

