### PR TITLE
r/aws_ecs_service: fix `load_balancer` & `service_registries` to update without destroy & recreate

### DIFF
--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1073,7 +1073,9 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.HasChange("load_balancer") {
-			input.LoadBalancers = expandLoadBalancers(d.Get("load_balancer").([]interface{}))
+			if v, ok := d.Get("load_balancer").(*schema.Set); ok && v != nil {
+				input.LoadBalancers = expandLoadBalancers(v.List())
+			}
 		}
 
 		if d.HasChange("propagate_tags") {

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -185,26 +185,22 @@ func ResourceService() *schema.Resource {
 						"elb_name": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 						},
 
 						"target_group_arn": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 
 						"container_name": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 
 						"container_port": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(0, 65536),
 						},
 					},
@@ -319,24 +315,20 @@ func ResourceService() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"container_name": {
 							Type:     schema.TypeString,
-							ForceNew: true,
 							Optional: true,
 						},
 						"container_port": {
 							Type:         schema.TypeInt,
-							ForceNew:     true,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 65536),
 						},
 						"port": {
 							Type:         schema.TypeInt,
-							ForceNew:     true,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 65536),
 						},
 						"registry_arn": {
 							Type:         schema.TypeString,
-							ForceNew:     true,
 							Required:     true,
 							ValidateFunc: verify.ValidARN,
 						},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #23596
Relates to #23581

Relates to https://github.com/hashicorp/terraform-provider-aws/pull/23600

The above mentioned PR seems to not eliminate the recreation of the ECS service when updating the `load_balancer` and `service_registries`. It looks like there were some left over `ForceNew`s.

**Also, there is a cast error when using the `load_balancer` field which can lead to a panic.**

Unfortunately it seems like the AWS ECS API has a bug in the UpdateService call since we cannot update with a classic load balancer. Any idea how to proceed here?

Output from acceptance testing:

```
$ make testacc TESTS=TestAccECSService PKG=ecs
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService'  -timeout 180m
=== RUN   TestAccECSServiceDataSource_basic
=== PAUSE TestAccECSServiceDataSource_basic
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_basicImport
=== PAUSE TestAccECSService_basicImport
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_CapacityProviderStrategy_multiple
=== PAUSE TestAccECSService_CapacityProviderStrategy_multiple
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_renamedCluster
=== PAUSE TestAccECSService_renamedCluster
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== CONT  TestAccECSServiceDataSource_basic
=== CONT  TestAccECSService_multipleTargetGroups
=== CONT  TestAccECSService_ServiceRegistries_changes
=== CONT  TestAccECSService_executeCommand
=== CONT  TestAccECSService_Tags_propagate
=== CONT  TestAccECSService_Tags_managed
=== CONT  TestAccECSService_Tags_basic
=== CONT  TestAccECSService_LaunchTypeFargate_basic
=== CONT  TestAccECSService_LaunchTypeEC2_network
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
=== CONT  TestAccECSService_PlacementStrategy_missing
=== CONT  TestAccECSService_PlacementConstraints_basic
=== CONT  TestAccECSService_PlacementStrategy_basic
=== CONT  TestAccECSService_forceNewDeployment
=== CONT  TestAccECSService_ServiceRegistries_basic
=== CONT  TestAccECSService_ServiceRegistries_container
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_PlacementStrategy_missing (17.34s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (110.80s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_replicaSchedulingStrategy (156.62s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (157.41s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSServiceDataSource_basic (157.97s)
=== CONT  TestAccECSService_loadBalancerChanges
--- PASS: TestAccECSService_Tags_managed (161.92s)
=== CONT  TestAccECSService_deploymentCircuitBreaker
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (190.32s)
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
--- PASS: TestAccECSService_forceNewDeployment (203.07s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_PlacementConstraints_basic (204.13s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_executeCommand (224.70s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_LaunchTypeEC2_network (226.00s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_ServiceRegistries_container (239.25s)
=== CONT  TestAccECSService_iamRole
--- PASS: TestAccECSService_ServiceRegistries_basic (241.41s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== CONT  TestAccECSService_loadBalancerChanges
    service_test.go:564: Step 2/2 error: Error running apply: exit status 1
        
        Error: error updating ECS Service (arn:aws:ecs:eu-central-1:671112438854:service/tf-acc-test-699177274688101980/tf-acc-test-699177274688101980): InvalidParameterException: Target Group Arn can not be blank.
        
          with aws_ecs_service.test,
          on terraform_plugin_test.tf line 111, in resource "aws_ecs_service" "test":
         111: resource "aws_ecs_service" "test" {
        
--- PASS: TestAccECSService_Tags_propagate (258.67s)
=== CONT  TestAccECSService_renamedCluster
--- PASS: TestAccECSService_clusterName (102.54s)
=== CONT  TestAccECSService_familyAndRevision
--- PASS: TestAccECSService_Tags_basic (267.45s)
=== CONT  TestAccECSService_CapacityProviderStrategy_multiple
--- PASS: TestAccECSService_deploymentCircuitBreaker (111.37s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
--- FAIL: TestAccECSService_loadBalancerChanges (117.86s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_DeploymentControllerType_external (74.22s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_PlacementStrategy_basic (300.80s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (110.52s)
=== CONT  TestAccECSService_basicImport
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (301.24s)
=== CONT  TestAccECSService_basic
--- PASS: TestAccECSService_LaunchTypeFargate_basic (301.32s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_DeploymentValues_basic (101.32s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (311.68s)
--- PASS: TestAccECSService_iamRole (89.64s)
--- PASS: TestAccECSService_multipleTargetGroups (331.09s)
--- PASS: TestAccECSService_disappears (80.10s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (57.47s)
--- PASS: TestAccECSService_ServiceRegistries_changes (359.84s)
--- PASS: TestAccECSService_familyAndRevision (112.50s)
--- PASS: TestAccECSService_renamedCluster (123.91s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (115.91s)
--- PASS: TestAccECSService_basicImport (92.96s)
--- PASS: TestAccECSService_basic (98.87s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (103.66s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (170.26s)
--- PASS: TestAccECSService_alb (301.24s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (187.97s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (343.75s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (307.74s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (287.71s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (415.54s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ecs        640.391s
FAIL
make: *** [GNUmakefile:36: testacc] Error 1
...
```
