### PR TITLE
docs/s3_bucket_object_lock_configuration: remove indentation of code blocks in ordered list

### DIFF
--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -44,37 +44,41 @@ This is a multistep process that requires AWS Support intervention.
 1. Enable versioning on your S3 bucket, if you have not already done so.
 Doing so will generate an "Object Lock token" in the back-end.
 
-   ```terraform
-    resource "aws_s3_bucket" "example" {
-      bucket = "mybucket"
-    }
+<!-- markdownlint-disable MD029 -->
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "mybucket"
+}
 
-    resource "aws_s3_bucket_versioning" "example" {
-      bucket = aws_s3_bucket.example.bucket
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.bucket
 
-      versioning_configuration {
-        status = "Enabled"
-      }
-    }
-    ```
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+```
+<!-- markdownlint-disable MD029 -->
 
 2. Contact AWS Support to provide you with the "Object Lock token" for the specified bucket and use the token (or token ID) within your new `aws_s3_bucket_object_lock_configuration` resource.
-   Notice the `object_lock_enabled` argument does not need to be specified as it defaults to `Enabled`.
+Notice the `object_lock_enabled` argument does not need to be specified as it defaults to `Enabled`.
 
-    ```terraform
-    resource "aws_s3_bucket_object_lock_configuration" "example" {
-      bucket = aws_s3_bucket.example.bucket
+<!-- markdownlint-disable MD029 -->
+```terraform
+resource "aws_s3_bucket_object_lock_configuration" "example" {
+  bucket = aws_s3_bucket.example.bucket
 
-      rule {
-        default_retention {
-          mode = "COMPLIANCE"
-          days = 5
-        }
-      }
-
-      token = "NG2MKsfoLqV3A+aquXneSG4LOu/ekrlXkRXwIPFVfERT7XOPos+/k444d7RIH0E3W3p5QU6ml2exS2F/eYCFmMWHJ3hFZGk6al1sIJkmNhUMYmsv0jYVQyTTZNLM+DnfooA6SATt39mM1VW1yJh4E+XljMlWzaBwHKbss3/EjlGDjOmVhaSs4Z6427mMCaFD0RLwsYY7zX49gEc31YfOMJGxbXCXSeyNwAhhM/A8UH7gQf38RmjHjjAFbbbLtl8arsxTPW8F1IYohqwmKIr9DnotLLj8Tg44U2SPwujVaqmlKKP9s41rfgb4UbIm7khSafDBng0LGfxC4pMlT9Ny2w=="
+  rule {
+    default_retention {
+      mode = "COMPLIANCE"
+      days = 5
     }
-    ```
+  }
+
+  token = "NG2MKsfoLqV3A+aquXneSG4LOu/ekrlXkRXwIPFVfERT7XOPos+/k444d7RIH0E3W3p5QU6ml2exS2F/eYCFmMWHJ3hFZGk6al1sIJkmNhUMYmsv0jYVQyTTZNLM+DnfooA6SATt39mM1VW1yJh4E+XljMlWzaBwHKbss3/EjlGDjOmVhaSs4Z6427mMCaFD0RLwsYY7zX49gEc31YfOMJGxbXCXSeyNwAhhM/A8UH7gQf38RmjHjjAFbbbLtl8arsxTPW8F1IYohqwmKIr9DnotLLj8Tg44U2SPwujVaqmlKKP9s41rfgb4UbIm7khSafDBng0LGfxC4pMlT9Ny2w=="
+}
+```
+<!-- markdownlint-disable MD029 -->
 
 ## Usage Notes
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Notes
* had to disable `MD029` in the doc section as it does not seem to like having code blocks between ordered list items
* removed the indentation of the code blocks as that seems to be problematic but it's not tested

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23761
Relates #23449 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
