### PR TITLE
Move service name info out of internal

### DIFF
--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestProvider(t *testing.T) {
@@ -174,7 +175,7 @@ func TestAccProvider_endpoints(t *testing.T) {
 	var endpoints strings.Builder
 
 	// Initialize each endpoint configuration with matching name and value
-	for _, serviceKey := range conns.ServiceKeys() {
+	for _, serviceKey := range names.ServiceKeys() {
 		endpoints.WriteString(fmt.Sprintf("%s = \"http://%s\"\n", serviceKey, serviceKey))
 	}
 
@@ -829,7 +830,7 @@ func testAccCheckEndpoints(providers *[]*schema.Provider) resource.TestCheckFunc
 			return func(name string) bool {
 				serviceUpper := ""
 				var err error
-				if serviceUpper, err = conns.ServiceProviderNameUpper(key); err != nil {
+				if serviceUpper, err = names.ServiceProviderNameUpper(key); err != nil {
 					return false
 				}
 
@@ -844,7 +845,7 @@ func testAccCheckEndpoints(providers *[]*schema.Provider) resource.TestCheckFunc
 
 			providerClient := provo.Meta().(*conns.AWSClient)
 
-			for _, serviceKey := range conns.ServiceKeys() {
+			for _, serviceKey := range names.ServiceKeys() {
 				providerClientField := reflect.Indirect(reflect.ValueOf(providerClient)).FieldByNameFunc(endpointFieldNameF(serviceKey))
 
 				if !providerClientField.IsValid() {
@@ -875,7 +876,7 @@ func testAccCheckUnusualEndpoints(providers *[]*schema.Provider, unusual1, unusu
 			return func(name string) bool {
 				serviceUpper := ""
 				var err error
-				if serviceUpper, err = conns.ServiceProviderNameUpper(key); err != nil {
+				if serviceUpper, err = names.ServiceProviderNameUpper(key); err != nil {
 					return false
 				}
 

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -288,584 +288,9 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
 	"github.com/hashicorp/terraform-provider-aws/version"
 )
-
-const (
-	AccessAnalyzer                = "accessanalyzer"
-	Account                       = "account"
-	ACM                           = "acm"
-	ACMPCA                        = "acmpca"
-	AlexaForBusiness              = "alexaforbusiness"
-	AMP                           = "amp"
-	Amplify                       = "amplify"
-	AmplifyBackend                = "amplifybackend"
-	APIGateway                    = "apigateway"
-	APIGatewayV2                  = "apigatewayv2"
-	AppAutoScaling                = "appautoscaling"
-	AppConfig                     = "appconfig"
-	AppFlow                       = "appflow"
-	AppIntegrations               = "appintegrations"
-	ApplicationCostProfiler       = "applicationcostprofiler"
-	ApplicationDiscovery          = "applicationdiscovery"
-	ApplicationInsights           = "applicationinsights"
-	AppMesh                       = "appmesh"
-	AppRegistry                   = "appregistry"
-	AppRunner                     = "apprunner"
-	AppStream                     = "appstream"
-	AppSync                       = "appsync"
-	Athena                        = "athena"
-	AuditManager                  = "auditmanager"
-	AugmentedAIRuntime            = "augmentedairuntime"
-	AutoScaling                   = "autoscaling"
-	AutoScalingPlans              = "autoscalingplans"
-	Backup                        = "backup"
-	Batch                         = "batch"
-	Braket                        = "braket"
-	Budgets                       = "budgets"
-	Chime                         = "chime"
-	Cloud9                        = "cloud9"
-	CloudControl                  = "cloudcontrol"
-	CloudDirectory                = "clouddirectory"
-	CloudFormation                = "cloudformation"
-	CloudFront                    = "cloudfront"
-	CloudHSMV2                    = "cloudhsmv2"
-	CloudSearch                   = "cloudsearch"
-	CloudSearchDomain             = "cloudsearchdomain"
-	CloudTrail                    = "cloudtrail"
-	CloudWatch                    = "cloudwatch"
-	CloudWatchLogs                = "cloudwatchlogs"
-	CloudWatchRUM                 = "cloudwatchrum"
-	CodeArtifact                  = "codeartifact"
-	CodeBuild                     = "codebuild"
-	CodeCommit                    = "codecommit"
-	CodeDeploy                    = "codedeploy"
-	CodeGuruProfiler              = "codeguruprofiler"
-	CodeGuruReviewer              = "codegurureviewer"
-	CodePipeline                  = "codepipeline"
-	CodeStar                      = "codestar"
-	CodeStarConnections           = "codestarconnections"
-	CodeStarNotifications         = "codestarnotifications"
-	CognitoIdentity               = "cognitoidentity"
-	CognitoIDP                    = "cognitoidp"
-	CognitoSync                   = "cognitosync"
-	Comprehend                    = "comprehend"
-	ComprehendMedical             = "comprehendmedical"
-	ComputeOptimizer              = "computeoptimizer"
-	ConfigService                 = "configservice"
-	Connect                       = "connect"
-	ConnectContactLens            = "connectcontactlens"
-	ConnectParticipant            = "connectparticipant"
-	CostExplorer                  = "costexplorer"
-	CUR                           = "cur"
-	CustomerProfiles              = "customerprofiles"
-	DataExchange                  = "dataexchange"
-	DataPipeline                  = "datapipeline"
-	DataSync                      = "datasync"
-	DAX                           = "dax"
-	Detective                     = "detective"
-	DeviceFarm                    = "devicefarm"
-	DevOpsGuru                    = "devopsguru"
-	DirectConnect                 = "directconnect"
-	DLM                           = "dlm"
-	DMS                           = "dms"
-	DocDB                         = "docdb"
-	DS                            = "ds"
-	DynamoDB                      = "dynamodb"
-	DynamoDBStreams               = "dynamodbstreams"
-	EC2                           = "ec2"
-	EC2InstanceConnect            = "ec2instanceconnect"
-	ECR                           = "ecr"
-	ECRPublic                     = "ecrpublic"
-	ECS                           = "ecs"
-	EFS                           = "efs"
-	EKS                           = "eks"
-	ElastiCache                   = "elasticache"
-	ElasticBeanstalk              = "elasticbeanstalk"
-	ElasticInference              = "elasticinference"
-	Elasticsearch                 = "elasticsearch"
-	ElasticTranscoder             = "elastictranscoder"
-	ELB                           = "elb"
-	ELBV2                         = "elbv2"
-	EMR                           = "emr"
-	EMRContainers                 = "emrcontainers"
-	Events                        = "events"
-	FinSpace                      = "finspace"
-	FinSpaceData                  = "finspacedata"
-	Firehose                      = "firehose"
-	FIS                           = "fis"
-	FMS                           = "fms"
-	Forecast                      = "forecast"
-	ForecastQuery                 = "forecastquery"
-	FraudDetector                 = "frauddetector"
-	FSx                           = "fsx"
-	GameLift                      = "gamelift"
-	Glacier                       = "glacier"
-	GlobalAccelerator             = "globalaccelerator"
-	Glue                          = "glue"
-	GlueDataBrew                  = "gluedatabrew"
-	Grafana                       = "grafana"
-	Greengrass                    = "greengrass"
-	GreengrassV2                  = "greengrassv2"
-	GroundStation                 = "groundstation"
-	GuardDuty                     = "guardduty"
-	Health                        = "health"
-	HealthLake                    = "healthlake"
-	Honeycode                     = "honeycode"
-	IAM                           = "iam"
-	IdentityStore                 = "identitystore"
-	ImageBuilder                  = "imagebuilder"
-	Inspector                     = "inspector"
-	IoT                           = "iot"
-	IoT1ClickDevices              = "iot1clickdevices"
-	IoT1ClickProjects             = "iot1clickprojects"
-	IoTAnalytics                  = "iotanalytics"
-	IoTDataPlane                  = "iotdataplane"
-	IoTDeviceAdvisor              = "iotdeviceadvisor"
-	IoTEvents                     = "iotevents"
-	IoTEventsData                 = "ioteventsdata"
-	IoTFleetHub                   = "iotfleethub"
-	IoTJobsDataPlane              = "iotjobsdataplane"
-	IoTSecureTunneling            = "iotsecuretunneling"
-	IoTSiteWise                   = "iotsitewise"
-	IoTThingsGraph                = "iotthingsgraph"
-	IoTWireless                   = "iotwireless"
-	IVS                           = "ivs"
-	Kafka                         = "kafka"
-	KafkaConnect                  = "kafkaconnect"
-	Kendra                        = "kendra"
-	Keyspaces                     = "keyspaces"
-	Kinesis                       = "kinesis"
-	KinesisAnalytics              = "kinesisanalytics"
-	KinesisAnalyticsV2            = "kinesisanalyticsv2"
-	KinesisVideo                  = "kinesisvideo"
-	KinesisVideoArchivedMedia     = "kinesisvideoarchivedmedia"
-	KinesisVideoMedia             = "kinesisvideomedia"
-	KinesisVideoSignalingChannels = "kinesisvideosignalingchannels"
-	KMS                           = "kms"
-	LakeFormation                 = "lakeformation"
-	Lambda                        = "lambda"
-	LexModels                     = "lexmodels"
-	LexModelsV2                   = "lexmodelsv2"
-	LexRuntime                    = "lexruntime"
-	LexRuntimeV2                  = "lexruntimev2"
-	LicenseManager                = "licensemanager"
-	Lightsail                     = "lightsail"
-	Location                      = "location"
-	LookoutEquipment              = "lookoutequipment"
-	LookoutForVision              = "lookoutforvision"
-	LookoutMetrics                = "lookoutmetrics"
-	MachineLearning               = "machinelearning"
-	Macie                         = "macie"
-	Macie2                        = "macie2"
-	ManagedBlockchain             = "managedblockchain"
-	MarketplaceCatalog            = "marketplacecatalog"
-	MarketplaceCommerceAnalytics  = "marketplacecommerceanalytics"
-	MarketplaceEntitlement        = "marketplaceentitlement"
-	MarketplaceMetering           = "marketplacemetering"
-	MediaConnect                  = "mediaconnect"
-	MediaConvert                  = "mediaconvert"
-	MediaLive                     = "medialive"
-	MediaPackage                  = "mediapackage"
-	MediaPackageVOD               = "mediapackagevod"
-	MediaStore                    = "mediastore"
-	MediaStoreData                = "mediastoredata"
-	MediaTailor                   = "mediatailor"
-	MemoryDB                      = "memorydb"
-	Mgn                           = "mgn"
-	MigrationHub                  = "migrationhub"
-	MigrationHubConfig            = "migrationhubconfig"
-	Mobile                        = "mobile"
-	MobileAnalytics               = "mobileanalytics"
-	MQ                            = "mq"
-	MTurk                         = "mturk"
-	MWAA                          = "mwaa"
-	Neptune                       = "neptune"
-	NetworkFirewall               = "networkfirewall"
-	NetworkManager                = "networkmanager"
-	NimbleStudio                  = "nimblestudio"
-	OpsWorks                      = "opsworks"
-	OpsWorksCM                    = "opsworkscm"
-	Organizations                 = "organizations"
-	Outposts                      = "outposts"
-	Personalize                   = "personalize"
-	PersonalizeEvents             = "personalizeevents"
-	PersonalizeRuntime            = "personalizeruntime"
-	PI                            = "pi"
-	Pinpoint                      = "pinpoint"
-	PinpointEmail                 = "pinpointemail"
-	PinpointSMSVoice              = "pinpointsmsvoice"
-	Polly                         = "polly"
-	Pricing                       = "pricing"
-	Proton                        = "proton"
-	QLDB                          = "qldb"
-	QLDBSession                   = "qldbsession"
-	QuickSight                    = "quicksight"
-	RAM                           = "ram"
-	RDS                           = "rds"
-	RDSData                       = "rdsdata"
-	Redshift                      = "redshift"
-	RedshiftData                  = "redshiftdata"
-	Rekognition                   = "rekognition"
-	ResourceGroups                = "resourcegroups"
-	ResourceGroupsTaggingAPI      = "resourcegroupstaggingapi"
-	RoboMaker                     = "robomaker"
-	Route53                       = "route53"
-	Route53Domains                = "route53domains"
-	Route53RecoveryControlConfig  = "route53recoverycontrolconfig"
-	Route53RecoveryReadiness      = "route53recoveryreadiness"
-	Route53Resolver               = "route53resolver"
-	S3                            = "s3"
-	S3Control                     = "s3control"
-	S3Outposts                    = "s3outposts"
-	SageMaker                     = "sagemaker"
-	SageMakerEdgeManager          = "sagemakeredgemanager"
-	SageMakerFeatureStoreRuntime  = "sagemakerfeaturestoreruntime"
-	SageMakerRuntime              = "sagemakerruntime"
-	SavingsPlans                  = "savingsplans"
-	Schemas                       = "schemas"
-	SecretsManager                = "secretsmanager"
-	SecurityHub                   = "securityhub"
-	ServerlessRepo                = "serverlessrepo"
-	ServiceCatalog                = "servicecatalog"
-	ServiceDiscovery              = "servicediscovery"
-	ServiceQuotas                 = "servicequotas"
-	SES                           = "ses"
-	SESV2                         = "sesv2"
-	SFN                           = "sfn"
-	Shield                        = "shield"
-	Signer                        = "signer"
-	SimpleDB                      = "simpledb"
-	SMS                           = "sms"
-	Snowball                      = "snowball"
-	SNS                           = "sns"
-	SQS                           = "sqs"
-	SSM                           = "ssm"
-	SSMContacts                   = "ssmcontacts"
-	SSMIncidents                  = "ssmincidents"
-	SSO                           = "sso"
-	SSOAdmin                      = "ssoadmin"
-	SSOOIDC                       = "ssooidc"
-	StorageGateway                = "storagegateway"
-	STS                           = "sts"
-	Support                       = "support"
-	SWF                           = "swf"
-	Synthetics                    = "synthetics"
-	Textract                      = "textract"
-	TimestreamQuery               = "timestreamquery"
-	TimestreamWrite               = "timestreamwrite"
-	Transcribe                    = "transcribe"
-	TranscribeStreaming           = "transcribestreaming"
-	Transfer                      = "transfer"
-	Translate                     = "translate"
-	WAF                           = "waf"
-	WAFRegional                   = "wafregional"
-	WAFV2                         = "wafv2"
-	WellArchitected               = "wellarchitected"
-	WorkDocs                      = "workdocs"
-	WorkLink                      = "worklink"
-	WorkMail                      = "workmail"
-	WorkMailMessageFlow           = "workmailmessageflow"
-	WorkSpaces                    = "workspaces"
-	XRay                          = "xray"
-)
-
-// These "should" be defined by the AWS Go SDK v2, but currently aren't.
-const (
-	Route53DomainsEndpointID  = "route53domains"
-	Route53DomainsServiceName = "route53domains"
-)
-
-type ServiceDatum struct {
-	AWSClientName     string
-	AWSServiceName    string
-	AWSEndpointsID    string
-	AWSServiceID      string
-	ProviderNameUpper string
-	HCLKeys           []string
-	EnvVar            string
-	DeprecatedEnvVar  string
-}
-
-var serviceData map[string]*ServiceDatum
-
-func init() {
-	serviceData = make(map[string]*ServiceDatum)
-
-	serviceData[AccessAnalyzer] = &ServiceDatum{AWSClientName: "AccessAnalyzer", AWSServiceName: accessanalyzer.ServiceName, AWSEndpointsID: accessanalyzer.EndpointsID, AWSServiceID: accessanalyzer.ServiceID, ProviderNameUpper: "AccessAnalyzer", HCLKeys: []string{"accessanalyzer"}}
-	serviceData[Account] = &ServiceDatum{AWSClientName: "Account", AWSServiceName: account.ServiceName, AWSEndpointsID: account.EndpointsID, AWSServiceID: account.ServiceID, ProviderNameUpper: "Account", HCLKeys: []string{"account"}}
-	serviceData[ACM] = &ServiceDatum{AWSClientName: "ACM", AWSServiceName: acm.ServiceName, AWSEndpointsID: acm.EndpointsID, AWSServiceID: acm.ServiceID, ProviderNameUpper: "ACM", HCLKeys: []string{"acm"}}
-	serviceData[ACMPCA] = &ServiceDatum{AWSClientName: "ACMPCA", AWSServiceName: acmpca.ServiceName, AWSEndpointsID: acmpca.EndpointsID, AWSServiceID: acmpca.ServiceID, ProviderNameUpper: "ACMPCA", HCLKeys: []string{"acmpca"}}
-	serviceData[AlexaForBusiness] = &ServiceDatum{AWSClientName: "AlexaForBusiness", AWSServiceName: alexaforbusiness.ServiceName, AWSEndpointsID: alexaforbusiness.EndpointsID, AWSServiceID: alexaforbusiness.ServiceID, ProviderNameUpper: "AlexaForBusiness", HCLKeys: []string{"alexaforbusiness"}}
-	serviceData[AMP] = &ServiceDatum{AWSClientName: "PrometheusService", AWSServiceName: prometheusservice.ServiceName, AWSEndpointsID: prometheusservice.EndpointsID, AWSServiceID: prometheusservice.ServiceID, ProviderNameUpper: "AMP", HCLKeys: []string{"amp", "prometheus", "prometheusservice"}}
-	serviceData[Amplify] = &ServiceDatum{AWSClientName: "Amplify", AWSServiceName: amplify.ServiceName, AWSEndpointsID: amplify.EndpointsID, AWSServiceID: amplify.ServiceID, ProviderNameUpper: "Amplify", HCLKeys: []string{"amplify"}}
-	serviceData[AmplifyBackend] = &ServiceDatum{AWSClientName: "AmplifyBackend", AWSServiceName: amplifybackend.ServiceName, AWSEndpointsID: amplifybackend.EndpointsID, AWSServiceID: amplifybackend.ServiceID, ProviderNameUpper: "AmplifyBackend", HCLKeys: []string{"amplifybackend"}}
-	serviceData[APIGateway] = &ServiceDatum{AWSClientName: "APIGateway", AWSServiceName: apigateway.ServiceName, AWSEndpointsID: apigateway.EndpointsID, AWSServiceID: apigateway.ServiceID, ProviderNameUpper: "APIGateway", HCLKeys: []string{"apigateway"}}
-	serviceData[APIGatewayV2] = &ServiceDatum{AWSClientName: "APIGatewayV2", AWSServiceName: apigatewayv2.ServiceName, AWSEndpointsID: apigatewayv2.EndpointsID, AWSServiceID: apigatewayv2.ServiceID, ProviderNameUpper: "APIGatewayV2", HCLKeys: []string{"apigatewayv2"}}
-	serviceData[AppAutoScaling] = &ServiceDatum{AWSClientName: "ApplicationAutoScaling", AWSServiceName: applicationautoscaling.ServiceName, AWSEndpointsID: applicationautoscaling.EndpointsID, AWSServiceID: applicationautoscaling.ServiceID, ProviderNameUpper: "AppAutoScaling", HCLKeys: []string{"appautoscaling", "applicationautoscaling"}}
-	serviceData[AppConfig] = &ServiceDatum{AWSClientName: "AppConfig", AWSServiceName: appconfig.ServiceName, AWSEndpointsID: appconfig.EndpointsID, AWSServiceID: appconfig.ServiceID, ProviderNameUpper: "AppConfig", HCLKeys: []string{"appconfig"}}
-	serviceData[AppFlow] = &ServiceDatum{AWSClientName: "Appflow", AWSServiceName: appflow.ServiceName, AWSEndpointsID: appflow.EndpointsID, AWSServiceID: appflow.ServiceID, ProviderNameUpper: "AppFlow", HCLKeys: []string{"appflow"}}
-	serviceData[AppIntegrations] = &ServiceDatum{AWSClientName: "AppIntegrationsService", AWSServiceName: appintegrationsservice.ServiceName, AWSEndpointsID: appintegrationsservice.EndpointsID, AWSServiceID: appintegrationsservice.ServiceID, ProviderNameUpper: "AppIntegrations", HCLKeys: []string{"appintegrations", "appintegrationsservice"}}
-	serviceData[ApplicationCostProfiler] = &ServiceDatum{AWSClientName: "ApplicationCostProfiler", AWSServiceName: applicationcostprofiler.ServiceName, AWSEndpointsID: applicationcostprofiler.EndpointsID, AWSServiceID: applicationcostprofiler.ServiceID, ProviderNameUpper: "ApplicationCostProfiler", HCLKeys: []string{"applicationcostprofiler"}}
-	serviceData[ApplicationDiscovery] = &ServiceDatum{AWSClientName: "ApplicationDiscoveryService", AWSServiceName: applicationdiscoveryservice.ServiceName, AWSEndpointsID: applicationdiscoveryservice.EndpointsID, AWSServiceID: applicationdiscoveryservice.ServiceID, ProviderNameUpper: "ApplicationDiscovery", HCLKeys: []string{"applicationdiscovery", "applicationdiscoveryservice"}}
-	serviceData[ApplicationInsights] = &ServiceDatum{AWSClientName: "ApplicationInsights", AWSServiceName: applicationinsights.ServiceName, AWSEndpointsID: applicationinsights.EndpointsID, AWSServiceID: applicationinsights.ServiceID, ProviderNameUpper: "ApplicationInsights", HCLKeys: []string{"applicationinsights"}}
-	serviceData[AppMesh] = &ServiceDatum{AWSClientName: "AppMesh", AWSServiceName: appmesh.ServiceName, AWSEndpointsID: appmesh.EndpointsID, AWSServiceID: appmesh.ServiceID, ProviderNameUpper: "AppMesh", HCLKeys: []string{"appmesh"}}
-	serviceData[AppRegistry] = &ServiceDatum{AWSClientName: "AppRegistry", AWSServiceName: appregistry.ServiceName, AWSEndpointsID: appregistry.EndpointsID, AWSServiceID: appregistry.ServiceID, ProviderNameUpper: "AppRegistry", HCLKeys: []string{"appregistry"}}
-	serviceData[AppRunner] = &ServiceDatum{AWSClientName: "AppRunner", AWSServiceName: apprunner.ServiceName, AWSEndpointsID: apprunner.EndpointsID, AWSServiceID: apprunner.ServiceID, ProviderNameUpper: "AppRunner", HCLKeys: []string{"apprunner"}}
-	serviceData[AppStream] = &ServiceDatum{AWSClientName: "AppStream", AWSServiceName: appstream.ServiceName, AWSEndpointsID: appstream.EndpointsID, AWSServiceID: appstream.ServiceID, ProviderNameUpper: "AppStream", HCLKeys: []string{"appstream"}}
-	serviceData[AppSync] = &ServiceDatum{AWSClientName: "AppSync", AWSServiceName: appsync.ServiceName, AWSEndpointsID: appsync.EndpointsID, AWSServiceID: appsync.ServiceID, ProviderNameUpper: "AppSync", HCLKeys: []string{"appsync"}}
-	serviceData[Athena] = &ServiceDatum{AWSClientName: "Athena", AWSServiceName: athena.ServiceName, AWSEndpointsID: athena.EndpointsID, AWSServiceID: athena.ServiceID, ProviderNameUpper: "Athena", HCLKeys: []string{"athena"}}
-	serviceData[AuditManager] = &ServiceDatum{AWSClientName: "AuditManager", AWSServiceName: auditmanager.ServiceName, AWSEndpointsID: auditmanager.EndpointsID, AWSServiceID: auditmanager.ServiceID, ProviderNameUpper: "AuditManager", HCLKeys: []string{"auditmanager"}}
-	serviceData[AugmentedAIRuntime] = &ServiceDatum{AWSClientName: "AugmentedAIRuntime", AWSServiceName: augmentedairuntime.ServiceName, AWSEndpointsID: augmentedairuntime.EndpointsID, AWSServiceID: augmentedairuntime.ServiceID, ProviderNameUpper: "AugmentedAIRuntime", HCLKeys: []string{"augmentedairuntime"}}
-	serviceData[AutoScaling] = &ServiceDatum{AWSClientName: "AutoScaling", AWSServiceName: autoscaling.ServiceName, AWSEndpointsID: autoscaling.EndpointsID, AWSServiceID: autoscaling.ServiceID, ProviderNameUpper: "AutoScaling", HCLKeys: []string{"autoscaling"}}
-	serviceData[AutoScalingPlans] = &ServiceDatum{AWSClientName: "AutoScalingPlans", AWSServiceName: autoscalingplans.ServiceName, AWSEndpointsID: autoscalingplans.EndpointsID, AWSServiceID: autoscalingplans.ServiceID, ProviderNameUpper: "AutoScalingPlans", HCLKeys: []string{"autoscalingplans"}}
-	serviceData[Backup] = &ServiceDatum{AWSClientName: "Backup", AWSServiceName: backup.ServiceName, AWSEndpointsID: backup.EndpointsID, AWSServiceID: backup.ServiceID, ProviderNameUpper: "Backup", HCLKeys: []string{"backup"}}
-	serviceData[Batch] = &ServiceDatum{AWSClientName: "Batch", AWSServiceName: batch.ServiceName, AWSEndpointsID: batch.EndpointsID, AWSServiceID: batch.ServiceID, ProviderNameUpper: "Batch", HCLKeys: []string{"batch"}}
-	serviceData[Braket] = &ServiceDatum{AWSClientName: "Braket", AWSServiceName: braket.ServiceName, AWSEndpointsID: braket.EndpointsID, AWSServiceID: braket.ServiceID, ProviderNameUpper: "Braket", HCLKeys: []string{"braket"}}
-	serviceData[Budgets] = &ServiceDatum{AWSClientName: "Budgets", AWSServiceName: budgets.ServiceName, AWSEndpointsID: budgets.EndpointsID, AWSServiceID: budgets.ServiceID, ProviderNameUpper: "Budgets", HCLKeys: []string{"budgets"}}
-	serviceData[Chime] = &ServiceDatum{AWSClientName: "Chime", AWSServiceName: chime.ServiceName, AWSEndpointsID: chime.EndpointsID, AWSServiceID: chime.ServiceID, ProviderNameUpper: "Chime", HCLKeys: []string{"chime"}}
-	serviceData[Cloud9] = &ServiceDatum{AWSClientName: "Cloud9", AWSServiceName: cloud9.ServiceName, AWSEndpointsID: cloud9.EndpointsID, AWSServiceID: cloud9.ServiceID, ProviderNameUpper: "Cloud9", HCLKeys: []string{"cloud9"}}
-	serviceData[CloudControl] = &ServiceDatum{AWSClientName: "CloudControlApi", AWSServiceName: cloudcontrolapi.ServiceName, AWSEndpointsID: cloudcontrolapi.EndpointsID, AWSServiceID: cloudcontrolapi.ServiceID, ProviderNameUpper: "CloudControl", HCLKeys: []string{"cloudcontrolapi", "cloudcontrol"}}
-	serviceData[CloudDirectory] = &ServiceDatum{AWSClientName: "CloudDirectory", AWSServiceName: clouddirectory.ServiceName, AWSEndpointsID: clouddirectory.EndpointsID, AWSServiceID: clouddirectory.ServiceID, ProviderNameUpper: "CloudDirectory", HCLKeys: []string{"clouddirectory"}}
-	serviceData[CloudFormation] = &ServiceDatum{AWSClientName: "CloudFormation", AWSServiceName: cloudformation.ServiceName, AWSEndpointsID: cloudformation.EndpointsID, AWSServiceID: cloudformation.ServiceID, ProviderNameUpper: "CloudFormation", HCLKeys: []string{"cloudformation"}}
-	serviceData[CloudFront] = &ServiceDatum{AWSClientName: "CloudFront", AWSServiceName: cloudfront.ServiceName, AWSEndpointsID: cloudfront.EndpointsID, AWSServiceID: cloudfront.ServiceID, ProviderNameUpper: "CloudFront", HCLKeys: []string{"cloudfront"}}
-	serviceData[CloudHSMV2] = &ServiceDatum{AWSClientName: "CloudHSMV2", AWSServiceName: cloudhsmv2.ServiceName, AWSEndpointsID: cloudhsmv2.EndpointsID, AWSServiceID: cloudhsmv2.ServiceID, ProviderNameUpper: "CloudHSMV2", HCLKeys: []string{"cloudhsm", "cloudhsmv2"}}
-	serviceData[CloudSearch] = &ServiceDatum{AWSClientName: "CloudSearch", AWSServiceName: cloudsearch.ServiceName, AWSEndpointsID: cloudsearch.EndpointsID, AWSServiceID: cloudsearch.ServiceID, ProviderNameUpper: "CloudSearch", HCLKeys: []string{"cloudsearch"}}
-	serviceData[CloudSearchDomain] = &ServiceDatum{AWSClientName: "CloudSearchDomain", AWSServiceName: cloudsearchdomain.ServiceName, AWSEndpointsID: cloudsearchdomain.EndpointsID, AWSServiceID: cloudsearchdomain.ServiceID, ProviderNameUpper: "CloudSearchDomain", HCLKeys: []string{"cloudsearchdomain"}}
-	serviceData[CloudTrail] = &ServiceDatum{AWSClientName: "CloudTrail", AWSServiceName: cloudtrail.ServiceName, AWSEndpointsID: cloudtrail.EndpointsID, AWSServiceID: cloudtrail.ServiceID, ProviderNameUpper: "CloudTrail", HCLKeys: []string{"cloudtrail"}}
-	serviceData[CloudWatch] = &ServiceDatum{AWSClientName: "CloudWatch", AWSServiceName: cloudwatch.ServiceName, AWSEndpointsID: cloudwatch.EndpointsID, AWSServiceID: cloudwatch.ServiceID, ProviderNameUpper: "CloudWatch", HCLKeys: []string{"cloudwatch"}}
-	serviceData[CloudWatchLogs] = &ServiceDatum{AWSClientName: "CloudWatchLogs", AWSServiceName: cloudwatchlogs.ServiceName, AWSEndpointsID: cloudwatchlogs.EndpointsID, AWSServiceID: cloudwatchlogs.ServiceID, ProviderNameUpper: "CloudWatchLogs", HCLKeys: []string{"cloudwatchlogs"}}
-	serviceData[CloudWatchRUM] = &ServiceDatum{AWSClientName: "CloudWatchRUM", AWSServiceName: cloudwatchrum.ServiceName, AWSEndpointsID: cloudwatchrum.EndpointsID, AWSServiceID: cloudwatchrum.ServiceID, ProviderNameUpper: "CloudWatchRUM", HCLKeys: []string{"cloudwatchrum"}}
-	serviceData[CodeArtifact] = &ServiceDatum{AWSClientName: "CodeArtifact", AWSServiceName: codeartifact.ServiceName, AWSEndpointsID: codeartifact.EndpointsID, AWSServiceID: codeartifact.ServiceID, ProviderNameUpper: "CodeArtifact", HCLKeys: []string{"codeartifact"}}
-	serviceData[CodeBuild] = &ServiceDatum{AWSClientName: "CodeBuild", AWSServiceName: codebuild.ServiceName, AWSEndpointsID: codebuild.EndpointsID, AWSServiceID: codebuild.ServiceID, ProviderNameUpper: "CodeBuild", HCLKeys: []string{"codebuild"}}
-	serviceData[CodeCommit] = &ServiceDatum{AWSClientName: "CodeCommit", AWSServiceName: codecommit.ServiceName, AWSEndpointsID: codecommit.EndpointsID, AWSServiceID: codecommit.ServiceID, ProviderNameUpper: "CodeCommit", HCLKeys: []string{"codecommit"}}
-	serviceData[CodeDeploy] = &ServiceDatum{AWSClientName: "CodeDeploy", AWSServiceName: codedeploy.ServiceName, AWSEndpointsID: codedeploy.EndpointsID, AWSServiceID: codedeploy.ServiceID, ProviderNameUpper: "CodeDeploy", HCLKeys: []string{"codedeploy"}}
-	serviceData[CodeGuruProfiler] = &ServiceDatum{AWSClientName: "CodeGuruProfiler", AWSServiceName: codeguruprofiler.ServiceName, AWSEndpointsID: codeguruprofiler.EndpointsID, AWSServiceID: codeguruprofiler.ServiceID, ProviderNameUpper: "CodeGuruProfiler", HCLKeys: []string{"codeguruprofiler"}}
-	serviceData[CodeGuruReviewer] = &ServiceDatum{AWSClientName: "CodeGuruReviewer", AWSServiceName: codegurureviewer.ServiceName, AWSEndpointsID: codegurureviewer.EndpointsID, AWSServiceID: codegurureviewer.ServiceID, ProviderNameUpper: "CodeGuruReviewer", HCLKeys: []string{"codegurureviewer"}}
-	serviceData[CodePipeline] = &ServiceDatum{AWSClientName: "CodePipeline", AWSServiceName: codepipeline.ServiceName, AWSEndpointsID: codepipeline.EndpointsID, AWSServiceID: codepipeline.ServiceID, ProviderNameUpper: "CodePipeline", HCLKeys: []string{"codepipeline"}}
-	serviceData[CodeStar] = &ServiceDatum{AWSClientName: "CodeStar", AWSServiceName: codestar.ServiceName, AWSEndpointsID: codestar.EndpointsID, AWSServiceID: codestar.ServiceID, ProviderNameUpper: "CodeStar", HCLKeys: []string{"codestar"}}
-	serviceData[CodeStarConnections] = &ServiceDatum{AWSClientName: "CodeStarConnections", AWSServiceName: codestarconnections.ServiceName, AWSEndpointsID: codestarconnections.EndpointsID, AWSServiceID: codestarconnections.ServiceID, ProviderNameUpper: "CodeStarConnections", HCLKeys: []string{"codestarconnections"}}
-	serviceData[CodeStarNotifications] = &ServiceDatum{AWSClientName: "CodeStarNotifications", AWSServiceName: codestarnotifications.ServiceName, AWSEndpointsID: codestarnotifications.EndpointsID, AWSServiceID: codestarnotifications.ServiceID, ProviderNameUpper: "CodeStarNotifications", HCLKeys: []string{"codestarnotifications"}}
-	serviceData[CognitoIdentity] = &ServiceDatum{AWSClientName: "CognitoIdentity", AWSServiceName: cognitoidentity.ServiceName, AWSEndpointsID: cognitoidentity.EndpointsID, AWSServiceID: cognitoidentity.ServiceID, ProviderNameUpper: "CognitoIdentity", HCLKeys: []string{"cognitoidentity"}}
-	serviceData[CognitoIDP] = &ServiceDatum{AWSClientName: "CognitoIdentityProvider", AWSServiceName: cognitoidentityprovider.ServiceName, AWSEndpointsID: cognitoidentityprovider.EndpointsID, AWSServiceID: cognitoidentityprovider.ServiceID, ProviderNameUpper: "CognitoIDP", HCLKeys: []string{"cognitoidp", "cognitoidentityprovider"}}
-	serviceData[CognitoSync] = &ServiceDatum{AWSClientName: "CognitoSync", AWSServiceName: cognitosync.ServiceName, AWSEndpointsID: cognitosync.EndpointsID, AWSServiceID: cognitosync.ServiceID, ProviderNameUpper: "CognitoSync", HCLKeys: []string{"cognitosync"}}
-	serviceData[Comprehend] = &ServiceDatum{AWSClientName: "Comprehend", AWSServiceName: comprehend.ServiceName, AWSEndpointsID: comprehend.EndpointsID, AWSServiceID: comprehend.ServiceID, ProviderNameUpper: "Comprehend", HCLKeys: []string{"comprehend"}}
-	serviceData[ComprehendMedical] = &ServiceDatum{AWSClientName: "ComprehendMedical", AWSServiceName: comprehendmedical.ServiceName, AWSEndpointsID: comprehendmedical.EndpointsID, AWSServiceID: comprehendmedical.ServiceID, ProviderNameUpper: "ComprehendMedical", HCLKeys: []string{"comprehendmedical"}}
-	serviceData[ConfigService] = &ServiceDatum{AWSClientName: "ConfigService", AWSServiceName: configservice.ServiceName, AWSEndpointsID: configservice.EndpointsID, AWSServiceID: configservice.ServiceID, ProviderNameUpper: "ConfigService", HCLKeys: []string{"configservice", "config"}}
-	serviceData[Connect] = &ServiceDatum{AWSClientName: "Connect", AWSServiceName: connect.ServiceName, AWSEndpointsID: connect.EndpointsID, AWSServiceID: connect.ServiceID, ProviderNameUpper: "Connect", HCLKeys: []string{"connect"}}
-	serviceData[ConnectContactLens] = &ServiceDatum{AWSClientName: "ConnectContactLens", AWSServiceName: connectcontactlens.ServiceName, AWSEndpointsID: connectcontactlens.EndpointsID, AWSServiceID: connectcontactlens.ServiceID, ProviderNameUpper: "ConnectContactLens", HCLKeys: []string{"connectcontactlens"}}
-	serviceData[ConnectParticipant] = &ServiceDatum{AWSClientName: "ConnectParticipant", AWSServiceName: connectparticipant.ServiceName, AWSEndpointsID: connectparticipant.EndpointsID, AWSServiceID: connectparticipant.ServiceID, ProviderNameUpper: "ConnectParticipant", HCLKeys: []string{"connectparticipant"}}
-	serviceData[CostExplorer] = &ServiceDatum{AWSClientName: "CostExplorer", AWSServiceName: costexplorer.ServiceName, AWSEndpointsID: costexplorer.EndpointsID, AWSServiceID: costexplorer.ServiceID, ProviderNameUpper: "CostExplorer", HCLKeys: []string{"costexplorer"}}
-	serviceData[CUR] = &ServiceDatum{AWSClientName: "CostandUsageReportService", AWSServiceName: costandusagereportservice.ServiceName, AWSEndpointsID: costandusagereportservice.EndpointsID, AWSServiceID: costandusagereportservice.ServiceID, ProviderNameUpper: "CUR", HCLKeys: []string{"cur", "costandusagereportservice"}}
-	serviceData[DataExchange] = &ServiceDatum{AWSClientName: "DataExchange", AWSServiceName: dataexchange.ServiceName, AWSEndpointsID: dataexchange.EndpointsID, AWSServiceID: dataexchange.ServiceID, ProviderNameUpper: "DataExchange", HCLKeys: []string{"dataexchange"}}
-	serviceData[DataPipeline] = &ServiceDatum{AWSClientName: "DataPipeline", AWSServiceName: datapipeline.ServiceName, AWSEndpointsID: datapipeline.EndpointsID, AWSServiceID: datapipeline.ServiceID, ProviderNameUpper: "DataPipeline", HCLKeys: []string{"datapipeline"}}
-	serviceData[DataSync] = &ServiceDatum{AWSClientName: "DataSync", AWSServiceName: datasync.ServiceName, AWSEndpointsID: datasync.EndpointsID, AWSServiceID: datasync.ServiceID, ProviderNameUpper: "DataSync", HCLKeys: []string{"datasync"}}
-	serviceData[DAX] = &ServiceDatum{AWSClientName: "DAX", AWSServiceName: dax.ServiceName, AWSEndpointsID: dax.EndpointsID, AWSServiceID: dax.ServiceID, ProviderNameUpper: "DAX", HCLKeys: []string{"dax"}}
-	serviceData[Detective] = &ServiceDatum{AWSClientName: "Detective", AWSServiceName: detective.ServiceName, AWSEndpointsID: detective.EndpointsID, AWSServiceID: detective.ServiceID, ProviderNameUpper: "Detective", HCLKeys: []string{"detective"}}
-	serviceData[DeviceFarm] = &ServiceDatum{AWSClientName: "DeviceFarm", AWSServiceName: devicefarm.ServiceName, AWSEndpointsID: devicefarm.EndpointsID, AWSServiceID: devicefarm.ServiceID, ProviderNameUpper: "DeviceFarm", HCLKeys: []string{"devicefarm"}}
-	serviceData[DevOpsGuru] = &ServiceDatum{AWSClientName: "DevOpsGuru", AWSServiceName: devopsguru.ServiceName, AWSEndpointsID: devopsguru.EndpointsID, AWSServiceID: devopsguru.ServiceID, ProviderNameUpper: "DevOpsGuru", HCLKeys: []string{"devopsguru"}}
-	serviceData[DirectConnect] = &ServiceDatum{AWSClientName: "DirectConnect", AWSServiceName: directconnect.ServiceName, AWSEndpointsID: directconnect.EndpointsID, AWSServiceID: directconnect.ServiceID, ProviderNameUpper: "DirectConnect", HCLKeys: []string{"directconnect"}}
-	serviceData[DLM] = &ServiceDatum{AWSClientName: "DLM", AWSServiceName: dlm.ServiceName, AWSEndpointsID: dlm.EndpointsID, AWSServiceID: dlm.ServiceID, ProviderNameUpper: "DLM", HCLKeys: []string{"dlm"}}
-	serviceData[DMS] = &ServiceDatum{AWSClientName: "DatabaseMigrationService", AWSServiceName: databasemigrationservice.ServiceName, AWSEndpointsID: databasemigrationservice.EndpointsID, AWSServiceID: databasemigrationservice.ServiceID, ProviderNameUpper: "DMS", HCLKeys: []string{"dms", "databasemigration", "databasemigrationservice"}}
-	serviceData[DocDB] = &ServiceDatum{AWSClientName: "DocDB", AWSServiceName: docdb.ServiceName, AWSEndpointsID: docdb.EndpointsID, AWSServiceID: docdb.ServiceID, ProviderNameUpper: "DocDB", HCLKeys: []string{"docdb"}}
-	serviceData[DS] = &ServiceDatum{AWSClientName: "DirectoryService", AWSServiceName: directoryservice.ServiceName, AWSEndpointsID: directoryservice.EndpointsID, AWSServiceID: directoryservice.ServiceID, ProviderNameUpper: "DS", HCLKeys: []string{"ds"}}
-	serviceData[DynamoDB] = &ServiceDatum{AWSClientName: "DynamoDB", AWSServiceName: dynamodb.ServiceName, AWSEndpointsID: dynamodb.EndpointsID, AWSServiceID: dynamodb.ServiceID, ProviderNameUpper: "DynamoDB", HCLKeys: []string{"dynamodb"}, EnvVar: "TF_AWS_DYNAMODB_ENDPOINT", DeprecatedEnvVar: "AWS_DYNAMODB_ENDPOINT"}
-	serviceData[DynamoDBStreams] = &ServiceDatum{AWSClientName: "DynamoDBStreams", AWSServiceName: dynamodbstreams.ServiceName, AWSEndpointsID: dynamodbstreams.EndpointsID, AWSServiceID: dynamodbstreams.ServiceID, ProviderNameUpper: "DynamoDBStreams", HCLKeys: []string{"dynamodbstreams"}}
-	serviceData[EC2] = &ServiceDatum{AWSClientName: "EC2", AWSServiceName: ec2.ServiceName, AWSEndpointsID: ec2.EndpointsID, AWSServiceID: ec2.ServiceID, ProviderNameUpper: "EC2", HCLKeys: []string{"ec2"}}
-	serviceData[EC2InstanceConnect] = &ServiceDatum{AWSClientName: "EC2InstanceConnect", AWSServiceName: ec2instanceconnect.ServiceName, AWSEndpointsID: ec2instanceconnect.EndpointsID, AWSServiceID: ec2instanceconnect.ServiceID, ProviderNameUpper: "EC2InstanceConnect", HCLKeys: []string{"ec2instanceconnect"}}
-	serviceData[ECR] = &ServiceDatum{AWSClientName: "ECR", AWSServiceName: ecr.ServiceName, AWSEndpointsID: ecr.EndpointsID, AWSServiceID: ecr.ServiceID, ProviderNameUpper: "ECR", HCLKeys: []string{"ecr"}}
-	serviceData[ECRPublic] = &ServiceDatum{AWSClientName: "ECRPublic", AWSServiceName: ecrpublic.ServiceName, AWSEndpointsID: ecrpublic.EndpointsID, AWSServiceID: ecrpublic.ServiceID, ProviderNameUpper: "ECRPublic", HCLKeys: []string{"ecrpublic"}}
-	serviceData[ECS] = &ServiceDatum{AWSClientName: "ECS", AWSServiceName: ecs.ServiceName, AWSEndpointsID: ecs.EndpointsID, AWSServiceID: ecs.ServiceID, ProviderNameUpper: "ECS", HCLKeys: []string{"ecs"}}
-	serviceData[EFS] = &ServiceDatum{AWSClientName: "EFS", AWSServiceName: efs.ServiceName, AWSEndpointsID: efs.EndpointsID, AWSServiceID: efs.ServiceID, ProviderNameUpper: "EFS", HCLKeys: []string{"efs"}}
-	serviceData[EKS] = &ServiceDatum{AWSClientName: "EKS", AWSServiceName: eks.ServiceName, AWSEndpointsID: eks.EndpointsID, AWSServiceID: eks.ServiceID, ProviderNameUpper: "EKS", HCLKeys: []string{"eks"}}
-	serviceData[ElastiCache] = &ServiceDatum{AWSClientName: "ElastiCache", AWSServiceName: elasticache.ServiceName, AWSEndpointsID: elasticache.EndpointsID, AWSServiceID: elasticache.ServiceID, ProviderNameUpper: "ElastiCache", HCLKeys: []string{"elasticache"}}
-	serviceData[ElasticBeanstalk] = &ServiceDatum{AWSClientName: "ElasticBeanstalk", AWSServiceName: elasticbeanstalk.ServiceName, AWSEndpointsID: elasticbeanstalk.EndpointsID, AWSServiceID: elasticbeanstalk.ServiceID, ProviderNameUpper: "ElasticBeanstalk", HCLKeys: []string{"elasticbeanstalk"}}
-	serviceData[ElasticInference] = &ServiceDatum{AWSClientName: "ElasticInference", AWSServiceName: elasticinference.ServiceName, AWSEndpointsID: elasticinference.EndpointsID, AWSServiceID: elasticinference.ServiceID, ProviderNameUpper: "ElasticInference", HCLKeys: []string{"elasticinference"}}
-	serviceData[Elasticsearch] = &ServiceDatum{AWSClientName: "ElasticsearchService", AWSServiceName: elasticsearch.ServiceName, AWSEndpointsID: elasticsearch.EndpointsID, AWSServiceID: elasticsearch.ServiceID, ProviderNameUpper: "Elasticsearch", HCLKeys: []string{"es", "elasticsearch", "elasticsearchservice"}}
-	serviceData[ElasticTranscoder] = &ServiceDatum{AWSClientName: "ElasticTranscoder", AWSServiceName: elastictranscoder.ServiceName, AWSEndpointsID: elastictranscoder.EndpointsID, AWSServiceID: elastictranscoder.ServiceID, ProviderNameUpper: "ElasticTranscoder", HCLKeys: []string{"elastictranscoder"}}
-	serviceData[ELB] = &ServiceDatum{AWSClientName: "ELB", AWSServiceName: elb.ServiceName, AWSEndpointsID: elb.EndpointsID, AWSServiceID: elb.ServiceID, ProviderNameUpper: "ELB", HCLKeys: []string{"elb"}}
-	serviceData[ELBV2] = &ServiceDatum{AWSClientName: "ELBV2", AWSServiceName: elbv2.ServiceName, AWSEndpointsID: elbv2.EndpointsID, AWSServiceID: elbv2.ServiceID, ProviderNameUpper: "ELBV2", HCLKeys: []string{"elbv2"}}
-	serviceData[EMR] = &ServiceDatum{AWSClientName: "EMR", AWSServiceName: emr.ServiceName, AWSEndpointsID: emr.EndpointsID, AWSServiceID: emr.ServiceID, ProviderNameUpper: "EMR", HCLKeys: []string{"emr"}}
-	serviceData[EMRContainers] = &ServiceDatum{AWSClientName: "EMRContainers", AWSServiceName: emrcontainers.ServiceName, AWSEndpointsID: emrcontainers.EndpointsID, AWSServiceID: emrcontainers.ServiceID, ProviderNameUpper: "EMRContainers", HCLKeys: []string{"emrcontainers"}}
-	serviceData[Events] = &ServiceDatum{AWSClientName: "EventBridge", AWSServiceName: eventbridge.ServiceName, AWSEndpointsID: eventbridge.EndpointsID, AWSServiceID: eventbridge.ServiceID, ProviderNameUpper: "Events", HCLKeys: []string{"eventbridge", "cloudwatchevents", "events"}}
-	serviceData[FinSpace] = &ServiceDatum{AWSClientName: "Finspace", AWSServiceName: finspace.ServiceName, AWSEndpointsID: finspace.EndpointsID, AWSServiceID: finspace.ServiceID, ProviderNameUpper: "FinSpace", HCLKeys: []string{"finspace"}}
-	serviceData[FinSpaceData] = &ServiceDatum{AWSClientName: "FinSpaceData", AWSServiceName: finspacedata.ServiceName, AWSEndpointsID: finspacedata.EndpointsID, AWSServiceID: finspacedata.ServiceID, ProviderNameUpper: "FinSpaceData", HCLKeys: []string{"finspacedata"}}
-	serviceData[Firehose] = &ServiceDatum{AWSClientName: "Firehose", AWSServiceName: firehose.ServiceName, AWSEndpointsID: firehose.EndpointsID, AWSServiceID: firehose.ServiceID, ProviderNameUpper: "Firehose", HCLKeys: []string{"firehose"}}
-	serviceData[FIS] = &ServiceDatum{AWSClientName: "FIS", AWSServiceName: fis.ServiceName, AWSEndpointsID: fis.EndpointsID, AWSServiceID: fis.ServiceID, ProviderNameUpper: "FIS", HCLKeys: []string{"fis"}}
-	serviceData[FMS] = &ServiceDatum{AWSClientName: "FMS", AWSServiceName: fms.ServiceName, AWSEndpointsID: fms.EndpointsID, AWSServiceID: fms.ServiceID, ProviderNameUpper: "FMS", HCLKeys: []string{"fms"}}
-	serviceData[Forecast] = &ServiceDatum{AWSClientName: "ForecastService", AWSServiceName: forecastservice.ServiceName, AWSEndpointsID: forecastservice.EndpointsID, AWSServiceID: forecastservice.ServiceID, ProviderNameUpper: "Forecast", HCLKeys: []string{"forecast", "forecastservice"}}
-	serviceData[ForecastQuery] = &ServiceDatum{AWSClientName: "ForecastQueryService", AWSServiceName: forecastqueryservice.ServiceName, AWSEndpointsID: forecastqueryservice.EndpointsID, AWSServiceID: forecastqueryservice.ServiceID, ProviderNameUpper: "ForecastQuery", HCLKeys: []string{"forecastquery", "forecastqueryservice"}}
-	serviceData[FraudDetector] = &ServiceDatum{AWSClientName: "FraudDetector", AWSServiceName: frauddetector.ServiceName, AWSEndpointsID: frauddetector.EndpointsID, AWSServiceID: frauddetector.ServiceID, ProviderNameUpper: "FraudDetector", HCLKeys: []string{"frauddetector"}}
-	serviceData[FSx] = &ServiceDatum{AWSClientName: "FSx", AWSServiceName: fsx.ServiceName, AWSEndpointsID: fsx.EndpointsID, AWSServiceID: fsx.ServiceID, ProviderNameUpper: "FSx", HCLKeys: []string{"fsx"}}
-	serviceData[GameLift] = &ServiceDatum{AWSClientName: "GameLift", AWSServiceName: gamelift.ServiceName, AWSEndpointsID: gamelift.EndpointsID, AWSServiceID: gamelift.ServiceID, ProviderNameUpper: "GameLift", HCLKeys: []string{"gamelift"}}
-	serviceData[Glacier] = &ServiceDatum{AWSClientName: "Glacier", AWSServiceName: glacier.ServiceName, AWSEndpointsID: glacier.EndpointsID, AWSServiceID: glacier.ServiceID, ProviderNameUpper: "Glacier", HCLKeys: []string{"glacier"}}
-	serviceData[GlobalAccelerator] = &ServiceDatum{AWSClientName: "GlobalAccelerator", AWSServiceName: globalaccelerator.ServiceName, AWSEndpointsID: globalaccelerator.EndpointsID, AWSServiceID: globalaccelerator.ServiceID, ProviderNameUpper: "GlobalAccelerator", HCLKeys: []string{"globalaccelerator"}}
-	serviceData[Glue] = &ServiceDatum{AWSClientName: "Glue", AWSServiceName: glue.ServiceName, AWSEndpointsID: glue.EndpointsID, AWSServiceID: glue.ServiceID, ProviderNameUpper: "Glue", HCLKeys: []string{"glue"}}
-	serviceData[GlueDataBrew] = &ServiceDatum{AWSClientName: "GlueDataBrew", AWSServiceName: gluedatabrew.ServiceName, AWSEndpointsID: gluedatabrew.EndpointsID, AWSServiceID: gluedatabrew.ServiceID, ProviderNameUpper: "GlueDataBrew", HCLKeys: []string{"gluedatabrew"}}
-	serviceData[Grafana] = &ServiceDatum{AWSClientName: "Grafana", AWSServiceName: managedgrafana.ServiceName, AWSEndpointsID: managedgrafana.EndpointsID, AWSServiceID: managedgrafana.ServiceID, ProviderNameUpper: "Grafana", HCLKeys: []string{"grafana", "managedgrafana", "amg"}}
-	serviceData[Greengrass] = &ServiceDatum{AWSClientName: "Greengrass", AWSServiceName: greengrass.ServiceName, AWSEndpointsID: greengrass.EndpointsID, AWSServiceID: greengrass.ServiceID, ProviderNameUpper: "Greengrass", HCLKeys: []string{"greengrass"}}
-	serviceData[GreengrassV2] = &ServiceDatum{AWSClientName: "GreengrassV2", AWSServiceName: greengrassv2.ServiceName, AWSEndpointsID: greengrassv2.EndpointsID, AWSServiceID: greengrassv2.ServiceID, ProviderNameUpper: "GreengrassV2", HCLKeys: []string{"greengrassv2"}}
-	serviceData[GroundStation] = &ServiceDatum{AWSClientName: "GroundStation", AWSServiceName: groundstation.ServiceName, AWSEndpointsID: groundstation.EndpointsID, AWSServiceID: groundstation.ServiceID, ProviderNameUpper: "GroundStation", HCLKeys: []string{"groundstation"}}
-	serviceData[GuardDuty] = &ServiceDatum{AWSClientName: "GuardDuty", AWSServiceName: guardduty.ServiceName, AWSEndpointsID: guardduty.EndpointsID, AWSServiceID: guardduty.ServiceID, ProviderNameUpper: "GuardDuty", HCLKeys: []string{"guardduty"}}
-	serviceData[Health] = &ServiceDatum{AWSClientName: "Health", AWSServiceName: health.ServiceName, AWSEndpointsID: health.EndpointsID, AWSServiceID: health.ServiceID, ProviderNameUpper: "Health", HCLKeys: []string{"health"}}
-	serviceData[HealthLake] = &ServiceDatum{AWSClientName: "HealthLake", AWSServiceName: healthlake.ServiceName, AWSEndpointsID: healthlake.EndpointsID, AWSServiceID: healthlake.ServiceID, ProviderNameUpper: "HealthLake", HCLKeys: []string{"healthlake"}}
-	serviceData[Honeycode] = &ServiceDatum{AWSClientName: "Honeycode", AWSServiceName: honeycode.ServiceName, AWSEndpointsID: honeycode.EndpointsID, AWSServiceID: honeycode.ServiceID, ProviderNameUpper: "Honeycode", HCLKeys: []string{"honeycode"}}
-	serviceData[IAM] = &ServiceDatum{AWSClientName: "IAM", AWSServiceName: iam.ServiceName, AWSEndpointsID: iam.EndpointsID, AWSServiceID: iam.ServiceID, ProviderNameUpper: "IAM", HCLKeys: []string{"iam"}, EnvVar: "TF_AWS_IAM_ENDPOINT", DeprecatedEnvVar: "AWS_IAM_ENDPOINT"}
-	serviceData[IdentityStore] = &ServiceDatum{AWSClientName: "IdentityStore", AWSServiceName: identitystore.ServiceName, AWSEndpointsID: identitystore.EndpointsID, AWSServiceID: identitystore.ServiceID, ProviderNameUpper: "IdentityStore", HCLKeys: []string{"identitystore"}}
-	serviceData[ImageBuilder] = &ServiceDatum{AWSClientName: "ImageBuilder", AWSServiceName: imagebuilder.ServiceName, AWSEndpointsID: imagebuilder.EndpointsID, AWSServiceID: imagebuilder.ServiceID, ProviderNameUpper: "ImageBuilder", HCLKeys: []string{"imagebuilder"}}
-	serviceData[Inspector] = &ServiceDatum{AWSClientName: "Inspector", AWSServiceName: inspector.ServiceName, AWSEndpointsID: inspector.EndpointsID, AWSServiceID: inspector.ServiceID, ProviderNameUpper: "Inspector", HCLKeys: []string{"inspector"}}
-	serviceData[IoT] = &ServiceDatum{AWSClientName: "IoT", AWSServiceName: iot.ServiceName, AWSEndpointsID: iot.EndpointsID, AWSServiceID: iot.ServiceID, ProviderNameUpper: "IoT", HCLKeys: []string{"iot"}}
-	serviceData[IoT1ClickDevices] = &ServiceDatum{AWSClientName: "IoT1ClickDevicesService", AWSServiceName: iot1clickdevicesservice.ServiceName, AWSEndpointsID: iot1clickdevicesservice.EndpointsID, AWSServiceID: iot1clickdevicesservice.ServiceID, ProviderNameUpper: "IoT1ClickDevices", HCLKeys: []string{"iot1clickdevices", "iot1clickdevicesservice"}}
-	serviceData[IoT1ClickProjects] = &ServiceDatum{AWSClientName: "IoT1ClickProjects", AWSServiceName: iot1clickprojects.ServiceName, AWSEndpointsID: iot1clickprojects.EndpointsID, AWSServiceID: iot1clickprojects.ServiceID, ProviderNameUpper: "IoT1ClickProjects", HCLKeys: []string{"iot1clickprojects"}}
-	serviceData[IoTAnalytics] = &ServiceDatum{AWSClientName: "IoTAnalytics", AWSServiceName: iotanalytics.ServiceName, AWSEndpointsID: iotanalytics.EndpointsID, AWSServiceID: iotanalytics.ServiceID, ProviderNameUpper: "IoTAnalytics", HCLKeys: []string{"iotanalytics"}}
-	serviceData[IoTDataPlane] = &ServiceDatum{AWSClientName: "IoTDataPlane", AWSServiceName: iotdataplane.ServiceName, AWSEndpointsID: iotdataplane.EndpointsID, AWSServiceID: iotdataplane.ServiceID, ProviderNameUpper: "IoTDataPlane", HCLKeys: []string{"iotdataplane"}}
-	serviceData[IoTDeviceAdvisor] = &ServiceDatum{AWSClientName: "IoTDeviceAdvisor", AWSServiceName: iotdeviceadvisor.ServiceName, AWSEndpointsID: iotdeviceadvisor.EndpointsID, AWSServiceID: iotdeviceadvisor.ServiceID, ProviderNameUpper: "IoTDeviceAdvisor", HCLKeys: []string{"iotdeviceadvisor"}}
-	serviceData[IoTEvents] = &ServiceDatum{AWSClientName: "IoTEvents", AWSServiceName: iotevents.ServiceName, AWSEndpointsID: iotevents.EndpointsID, AWSServiceID: iotevents.ServiceID, ProviderNameUpper: "IoTEvents", HCLKeys: []string{"iotevents"}}
-	serviceData[IoTEventsData] = &ServiceDatum{AWSClientName: "IoTEventsData", AWSServiceName: ioteventsdata.ServiceName, AWSEndpointsID: ioteventsdata.EndpointsID, AWSServiceID: ioteventsdata.ServiceID, ProviderNameUpper: "IoTEventsData", HCLKeys: []string{"ioteventsdata"}}
-	serviceData[IoTFleetHub] = &ServiceDatum{AWSClientName: "IoTFleetHub", AWSServiceName: iotfleethub.ServiceName, AWSEndpointsID: iotfleethub.EndpointsID, AWSServiceID: iotfleethub.ServiceID, ProviderNameUpper: "IoTFleetHub", HCLKeys: []string{"iotfleethub"}}
-	serviceData[IoTJobsDataPlane] = &ServiceDatum{AWSClientName: "IoTJobsDataPlane", AWSServiceName: iotjobsdataplane.ServiceName, AWSEndpointsID: iotjobsdataplane.EndpointsID, AWSServiceID: iotjobsdataplane.ServiceID, ProviderNameUpper: "IoTJobsDataPlane", HCLKeys: []string{"iotjobsdataplane"}}
-	serviceData[IoTSecureTunneling] = &ServiceDatum{AWSClientName: "IoTSecureTunneling", AWSServiceName: iotsecuretunneling.ServiceName, AWSEndpointsID: iotsecuretunneling.EndpointsID, AWSServiceID: iotsecuretunneling.ServiceID, ProviderNameUpper: "IoTSecureTunneling", HCLKeys: []string{"iotsecuretunneling"}}
-	serviceData[IoTSiteWise] = &ServiceDatum{AWSClientName: "IoTSiteWise", AWSServiceName: iotsitewise.ServiceName, AWSEndpointsID: iotsitewise.EndpointsID, AWSServiceID: iotsitewise.ServiceID, ProviderNameUpper: "IoTSiteWise", HCLKeys: []string{"iotsitewise"}}
-	serviceData[IoTThingsGraph] = &ServiceDatum{AWSClientName: "IoTThingsGraph", AWSServiceName: iotthingsgraph.ServiceName, AWSEndpointsID: iotthingsgraph.EndpointsID, AWSServiceID: iotthingsgraph.ServiceID, ProviderNameUpper: "IoTThingsGraph", HCLKeys: []string{"iotthingsgraph"}}
-	serviceData[IoTWireless] = &ServiceDatum{AWSClientName: "IoTWireless", AWSServiceName: iotwireless.ServiceName, AWSEndpointsID: iotwireless.EndpointsID, AWSServiceID: iotwireless.ServiceID, ProviderNameUpper: "IoTWireless", HCLKeys: []string{"iotwireless"}}
-	serviceData[Kafka] = &ServiceDatum{AWSClientName: "Kafka", AWSServiceName: kafka.ServiceName, AWSEndpointsID: kafka.EndpointsID, AWSServiceID: kafka.ServiceID, ProviderNameUpper: "Kafka", HCLKeys: []string{"kafka"}}
-	serviceData[KafkaConnect] = &ServiceDatum{AWSClientName: "KafkaConnect", AWSServiceName: kafkaconnect.ServiceName, AWSEndpointsID: kafkaconnect.EndpointsID, AWSServiceID: kafkaconnect.ServiceID, ProviderNameUpper: "KafkaConnect", HCLKeys: []string{"kafkaconnect"}}
-	serviceData[Kendra] = &ServiceDatum{AWSClientName: "Kendra", AWSServiceName: kendra.ServiceName, AWSEndpointsID: kendra.EndpointsID, AWSServiceID: kendra.ServiceID, ProviderNameUpper: "Kendra", HCLKeys: []string{"kendra"}}
-	serviceData[Keyspaces] = &ServiceDatum{AWSClientName: "Keyspaces", AWSServiceName: keyspaces.ServiceName, AWSEndpointsID: keyspaces.EndpointsID, AWSServiceID: keyspaces.ServiceID, ProviderNameUpper: "Keyspaces", HCLKeys: []string{"keyspaces"}}
-	serviceData[Kinesis] = &ServiceDatum{AWSClientName: "Kinesis", AWSServiceName: kinesis.ServiceName, AWSEndpointsID: kinesis.EndpointsID, AWSServiceID: kinesis.ServiceID, ProviderNameUpper: "Kinesis", HCLKeys: []string{"kinesis"}}
-	serviceData[KinesisAnalytics] = &ServiceDatum{AWSClientName: "KinesisAnalytics", AWSServiceName: kinesisanalytics.ServiceName, AWSEndpointsID: kinesisanalytics.EndpointsID, AWSServiceID: kinesisanalytics.ServiceID, ProviderNameUpper: "KinesisAnalytics", HCLKeys: []string{"kinesisanalytics"}}
-	serviceData[KinesisAnalyticsV2] = &ServiceDatum{AWSClientName: "KinesisAnalyticsV2", AWSServiceName: kinesisanalyticsv2.ServiceName, AWSEndpointsID: kinesisanalyticsv2.EndpointsID, AWSServiceID: kinesisanalyticsv2.ServiceID, ProviderNameUpper: "KinesisAnalyticsV2", HCLKeys: []string{"kinesisanalyticsv2"}}
-	serviceData[KinesisVideo] = &ServiceDatum{AWSClientName: "KinesisVideo", AWSServiceName: kinesisvideo.ServiceName, AWSEndpointsID: kinesisvideo.EndpointsID, AWSServiceID: kinesisvideo.ServiceID, ProviderNameUpper: "KinesisVideo", HCLKeys: []string{"kinesisvideo"}}
-	serviceData[KinesisVideoArchivedMedia] = &ServiceDatum{AWSClientName: "KinesisVideoArchivedMedia", AWSServiceName: kinesisvideoarchivedmedia.ServiceName, AWSEndpointsID: kinesisvideoarchivedmedia.EndpointsID, AWSServiceID: kinesisvideoarchivedmedia.ServiceID, ProviderNameUpper: "KinesisVideoArchivedMedia", HCLKeys: []string{"kinesisvideoarchivedmedia"}}
-	serviceData[KinesisVideoMedia] = &ServiceDatum{AWSClientName: "KinesisVideoMedia", AWSServiceName: kinesisvideomedia.ServiceName, AWSEndpointsID: kinesisvideomedia.EndpointsID, AWSServiceID: kinesisvideomedia.ServiceID, ProviderNameUpper: "KinesisVideoMedia", HCLKeys: []string{"kinesisvideomedia"}}
-	serviceData[KinesisVideoSignalingChannels] = &ServiceDatum{AWSClientName: "KinesisVideoSignalingChannels", AWSServiceName: kinesisvideosignalingchannels.ServiceName, AWSEndpointsID: kinesisvideosignalingchannels.EndpointsID, AWSServiceID: kinesisvideosignalingchannels.ServiceID, ProviderNameUpper: "KinesisVideoSignalingChannels", HCLKeys: []string{"kinesisvideosignalingchannels"}}
-	serviceData[KMS] = &ServiceDatum{AWSClientName: "KMS", AWSServiceName: kms.ServiceName, AWSEndpointsID: kms.EndpointsID, AWSServiceID: kms.ServiceID, ProviderNameUpper: "KMS", HCLKeys: []string{"kms"}}
-	serviceData[LakeFormation] = &ServiceDatum{AWSClientName: "LakeFormation", AWSServiceName: lakeformation.ServiceName, AWSEndpointsID: lakeformation.EndpointsID, AWSServiceID: lakeformation.ServiceID, ProviderNameUpper: "LakeFormation", HCLKeys: []string{"lakeformation"}}
-	serviceData[Lambda] = &ServiceDatum{AWSClientName: "Lambda", AWSServiceName: lambda.ServiceName, AWSEndpointsID: lambda.EndpointsID, AWSServiceID: lambda.ServiceID, ProviderNameUpper: "Lambda", HCLKeys: []string{"lambda"}}
-	serviceData[LexModels] = &ServiceDatum{AWSClientName: "LexModelBuildingService", AWSServiceName: lexmodelbuildingservice.ServiceName, AWSEndpointsID: lexmodelbuildingservice.EndpointsID, AWSServiceID: lexmodelbuildingservice.ServiceID, ProviderNameUpper: "LexModels", HCLKeys: []string{"lexmodels", "lexmodelbuilding", "lexmodelbuildingservice"}}
-	serviceData[LexModelsV2] = &ServiceDatum{AWSClientName: "LexModelsV2", AWSServiceName: lexmodelsv2.ServiceName, AWSEndpointsID: lexmodelsv2.EndpointsID, AWSServiceID: lexmodelsv2.ServiceID, ProviderNameUpper: "LexModelsV2", HCLKeys: []string{"lexmodelsv2"}}
-	serviceData[LexRuntime] = &ServiceDatum{AWSClientName: "LexRuntimeService", AWSServiceName: lexruntimeservice.ServiceName, AWSEndpointsID: lexruntimeservice.EndpointsID, AWSServiceID: lexruntimeservice.ServiceID, ProviderNameUpper: "LexRuntime", HCLKeys: []string{"lexruntime", "lexruntimeservice"}}
-	serviceData[LexRuntimeV2] = &ServiceDatum{AWSClientName: "LexRuntimeV2", AWSServiceName: lexruntimev2.ServiceName, AWSEndpointsID: lexruntimev2.EndpointsID, AWSServiceID: lexruntimev2.ServiceID, ProviderNameUpper: "LexRuntimeV2", HCLKeys: []string{"lexruntimev2"}}
-	serviceData[LicenseManager] = &ServiceDatum{AWSClientName: "LicenseManager", AWSServiceName: licensemanager.ServiceName, AWSEndpointsID: licensemanager.EndpointsID, AWSServiceID: licensemanager.ServiceID, ProviderNameUpper: "LicenseManager", HCLKeys: []string{"licensemanager"}}
-	serviceData[Lightsail] = &ServiceDatum{AWSClientName: "Lightsail", AWSServiceName: lightsail.ServiceName, AWSEndpointsID: lightsail.EndpointsID, AWSServiceID: lightsail.ServiceID, ProviderNameUpper: "Lightsail", HCLKeys: []string{"lightsail"}}
-	serviceData[Location] = &ServiceDatum{AWSClientName: "LocationService", AWSServiceName: locationservice.ServiceName, AWSEndpointsID: locationservice.EndpointsID, AWSServiceID: locationservice.ServiceID, ProviderNameUpper: "Location", HCLKeys: []string{"location"}}
-	serviceData[LookoutEquipment] = &ServiceDatum{AWSClientName: "LookoutEquipment", AWSServiceName: lookoutequipment.ServiceName, AWSEndpointsID: lookoutequipment.EndpointsID, AWSServiceID: lookoutequipment.ServiceID, ProviderNameUpper: "LookoutEquipment", HCLKeys: []string{"lookoutequipment"}}
-	serviceData[LookoutForVision] = &ServiceDatum{AWSClientName: "LookoutForVision", AWSServiceName: lookoutforvision.ServiceName, AWSEndpointsID: lookoutforvision.EndpointsID, AWSServiceID: lookoutforvision.ServiceID, ProviderNameUpper: "LookoutForVision", HCLKeys: []string{"lookoutforvision"}}
-	serviceData[LookoutMetrics] = &ServiceDatum{AWSClientName: "LookoutMetrics", AWSServiceName: lookoutmetrics.ServiceName, AWSEndpointsID: lookoutmetrics.EndpointsID, AWSServiceID: lookoutmetrics.ServiceID, ProviderNameUpper: "LookoutMetrics", HCLKeys: []string{"lookoutmetrics"}}
-	serviceData[MachineLearning] = &ServiceDatum{AWSClientName: "MachineLearning", AWSServiceName: machinelearning.ServiceName, AWSEndpointsID: machinelearning.EndpointsID, AWSServiceID: machinelearning.ServiceID, ProviderNameUpper: "MachineLearning", HCLKeys: []string{"machinelearning"}}
-	serviceData[Macie] = &ServiceDatum{AWSClientName: "Macie", AWSServiceName: macie.ServiceName, AWSEndpointsID: macie.EndpointsID, AWSServiceID: macie.ServiceID, ProviderNameUpper: "Macie", HCLKeys: []string{"macie"}}
-	serviceData[Macie2] = &ServiceDatum{AWSClientName: "Macie2", AWSServiceName: macie2.ServiceName, AWSEndpointsID: macie2.EndpointsID, AWSServiceID: macie2.ServiceID, ProviderNameUpper: "Macie2", HCLKeys: []string{"macie2"}}
-	serviceData[ManagedBlockchain] = &ServiceDatum{AWSClientName: "ManagedBlockchain", AWSServiceName: managedblockchain.ServiceName, AWSEndpointsID: managedblockchain.EndpointsID, AWSServiceID: managedblockchain.ServiceID, ProviderNameUpper: "ManagedBlockchain", HCLKeys: []string{"managedblockchain"}}
-	serviceData[MarketplaceCatalog] = &ServiceDatum{AWSClientName: "MarketplaceCatalog", AWSServiceName: marketplacecatalog.ServiceName, AWSEndpointsID: marketplacecatalog.EndpointsID, AWSServiceID: marketplacecatalog.ServiceID, ProviderNameUpper: "MarketplaceCatalog", HCLKeys: []string{"marketplacecatalog"}}
-	serviceData[MarketplaceCommerceAnalytics] = &ServiceDatum{AWSClientName: "MarketplaceCommerceAnalytics", AWSServiceName: marketplacecommerceanalytics.ServiceName, AWSEndpointsID: marketplacecommerceanalytics.EndpointsID, AWSServiceID: marketplacecommerceanalytics.ServiceID, ProviderNameUpper: "MarketplaceCommerceAnalytics", HCLKeys: []string{"marketplacecommerceanalytics"}}
-	serviceData[MarketplaceEntitlement] = &ServiceDatum{AWSClientName: "MarketplaceEntitlementService", AWSServiceName: marketplaceentitlementservice.ServiceName, AWSEndpointsID: marketplaceentitlementservice.EndpointsID, AWSServiceID: marketplaceentitlementservice.ServiceID, ProviderNameUpper: "MarketplaceEntitlement", HCLKeys: []string{"marketplaceentitlement", "marketplaceentitlementservice"}}
-	serviceData[MarketplaceMetering] = &ServiceDatum{AWSClientName: "MarketplaceMetering", AWSServiceName: marketplacemetering.ServiceName, AWSEndpointsID: marketplacemetering.EndpointsID, AWSServiceID: marketplacemetering.ServiceID, ProviderNameUpper: "MarketplaceMetering", HCLKeys: []string{"marketplacemetering"}}
-	serviceData[MediaConnect] = &ServiceDatum{AWSClientName: "MediaConnect", AWSServiceName: mediaconnect.ServiceName, AWSEndpointsID: mediaconnect.EndpointsID, AWSServiceID: mediaconnect.ServiceID, ProviderNameUpper: "MediaConnect", HCLKeys: []string{"mediaconnect"}}
-	serviceData[MediaConvert] = &ServiceDatum{AWSClientName: "MediaConvert", AWSServiceName: mediaconvert.ServiceName, AWSEndpointsID: mediaconvert.EndpointsID, AWSServiceID: mediaconvert.ServiceID, ProviderNameUpper: "MediaConvert", HCLKeys: []string{"mediaconvert"}}
-	serviceData[MediaLive] = &ServiceDatum{AWSClientName: "MediaLive", AWSServiceName: medialive.ServiceName, AWSEndpointsID: medialive.EndpointsID, AWSServiceID: medialive.ServiceID, ProviderNameUpper: "MediaLive", HCLKeys: []string{"medialive"}}
-	serviceData[MediaPackage] = &ServiceDatum{AWSClientName: "MediaPackage", AWSServiceName: mediapackage.ServiceName, AWSEndpointsID: mediapackage.EndpointsID, AWSServiceID: mediapackage.ServiceID, ProviderNameUpper: "MediaPackage", HCLKeys: []string{"mediapackage"}}
-	serviceData[MediaPackageVOD] = &ServiceDatum{AWSClientName: "MediaPackageVOD", AWSServiceName: mediapackagevod.ServiceName, AWSEndpointsID: mediapackagevod.EndpointsID, AWSServiceID: mediapackagevod.ServiceID, ProviderNameUpper: "MediaPackageVOD", HCLKeys: []string{"mediapackagevod"}}
-	serviceData[MediaStore] = &ServiceDatum{AWSClientName: "MediaStore", AWSServiceName: mediastore.ServiceName, AWSEndpointsID: mediastore.EndpointsID, AWSServiceID: mediastore.ServiceID, ProviderNameUpper: "MediaStore", HCLKeys: []string{"mediastore"}}
-	serviceData[MediaStoreData] = &ServiceDatum{AWSClientName: "MediaStoreData", AWSServiceName: mediastoredata.ServiceName, AWSEndpointsID: mediastoredata.EndpointsID, AWSServiceID: mediastoredata.ServiceID, ProviderNameUpper: "MediaStoreData", HCLKeys: []string{"mediastoredata"}}
-	serviceData[MediaTailor] = &ServiceDatum{AWSClientName: "MediaTailor", AWSServiceName: mediatailor.ServiceName, AWSEndpointsID: mediatailor.EndpointsID, AWSServiceID: mediatailor.ServiceID, ProviderNameUpper: "MediaTailor", HCLKeys: []string{"mediatailor"}}
-	serviceData[MemoryDB] = &ServiceDatum{AWSClientName: "MemoryDB", AWSServiceName: memorydb.ServiceName, AWSEndpointsID: memorydb.EndpointsID, AWSServiceID: memorydb.ServiceID, ProviderNameUpper: "MemoryDB", HCLKeys: []string{"memorydb"}}
-	serviceData[Mgn] = &ServiceDatum{AWSClientName: "Mgn", AWSServiceName: mgn.ServiceName, AWSEndpointsID: mgn.EndpointsID, AWSServiceID: mgn.ServiceID, ProviderNameUpper: "Mgn", HCLKeys: []string{"mgn"}}
-	serviceData[MigrationHub] = &ServiceDatum{AWSClientName: "MigrationHub", AWSServiceName: migrationhub.ServiceName, AWSEndpointsID: migrationhub.EndpointsID, AWSServiceID: migrationhub.ServiceID, ProviderNameUpper: "MigrationHub", HCLKeys: []string{"migrationhub"}}
-	serviceData[MigrationHubConfig] = &ServiceDatum{AWSClientName: "MigrationHubConfig", AWSServiceName: migrationhubconfig.ServiceName, AWSEndpointsID: migrationhubconfig.EndpointsID, AWSServiceID: migrationhubconfig.ServiceID, ProviderNameUpper: "MigrationHubConfig", HCLKeys: []string{"migrationhubconfig"}}
-	serviceData[Mobile] = &ServiceDatum{AWSClientName: "Mobile", AWSServiceName: mobile.ServiceName, AWSEndpointsID: mobile.EndpointsID, AWSServiceID: mobile.ServiceID, ProviderNameUpper: "Mobile", HCLKeys: []string{"mobile"}}
-	serviceData[MobileAnalytics] = &ServiceDatum{AWSClientName: "MobileAnalytics", AWSServiceName: mobileanalytics.ServiceName, AWSEndpointsID: mobileanalytics.EndpointsID, AWSServiceID: mobileanalytics.ServiceID, ProviderNameUpper: "MobileAnalytics", HCLKeys: []string{"mobileanalytics"}}
-	serviceData[MQ] = &ServiceDatum{AWSClientName: "MQ", AWSServiceName: mq.ServiceName, AWSEndpointsID: mq.EndpointsID, AWSServiceID: mq.ServiceID, ProviderNameUpper: "MQ", HCLKeys: []string{"mq"}}
-	serviceData[MTurk] = &ServiceDatum{AWSClientName: "MTurk", AWSServiceName: mturk.ServiceName, AWSEndpointsID: mturk.EndpointsID, AWSServiceID: mturk.ServiceID, ProviderNameUpper: "MTurk", HCLKeys: []string{"mturk"}}
-	serviceData[MWAA] = &ServiceDatum{AWSClientName: "MWAA", AWSServiceName: mwaa.ServiceName, AWSEndpointsID: mwaa.EndpointsID, AWSServiceID: mwaa.ServiceID, ProviderNameUpper: "MWAA", HCLKeys: []string{"mwaa"}}
-	serviceData[Neptune] = &ServiceDatum{AWSClientName: "Neptune", AWSServiceName: neptune.ServiceName, AWSEndpointsID: neptune.EndpointsID, AWSServiceID: neptune.ServiceID, ProviderNameUpper: "Neptune", HCLKeys: []string{"neptune"}}
-	serviceData[NetworkFirewall] = &ServiceDatum{AWSClientName: "NetworkFirewall", AWSServiceName: networkfirewall.ServiceName, AWSEndpointsID: networkfirewall.EndpointsID, AWSServiceID: networkfirewall.ServiceID, ProviderNameUpper: "NetworkFirewall", HCLKeys: []string{"networkfirewall"}}
-	serviceData[NetworkManager] = &ServiceDatum{AWSClientName: "NetworkManager", AWSServiceName: networkmanager.ServiceName, AWSEndpointsID: networkmanager.EndpointsID, AWSServiceID: networkmanager.ServiceID, ProviderNameUpper: "NetworkManager", HCLKeys: []string{"networkmanager"}}
-	serviceData[NimbleStudio] = &ServiceDatum{AWSClientName: "NimbleStudio", AWSServiceName: nimblestudio.ServiceName, AWSEndpointsID: nimblestudio.EndpointsID, AWSServiceID: nimblestudio.ServiceID, ProviderNameUpper: "NimbleStudio", HCLKeys: []string{"nimblestudio"}}
-	serviceData[OpsWorks] = &ServiceDatum{AWSClientName: "OpsWorks", AWSServiceName: opsworks.ServiceName, AWSEndpointsID: opsworks.EndpointsID, AWSServiceID: opsworks.ServiceID, ProviderNameUpper: "OpsWorks", HCLKeys: []string{"opsworks"}}
-	serviceData[OpsWorksCM] = &ServiceDatum{AWSClientName: "OpsWorksCM", AWSServiceName: opsworkscm.ServiceName, AWSEndpointsID: opsworkscm.EndpointsID, AWSServiceID: opsworkscm.ServiceID, ProviderNameUpper: "OpsWorksCM", HCLKeys: []string{"opsworkscm"}}
-	serviceData[Organizations] = &ServiceDatum{AWSClientName: "Organizations", AWSServiceName: organizations.ServiceName, AWSEndpointsID: organizations.EndpointsID, AWSServiceID: organizations.ServiceID, ProviderNameUpper: "Organizations", HCLKeys: []string{"organizations"}}
-	serviceData[Outposts] = &ServiceDatum{AWSClientName: "Outposts", AWSServiceName: outposts.ServiceName, AWSEndpointsID: outposts.EndpointsID, AWSServiceID: outposts.ServiceID, ProviderNameUpper: "Outposts", HCLKeys: []string{"outposts"}}
-	serviceData[Personalize] = &ServiceDatum{AWSClientName: "Personalize", AWSServiceName: personalize.ServiceName, AWSEndpointsID: personalize.EndpointsID, AWSServiceID: personalize.ServiceID, ProviderNameUpper: "Personalize", HCLKeys: []string{"personalize"}}
-	serviceData[PersonalizeEvents] = &ServiceDatum{AWSClientName: "PersonalizeEvents", AWSServiceName: personalizeevents.ServiceName, AWSEndpointsID: personalizeevents.EndpointsID, AWSServiceID: personalizeevents.ServiceID, ProviderNameUpper: "PersonalizeEvents", HCLKeys: []string{"personalizeevents"}}
-	serviceData[PersonalizeRuntime] = &ServiceDatum{AWSClientName: "PersonalizeRuntime", AWSServiceName: personalizeruntime.ServiceName, AWSEndpointsID: personalizeruntime.EndpointsID, AWSServiceID: personalizeruntime.ServiceID, ProviderNameUpper: "PersonalizeRuntime", HCLKeys: []string{"personalizeruntime"}}
-	serviceData[PI] = &ServiceDatum{AWSClientName: "PI", AWSServiceName: pi.ServiceName, AWSEndpointsID: pi.EndpointsID, AWSServiceID: pi.ServiceID, ProviderNameUpper: "PI", HCLKeys: []string{"pi"}}
-	serviceData[Pinpoint] = &ServiceDatum{AWSClientName: "Pinpoint", AWSServiceName: pinpoint.ServiceName, AWSEndpointsID: pinpoint.EndpointsID, AWSServiceID: pinpoint.ServiceID, ProviderNameUpper: "Pinpoint", HCLKeys: []string{"pinpoint"}}
-	serviceData[PinpointEmail] = &ServiceDatum{AWSClientName: "PinpointEmail", AWSServiceName: pinpointemail.ServiceName, AWSEndpointsID: pinpointemail.EndpointsID, AWSServiceID: pinpointemail.ServiceID, ProviderNameUpper: "PinpointEmail", HCLKeys: []string{"pinpointemail"}}
-	serviceData[PinpointSMSVoice] = &ServiceDatum{AWSClientName: "PinpointSMSVoice", AWSServiceName: pinpointsmsvoice.ServiceName, AWSEndpointsID: pinpointsmsvoice.EndpointsID, AWSServiceID: pinpointsmsvoice.ServiceID, ProviderNameUpper: "PinpointSMSVoice", HCLKeys: []string{"pinpointsmsvoice"}}
-	serviceData[Polly] = &ServiceDatum{AWSClientName: "Polly", AWSServiceName: polly.ServiceName, AWSEndpointsID: polly.EndpointsID, AWSServiceID: polly.ServiceID, ProviderNameUpper: "Polly", HCLKeys: []string{"polly"}}
-	serviceData[Pricing] = &ServiceDatum{AWSClientName: "Pricing", AWSServiceName: pricing.ServiceName, AWSEndpointsID: pricing.EndpointsID, AWSServiceID: pricing.ServiceID, ProviderNameUpper: "Pricing", HCLKeys: []string{"pricing"}}
-	serviceData[Proton] = &ServiceDatum{AWSClientName: "Proton", AWSServiceName: proton.ServiceName, AWSEndpointsID: proton.EndpointsID, AWSServiceID: proton.ServiceID, ProviderNameUpper: "Proton", HCLKeys: []string{"proton"}}
-	serviceData[QLDB] = &ServiceDatum{AWSClientName: "QLDB", AWSServiceName: qldb.ServiceName, AWSEndpointsID: qldb.EndpointsID, AWSServiceID: qldb.ServiceID, ProviderNameUpper: "QLDB", HCLKeys: []string{"qldb"}}
-	serviceData[QLDBSession] = &ServiceDatum{AWSClientName: "QLDBSession", AWSServiceName: qldbsession.ServiceName, AWSEndpointsID: qldbsession.EndpointsID, AWSServiceID: qldbsession.ServiceID, ProviderNameUpper: "QLDBSession", HCLKeys: []string{"qldbsession"}}
-	serviceData[QuickSight] = &ServiceDatum{AWSClientName: "QuickSight", AWSServiceName: quicksight.ServiceName, AWSEndpointsID: quicksight.EndpointsID, AWSServiceID: quicksight.ServiceID, ProviderNameUpper: "QuickSight", HCLKeys: []string{"quicksight"}}
-	serviceData[RAM] = &ServiceDatum{AWSClientName: "RAM", AWSServiceName: ram.ServiceName, AWSEndpointsID: ram.EndpointsID, AWSServiceID: ram.ServiceID, ProviderNameUpper: "RAM", HCLKeys: []string{"ram"}}
-	serviceData[RDS] = &ServiceDatum{AWSClientName: "RDS", AWSServiceName: rds.ServiceName, AWSEndpointsID: rds.EndpointsID, AWSServiceID: rds.ServiceID, ProviderNameUpper: "RDS", HCLKeys: []string{"rds"}}
-	serviceData[RDSData] = &ServiceDatum{AWSClientName: "RDSDataService", AWSServiceName: rdsdataservice.ServiceName, AWSEndpointsID: rdsdataservice.EndpointsID, AWSServiceID: rdsdataservice.ServiceID, ProviderNameUpper: "RDSData", HCLKeys: []string{"rdsdata", "rdsdataservice"}}
-	serviceData[Redshift] = &ServiceDatum{AWSClientName: "Redshift", AWSServiceName: redshift.ServiceName, AWSEndpointsID: redshift.EndpointsID, AWSServiceID: redshift.ServiceID, ProviderNameUpper: "Redshift", HCLKeys: []string{"redshift"}}
-	serviceData[RedshiftData] = &ServiceDatum{AWSClientName: "RedshiftData", AWSServiceName: redshiftdataapiservice.ServiceName, AWSEndpointsID: redshiftdataapiservice.EndpointsID, AWSServiceID: redshiftdataapiservice.ServiceID, ProviderNameUpper: "RedshiftData", HCLKeys: []string{"redshiftdata"}}
-	serviceData[Rekognition] = &ServiceDatum{AWSClientName: "Rekognition", AWSServiceName: rekognition.ServiceName, AWSEndpointsID: rekognition.EndpointsID, AWSServiceID: rekognition.ServiceID, ProviderNameUpper: "Rekognition", HCLKeys: []string{"rekognition"}}
-	serviceData[ResourceGroups] = &ServiceDatum{AWSClientName: "ResourceGroups", AWSServiceName: resourcegroups.ServiceName, AWSEndpointsID: resourcegroups.EndpointsID, AWSServiceID: resourcegroups.ServiceID, ProviderNameUpper: "ResourceGroups", HCLKeys: []string{"resourcegroups"}}
-	serviceData[ResourceGroupsTaggingAPI] = &ServiceDatum{AWSClientName: "ResourceGroupsTaggingAPI", AWSServiceName: resourcegroupstaggingapi.ServiceName, AWSEndpointsID: resourcegroupstaggingapi.EndpointsID, AWSServiceID: resourcegroupstaggingapi.ServiceID, ProviderNameUpper: "ResourceGroupsTaggingAPI", HCLKeys: []string{"resourcegroupstaggingapi", "resourcegroupstagging"}}
-	serviceData[RoboMaker] = &ServiceDatum{AWSClientName: "RoboMaker", AWSServiceName: robomaker.ServiceName, AWSEndpointsID: robomaker.EndpointsID, AWSServiceID: robomaker.ServiceID, ProviderNameUpper: "RoboMaker", HCLKeys: []string{"robomaker"}}
-	serviceData[Route53] = &ServiceDatum{AWSClientName: "Route53", AWSServiceName: route53.ServiceName, AWSEndpointsID: route53.EndpointsID, AWSServiceID: route53.ServiceID, ProviderNameUpper: "Route53", HCLKeys: []string{"route53"}}
-	serviceData[Route53Domains] = &ServiceDatum{AWSClientName: "Route53Domains", AWSServiceName: Route53DomainsServiceName, AWSEndpointsID: Route53DomainsEndpointID, AWSServiceID: route53domains.ServiceID, ProviderNameUpper: "Route53Domains", HCLKeys: []string{"route53domains"}}
-	serviceData[Route53RecoveryControlConfig] = &ServiceDatum{AWSClientName: "Route53RecoveryControlConfig", AWSServiceName: route53recoverycontrolconfig.ServiceName, AWSEndpointsID: route53recoverycontrolconfig.EndpointsID, AWSServiceID: route53recoverycontrolconfig.ServiceID, ProviderNameUpper: "Route53RecoveryControlConfig", HCLKeys: []string{"route53recoverycontrolconfig"}}
-	serviceData[Route53RecoveryReadiness] = &ServiceDatum{AWSClientName: "Route53RecoveryReadiness", AWSServiceName: route53recoveryreadiness.ServiceName, AWSEndpointsID: route53recoveryreadiness.EndpointsID, AWSServiceID: route53recoveryreadiness.ServiceID, ProviderNameUpper: "Route53RecoveryReadiness", HCLKeys: []string{"route53recoveryreadiness"}}
-	serviceData[Route53Resolver] = &ServiceDatum{AWSClientName: "Route53Resolver", AWSServiceName: route53resolver.ServiceName, AWSEndpointsID: route53resolver.EndpointsID, AWSServiceID: route53resolver.ServiceID, ProviderNameUpper: "Route53Resolver", HCLKeys: []string{"route53resolver"}}
-	serviceData[S3] = &ServiceDatum{AWSClientName: "S3", AWSServiceName: s3.ServiceName, AWSEndpointsID: s3.EndpointsID, AWSServiceID: s3.ServiceID, ProviderNameUpper: "S3", HCLKeys: []string{"s3"}, EnvVar: "TF_AWS_S3_ENDPOINT", DeprecatedEnvVar: "AWS_S3_ENDPOINT"}
-	serviceData[S3Control] = &ServiceDatum{AWSClientName: "S3Control", AWSServiceName: s3control.ServiceName, AWSEndpointsID: s3control.EndpointsID, AWSServiceID: s3control.ServiceID, ProviderNameUpper: "S3Control", HCLKeys: []string{"s3control"}}
-	serviceData[S3Outposts] = &ServiceDatum{AWSClientName: "S3Outposts", AWSServiceName: s3outposts.ServiceName, AWSEndpointsID: s3outposts.EndpointsID, AWSServiceID: s3outposts.ServiceID, ProviderNameUpper: "S3Outposts", HCLKeys: []string{"s3outposts"}}
-	serviceData[SageMaker] = &ServiceDatum{AWSClientName: "SageMaker", AWSServiceName: sagemaker.ServiceName, AWSEndpointsID: sagemaker.EndpointsID, AWSServiceID: sagemaker.ServiceID, ProviderNameUpper: "SageMaker", HCLKeys: []string{"sagemaker"}}
-	serviceData[SageMakerEdgeManager] = &ServiceDatum{AWSClientName: "SagemakerEdgeManager", AWSServiceName: sagemakeredgemanager.ServiceName, AWSEndpointsID: sagemakeredgemanager.EndpointsID, AWSServiceID: sagemakeredgemanager.ServiceID, ProviderNameUpper: "SageMakerEdgeManager", HCLKeys: []string{"sagemakeredgemanager"}}
-	serviceData[SageMakerFeatureStoreRuntime] = &ServiceDatum{AWSClientName: "SageMakerFeatureStoreRuntime", AWSServiceName: sagemakerfeaturestoreruntime.ServiceName, AWSEndpointsID: sagemakerfeaturestoreruntime.EndpointsID, AWSServiceID: sagemakerfeaturestoreruntime.ServiceID, ProviderNameUpper: "SageMakerFeatureStoreRuntime", HCLKeys: []string{"sagemakerfeaturestoreruntime"}}
-	serviceData[SageMakerRuntime] = &ServiceDatum{AWSClientName: "SageMakerRuntime", AWSServiceName: sagemakerruntime.ServiceName, AWSEndpointsID: sagemakerruntime.EndpointsID, AWSServiceID: sagemakerruntime.ServiceID, ProviderNameUpper: "SageMakerRuntime", HCLKeys: []string{"sagemakerruntime"}}
-	serviceData[SavingsPlans] = &ServiceDatum{AWSClientName: "SavingsPlans", AWSServiceName: savingsplans.ServiceName, AWSEndpointsID: savingsplans.EndpointsID, AWSServiceID: savingsplans.ServiceID, ProviderNameUpper: "SavingsPlans", HCLKeys: []string{"savingsplans"}}
-	serviceData[Schemas] = &ServiceDatum{AWSClientName: "Schemas", AWSServiceName: schemas.ServiceName, AWSEndpointsID: schemas.EndpointsID, AWSServiceID: schemas.ServiceID, ProviderNameUpper: "Schemas", HCLKeys: []string{"schemas"}}
-	serviceData[SecretsManager] = &ServiceDatum{AWSClientName: "SecretsManager", AWSServiceName: secretsmanager.ServiceName, AWSEndpointsID: secretsmanager.EndpointsID, AWSServiceID: secretsmanager.ServiceID, ProviderNameUpper: "SecretsManager", HCLKeys: []string{"secretsmanager"}}
-	serviceData[SecurityHub] = &ServiceDatum{AWSClientName: "SecurityHub", AWSServiceName: securityhub.ServiceName, AWSEndpointsID: securityhub.EndpointsID, AWSServiceID: securityhub.ServiceID, ProviderNameUpper: "SecurityHub", HCLKeys: []string{"securityhub"}}
-	serviceData[ServerlessRepo] = &ServiceDatum{AWSClientName: "ServerlessApplicationRepository", AWSServiceName: serverlessapplicationrepository.ServiceName, AWSEndpointsID: serverlessapplicationrepository.EndpointsID, AWSServiceID: serverlessapplicationrepository.ServiceID, ProviderNameUpper: "ServerlessRepo", HCLKeys: []string{"serverlessrepo", "serverlessapprepo", "serverlessapplicationrepository"}}
-	serviceData[ServiceCatalog] = &ServiceDatum{AWSClientName: "ServiceCatalog", AWSServiceName: servicecatalog.ServiceName, AWSEndpointsID: servicecatalog.EndpointsID, AWSServiceID: servicecatalog.ServiceID, ProviderNameUpper: "ServiceCatalog", HCLKeys: []string{"servicecatalog"}}
-	serviceData[ServiceDiscovery] = &ServiceDatum{AWSClientName: "ServiceDiscovery", AWSServiceName: servicediscovery.ServiceName, AWSEndpointsID: servicediscovery.EndpointsID, AWSServiceID: servicediscovery.ServiceID, ProviderNameUpper: "ServiceDiscovery", HCLKeys: []string{"servicediscovery"}}
-	serviceData[ServiceQuotas] = &ServiceDatum{AWSClientName: "ServiceQuotas", AWSServiceName: servicequotas.ServiceName, AWSEndpointsID: servicequotas.EndpointsID, AWSServiceID: servicequotas.ServiceID, ProviderNameUpper: "ServiceQuotas", HCLKeys: []string{"servicequotas"}}
-	serviceData[SES] = &ServiceDatum{AWSClientName: "SES", AWSServiceName: ses.ServiceName, AWSEndpointsID: ses.EndpointsID, AWSServiceID: ses.ServiceID, ProviderNameUpper: "SES", HCLKeys: []string{"ses"}}
-	serviceData[SESV2] = &ServiceDatum{AWSClientName: "SESV2", AWSServiceName: sesv2.ServiceName, AWSEndpointsID: sesv2.EndpointsID, AWSServiceID: sesv2.ServiceID, ProviderNameUpper: "SESV2", HCLKeys: []string{"sesv2"}}
-	serviceData[SFN] = &ServiceDatum{AWSClientName: "SFN", AWSServiceName: sfn.ServiceName, AWSEndpointsID: sfn.EndpointsID, AWSServiceID: sfn.ServiceID, ProviderNameUpper: "SFN", HCLKeys: []string{"stepfunctions", "sfn"}}
-	serviceData[Shield] = &ServiceDatum{AWSClientName: "Shield", AWSServiceName: shield.ServiceName, AWSEndpointsID: shield.EndpointsID, AWSServiceID: shield.ServiceID, ProviderNameUpper: "Shield", HCLKeys: []string{"shield"}}
-	serviceData[Signer] = &ServiceDatum{AWSClientName: "Signer", AWSServiceName: signer.ServiceName, AWSEndpointsID: signer.EndpointsID, AWSServiceID: signer.ServiceID, ProviderNameUpper: "Signer", HCLKeys: []string{"signer"}}
-	serviceData[SimpleDB] = &ServiceDatum{AWSClientName: "SimpleDB", AWSServiceName: simpledb.ServiceName, AWSEndpointsID: simpledb.EndpointsID, AWSServiceID: simpledb.ServiceID, ProviderNameUpper: "SimpleDB", HCLKeys: []string{"sdb", "simpledb"}}
-	serviceData[SMS] = &ServiceDatum{AWSClientName: "SMS", AWSServiceName: sms.ServiceName, AWSEndpointsID: sms.EndpointsID, AWSServiceID: sms.ServiceID, ProviderNameUpper: "SMS", HCLKeys: []string{"sms"}}
-	serviceData[Snowball] = &ServiceDatum{AWSClientName: "Snowball", AWSServiceName: snowball.ServiceName, AWSEndpointsID: snowball.EndpointsID, AWSServiceID: snowball.ServiceID, ProviderNameUpper: "Snowball", HCLKeys: []string{"snowball"}}
-	serviceData[SNS] = &ServiceDatum{AWSClientName: "SNS", AWSServiceName: sns.ServiceName, AWSEndpointsID: sns.EndpointsID, AWSServiceID: sns.ServiceID, ProviderNameUpper: "SNS", HCLKeys: []string{"sns"}}
-	serviceData[SQS] = &ServiceDatum{AWSClientName: "SQS", AWSServiceName: sqs.ServiceName, AWSEndpointsID: sqs.EndpointsID, AWSServiceID: sqs.ServiceID, ProviderNameUpper: "SQS", HCLKeys: []string{"sqs"}}
-	serviceData[SSM] = &ServiceDatum{AWSClientName: "SSM", AWSServiceName: ssm.ServiceName, AWSEndpointsID: ssm.EndpointsID, AWSServiceID: ssm.ServiceID, ProviderNameUpper: "SSM", HCLKeys: []string{"ssm"}}
-	serviceData[SSMContacts] = &ServiceDatum{AWSClientName: "SSMContacts", AWSServiceName: ssmcontacts.ServiceName, AWSEndpointsID: ssmcontacts.EndpointsID, AWSServiceID: ssmcontacts.ServiceID, ProviderNameUpper: "SSMContacts", HCLKeys: []string{"ssmcontacts"}}
-	serviceData[SSMIncidents] = &ServiceDatum{AWSClientName: "SSMIncidents", AWSServiceName: ssmincidents.ServiceName, AWSEndpointsID: ssmincidents.EndpointsID, AWSServiceID: ssmincidents.ServiceID, ProviderNameUpper: "SSMIncidents", HCLKeys: []string{"ssmincidents"}}
-	serviceData[SSO] = &ServiceDatum{AWSClientName: "SSO", AWSServiceName: sso.ServiceName, AWSEndpointsID: sso.EndpointsID, AWSServiceID: sso.ServiceID, ProviderNameUpper: "SSO", HCLKeys: []string{"sso"}}
-	serviceData[SSOAdmin] = &ServiceDatum{AWSClientName: "SSOAdmin", AWSServiceName: ssoadmin.ServiceName, AWSEndpointsID: ssoadmin.EndpointsID, AWSServiceID: ssoadmin.ServiceID, ProviderNameUpper: "SSOAdmin", HCLKeys: []string{"ssoadmin"}}
-	serviceData[SSOOIDC] = &ServiceDatum{AWSClientName: "SSOOIDC", AWSServiceName: ssooidc.ServiceName, AWSEndpointsID: ssooidc.EndpointsID, AWSServiceID: ssooidc.ServiceID, ProviderNameUpper: "SSOOIDC", HCLKeys: []string{"ssooidc"}}
-	serviceData[StorageGateway] = &ServiceDatum{AWSClientName: "StorageGateway", AWSServiceName: storagegateway.ServiceName, AWSEndpointsID: storagegateway.EndpointsID, AWSServiceID: storagegateway.ServiceID, ProviderNameUpper: "StorageGateway", HCLKeys: []string{"storagegateway"}}
-	serviceData[STS] = &ServiceDatum{AWSClientName: "STS", AWSServiceName: sts.ServiceName, AWSEndpointsID: sts.EndpointsID, AWSServiceID: sts.ServiceID, ProviderNameUpper: "STS", HCLKeys: []string{"sts"}, EnvVar: "TF_AWS_STS_ENDPOINT", DeprecatedEnvVar: "AWS_STS_ENDPOINT"}
-	serviceData[Support] = &ServiceDatum{AWSClientName: "Support", AWSServiceName: support.ServiceName, AWSEndpointsID: support.EndpointsID, AWSServiceID: support.ServiceID, ProviderNameUpper: "Support", HCLKeys: []string{"support"}}
-	serviceData[SWF] = &ServiceDatum{AWSClientName: "SWF", AWSServiceName: swf.ServiceName, AWSEndpointsID: swf.EndpointsID, AWSServiceID: swf.ServiceID, ProviderNameUpper: "SWF", HCLKeys: []string{"swf"}}
-	serviceData[Synthetics] = &ServiceDatum{AWSClientName: "Synthetics", AWSServiceName: synthetics.ServiceName, AWSEndpointsID: synthetics.EndpointsID, AWSServiceID: synthetics.ServiceID, ProviderNameUpper: "Synthetics", HCLKeys: []string{"synthetics"}}
-	serviceData[Textract] = &ServiceDatum{AWSClientName: "Textract", AWSServiceName: textract.ServiceName, AWSEndpointsID: textract.EndpointsID, AWSServiceID: textract.ServiceID, ProviderNameUpper: "Textract", HCLKeys: []string{"textract"}}
-	serviceData[TimestreamQuery] = &ServiceDatum{AWSClientName: "TimestreamQuery", AWSServiceName: timestreamquery.ServiceName, AWSEndpointsID: timestreamquery.EndpointsID, AWSServiceID: timestreamquery.ServiceID, ProviderNameUpper: "TimestreamQuery", HCLKeys: []string{"timestreamquery"}}
-	serviceData[TimestreamWrite] = &ServiceDatum{AWSClientName: "TimestreamWrite", AWSServiceName: timestreamwrite.ServiceName, AWSEndpointsID: timestreamwrite.EndpointsID, AWSServiceID: timestreamwrite.ServiceID, ProviderNameUpper: "TimestreamWrite", HCLKeys: []string{"timestreamwrite"}}
-	serviceData[Transcribe] = &ServiceDatum{AWSClientName: "TranscribeService", AWSServiceName: transcribeservice.ServiceName, AWSEndpointsID: transcribeservice.EndpointsID, AWSServiceID: transcribeservice.ServiceID, ProviderNameUpper: "Transcribe", HCLKeys: []string{"transcribe", "transcribeservice"}}
-	serviceData[TranscribeStreaming] = &ServiceDatum{AWSClientName: "TranscribeStreamingService", AWSServiceName: transcribestreamingservice.ServiceName, AWSEndpointsID: transcribestreamingservice.EndpointsID, AWSServiceID: transcribestreamingservice.ServiceID, ProviderNameUpper: "TranscribeStreaming", HCLKeys: []string{"transcribestreaming", "transcribestreamingservice"}}
-	serviceData[Transfer] = &ServiceDatum{AWSClientName: "Transfer", AWSServiceName: transfer.ServiceName, AWSEndpointsID: transfer.EndpointsID, AWSServiceID: transfer.ServiceID, ProviderNameUpper: "Transfer", HCLKeys: []string{"transfer"}}
-	serviceData[Translate] = &ServiceDatum{AWSClientName: "Translate", AWSServiceName: translate.ServiceName, AWSEndpointsID: translate.EndpointsID, AWSServiceID: translate.ServiceID, ProviderNameUpper: "Translate", HCLKeys: []string{"translate"}}
-	serviceData[WAF] = &ServiceDatum{AWSClientName: "WAF", AWSServiceName: waf.ServiceName, AWSEndpointsID: waf.EndpointsID, AWSServiceID: waf.ServiceID, ProviderNameUpper: "WAF", HCLKeys: []string{"waf"}}
-	serviceData[WAFRegional] = &ServiceDatum{AWSClientName: "WAFRegional", AWSServiceName: wafregional.ServiceName, AWSEndpointsID: wafregional.EndpointsID, AWSServiceID: wafregional.ServiceID, ProviderNameUpper: "WAFRegional", HCLKeys: []string{"wafregional"}}
-	serviceData[WAFV2] = &ServiceDatum{AWSClientName: "WAFV2", AWSServiceName: wafv2.ServiceName, AWSEndpointsID: wafv2.EndpointsID, AWSServiceID: wafv2.ServiceID, ProviderNameUpper: "WAFV2", HCLKeys: []string{"wafv2"}}
-	serviceData[WellArchitected] = &ServiceDatum{AWSClientName: "WellArchitected", AWSServiceName: wellarchitected.ServiceName, AWSEndpointsID: wellarchitected.EndpointsID, AWSServiceID: wellarchitected.ServiceID, ProviderNameUpper: "WellArchitected", HCLKeys: []string{"wellarchitected"}}
-	serviceData[WorkDocs] = &ServiceDatum{AWSClientName: "WorkDocs", AWSServiceName: workdocs.ServiceName, AWSEndpointsID: workdocs.EndpointsID, AWSServiceID: workdocs.ServiceID, ProviderNameUpper: "WorkDocs", HCLKeys: []string{"workdocs"}}
-	serviceData[WorkLink] = &ServiceDatum{AWSClientName: "WorkLink", AWSServiceName: worklink.ServiceName, AWSEndpointsID: worklink.EndpointsID, AWSServiceID: worklink.ServiceID, ProviderNameUpper: "WorkLink", HCLKeys: []string{"worklink"}}
-	serviceData[WorkMail] = &ServiceDatum{AWSClientName: "WorkMail", AWSServiceName: workmail.ServiceName, AWSEndpointsID: workmail.EndpointsID, AWSServiceID: workmail.ServiceID, ProviderNameUpper: "WorkMail", HCLKeys: []string{"workmail"}}
-	serviceData[WorkMailMessageFlow] = &ServiceDatum{AWSClientName: "WorkMailMessageFlow", AWSServiceName: workmailmessageflow.ServiceName, AWSEndpointsID: workmailmessageflow.EndpointsID, AWSServiceID: workmailmessageflow.ServiceID, ProviderNameUpper: "WorkMailMessageFlow", HCLKeys: []string{"workmailmessageflow"}}
-	serviceData[WorkSpaces] = &ServiceDatum{AWSClientName: "WorkSpaces", AWSServiceName: workspaces.ServiceName, AWSEndpointsID: workspaces.EndpointsID, AWSServiceID: workspaces.ServiceID, ProviderNameUpper: "WorkSpaces", HCLKeys: []string{"workspaces"}}
-	serviceData[XRay] = &ServiceDatum{AWSClientName: "XRay", AWSServiceName: xray.ServiceName, AWSEndpointsID: xray.EndpointsID, AWSServiceID: xray.ServiceID, ProviderNameUpper: "XRay", HCLKeys: []string{"xray"}}
-}
 
 type Config struct {
 	AccessKey                      string
@@ -1208,7 +633,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		APNInfo:                 StdUserAgentProducts(c.TerraformVersion),
 		CallerDocumentationURL:  "https://registry.terraform.io/providers/hashicorp/aws",
 		CallerName:              "Terraform AWS Provider",
-		IamEndpoint:             c.Endpoints[IAM],
+		IamEndpoint:             c.Endpoints[names.IAM],
 		Insecure:                c.Insecure,
 		HTTPProxy:               c.HTTPProxy,
 		MaxRetries:              c.MaxRetries,
@@ -1218,7 +643,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		SkipCredsValidation:     c.SkipCredsValidation,
 		SkipEC2MetadataApiCheck: c.SkipMetadataApiCheck,
 		SkipRequestingAccountId: c.SkipRequestingAccountId,
-		StsEndpoint:             c.Endpoints[STS],
+		StsEndpoint:             c.Endpoints[names.STS],
 		Token:                   c.Token,
 		UseDualStackEndpoint:    c.UseDualStackEndpoint,
 		UseFIPSEndpoint:         c.UseFIPSEndpoint,
@@ -1301,295 +726,295 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	}
 
 	client := &AWSClient{
-		AccessAnalyzerConn:                accessanalyzer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AccessAnalyzer])})),
-		AccountConn:                       account.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Account])})),
+		AccessAnalyzerConn:                accessanalyzer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AccessAnalyzer])})),
+		AccountConn:                       account.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Account])})),
 		AccountID:                         accountID,
-		ACMConn:                           acm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ACM])})),
-		ACMPCAConn:                        acmpca.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ACMPCA])})),
-		AlexaForBusinessConn:              alexaforbusiness.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AlexaForBusiness])})),
-		AMPConn:                           prometheusservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AMP])})),
-		AmplifyBackendConn:                amplifybackend.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AmplifyBackend])})),
-		AmplifyConn:                       amplify.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Amplify])})),
-		APIGatewayConn:                    apigateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[APIGateway])})),
-		APIGatewayV2Conn:                  apigatewayv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[APIGatewayV2])})),
-		AppAutoScalingConn:                applicationautoscaling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppAutoScaling])})),
-		AppConfigConn:                     appconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppConfig])})),
-		AppFlowConn:                       appflow.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppFlow])})),
-		AppIntegrationsConn:               appintegrationsservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppIntegrations])})),
-		ApplicationCostProfilerConn:       applicationcostprofiler.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ApplicationCostProfiler])})),
-		ApplicationDiscoveryConn:          applicationdiscoveryservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ApplicationDiscovery])})),
-		ApplicationInsightsConn:           applicationinsights.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ApplicationInsights])})),
-		AppMeshConn:                       appmesh.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppMesh])})),
-		AppRegistryConn:                   appregistry.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppRegistry])})),
-		AppRunnerConn:                     apprunner.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppRunner])})),
-		AppStreamConn:                     appstream.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppStream])})),
-		AppSyncConn:                       appsync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AppSync])})),
-		AthenaConn:                        athena.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Athena])})),
-		AuditManagerConn:                  auditmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AuditManager])})),
-		AugmentedAIRuntimeConn:            augmentedairuntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AugmentedAIRuntime])})),
-		AutoScalingConn:                   autoscaling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AutoScaling])})),
-		AutoScalingPlansConn:              autoscalingplans.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[AutoScalingPlans])})),
-		BackupConn:                        backup.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Backup])})),
-		BatchConn:                         batch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Batch])})),
-		BraketConn:                        braket.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Braket])})),
-		BudgetsConn:                       budgets.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Budgets])})),
-		ChimeConn:                         chime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Chime])})),
-		Cloud9Conn:                        cloud9.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Cloud9])})),
-		CloudControlConn:                  cloudcontrolapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudControl])})),
-		CloudDirectoryConn:                clouddirectory.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudDirectory])})),
-		CloudFormationConn:                cloudformation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudFormation])})),
-		CloudFrontConn:                    cloudfront.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudFront])})),
-		CloudHSMV2Conn:                    cloudhsmv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudHSMV2])})),
-		CloudSearchConn:                   cloudsearch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudSearch])})),
-		CloudSearchDomainConn:             cloudsearchdomain.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudSearchDomain])})),
-		CloudTrailConn:                    cloudtrail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudTrail])})),
-		CloudWatchConn:                    cloudwatch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudWatch])})),
-		CloudWatchLogsConn:                cloudwatchlogs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudWatchLogs])})),
-		CloudWatchRUMConn:                 cloudwatchrum.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CloudWatchRUM])})),
-		CodeArtifactConn:                  codeartifact.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeArtifact])})),
-		CodeBuildConn:                     codebuild.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeBuild])})),
-		CodeCommitConn:                    codecommit.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeCommit])})),
-		CodeDeployConn:                    codedeploy.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeDeploy])})),
-		CodeGuruProfilerConn:              codeguruprofiler.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeGuruProfiler])})),
-		CodeGuruReviewerConn:              codegurureviewer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeGuruReviewer])})),
-		CodePipelineConn:                  codepipeline.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodePipeline])})),
-		CodeStarConn:                      codestar.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeStar])})),
-		CodeStarConnectionsConn:           codestarconnections.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeStarConnections])})),
-		CodeStarNotificationsConn:         codestarnotifications.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CodeStarNotifications])})),
-		CognitoIdentityConn:               cognitoidentity.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CognitoIdentity])})),
-		CognitoIDPConn:                    cognitoidentityprovider.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CognitoIDP])})),
-		CognitoSyncConn:                   cognitosync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CognitoSync])})),
-		ComprehendConn:                    comprehend.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Comprehend])})),
-		ComprehendMedicalConn:             comprehendmedical.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ComprehendMedical])})),
-		ConfigServiceConn:                 configservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ConfigService])})),
-		ConnectConn:                       connect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Connect])})),
-		ConnectContactLensConn:            connectcontactlens.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ConnectContactLens])})),
-		ConnectParticipantConn:            connectparticipant.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ConnectParticipant])})),
-		CostExplorerConn:                  costexplorer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CostExplorer])})),
-		CURConn:                           costandusagereportservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[CUR])})),
-		DataExchangeConn:                  dataexchange.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DataExchange])})),
-		DataPipelineConn:                  datapipeline.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DataPipeline])})),
-		DataSyncConn:                      datasync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DataSync])})),
-		DAXConn:                           dax.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DAX])})),
+		ACMConn:                           acm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ACM])})),
+		ACMPCAConn:                        acmpca.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ACMPCA])})),
+		AlexaForBusinessConn:              alexaforbusiness.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AlexaForBusiness])})),
+		AMPConn:                           prometheusservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AMP])})),
+		AmplifyBackendConn:                amplifybackend.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AmplifyBackend])})),
+		AmplifyConn:                       amplify.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Amplify])})),
+		APIGatewayConn:                    apigateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.APIGateway])})),
+		APIGatewayV2Conn:                  apigatewayv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.APIGatewayV2])})),
+		AppAutoScalingConn:                applicationautoscaling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppAutoScaling])})),
+		AppConfigConn:                     appconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppConfig])})),
+		AppFlowConn:                       appflow.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppFlow])})),
+		AppIntegrationsConn:               appintegrationsservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppIntegrations])})),
+		ApplicationCostProfilerConn:       applicationcostprofiler.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ApplicationCostProfiler])})),
+		ApplicationDiscoveryConn:          applicationdiscoveryservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ApplicationDiscovery])})),
+		ApplicationInsightsConn:           applicationinsights.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ApplicationInsights])})),
+		AppMeshConn:                       appmesh.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppMesh])})),
+		AppRegistryConn:                   appregistry.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppRegistry])})),
+		AppRunnerConn:                     apprunner.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppRunner])})),
+		AppStreamConn:                     appstream.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppStream])})),
+		AppSyncConn:                       appsync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AppSync])})),
+		AthenaConn:                        athena.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Athena])})),
+		AuditManagerConn:                  auditmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AuditManager])})),
+		AugmentedAIRuntimeConn:            augmentedairuntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AugmentedAIRuntime])})),
+		AutoScalingConn:                   autoscaling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AutoScaling])})),
+		AutoScalingPlansConn:              autoscalingplans.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AutoScalingPlans])})),
+		BackupConn:                        backup.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Backup])})),
+		BatchConn:                         batch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Batch])})),
+		BraketConn:                        braket.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Braket])})),
+		BudgetsConn:                       budgets.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Budgets])})),
+		ChimeConn:                         chime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Chime])})),
+		Cloud9Conn:                        cloud9.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Cloud9])})),
+		CloudControlConn:                  cloudcontrolapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudControl])})),
+		CloudDirectoryConn:                clouddirectory.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudDirectory])})),
+		CloudFormationConn:                cloudformation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudFormation])})),
+		CloudFrontConn:                    cloudfront.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudFront])})),
+		CloudHSMV2Conn:                    cloudhsmv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudHSMV2])})),
+		CloudSearchConn:                   cloudsearch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudSearch])})),
+		CloudSearchDomainConn:             cloudsearchdomain.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudSearchDomain])})),
+		CloudTrailConn:                    cloudtrail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudTrail])})),
+		CloudWatchConn:                    cloudwatch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatch])})),
+		CloudWatchLogsConn:                cloudwatchlogs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatchLogs])})),
+		CloudWatchRUMConn:                 cloudwatchrum.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatchRUM])})),
+		CodeArtifactConn:                  codeartifact.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeArtifact])})),
+		CodeBuildConn:                     codebuild.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeBuild])})),
+		CodeCommitConn:                    codecommit.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeCommit])})),
+		CodeDeployConn:                    codedeploy.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeDeploy])})),
+		CodeGuruProfilerConn:              codeguruprofiler.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeGuruProfiler])})),
+		CodeGuruReviewerConn:              codegurureviewer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeGuruReviewer])})),
+		CodePipelineConn:                  codepipeline.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodePipeline])})),
+		CodeStarConn:                      codestar.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeStar])})),
+		CodeStarConnectionsConn:           codestarconnections.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeStarConnections])})),
+		CodeStarNotificationsConn:         codestarnotifications.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeStarNotifications])})),
+		CognitoIdentityConn:               cognitoidentity.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CognitoIdentity])})),
+		CognitoIDPConn:                    cognitoidentityprovider.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CognitoIDP])})),
+		CognitoSyncConn:                   cognitosync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CognitoSync])})),
+		ComprehendConn:                    comprehend.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Comprehend])})),
+		ComprehendMedicalConn:             comprehendmedical.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ComprehendMedical])})),
+		ConfigServiceConn:                 configservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ConfigService])})),
+		ConnectConn:                       connect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Connect])})),
+		ConnectContactLensConn:            connectcontactlens.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ConnectContactLens])})),
+		ConnectParticipantConn:            connectparticipant.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ConnectParticipant])})),
+		CostExplorerConn:                  costexplorer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CostExplorer])})),
+		CURConn:                           costandusagereportservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CUR])})),
+		DataExchangeConn:                  dataexchange.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DataExchange])})),
+		DataPipelineConn:                  datapipeline.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DataPipeline])})),
+		DataSyncConn:                      datasync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DataSync])})),
+		DAXConn:                           dax.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DAX])})),
 		DefaultTagsConfig:                 c.DefaultTagsConfig,
-		DetectiveConn:                     detective.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Detective])})),
-		DeviceFarmConn:                    devicefarm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DeviceFarm])})),
-		DevOpsGuruConn:                    devopsguru.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DevOpsGuru])})),
-		DirectConnectConn:                 directconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DirectConnect])})),
-		DLMConn:                           dlm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DLM])})),
-		DMSConn:                           databasemigrationservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DMS])})),
+		DetectiveConn:                     detective.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Detective])})),
+		DeviceFarmConn:                    devicefarm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DeviceFarm])})),
+		DevOpsGuruConn:                    devopsguru.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DevOpsGuru])})),
+		DirectConnectConn:                 directconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DirectConnect])})),
+		DLMConn:                           dlm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DLM])})),
+		DMSConn:                           databasemigrationservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DMS])})),
 		DNSSuffix:                         DNSSuffix,
-		DocDBConn:                         docdb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DocDB])})),
-		DSConn:                            directoryservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DS])})),
-		DynamoDBConn:                      dynamodb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DynamoDB])})),
-		DynamoDBStreamsConn:               dynamodbstreams.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[DynamoDBStreams])})),
-		EC2Conn:                           ec2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[EC2])})),
-		EC2InstanceConnectConn:            ec2instanceconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[EC2InstanceConnect])})),
-		ECRConn:                           ecr.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ECR])})),
-		ECRPublicConn:                     ecrpublic.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ECRPublic])})),
-		ECSConn:                           ecs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ECS])})),
-		EFSConn:                           efs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[EFS])})),
-		EKSConn:                           eks.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[EKS])})),
-		ElastiCacheConn:                   elasticache.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ElastiCache])})),
-		ElasticBeanstalkConn:              elasticbeanstalk.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ElasticBeanstalk])})),
-		ElasticInferenceConn:              elasticinference.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ElasticInference])})),
-		ElasticsearchConn:                 elasticsearch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Elasticsearch])})),
-		ElasticTranscoderConn:             elastictranscoder.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ElasticTranscoder])})),
-		ELBConn:                           elb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ELB])})),
-		ELBV2Conn:                         elbv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ELBV2])})),
-		EMRConn:                           emr.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[EMR])})),
-		EMRContainersConn:                 emrcontainers.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[EMRContainers])})),
-		EventsConn:                        eventbridge.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Events])})),
-		FinSpaceConn:                      finspace.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[FinSpace])})),
-		FinSpaceDataConn:                  finspacedata.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[FinSpaceData])})),
-		FirehoseConn:                      firehose.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Firehose])})),
-		FISConn:                           fis.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[FIS])})),
-		FMSConn:                           fms.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[FMS])})),
-		ForecastConn:                      forecastservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Forecast])})),
-		ForecastQueryConn:                 forecastqueryservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ForecastQuery])})),
-		FraudDetectorConn:                 frauddetector.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[FraudDetector])})),
-		FSxConn:                           fsx.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[FSx])})),
-		GameLiftConn:                      gamelift.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[GameLift])})),
-		GlacierConn:                       glacier.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Glacier])})),
-		GlueConn:                          glue.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Glue])})),
-		GlueDataBrewConn:                  gluedatabrew.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[GlueDataBrew])})),
-		GrafanaConn:                       managedgrafana.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Grafana])})),
-		GreengrassConn:                    greengrass.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Greengrass])})),
-		GreengrassV2Conn:                  greengrassv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[GreengrassV2])})),
-		GroundStationConn:                 groundstation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[GroundStation])})),
-		GuardDutyConn:                     guardduty.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[GuardDuty])})),
-		HealthConn:                        health.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Health])})),
-		HealthLakeConn:                    healthlake.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[HealthLake])})),
-		HoneycodeConn:                     honeycode.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Honeycode])})),
-		IAMConn:                           iam.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IAM])})),
-		IdentityStoreConn:                 identitystore.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IdentityStore])})),
+		DocDBConn:                         docdb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DocDB])})),
+		DSConn:                            directoryservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DS])})),
+		DynamoDBConn:                      dynamodb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DynamoDB])})),
+		DynamoDBStreamsConn:               dynamodbstreams.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.DynamoDBStreams])})),
+		EC2Conn:                           ec2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EC2])})),
+		EC2InstanceConnectConn:            ec2instanceconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EC2InstanceConnect])})),
+		ECRConn:                           ecr.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ECR])})),
+		ECRPublicConn:                     ecrpublic.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ECRPublic])})),
+		ECSConn:                           ecs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ECS])})),
+		EFSConn:                           efs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EFS])})),
+		EKSConn:                           eks.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EKS])})),
+		ElastiCacheConn:                   elasticache.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ElastiCache])})),
+		ElasticBeanstalkConn:              elasticbeanstalk.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ElasticBeanstalk])})),
+		ElasticInferenceConn:              elasticinference.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ElasticInference])})),
+		ElasticsearchConn:                 elasticsearch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Elasticsearch])})),
+		ElasticTranscoderConn:             elastictranscoder.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ElasticTranscoder])})),
+		ELBConn:                           elb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ELB])})),
+		ELBV2Conn:                         elbv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ELBV2])})),
+		EMRConn:                           emr.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EMR])})),
+		EMRContainersConn:                 emrcontainers.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EMRContainers])})),
+		EventsConn:                        eventbridge.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Events])})),
+		FinSpaceConn:                      finspace.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.FinSpace])})),
+		FinSpaceDataConn:                  finspacedata.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.FinSpaceData])})),
+		FirehoseConn:                      firehose.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Firehose])})),
+		FISConn:                           fis.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.FIS])})),
+		FMSConn:                           fms.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.FMS])})),
+		ForecastConn:                      forecastservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Forecast])})),
+		ForecastQueryConn:                 forecastqueryservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ForecastQuery])})),
+		FraudDetectorConn:                 frauddetector.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.FraudDetector])})),
+		FSxConn:                           fsx.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.FSx])})),
+		GameLiftConn:                      gamelift.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.GameLift])})),
+		GlacierConn:                       glacier.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Glacier])})),
+		GlueConn:                          glue.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Glue])})),
+		GlueDataBrewConn:                  gluedatabrew.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.GlueDataBrew])})),
+		GrafanaConn:                       managedgrafana.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Grafana])})),
+		GreengrassConn:                    greengrass.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Greengrass])})),
+		GreengrassV2Conn:                  greengrassv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.GreengrassV2])})),
+		GroundStationConn:                 groundstation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.GroundStation])})),
+		GuardDutyConn:                     guardduty.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.GuardDuty])})),
+		HealthConn:                        health.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Health])})),
+		HealthLakeConn:                    healthlake.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.HealthLake])})),
+		HoneycodeConn:                     honeycode.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Honeycode])})),
+		IAMConn:                           iam.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IAM])})),
+		IdentityStoreConn:                 identitystore.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IdentityStore])})),
 		IgnoreTagsConfig:                  c.IgnoreTagsConfig,
-		ImageBuilderConn:                  imagebuilder.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ImageBuilder])})),
-		InspectorConn:                     inspector.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Inspector])})),
-		IoT1ClickDevicesConn:              iot1clickdevicesservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoT1ClickDevices])})),
-		IoT1ClickProjectsConn:             iot1clickprojects.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoT1ClickProjects])})),
-		IoTAnalyticsConn:                  iotanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTAnalytics])})),
-		IoTConn:                           iot.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoT])})),
-		IoTDataPlaneConn:                  iotdataplane.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTDataPlane])})),
-		IoTDeviceAdvisorConn:              iotdeviceadvisor.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTDeviceAdvisor])})),
-		IoTEventsConn:                     iotevents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTEvents])})),
-		IoTEventsDataConn:                 ioteventsdata.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTEventsData])})),
-		IoTFleetHubConn:                   iotfleethub.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTFleetHub])})),
-		IoTJobsDataPlaneConn:              iotjobsdataplane.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTJobsDataPlane])})),
-		IoTSecureTunnelingConn:            iotsecuretunneling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTSecureTunneling])})),
-		IoTSiteWiseConn:                   iotsitewise.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTSiteWise])})),
-		IoTThingsGraphConn:                iotthingsgraph.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTThingsGraph])})),
-		IoTWirelessConn:                   iotwireless.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[IoTWireless])})),
-		KafkaConn:                         kafka.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Kafka])})),
-		KafkaConnectConn:                  kafkaconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KafkaConnect])})),
-		KendraConn:                        kendra.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Kendra])})),
-		KeyspacesConn:                     keyspaces.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Keyspaces])})),
-		KinesisAnalyticsConn:              kinesisanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KinesisAnalytics])})),
-		KinesisAnalyticsV2Conn:            kinesisanalyticsv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KinesisAnalyticsV2])})),
-		KinesisConn:                       kinesis.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Kinesis])})),
-		KinesisVideoArchivedMediaConn:     kinesisvideoarchivedmedia.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KinesisVideoArchivedMedia])})),
-		KinesisVideoConn:                  kinesisvideo.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KinesisVideo])})),
-		KinesisVideoMediaConn:             kinesisvideomedia.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KinesisVideoMedia])})),
-		KinesisVideoSignalingChannelsConn: kinesisvideosignalingchannels.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KinesisVideoSignalingChannels])})),
-		KMSConn:                           kms.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[KMS])})),
-		LakeFormationConn:                 lakeformation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LakeFormation])})),
-		LambdaConn:                        lambda.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Lambda])})),
-		LexModelsConn:                     lexmodelbuildingservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LexModels])})),
-		LexModelsV2Conn:                   lexmodelsv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LexModelsV2])})),
-		LexRuntimeConn:                    lexruntimeservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LexRuntime])})),
-		LexRuntimeV2Conn:                  lexruntimev2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LexRuntimeV2])})),
-		LicenseManagerConn:                licensemanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LicenseManager])})),
-		LightsailConn:                     lightsail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Lightsail])})),
-		LocationConn:                      locationservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Location])})),
-		LookoutEquipmentConn:              lookoutequipment.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LookoutEquipment])})),
-		LookoutForVisionConn:              lookoutforvision.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LookoutForVision])})),
-		LookoutMetricsConn:                lookoutmetrics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[LookoutMetrics])})),
-		MachineLearningConn:               machinelearning.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MachineLearning])})),
-		Macie2Conn:                        macie2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Macie2])})),
-		MacieConn:                         macie.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Macie])})),
-		ManagedBlockchainConn:             managedblockchain.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ManagedBlockchain])})),
-		MarketplaceCatalogConn:            marketplacecatalog.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MarketplaceCatalog])})),
-		MarketplaceCommerceAnalyticsConn:  marketplacecommerceanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MarketplaceCommerceAnalytics])})),
-		MarketplaceEntitlementConn:        marketplaceentitlementservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MarketplaceEntitlement])})),
-		MarketplaceMeteringConn:           marketplacemetering.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MarketplaceMetering])})),
-		MediaConnectConn:                  mediaconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaConnect])})),
-		MediaConvertConn:                  mediaconvert.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaConvert])})),
-		MediaLiveConn:                     medialive.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaLive])})),
-		MediaPackageConn:                  mediapackage.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaPackage])})),
-		MediaPackageVODConn:               mediapackagevod.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaPackageVOD])})),
-		MediaStoreConn:                    mediastore.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaStore])})),
-		MediaStoreDataConn:                mediastoredata.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaStoreData])})),
-		MediaTailorConn:                   mediatailor.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MediaTailor])})),
-		MemoryDBConn:                      memorydb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MemoryDB])})),
-		MgnConn:                           mgn.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Mgn])})),
-		MigrationHubConfigConn:            migrationhubconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MigrationHubConfig])})),
-		MigrationHubConn:                  migrationhub.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MigrationHub])})),
-		MobileAnalyticsConn:               mobileanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MobileAnalytics])})),
-		MobileConn:                        mobile.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Mobile])})),
-		MQConn:                            mq.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MQ])})),
-		MTurkConn:                         mturk.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MTurk])})),
-		MWAAConn:                          mwaa.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[MWAA])})),
-		NeptuneConn:                       neptune.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Neptune])})),
-		NetworkFirewallConn:               networkfirewall.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[NetworkFirewall])})),
-		NetworkManagerConn:                networkmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[NetworkManager])})),
-		NimbleStudioConn:                  nimblestudio.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[NimbleStudio])})),
-		OpsWorksCMConn:                    opsworkscm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[OpsWorksCM])})),
-		OpsWorksConn:                      opsworks.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[OpsWorks])})),
-		OrganizationsConn:                 organizations.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Organizations])})),
-		OutpostsConn:                      outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Outposts])})),
+		ImageBuilderConn:                  imagebuilder.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ImageBuilder])})),
+		InspectorConn:                     inspector.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Inspector])})),
+		IoT1ClickDevicesConn:              iot1clickdevicesservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoT1ClickDevices])})),
+		IoT1ClickProjectsConn:             iot1clickprojects.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoT1ClickProjects])})),
+		IoTAnalyticsConn:                  iotanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTAnalytics])})),
+		IoTConn:                           iot.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoT])})),
+		IoTDataPlaneConn:                  iotdataplane.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTDataPlane])})),
+		IoTDeviceAdvisorConn:              iotdeviceadvisor.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTDeviceAdvisor])})),
+		IoTEventsConn:                     iotevents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTEvents])})),
+		IoTEventsDataConn:                 ioteventsdata.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTEventsData])})),
+		IoTFleetHubConn:                   iotfleethub.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTFleetHub])})),
+		IoTJobsDataPlaneConn:              iotjobsdataplane.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTJobsDataPlane])})),
+		IoTSecureTunnelingConn:            iotsecuretunneling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTSecureTunneling])})),
+		IoTSiteWiseConn:                   iotsitewise.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTSiteWise])})),
+		IoTThingsGraphConn:                iotthingsgraph.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTThingsGraph])})),
+		IoTWirelessConn:                   iotwireless.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IoTWireless])})),
+		KafkaConn:                         kafka.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Kafka])})),
+		KafkaConnectConn:                  kafkaconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KafkaConnect])})),
+		KendraConn:                        kendra.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Kendra])})),
+		KeyspacesConn:                     keyspaces.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Keyspaces])})),
+		KinesisAnalyticsConn:              kinesisanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KinesisAnalytics])})),
+		KinesisAnalyticsV2Conn:            kinesisanalyticsv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KinesisAnalyticsV2])})),
+		KinesisConn:                       kinesis.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Kinesis])})),
+		KinesisVideoArchivedMediaConn:     kinesisvideoarchivedmedia.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KinesisVideoArchivedMedia])})),
+		KinesisVideoConn:                  kinesisvideo.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KinesisVideo])})),
+		KinesisVideoMediaConn:             kinesisvideomedia.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KinesisVideoMedia])})),
+		KinesisVideoSignalingChannelsConn: kinesisvideosignalingchannels.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KinesisVideoSignalingChannels])})),
+		KMSConn:                           kms.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.KMS])})),
+		LakeFormationConn:                 lakeformation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LakeFormation])})),
+		LambdaConn:                        lambda.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Lambda])})),
+		LexModelsConn:                     lexmodelbuildingservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LexModels])})),
+		LexModelsV2Conn:                   lexmodelsv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LexModelsV2])})),
+		LexRuntimeConn:                    lexruntimeservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LexRuntime])})),
+		LexRuntimeV2Conn:                  lexruntimev2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LexRuntimeV2])})),
+		LicenseManagerConn:                licensemanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LicenseManager])})),
+		LightsailConn:                     lightsail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Lightsail])})),
+		LocationConn:                      locationservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Location])})),
+		LookoutEquipmentConn:              lookoutequipment.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LookoutEquipment])})),
+		LookoutForVisionConn:              lookoutforvision.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LookoutForVision])})),
+		LookoutMetricsConn:                lookoutmetrics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.LookoutMetrics])})),
+		MachineLearningConn:               machinelearning.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MachineLearning])})),
+		Macie2Conn:                        macie2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Macie2])})),
+		MacieConn:                         macie.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Macie])})),
+		ManagedBlockchainConn:             managedblockchain.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ManagedBlockchain])})),
+		MarketplaceCatalogConn:            marketplacecatalog.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MarketplaceCatalog])})),
+		MarketplaceCommerceAnalyticsConn:  marketplacecommerceanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MarketplaceCommerceAnalytics])})),
+		MarketplaceEntitlementConn:        marketplaceentitlementservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MarketplaceEntitlement])})),
+		MarketplaceMeteringConn:           marketplacemetering.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MarketplaceMetering])})),
+		MediaConnectConn:                  mediaconnect.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaConnect])})),
+		MediaConvertConn:                  mediaconvert.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaConvert])})),
+		MediaLiveConn:                     medialive.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaLive])})),
+		MediaPackageConn:                  mediapackage.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaPackage])})),
+		MediaPackageVODConn:               mediapackagevod.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaPackageVOD])})),
+		MediaStoreConn:                    mediastore.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaStore])})),
+		MediaStoreDataConn:                mediastoredata.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaStoreData])})),
+		MediaTailorConn:                   mediatailor.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MediaTailor])})),
+		MemoryDBConn:                      memorydb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MemoryDB])})),
+		MgnConn:                           mgn.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Mgn])})),
+		MigrationHubConfigConn:            migrationhubconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MigrationHubConfig])})),
+		MigrationHubConn:                  migrationhub.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MigrationHub])})),
+		MobileAnalyticsConn:               mobileanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MobileAnalytics])})),
+		MobileConn:                        mobile.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Mobile])})),
+		MQConn:                            mq.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MQ])})),
+		MTurkConn:                         mturk.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MTurk])})),
+		MWAAConn:                          mwaa.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.MWAA])})),
+		NeptuneConn:                       neptune.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Neptune])})),
+		NetworkFirewallConn:               networkfirewall.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.NetworkFirewall])})),
+		NetworkManagerConn:                networkmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.NetworkManager])})),
+		NimbleStudioConn:                  nimblestudio.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.NimbleStudio])})),
+		OpsWorksCMConn:                    opsworkscm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.OpsWorksCM])})),
+		OpsWorksConn:                      opsworks.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.OpsWorks])})),
+		OrganizationsConn:                 organizations.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Organizations])})),
+		OutpostsConn:                      outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Outposts])})),
 		Partition:                         partition,
-		PersonalizeConn:                   personalize.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Personalize])})),
-		PersonalizeEventsConn:             personalizeevents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PersonalizeEvents])})),
-		PersonalizeRuntimeConn:            personalizeruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PersonalizeRuntime])})),
-		PIConn:                            pi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PI])})),
-		PinpointConn:                      pinpoint.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Pinpoint])})),
-		PinpointEmailConn:                 pinpointemail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PinpointEmail])})),
-		PinpointSMSVoiceConn:              pinpointsmsvoice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[PinpointSMSVoice])})),
-		PollyConn:                         polly.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Polly])})),
-		PricingConn:                       pricing.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Pricing])})),
-		ProtonConn:                        proton.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Proton])})),
-		QLDBConn:                          qldb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[QLDB])})),
-		QLDBSessionConn:                   qldbsession.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[QLDBSession])})),
-		QuickSightConn:                    quicksight.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[QuickSight])})),
-		RAMConn:                           ram.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[RAM])})),
-		RDSConn:                           rds.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[RDS])})),
-		RDSDataConn:                       rdsdataservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[RDSData])})),
-		RedshiftConn:                      redshift.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Redshift])})),
-		RedshiftDataConn:                  redshiftdataapiservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[RedshiftData])})),
+		PersonalizeConn:                   personalize.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Personalize])})),
+		PersonalizeEventsConn:             personalizeevents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.PersonalizeEvents])})),
+		PersonalizeRuntimeConn:            personalizeruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.PersonalizeRuntime])})),
+		PIConn:                            pi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.PI])})),
+		PinpointConn:                      pinpoint.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Pinpoint])})),
+		PinpointEmailConn:                 pinpointemail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.PinpointEmail])})),
+		PinpointSMSVoiceConn:              pinpointsmsvoice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.PinpointSMSVoice])})),
+		PollyConn:                         polly.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Polly])})),
+		PricingConn:                       pricing.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Pricing])})),
+		ProtonConn:                        proton.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Proton])})),
+		QLDBConn:                          qldb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.QLDB])})),
+		QLDBSessionConn:                   qldbsession.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.QLDBSession])})),
+		QuickSightConn:                    quicksight.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.QuickSight])})),
+		RAMConn:                           ram.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.RAM])})),
+		RDSConn:                           rds.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.RDS])})),
+		RDSDataConn:                       rdsdataservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.RDSData])})),
+		RedshiftConn:                      redshift.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Redshift])})),
+		RedshiftDataConn:                  redshiftdataapiservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.RedshiftData])})),
 		Region:                            c.Region,
-		RekognitionConn:                   rekognition.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Rekognition])})),
-		ResourceGroupsConn:                resourcegroups.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ResourceGroups])})),
-		ResourceGroupsTaggingAPIConn:      resourcegroupstaggingapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ResourceGroupsTaggingAPI])})),
+		RekognitionConn:                   rekognition.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Rekognition])})),
+		ResourceGroupsConn:                resourcegroups.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ResourceGroups])})),
+		ResourceGroupsTaggingAPIConn:      resourcegroupstaggingapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ResourceGroupsTaggingAPI])})),
 		ReverseDNSPrefix:                  ReverseDNS(DNSSuffix),
-		RoboMakerConn:                     robomaker.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[RoboMaker])})),
+		RoboMakerConn:                     robomaker.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.RoboMaker])})),
 		Route53DomainsConn: route53domains.NewFromConfig(cfg, func(o *route53domains.Options) {
-			if endpoint := c.Endpoints[Route53Domains]; endpoint != "" {
+			if endpoint := c.Endpoints[names.Route53Domains]; endpoint != "" {
 				o.EndpointResolver = route53domains.EndpointResolverFromURL(endpoint)
 			} else if partition == endpoints.AwsPartitionID {
 				// Route 53 Domains is only available in AWS Commercial us-east-1 Region.
 				o.Region = endpoints.UsEast1RegionID
 			}
 		}),
-		Route53RecoveryControlConfigConn: route53recoverycontrolconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Route53RecoveryControlConfig])})),
-		Route53RecoveryReadinessConn:     route53recoveryreadiness.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Route53RecoveryReadiness])})),
-		Route53ResolverConn:              route53resolver.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Route53Resolver])})),
-		S3ControlConn:                    s3control.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[S3Control])})),
-		S3OutpostsConn:                   s3outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[S3Outposts])})),
-		SageMakerConn:                    sagemaker.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SageMaker])})),
-		SageMakerEdgeManagerConn:         sagemakeredgemanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SageMakerEdgeManager])})),
-		SageMakerFeatureStoreRuntimeConn: sagemakerfeaturestoreruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SageMakerFeatureStoreRuntime])})),
-		SageMakerRuntimeConn:             sagemakerruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SageMakerRuntime])})),
-		SavingsPlansConn:                 savingsplans.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SavingsPlans])})),
-		SchemasConn:                      schemas.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Schemas])})),
-		SecretsManagerConn:               secretsmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SecretsManager])})),
-		SecurityHubConn:                  securityhub.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SecurityHub])})),
-		ServerlessRepoConn:               serverlessapplicationrepository.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ServerlessRepo])})),
-		ServiceCatalogConn:               servicecatalog.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ServiceCatalog])})),
-		ServiceDiscoveryConn:             servicediscovery.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ServiceDiscovery])})),
-		ServiceQuotasConn:                servicequotas.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[ServiceQuotas])})),
-		SESConn:                          ses.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SES])})),
-		SESV2Conn:                        sesv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SESV2])})),
+		Route53RecoveryControlConfigConn: route53recoverycontrolconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Route53RecoveryControlConfig])})),
+		Route53RecoveryReadinessConn:     route53recoveryreadiness.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Route53RecoveryReadiness])})),
+		Route53ResolverConn:              route53resolver.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Route53Resolver])})),
+		S3ControlConn:                    s3control.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.S3Control])})),
+		S3OutpostsConn:                   s3outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.S3Outposts])})),
+		SageMakerConn:                    sagemaker.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMaker])})),
+		SageMakerEdgeManagerConn:         sagemakeredgemanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMakerEdgeManager])})),
+		SageMakerFeatureStoreRuntimeConn: sagemakerfeaturestoreruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMakerFeatureStoreRuntime])})),
+		SageMakerRuntimeConn:             sagemakerruntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMakerRuntime])})),
+		SavingsPlansConn:                 savingsplans.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SavingsPlans])})),
+		SchemasConn:                      schemas.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Schemas])})),
+		SecretsManagerConn:               secretsmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SecretsManager])})),
+		SecurityHubConn:                  securityhub.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SecurityHub])})),
+		ServerlessRepoConn:               serverlessapplicationrepository.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ServerlessRepo])})),
+		ServiceCatalogConn:               servicecatalog.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ServiceCatalog])})),
+		ServiceDiscoveryConn:             servicediscovery.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ServiceDiscovery])})),
+		ServiceQuotasConn:                servicequotas.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ServiceQuotas])})),
+		SESConn:                          ses.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SES])})),
+		SESV2Conn:                        sesv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SESV2])})),
 		Session:                          sess,
-		SFNConn:                          sfn.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SFN])})),
-		SignerConn:                       signer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Signer])})),
-		SimpleDBConn:                     simpledb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SimpleDB])})),
-		SMSConn:                          sms.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SMS])})),
-		SnowballConn:                     snowball.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Snowball])})),
-		SNSConn:                          sns.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SNS])})),
-		SQSConn:                          sqs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SQS])})),
-		SSMConn:                          ssm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSM])})),
-		SSMContactsConn:                  ssmcontacts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSMContacts])})),
-		SSMIncidentsConn:                 ssmincidents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSMIncidents])})),
-		SSOAdminConn:                     ssoadmin.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSOAdmin])})),
-		SSOConn:                          sso.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSO])})),
-		SSOOIDCConn:                      ssooidc.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSOOIDC])})),
-		StorageGatewayConn:               storagegateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[StorageGateway])})),
-		SupportConn:                      support.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Support])})),
-		SWFConn:                          swf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SWF])})),
-		SyntheticsConn:                   synthetics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Synthetics])})),
+		SFNConn:                          sfn.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SFN])})),
+		SignerConn:                       signer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Signer])})),
+		SimpleDBConn:                     simpledb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SimpleDB])})),
+		SMSConn:                          sms.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SMS])})),
+		SnowballConn:                     snowball.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Snowball])})),
+		SNSConn:                          sns.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SNS])})),
+		SQSConn:                          sqs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SQS])})),
+		SSMConn:                          ssm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSM])})),
+		SSMContactsConn:                  ssmcontacts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSMContacts])})),
+		SSMIncidentsConn:                 ssmincidents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSMIncidents])})),
+		SSOAdminConn:                     ssoadmin.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSOAdmin])})),
+		SSOConn:                          sso.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSO])})),
+		SSOOIDCConn:                      ssooidc.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSOOIDC])})),
+		StorageGatewayConn:               storagegateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.StorageGateway])})),
+		SupportConn:                      support.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Support])})),
+		SWFConn:                          swf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SWF])})),
+		SyntheticsConn:                   synthetics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Synthetics])})),
 		TerraformVersion:                 c.TerraformVersion,
-		TextractConn:                     textract.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Textract])})),
-		TimestreamQueryConn:              timestreamquery.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[TimestreamQuery])})),
-		TimestreamWriteConn:              timestreamwrite.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[TimestreamWrite])})),
-		TranscribeConn:                   transcribeservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Transcribe])})),
-		TranscribeStreamingConn:          transcribestreamingservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[TranscribeStreaming])})),
-		TransferConn:                     transfer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Transfer])})),
-		TranslateConn:                    translate.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Translate])})),
-		WAFConn:                          waf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WAF])})),
-		WAFRegionalConn:                  wafregional.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WAFRegional])})),
-		WAFV2Conn:                        wafv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WAFV2])})),
-		WellArchitectedConn:              wellarchitected.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WellArchitected])})),
-		WorkDocsConn:                     workdocs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WorkDocs])})),
-		WorkLinkConn:                     worklink.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WorkLink])})),
-		WorkMailConn:                     workmail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WorkMail])})),
-		WorkMailMessageFlowConn:          workmailmessageflow.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WorkMailMessageFlow])})),
-		WorkSpacesConn:                   workspaces.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[WorkSpaces])})),
-		XRayConn:                         xray.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[XRay])})),
+		TextractConn:                     textract.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Textract])})),
+		TimestreamQueryConn:              timestreamquery.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.TimestreamQuery])})),
+		TimestreamWriteConn:              timestreamwrite.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.TimestreamWrite])})),
+		TranscribeConn:                   transcribeservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Transcribe])})),
+		TranscribeStreamingConn:          transcribestreamingservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.TranscribeStreaming])})),
+		TransferConn:                     transfer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Transfer])})),
+		TranslateConn:                    translate.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Translate])})),
+		WAFConn:                          waf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WAF])})),
+		WAFRegionalConn:                  wafregional.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WAFRegional])})),
+		WAFV2Conn:                        wafv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WAFV2])})),
+		WellArchitectedConn:              wellarchitected.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WellArchitected])})),
+		WorkDocsConn:                     workdocs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WorkDocs])})),
+		WorkLinkConn:                     worklink.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WorkLink])})),
+		WorkMailConn:                     workmail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WorkMail])})),
+		WorkMailMessageFlowConn:          workmailmessageflow.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WorkMailMessageFlow])})),
+		WorkSpacesConn:                   workspaces.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.WorkSpaces])})),
+		XRayConn:                         xray.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.XRay])})),
 	}
 
 	// sts
 	stsConfig := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[STS]),
+		Endpoint: aws.String(c.Endpoints[names.STS]),
 	}
 
 	if c.STSRegion != "" {
@@ -1600,24 +1025,24 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 
 	// "Global" services that require customizations
 	globalAcceleratorConfig := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[GlobalAccelerator]),
+		Endpoint: aws.String(c.Endpoints[names.GlobalAccelerator]),
 	}
 	route53Config := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[Route53]),
+		Endpoint: aws.String(c.Endpoints[names.Route53]),
 	}
 	route53RecoveryControlConfigConfig := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[Route53RecoveryControlConfig]),
+		Endpoint: aws.String(c.Endpoints[names.Route53RecoveryControlConfig]),
 	}
 	route53RecoveryReadinessConfig := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[Route53RecoveryReadiness]),
+		Endpoint: aws.String(c.Endpoints[names.Route53RecoveryReadiness]),
 	}
 	shieldConfig := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[Shield]),
+		Endpoint: aws.String(c.Endpoints[names.Shield]),
 	}
 
 	// Services that require multiple client configurations
 	s3Config := &aws.Config{
-		Endpoint:         aws.String(c.Endpoints[S3]),
+		Endpoint:         aws.String(c.Endpoints[names.S3]),
 		S3ForcePathStyle: aws.Bool(c.S3UsePathStyle),
 	}
 
@@ -1975,61 +1400,3 @@ func ReverseDNS(hostname string) string {
 
 // This is a global MutexKV for use within this plugin.
 var GlobalMutexKV = NewMutexKV()
-
-func ServiceForHCLKey(s string) (string, error) {
-	for k, v := range serviceData {
-		for _, hclKey := range v.HCLKeys {
-			if s == hclKey {
-				return k, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("unable to find service for HCL key %s", s)
-}
-
-func ServiceKeys() []string {
-	keys := make([]string, len(serviceData))
-
-	i := 0
-	for k := range serviceData {
-		keys[i] = k
-		i++
-	}
-
-	return keys
-}
-
-func HCLKeys() []string {
-	keys := make([]string, 0)
-
-	for _, v := range serviceData {
-		keys = append(keys, v.HCLKeys...)
-	}
-
-	return keys
-}
-
-func ServiceProviderNameUpper(key string) (string, error) {
-	if v, ok := serviceData[key]; ok {
-		return v.ProviderNameUpper, nil
-	}
-
-	return "", fmt.Errorf("no service data found for %s", key)
-}
-
-func ServiceDeprecatedEnvVar(key string) string {
-	if v, ok := serviceData[key]; ok {
-		return v.DeprecatedEnvVar
-	}
-
-	return ""
-}
-
-func ServiceEnvVar(key string) string {
-	if v, ok := serviceData[key]; ok {
-		return v.EnvVar
-	}
-
-	return ""
-}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -171,6 +171,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/xray"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // Provider returns a *schema.Provider.
@@ -2124,7 +2125,7 @@ func assumeRoleSchema() *schema.Schema {
 func endpointsSchema() *schema.Schema {
 	endpointsAttributes := make(map[string]*schema.Schema)
 
-	for _, serviceKey := range conns.HCLKeys() {
+	for _, serviceKey := range names.HCLKeys() {
 		endpointsAttributes[serviceKey] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -2248,10 +2249,10 @@ func expandEndpoints(endpointsSetList []interface{}, out map[string]string) erro
 	for _, endpointsSetI := range endpointsSetList {
 		endpoints := endpointsSetI.(map[string]interface{})
 
-		for _, hclKey := range conns.HCLKeys() {
+		for _, hclKey := range names.HCLKeys() {
 			var serviceKey string
 			var err error
-			if serviceKey, err = conns.ServiceForHCLKey(hclKey); err != nil {
+			if serviceKey, err = names.ServiceForHCLKey(hclKey); err != nil {
 				return fmt.Errorf("failed to assign endpoint (%s): %w", hclKey, err)
 			}
 
@@ -2261,19 +2262,19 @@ func expandEndpoints(endpointsSetList []interface{}, out map[string]string) erro
 		}
 	}
 
-	for _, service := range conns.ServiceKeys() {
+	for _, service := range names.ServiceKeys() {
 		if out[service] != "" {
 			continue
 		}
 
-		envvar := conns.ServiceEnvVar(service)
+		envvar := names.ServiceEnvVar(service)
 		if envvar != "" {
 			if v := os.Getenv(envvar); v != "" {
 				out[service] = v
 				continue
 			}
 		}
-		if envvarDeprecated := conns.ServiceDeprecatedEnvVar(service); envvarDeprecated != "" {
+		if envvarDeprecated := names.ServiceDeprecatedEnvVar(service); envvarDeprecated != "" {
 			if v := os.Getenv(envvarDeprecated); v != "" {
 				log.Printf("[WARN] The environment variable %q is deprecated. Use %q instead.", envvarDeprecated, envvar)
 				out[service] = v

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestExpandEndpoints(t *testing.T) {
@@ -13,7 +13,7 @@ func TestExpandEndpoints(t *testing.T) {
 	defer popEnv(oldEnv)
 
 	endpoints := make(map[string]interface{})
-	for _, serviceKey := range conns.HCLKeys() {
+	for _, serviceKey := range names.HCLKeys() {
 		endpoints[serviceKey] = ""
 	}
 	endpoints["sts"] = "https://sts.fake.test"
@@ -44,14 +44,14 @@ func TestEndpointMultipleKeys(t *testing.T) {
 			endpoints: map[string]string{
 				"transcribe": "https://transcribe.fake.test",
 			},
-			expectedService:  conns.Transcribe,
+			expectedService:  names.Transcribe,
 			expectedEndpoint: "https://transcribe.fake.test",
 		},
 		{
 			endpoints: map[string]string{
 				"transcribeservice": "https://transcribe.fake.test",
 			},
-			expectedService:  conns.Transcribe,
+			expectedService:  names.Transcribe,
 			expectedEndpoint: "https://transcribe.fake.test",
 		},
 		{
@@ -59,7 +59,7 @@ func TestEndpointMultipleKeys(t *testing.T) {
 				"transcribe":        "https://transcribe.fake.test",
 				"transcribeservice": "https://transcribeservice.fake.test",
 			},
-			expectedService:  conns.Transcribe,
+			expectedService:  names.Transcribe,
 			expectedEndpoint: "https://transcribe.fake.test",
 		},
 	}
@@ -69,7 +69,7 @@ func TestEndpointMultipleKeys(t *testing.T) {
 		defer popEnv(oldEnv)
 
 		endpoints := make(map[string]interface{})
-		for _, serviceKey := range conns.HCLKeys() {
+		for _, serviceKey := range names.HCLKeys() {
 			endpoints[serviceKey] = ""
 		}
 		for k, v := range testcase.endpoints {
@@ -105,7 +105,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) {
 			envvars: map[string]string{
 				"TF_AWS_STS_ENDPOINT": "https://sts.fake.test",
 			},
-			expectedService:  conns.STS,
+			expectedService:  names.STS,
 			expectedEndpoint: "https://sts.fake.test",
 		},
 		{
@@ -113,7 +113,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) {
 			envvars: map[string]string{
 				"AWS_STS_ENDPOINT": "https://sts-deprecated.fake.test",
 			},
-			expectedService:  conns.STS,
+			expectedService:  names.STS,
 			expectedEndpoint: "https://sts-deprecated.fake.test",
 		},
 		{
@@ -122,7 +122,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) {
 				"TF_AWS_STS_ENDPOINT": "https://sts.fake.test",
 				"AWS_STS_ENDPOINT":    "https://sts-deprecated.fake.test",
 			},
-			expectedService:  conns.STS,
+			expectedService:  names.STS,
 			expectedEndpoint: "https://sts.fake.test",
 		},
 		{
@@ -132,7 +132,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) {
 			envvars: map[string]string{
 				"TF_AWS_STS_ENDPOINT": "https://sts-env.fake.test",
 			},
-			expectedService:  conns.STS,
+			expectedService:  names.STS,
 			expectedEndpoint: "https://sts-config.fake.test",
 		},
 	}
@@ -146,7 +146,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) {
 		}
 
 		endpoints := make(map[string]interface{})
-		for _, serviceKey := range conns.HCLKeys() {
+		for _, serviceKey := range names.HCLKeys() {
 			endpoints[serviceKey] = ""
 		}
 		for k, v := range testcase.endpoints {

--- a/internal/service/route53domains/registered_domain_test.go
+++ b/internal/service/route53domains/registered_domain_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccRoute53Domains_serial(t *testing.T) {
@@ -39,7 +40,7 @@ func TestAccRoute53Domains_serial(t *testing.T) {
 }
 
 func testAccPreCheckRoute53Domains(t *testing.T) {
-	acctest.PreCheckPartitionHasService(conns.Route53DomainsEndpointID, t)
+	acctest.PreCheckPartitionHasService(names.Route53DomainsEndpointID, t)
 
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53DomainsConn
 
@@ -67,7 +68,7 @@ func testAccRoute53DomainsRegisteredDomain_tags(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckRoute53Domains(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, conns.Route53DomainsEndpointID),
+		ErrorCheck:   acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckRegisteredDomainDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +109,7 @@ func testAccRoute53DomainsRegisteredDomain_autoRenew(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckRoute53Domains(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, conns.Route53DomainsEndpointID),
+		ErrorCheck:   acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckRegisteredDomainDestroy,
 		Steps: []resource.TestStep{
@@ -139,7 +140,7 @@ func testAccRoute53DomainsRegisteredDomain_contacts(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckRoute53Domains(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, conns.Route53DomainsEndpointID),
+		ErrorCheck:   acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckRegisteredDomainDestroy,
 		Steps: []resource.TestStep{
@@ -242,7 +243,7 @@ func testAccRoute53DomainsRegisteredDomain_contactPrivacy(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckRoute53Domains(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, conns.Route53DomainsEndpointID),
+		ErrorCheck:   acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckRegisteredDomainDestroy,
 		Steps: []resource.TestStep{
@@ -277,7 +278,7 @@ func testAccRoute53DomainsRegisteredDomain_nameservers(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckRoute53Domains(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, conns.Route53DomainsEndpointID),
+		ErrorCheck:   acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckRegisteredDomainDestroy,
 		Steps: []resource.TestStep{
@@ -321,7 +322,7 @@ func testAccRoute53DomainsRegisteredDomain_transferLock(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckRoute53Domains(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, conns.Route53DomainsEndpointID),
+		ErrorCheck:   acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckRegisteredDomainDestroy,
 		Steps: []resource.TestStep{

--- a/names/names.go
+++ b/names/names.go
@@ -1,0 +1,913 @@
+package names
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/route53domains"
+	"github.com/aws/aws-sdk-go/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go/service/account"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/aws/aws-sdk-go/service/alexaforbusiness"
+	"github.com/aws/aws-sdk-go/service/amplify"
+	"github.com/aws/aws-sdk-go/service/amplifybackend"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/aws/aws-sdk-go/service/appflow"
+	"github.com/aws/aws-sdk-go/service/appintegrationsservice"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go/service/applicationcostprofiler"
+	"github.com/aws/aws-sdk-go/service/applicationdiscoveryservice"
+	"github.com/aws/aws-sdk-go/service/applicationinsights"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/appregistry"
+	"github.com/aws/aws-sdk-go/service/apprunner"
+	"github.com/aws/aws-sdk-go/service/appstream"
+	"github.com/aws/aws-sdk-go/service/appsync"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/aws/aws-sdk-go/service/auditmanager"
+	"github.com/aws/aws-sdk-go/service/augmentedairuntime"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscalingplans"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/aws/aws-sdk-go/service/braket"
+	"github.com/aws/aws-sdk-go/service/budgets"
+	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/cloud9"
+	"github.com/aws/aws-sdk-go/service/cloudcontrolapi"
+	"github.com/aws/aws-sdk-go/service/clouddirectory"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
+	"github.com/aws/aws-sdk-go/service/cloudsearch"
+	"github.com/aws/aws-sdk-go/service/cloudsearchdomain"
+	"github.com/aws/aws-sdk-go/service/cloudtrail"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/cloudwatchrum"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/aws/aws-sdk-go/service/codecommit"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/aws/aws-sdk-go/service/codeguruprofiler"
+	"github.com/aws/aws-sdk-go/service/codegurureviewer"
+	"github.com/aws/aws-sdk-go/service/codepipeline"
+	"github.com/aws/aws-sdk-go/service/codestar"
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	"github.com/aws/aws-sdk-go/service/codestarnotifications"
+	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go/service/cognitosync"
+	"github.com/aws/aws-sdk-go/service/comprehend"
+	"github.com/aws/aws-sdk-go/service/comprehendmedical"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/aws/aws-sdk-go/service/connect"
+	"github.com/aws/aws-sdk-go/service/connectcontactlens"
+	"github.com/aws/aws-sdk-go/service/connectparticipant"
+	"github.com/aws/aws-sdk-go/service/costandusagereportservice"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/aws/aws-sdk-go/service/dataexchange"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/aws/aws-sdk-go/service/dax"
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/aws/aws-sdk-go/service/devopsguru"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/aws/aws-sdk-go/service/dlm"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2instanceconnect"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecrpublic"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/efs"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/aws/aws-sdk-go/service/elasticinference"
+	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/aws/aws-sdk-go/service/elastictranscoder"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/emr"
+	"github.com/aws/aws-sdk-go/service/emrcontainers"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/aws/aws-sdk-go/service/finspace"
+	"github.com/aws/aws-sdk-go/service/finspacedata"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/fis"
+	"github.com/aws/aws-sdk-go/service/fms"
+	"github.com/aws/aws-sdk-go/service/forecastqueryservice"
+	"github.com/aws/aws-sdk-go/service/forecastservice"
+	"github.com/aws/aws-sdk-go/service/frauddetector"
+	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/aws/aws-sdk-go/service/glacier"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/service/gluedatabrew"
+	"github.com/aws/aws-sdk-go/service/greengrass"
+	"github.com/aws/aws-sdk-go/service/greengrassv2"
+	"github.com/aws/aws-sdk-go/service/groundstation"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/aws/aws-sdk-go/service/health"
+	"github.com/aws/aws-sdk-go/service/healthlake"
+	"github.com/aws/aws-sdk-go/service/honeycode"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/identitystore"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/aws/aws-sdk-go/service/inspector"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/aws/aws-sdk-go/service/iot1clickdevicesservice"
+	"github.com/aws/aws-sdk-go/service/iot1clickprojects"
+	"github.com/aws/aws-sdk-go/service/iotanalytics"
+	"github.com/aws/aws-sdk-go/service/iotdataplane"
+	"github.com/aws/aws-sdk-go/service/iotdeviceadvisor"
+	"github.com/aws/aws-sdk-go/service/iotevents"
+	"github.com/aws/aws-sdk-go/service/ioteventsdata"
+	"github.com/aws/aws-sdk-go/service/iotfleethub"
+	"github.com/aws/aws-sdk-go/service/iotjobsdataplane"
+	"github.com/aws/aws-sdk-go/service/iotsecuretunneling"
+	"github.com/aws/aws-sdk-go/service/iotsitewise"
+	"github.com/aws/aws-sdk-go/service/iotthingsgraph"
+	"github.com/aws/aws-sdk-go/service/iotwireless"
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/aws/aws-sdk-go/service/kafkaconnect"
+	"github.com/aws/aws-sdk-go/service/kendra"
+	"github.com/aws/aws-sdk-go/service/keyspaces"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/aws/aws-sdk-go/service/kinesisanalyticsv2"
+	"github.com/aws/aws-sdk-go/service/kinesisvideo"
+	"github.com/aws/aws-sdk-go/service/kinesisvideoarchivedmedia"
+	"github.com/aws/aws-sdk-go/service/kinesisvideomedia"
+	"github.com/aws/aws-sdk-go/service/kinesisvideosignalingchannels"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
+	"github.com/aws/aws-sdk-go/service/lexmodelsv2"
+	"github.com/aws/aws-sdk-go/service/lexruntimeservice"
+	"github.com/aws/aws-sdk-go/service/lexruntimev2"
+	"github.com/aws/aws-sdk-go/service/licensemanager"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/aws/aws-sdk-go/service/lookoutequipment"
+	"github.com/aws/aws-sdk-go/service/lookoutforvision"
+	"github.com/aws/aws-sdk-go/service/lookoutmetrics"
+	"github.com/aws/aws-sdk-go/service/machinelearning"
+	"github.com/aws/aws-sdk-go/service/macie"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/aws/aws-sdk-go/service/managedblockchain"
+	"github.com/aws/aws-sdk-go/service/managedgrafana"
+	"github.com/aws/aws-sdk-go/service/marketplacecatalog"
+	"github.com/aws/aws-sdk-go/service/marketplacecommerceanalytics"
+	"github.com/aws/aws-sdk-go/service/marketplaceentitlementservice"
+	"github.com/aws/aws-sdk-go/service/marketplacemetering"
+	"github.com/aws/aws-sdk-go/service/mediaconnect"
+	"github.com/aws/aws-sdk-go/service/mediaconvert"
+	"github.com/aws/aws-sdk-go/service/medialive"
+	"github.com/aws/aws-sdk-go/service/mediapackage"
+	"github.com/aws/aws-sdk-go/service/mediapackagevod"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/aws/aws-sdk-go/service/mediastoredata"
+	"github.com/aws/aws-sdk-go/service/mediatailor"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/aws/aws-sdk-go/service/mgn"
+	"github.com/aws/aws-sdk-go/service/migrationhub"
+	"github.com/aws/aws-sdk-go/service/migrationhubconfig"
+	"github.com/aws/aws-sdk-go/service/mobile"
+	"github.com/aws/aws-sdk-go/service/mobileanalytics"
+	"github.com/aws/aws-sdk-go/service/mq"
+	"github.com/aws/aws-sdk-go/service/mturk"
+	"github.com/aws/aws-sdk-go/service/mwaa"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/aws/aws-sdk-go/service/networkfirewall"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/aws/aws-sdk-go/service/nimblestudio"
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/aws/aws-sdk-go/service/opsworkscm"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/aws/aws-sdk-go/service/personalize"
+	"github.com/aws/aws-sdk-go/service/personalizeevents"
+	"github.com/aws/aws-sdk-go/service/personalizeruntime"
+	"github.com/aws/aws-sdk-go/service/pi"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/aws/aws-sdk-go/service/pinpointemail"
+	"github.com/aws/aws-sdk-go/service/pinpointsmsvoice"
+	"github.com/aws/aws-sdk-go/service/polly"
+	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/aws-sdk-go/service/prometheusservice"
+	"github.com/aws/aws-sdk-go/service/proton"
+	"github.com/aws/aws-sdk-go/service/qldb"
+	"github.com/aws/aws-sdk-go/service/qldbsession"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rdsdataservice"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
+	"github.com/aws/aws-sdk-go/service/rekognition"
+	"github.com/aws/aws-sdk-go/service/resourcegroups"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53recoverycontrolconfig"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/aws/aws-sdk-go/service/s3outposts"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/aws/aws-sdk-go/service/sagemakeredgemanager"
+	"github.com/aws/aws-sdk-go/service/sagemakerfeaturestoreruntime"
+	"github.com/aws/aws-sdk-go/service/sagemakerruntime"
+	"github.com/aws/aws-sdk-go/service/savingsplans"
+	"github.com/aws/aws-sdk-go/service/schemas"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/sesv2"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go/service/signer"
+	"github.com/aws/aws-sdk-go/service/simpledb"
+	"github.com/aws/aws-sdk-go/service/sms"
+	"github.com/aws/aws-sdk-go/service/snowball"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssmcontacts"
+	"github.com/aws/aws-sdk-go/service/ssmincidents"
+	"github.com/aws/aws-sdk-go/service/sso"
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/aws/aws-sdk-go/service/ssooidc"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/support"
+	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/aws/aws-sdk-go/service/synthetics"
+	"github.com/aws/aws-sdk-go/service/textract"
+	"github.com/aws/aws-sdk-go/service/timestreamquery"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
+	"github.com/aws/aws-sdk-go/service/transcribeservice"
+	"github.com/aws/aws-sdk-go/service/transcribestreamingservice"
+	"github.com/aws/aws-sdk-go/service/transfer"
+	"github.com/aws/aws-sdk-go/service/translate"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/aws/aws-sdk-go/service/wellarchitected"
+	"github.com/aws/aws-sdk-go/service/workdocs"
+	"github.com/aws/aws-sdk-go/service/worklink"
+	"github.com/aws/aws-sdk-go/service/workmail"
+	"github.com/aws/aws-sdk-go/service/workmailmessageflow"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/aws/aws-sdk-go/service/xray"
+)
+
+const (
+	AccessAnalyzer                = "accessanalyzer"
+	Account                       = "account"
+	ACM                           = "acm"
+	ACMPCA                        = "acmpca"
+	AlexaForBusiness              = "alexaforbusiness"
+	AMP                           = "amp"
+	Amplify                       = "amplify"
+	AmplifyBackend                = "amplifybackend"
+	APIGateway                    = "apigateway"
+	APIGatewayV2                  = "apigatewayv2"
+	AppAutoScaling                = "appautoscaling"
+	AppConfig                     = "appconfig"
+	AppFlow                       = "appflow"
+	AppIntegrations               = "appintegrations"
+	ApplicationCostProfiler       = "applicationcostprofiler"
+	ApplicationDiscovery          = "applicationdiscovery"
+	ApplicationInsights           = "applicationinsights"
+	AppMesh                       = "appmesh"
+	AppRegistry                   = "appregistry"
+	AppRunner                     = "apprunner"
+	AppStream                     = "appstream"
+	AppSync                       = "appsync"
+	Athena                        = "athena"
+	AuditManager                  = "auditmanager"
+	AugmentedAIRuntime            = "augmentedairuntime"
+	AutoScaling                   = "autoscaling"
+	AutoScalingPlans              = "autoscalingplans"
+	Backup                        = "backup"
+	Batch                         = "batch"
+	Braket                        = "braket"
+	Budgets                       = "budgets"
+	Chime                         = "chime"
+	Cloud9                        = "cloud9"
+	CloudControl                  = "cloudcontrol"
+	CloudDirectory                = "clouddirectory"
+	CloudFormation                = "cloudformation"
+	CloudFront                    = "cloudfront"
+	CloudHSMV2                    = "cloudhsmv2"
+	CloudSearch                   = "cloudsearch"
+	CloudSearchDomain             = "cloudsearchdomain"
+	CloudTrail                    = "cloudtrail"
+	CloudWatch                    = "cloudwatch"
+	CloudWatchLogs                = "cloudwatchlogs"
+	CloudWatchRUM                 = "cloudwatchrum"
+	CodeArtifact                  = "codeartifact"
+	CodeBuild                     = "codebuild"
+	CodeCommit                    = "codecommit"
+	CodeDeploy                    = "codedeploy"
+	CodeGuruProfiler              = "codeguruprofiler"
+	CodeGuruReviewer              = "codegurureviewer"
+	CodePipeline                  = "codepipeline"
+	CodeStar                      = "codestar"
+	CodeStarConnections           = "codestarconnections"
+	CodeStarNotifications         = "codestarnotifications"
+	CognitoIdentity               = "cognitoidentity"
+	CognitoIDP                    = "cognitoidp"
+	CognitoSync                   = "cognitosync"
+	Comprehend                    = "comprehend"
+	ComprehendMedical             = "comprehendmedical"
+	ComputeOptimizer              = "computeoptimizer"
+	ConfigService                 = "configservice"
+	Connect                       = "connect"
+	ConnectContactLens            = "connectcontactlens"
+	ConnectParticipant            = "connectparticipant"
+	CostExplorer                  = "costexplorer"
+	CUR                           = "cur"
+	CustomerProfiles              = "customerprofiles"
+	DataExchange                  = "dataexchange"
+	DataPipeline                  = "datapipeline"
+	DataSync                      = "datasync"
+	DAX                           = "dax"
+	Detective                     = "detective"
+	DeviceFarm                    = "devicefarm"
+	DevOpsGuru                    = "devopsguru"
+	DirectConnect                 = "directconnect"
+	DLM                           = "dlm"
+	DMS                           = "dms"
+	DocDB                         = "docdb"
+	DS                            = "ds"
+	DynamoDB                      = "dynamodb"
+	DynamoDBStreams               = "dynamodbstreams"
+	EC2                           = "ec2"
+	EC2InstanceConnect            = "ec2instanceconnect"
+	ECR                           = "ecr"
+	ECRPublic                     = "ecrpublic"
+	ECS                           = "ecs"
+	EFS                           = "efs"
+	EKS                           = "eks"
+	ElastiCache                   = "elasticache"
+	ElasticBeanstalk              = "elasticbeanstalk"
+	ElasticInference              = "elasticinference"
+	Elasticsearch                 = "elasticsearch"
+	ElasticTranscoder             = "elastictranscoder"
+	ELB                           = "elb"
+	ELBV2                         = "elbv2"
+	EMR                           = "emr"
+	EMRContainers                 = "emrcontainers"
+	Events                        = "events"
+	FinSpace                      = "finspace"
+	FinSpaceData                  = "finspacedata"
+	Firehose                      = "firehose"
+	FIS                           = "fis"
+	FMS                           = "fms"
+	Forecast                      = "forecast"
+	ForecastQuery                 = "forecastquery"
+	FraudDetector                 = "frauddetector"
+	FSx                           = "fsx"
+	GameLift                      = "gamelift"
+	Glacier                       = "glacier"
+	GlobalAccelerator             = "globalaccelerator"
+	Glue                          = "glue"
+	GlueDataBrew                  = "gluedatabrew"
+	Grafana                       = "grafana"
+	Greengrass                    = "greengrass"
+	GreengrassV2                  = "greengrassv2"
+	GroundStation                 = "groundstation"
+	GuardDuty                     = "guardduty"
+	Health                        = "health"
+	HealthLake                    = "healthlake"
+	Honeycode                     = "honeycode"
+	IAM                           = "iam"
+	IdentityStore                 = "identitystore"
+	ImageBuilder                  = "imagebuilder"
+	Inspector                     = "inspector"
+	IoT                           = "iot"
+	IoT1ClickDevices              = "iot1clickdevices"
+	IoT1ClickProjects             = "iot1clickprojects"
+	IoTAnalytics                  = "iotanalytics"
+	IoTDataPlane                  = "iotdataplane"
+	IoTDeviceAdvisor              = "iotdeviceadvisor"
+	IoTEvents                     = "iotevents"
+	IoTEventsData                 = "ioteventsdata"
+	IoTFleetHub                   = "iotfleethub"
+	IoTJobsDataPlane              = "iotjobsdataplane"
+	IoTSecureTunneling            = "iotsecuretunneling"
+	IoTSiteWise                   = "iotsitewise"
+	IoTThingsGraph                = "iotthingsgraph"
+	IoTWireless                   = "iotwireless"
+	IVS                           = "ivs"
+	Kafka                         = "kafka"
+	KafkaConnect                  = "kafkaconnect"
+	Kendra                        = "kendra"
+	Keyspaces                     = "keyspaces"
+	Kinesis                       = "kinesis"
+	KinesisAnalytics              = "kinesisanalytics"
+	KinesisAnalyticsV2            = "kinesisanalyticsv2"
+	KinesisVideo                  = "kinesisvideo"
+	KinesisVideoArchivedMedia     = "kinesisvideoarchivedmedia"
+	KinesisVideoMedia             = "kinesisvideomedia"
+	KinesisVideoSignalingChannels = "kinesisvideosignalingchannels"
+	KMS                           = "kms"
+	LakeFormation                 = "lakeformation"
+	Lambda                        = "lambda"
+	LexModels                     = "lexmodels"
+	LexModelsV2                   = "lexmodelsv2"
+	LexRuntime                    = "lexruntime"
+	LexRuntimeV2                  = "lexruntimev2"
+	LicenseManager                = "licensemanager"
+	Lightsail                     = "lightsail"
+	Location                      = "location"
+	LookoutEquipment              = "lookoutequipment"
+	LookoutForVision              = "lookoutforvision"
+	LookoutMetrics                = "lookoutmetrics"
+	MachineLearning               = "machinelearning"
+	Macie                         = "macie"
+	Macie2                        = "macie2"
+	ManagedBlockchain             = "managedblockchain"
+	MarketplaceCatalog            = "marketplacecatalog"
+	MarketplaceCommerceAnalytics  = "marketplacecommerceanalytics"
+	MarketplaceEntitlement        = "marketplaceentitlement"
+	MarketplaceMetering           = "marketplacemetering"
+	MediaConnect                  = "mediaconnect"
+	MediaConvert                  = "mediaconvert"
+	MediaLive                     = "medialive"
+	MediaPackage                  = "mediapackage"
+	MediaPackageVOD               = "mediapackagevod"
+	MediaStore                    = "mediastore"
+	MediaStoreData                = "mediastoredata"
+	MediaTailor                   = "mediatailor"
+	MemoryDB                      = "memorydb"
+	Mgn                           = "mgn"
+	MigrationHub                  = "migrationhub"
+	MigrationHubConfig            = "migrationhubconfig"
+	Mobile                        = "mobile"
+	MobileAnalytics               = "mobileanalytics"
+	MQ                            = "mq"
+	MTurk                         = "mturk"
+	MWAA                          = "mwaa"
+	Neptune                       = "neptune"
+	NetworkFirewall               = "networkfirewall"
+	NetworkManager                = "networkmanager"
+	NimbleStudio                  = "nimblestudio"
+	OpsWorks                      = "opsworks"
+	OpsWorksCM                    = "opsworkscm"
+	Organizations                 = "organizations"
+	Outposts                      = "outposts"
+	Personalize                   = "personalize"
+	PersonalizeEvents             = "personalizeevents"
+	PersonalizeRuntime            = "personalizeruntime"
+	PI                            = "pi"
+	Pinpoint                      = "pinpoint"
+	PinpointEmail                 = "pinpointemail"
+	PinpointSMSVoice              = "pinpointsmsvoice"
+	Polly                         = "polly"
+	Pricing                       = "pricing"
+	Proton                        = "proton"
+	QLDB                          = "qldb"
+	QLDBSession                   = "qldbsession"
+	QuickSight                    = "quicksight"
+	RAM                           = "ram"
+	RDS                           = "rds"
+	RDSData                       = "rdsdata"
+	Redshift                      = "redshift"
+	RedshiftData                  = "redshiftdata"
+	Rekognition                   = "rekognition"
+	ResourceGroups                = "resourcegroups"
+	ResourceGroupsTaggingAPI      = "resourcegroupstaggingapi"
+	RoboMaker                     = "robomaker"
+	Route53                       = "route53"
+	Route53Domains                = "route53domains"
+	Route53RecoveryControlConfig  = "route53recoverycontrolconfig"
+	Route53RecoveryReadiness      = "route53recoveryreadiness"
+	Route53Resolver               = "route53resolver"
+	S3                            = "s3"
+	S3Control                     = "s3control"
+	S3Outposts                    = "s3outposts"
+	SageMaker                     = "sagemaker"
+	SageMakerEdgeManager          = "sagemakeredgemanager"
+	SageMakerFeatureStoreRuntime  = "sagemakerfeaturestoreruntime"
+	SageMakerRuntime              = "sagemakerruntime"
+	SavingsPlans                  = "savingsplans"
+	Schemas                       = "schemas"
+	SecretsManager                = "secretsmanager"
+	SecurityHub                   = "securityhub"
+	ServerlessRepo                = "serverlessrepo"
+	ServiceCatalog                = "servicecatalog"
+	ServiceDiscovery              = "servicediscovery"
+	ServiceQuotas                 = "servicequotas"
+	SES                           = "ses"
+	SESV2                         = "sesv2"
+	SFN                           = "sfn"
+	Shield                        = "shield"
+	Signer                        = "signer"
+	SimpleDB                      = "simpledb"
+	SMS                           = "sms"
+	Snowball                      = "snowball"
+	SNS                           = "sns"
+	SQS                           = "sqs"
+	SSM                           = "ssm"
+	SSMContacts                   = "ssmcontacts"
+	SSMIncidents                  = "ssmincidents"
+	SSO                           = "sso"
+	SSOAdmin                      = "ssoadmin"
+	SSOOIDC                       = "ssooidc"
+	StorageGateway                = "storagegateway"
+	STS                           = "sts"
+	Support                       = "support"
+	SWF                           = "swf"
+	Synthetics                    = "synthetics"
+	Textract                      = "textract"
+	TimestreamQuery               = "timestreamquery"
+	TimestreamWrite               = "timestreamwrite"
+	Transcribe                    = "transcribe"
+	TranscribeStreaming           = "transcribestreaming"
+	Transfer                      = "transfer"
+	Translate                     = "translate"
+	WAF                           = "waf"
+	WAFRegional                   = "wafregional"
+	WAFV2                         = "wafv2"
+	WellArchitected               = "wellarchitected"
+	WorkDocs                      = "workdocs"
+	WorkLink                      = "worklink"
+	WorkMail                      = "workmail"
+	WorkMailMessageFlow           = "workmailmessageflow"
+	WorkSpaces                    = "workspaces"
+	XRay                          = "xray"
+)
+
+// These "should" be defined by the AWS Go SDK v2, but currently aren't.
+const (
+	Route53DomainsEndpointID  = "route53domains"
+	Route53DomainsServiceName = "route53domains"
+)
+
+type ServiceDatum struct {
+	AWSClientName     string
+	AWSServiceName    string
+	AWSEndpointsID    string
+	AWSServiceID      string
+	ProviderNameUpper string
+	HCLKeys           []string
+	EnvVar            string
+	DeprecatedEnvVar  string
+}
+
+var serviceData map[string]*ServiceDatum
+
+func init() {
+	serviceData = make(map[string]*ServiceDatum)
+
+	serviceData[AccessAnalyzer] = &ServiceDatum{AWSClientName: "AccessAnalyzer", AWSServiceName: accessanalyzer.ServiceName, AWSEndpointsID: accessanalyzer.EndpointsID, AWSServiceID: accessanalyzer.ServiceID, ProviderNameUpper: "AccessAnalyzer", HCLKeys: []string{"accessanalyzer"}}
+	serviceData[Account] = &ServiceDatum{AWSClientName: "Account", AWSServiceName: account.ServiceName, AWSEndpointsID: account.EndpointsID, AWSServiceID: account.ServiceID, ProviderNameUpper: "Account", HCLKeys: []string{"account"}}
+	serviceData[ACM] = &ServiceDatum{AWSClientName: "ACM", AWSServiceName: acm.ServiceName, AWSEndpointsID: acm.EndpointsID, AWSServiceID: acm.ServiceID, ProviderNameUpper: "ACM", HCLKeys: []string{"acm"}}
+	serviceData[ACMPCA] = &ServiceDatum{AWSClientName: "ACMPCA", AWSServiceName: acmpca.ServiceName, AWSEndpointsID: acmpca.EndpointsID, AWSServiceID: acmpca.ServiceID, ProviderNameUpper: "ACMPCA", HCLKeys: []string{"acmpca"}}
+	serviceData[AlexaForBusiness] = &ServiceDatum{AWSClientName: "AlexaForBusiness", AWSServiceName: alexaforbusiness.ServiceName, AWSEndpointsID: alexaforbusiness.EndpointsID, AWSServiceID: alexaforbusiness.ServiceID, ProviderNameUpper: "AlexaForBusiness", HCLKeys: []string{"alexaforbusiness"}}
+	serviceData[AMP] = &ServiceDatum{AWSClientName: "PrometheusService", AWSServiceName: prometheusservice.ServiceName, AWSEndpointsID: prometheusservice.EndpointsID, AWSServiceID: prometheusservice.ServiceID, ProviderNameUpper: "AMP", HCLKeys: []string{"amp", "prometheus", "prometheusservice"}}
+	serviceData[Amplify] = &ServiceDatum{AWSClientName: "Amplify", AWSServiceName: amplify.ServiceName, AWSEndpointsID: amplify.EndpointsID, AWSServiceID: amplify.ServiceID, ProviderNameUpper: "Amplify", HCLKeys: []string{"amplify"}}
+	serviceData[AmplifyBackend] = &ServiceDatum{AWSClientName: "AmplifyBackend", AWSServiceName: amplifybackend.ServiceName, AWSEndpointsID: amplifybackend.EndpointsID, AWSServiceID: amplifybackend.ServiceID, ProviderNameUpper: "AmplifyBackend", HCLKeys: []string{"amplifybackend"}}
+	serviceData[APIGateway] = &ServiceDatum{AWSClientName: "APIGateway", AWSServiceName: apigateway.ServiceName, AWSEndpointsID: apigateway.EndpointsID, AWSServiceID: apigateway.ServiceID, ProviderNameUpper: "APIGateway", HCLKeys: []string{"apigateway"}}
+	serviceData[APIGatewayV2] = &ServiceDatum{AWSClientName: "APIGatewayV2", AWSServiceName: apigatewayv2.ServiceName, AWSEndpointsID: apigatewayv2.EndpointsID, AWSServiceID: apigatewayv2.ServiceID, ProviderNameUpper: "APIGatewayV2", HCLKeys: []string{"apigatewayv2"}}
+	serviceData[AppAutoScaling] = &ServiceDatum{AWSClientName: "ApplicationAutoScaling", AWSServiceName: applicationautoscaling.ServiceName, AWSEndpointsID: applicationautoscaling.EndpointsID, AWSServiceID: applicationautoscaling.ServiceID, ProviderNameUpper: "AppAutoScaling", HCLKeys: []string{"appautoscaling", "applicationautoscaling"}}
+	serviceData[AppConfig] = &ServiceDatum{AWSClientName: "AppConfig", AWSServiceName: appconfig.ServiceName, AWSEndpointsID: appconfig.EndpointsID, AWSServiceID: appconfig.ServiceID, ProviderNameUpper: "AppConfig", HCLKeys: []string{"appconfig"}}
+	serviceData[AppFlow] = &ServiceDatum{AWSClientName: "Appflow", AWSServiceName: appflow.ServiceName, AWSEndpointsID: appflow.EndpointsID, AWSServiceID: appflow.ServiceID, ProviderNameUpper: "AppFlow", HCLKeys: []string{"appflow"}}
+	serviceData[AppIntegrations] = &ServiceDatum{AWSClientName: "AppIntegrationsService", AWSServiceName: appintegrationsservice.ServiceName, AWSEndpointsID: appintegrationsservice.EndpointsID, AWSServiceID: appintegrationsservice.ServiceID, ProviderNameUpper: "AppIntegrations", HCLKeys: []string{"appintegrations", "appintegrationsservice"}}
+	serviceData[ApplicationCostProfiler] = &ServiceDatum{AWSClientName: "ApplicationCostProfiler", AWSServiceName: applicationcostprofiler.ServiceName, AWSEndpointsID: applicationcostprofiler.EndpointsID, AWSServiceID: applicationcostprofiler.ServiceID, ProviderNameUpper: "ApplicationCostProfiler", HCLKeys: []string{"applicationcostprofiler"}}
+	serviceData[ApplicationDiscovery] = &ServiceDatum{AWSClientName: "ApplicationDiscoveryService", AWSServiceName: applicationdiscoveryservice.ServiceName, AWSEndpointsID: applicationdiscoveryservice.EndpointsID, AWSServiceID: applicationdiscoveryservice.ServiceID, ProviderNameUpper: "ApplicationDiscovery", HCLKeys: []string{"applicationdiscovery", "applicationdiscoveryservice"}}
+	serviceData[ApplicationInsights] = &ServiceDatum{AWSClientName: "ApplicationInsights", AWSServiceName: applicationinsights.ServiceName, AWSEndpointsID: applicationinsights.EndpointsID, AWSServiceID: applicationinsights.ServiceID, ProviderNameUpper: "ApplicationInsights", HCLKeys: []string{"applicationinsights"}}
+	serviceData[AppMesh] = &ServiceDatum{AWSClientName: "AppMesh", AWSServiceName: appmesh.ServiceName, AWSEndpointsID: appmesh.EndpointsID, AWSServiceID: appmesh.ServiceID, ProviderNameUpper: "AppMesh", HCLKeys: []string{"appmesh"}}
+	serviceData[AppRegistry] = &ServiceDatum{AWSClientName: "AppRegistry", AWSServiceName: appregistry.ServiceName, AWSEndpointsID: appregistry.EndpointsID, AWSServiceID: appregistry.ServiceID, ProviderNameUpper: "AppRegistry", HCLKeys: []string{"appregistry"}}
+	serviceData[AppRunner] = &ServiceDatum{AWSClientName: "AppRunner", AWSServiceName: apprunner.ServiceName, AWSEndpointsID: apprunner.EndpointsID, AWSServiceID: apprunner.ServiceID, ProviderNameUpper: "AppRunner", HCLKeys: []string{"apprunner"}}
+	serviceData[AppStream] = &ServiceDatum{AWSClientName: "AppStream", AWSServiceName: appstream.ServiceName, AWSEndpointsID: appstream.EndpointsID, AWSServiceID: appstream.ServiceID, ProviderNameUpper: "AppStream", HCLKeys: []string{"appstream"}}
+	serviceData[AppSync] = &ServiceDatum{AWSClientName: "AppSync", AWSServiceName: appsync.ServiceName, AWSEndpointsID: appsync.EndpointsID, AWSServiceID: appsync.ServiceID, ProviderNameUpper: "AppSync", HCLKeys: []string{"appsync"}}
+	serviceData[Athena] = &ServiceDatum{AWSClientName: "Athena", AWSServiceName: athena.ServiceName, AWSEndpointsID: athena.EndpointsID, AWSServiceID: athena.ServiceID, ProviderNameUpper: "Athena", HCLKeys: []string{"athena"}}
+	serviceData[AuditManager] = &ServiceDatum{AWSClientName: "AuditManager", AWSServiceName: auditmanager.ServiceName, AWSEndpointsID: auditmanager.EndpointsID, AWSServiceID: auditmanager.ServiceID, ProviderNameUpper: "AuditManager", HCLKeys: []string{"auditmanager"}}
+	serviceData[AugmentedAIRuntime] = &ServiceDatum{AWSClientName: "AugmentedAIRuntime", AWSServiceName: augmentedairuntime.ServiceName, AWSEndpointsID: augmentedairuntime.EndpointsID, AWSServiceID: augmentedairuntime.ServiceID, ProviderNameUpper: "AugmentedAIRuntime", HCLKeys: []string{"augmentedairuntime"}}
+	serviceData[AutoScaling] = &ServiceDatum{AWSClientName: "AutoScaling", AWSServiceName: autoscaling.ServiceName, AWSEndpointsID: autoscaling.EndpointsID, AWSServiceID: autoscaling.ServiceID, ProviderNameUpper: "AutoScaling", HCLKeys: []string{"autoscaling"}}
+	serviceData[AutoScalingPlans] = &ServiceDatum{AWSClientName: "AutoScalingPlans", AWSServiceName: autoscalingplans.ServiceName, AWSEndpointsID: autoscalingplans.EndpointsID, AWSServiceID: autoscalingplans.ServiceID, ProviderNameUpper: "AutoScalingPlans", HCLKeys: []string{"autoscalingplans"}}
+	serviceData[Backup] = &ServiceDatum{AWSClientName: "Backup", AWSServiceName: backup.ServiceName, AWSEndpointsID: backup.EndpointsID, AWSServiceID: backup.ServiceID, ProviderNameUpper: "Backup", HCLKeys: []string{"backup"}}
+	serviceData[Batch] = &ServiceDatum{AWSClientName: "Batch", AWSServiceName: batch.ServiceName, AWSEndpointsID: batch.EndpointsID, AWSServiceID: batch.ServiceID, ProviderNameUpper: "Batch", HCLKeys: []string{"batch"}}
+	serviceData[Braket] = &ServiceDatum{AWSClientName: "Braket", AWSServiceName: braket.ServiceName, AWSEndpointsID: braket.EndpointsID, AWSServiceID: braket.ServiceID, ProviderNameUpper: "Braket", HCLKeys: []string{"braket"}}
+	serviceData[Budgets] = &ServiceDatum{AWSClientName: "Budgets", AWSServiceName: budgets.ServiceName, AWSEndpointsID: budgets.EndpointsID, AWSServiceID: budgets.ServiceID, ProviderNameUpper: "Budgets", HCLKeys: []string{"budgets"}}
+	serviceData[Chime] = &ServiceDatum{AWSClientName: "Chime", AWSServiceName: chime.ServiceName, AWSEndpointsID: chime.EndpointsID, AWSServiceID: chime.ServiceID, ProviderNameUpper: "Chime", HCLKeys: []string{"chime"}}
+	serviceData[Cloud9] = &ServiceDatum{AWSClientName: "Cloud9", AWSServiceName: cloud9.ServiceName, AWSEndpointsID: cloud9.EndpointsID, AWSServiceID: cloud9.ServiceID, ProviderNameUpper: "Cloud9", HCLKeys: []string{"cloud9"}}
+	serviceData[CloudControl] = &ServiceDatum{AWSClientName: "CloudControlApi", AWSServiceName: cloudcontrolapi.ServiceName, AWSEndpointsID: cloudcontrolapi.EndpointsID, AWSServiceID: cloudcontrolapi.ServiceID, ProviderNameUpper: "CloudControl", HCLKeys: []string{"cloudcontrolapi", "cloudcontrol"}}
+	serviceData[CloudDirectory] = &ServiceDatum{AWSClientName: "CloudDirectory", AWSServiceName: clouddirectory.ServiceName, AWSEndpointsID: clouddirectory.EndpointsID, AWSServiceID: clouddirectory.ServiceID, ProviderNameUpper: "CloudDirectory", HCLKeys: []string{"clouddirectory"}}
+	serviceData[CloudFormation] = &ServiceDatum{AWSClientName: "CloudFormation", AWSServiceName: cloudformation.ServiceName, AWSEndpointsID: cloudformation.EndpointsID, AWSServiceID: cloudformation.ServiceID, ProviderNameUpper: "CloudFormation", HCLKeys: []string{"cloudformation"}}
+	serviceData[CloudFront] = &ServiceDatum{AWSClientName: "CloudFront", AWSServiceName: cloudfront.ServiceName, AWSEndpointsID: cloudfront.EndpointsID, AWSServiceID: cloudfront.ServiceID, ProviderNameUpper: "CloudFront", HCLKeys: []string{"cloudfront"}}
+	serviceData[CloudHSMV2] = &ServiceDatum{AWSClientName: "CloudHSMV2", AWSServiceName: cloudhsmv2.ServiceName, AWSEndpointsID: cloudhsmv2.EndpointsID, AWSServiceID: cloudhsmv2.ServiceID, ProviderNameUpper: "CloudHSMV2", HCLKeys: []string{"cloudhsm", "cloudhsmv2"}}
+	serviceData[CloudSearch] = &ServiceDatum{AWSClientName: "CloudSearch", AWSServiceName: cloudsearch.ServiceName, AWSEndpointsID: cloudsearch.EndpointsID, AWSServiceID: cloudsearch.ServiceID, ProviderNameUpper: "CloudSearch", HCLKeys: []string{"cloudsearch"}}
+	serviceData[CloudSearchDomain] = &ServiceDatum{AWSClientName: "CloudSearchDomain", AWSServiceName: cloudsearchdomain.ServiceName, AWSEndpointsID: cloudsearchdomain.EndpointsID, AWSServiceID: cloudsearchdomain.ServiceID, ProviderNameUpper: "CloudSearchDomain", HCLKeys: []string{"cloudsearchdomain"}}
+	serviceData[CloudTrail] = &ServiceDatum{AWSClientName: "CloudTrail", AWSServiceName: cloudtrail.ServiceName, AWSEndpointsID: cloudtrail.EndpointsID, AWSServiceID: cloudtrail.ServiceID, ProviderNameUpper: "CloudTrail", HCLKeys: []string{"cloudtrail"}}
+	serviceData[CloudWatch] = &ServiceDatum{AWSClientName: "CloudWatch", AWSServiceName: cloudwatch.ServiceName, AWSEndpointsID: cloudwatch.EndpointsID, AWSServiceID: cloudwatch.ServiceID, ProviderNameUpper: "CloudWatch", HCLKeys: []string{"cloudwatch"}}
+	serviceData[CloudWatchLogs] = &ServiceDatum{AWSClientName: "CloudWatchLogs", AWSServiceName: cloudwatchlogs.ServiceName, AWSEndpointsID: cloudwatchlogs.EndpointsID, AWSServiceID: cloudwatchlogs.ServiceID, ProviderNameUpper: "CloudWatchLogs", HCLKeys: []string{"cloudwatchlogs"}}
+	serviceData[CloudWatchRUM] = &ServiceDatum{AWSClientName: "CloudWatchRUM", AWSServiceName: cloudwatchrum.ServiceName, AWSEndpointsID: cloudwatchrum.EndpointsID, AWSServiceID: cloudwatchrum.ServiceID, ProviderNameUpper: "CloudWatchRUM", HCLKeys: []string{"cloudwatchrum"}}
+	serviceData[CodeArtifact] = &ServiceDatum{AWSClientName: "CodeArtifact", AWSServiceName: codeartifact.ServiceName, AWSEndpointsID: codeartifact.EndpointsID, AWSServiceID: codeartifact.ServiceID, ProviderNameUpper: "CodeArtifact", HCLKeys: []string{"codeartifact"}}
+	serviceData[CodeBuild] = &ServiceDatum{AWSClientName: "CodeBuild", AWSServiceName: codebuild.ServiceName, AWSEndpointsID: codebuild.EndpointsID, AWSServiceID: codebuild.ServiceID, ProviderNameUpper: "CodeBuild", HCLKeys: []string{"codebuild"}}
+	serviceData[CodeCommit] = &ServiceDatum{AWSClientName: "CodeCommit", AWSServiceName: codecommit.ServiceName, AWSEndpointsID: codecommit.EndpointsID, AWSServiceID: codecommit.ServiceID, ProviderNameUpper: "CodeCommit", HCLKeys: []string{"codecommit"}}
+	serviceData[CodeDeploy] = &ServiceDatum{AWSClientName: "CodeDeploy", AWSServiceName: codedeploy.ServiceName, AWSEndpointsID: codedeploy.EndpointsID, AWSServiceID: codedeploy.ServiceID, ProviderNameUpper: "CodeDeploy", HCLKeys: []string{"codedeploy"}}
+	serviceData[CodeGuruProfiler] = &ServiceDatum{AWSClientName: "CodeGuruProfiler", AWSServiceName: codeguruprofiler.ServiceName, AWSEndpointsID: codeguruprofiler.EndpointsID, AWSServiceID: codeguruprofiler.ServiceID, ProviderNameUpper: "CodeGuruProfiler", HCLKeys: []string{"codeguruprofiler"}}
+	serviceData[CodeGuruReviewer] = &ServiceDatum{AWSClientName: "CodeGuruReviewer", AWSServiceName: codegurureviewer.ServiceName, AWSEndpointsID: codegurureviewer.EndpointsID, AWSServiceID: codegurureviewer.ServiceID, ProviderNameUpper: "CodeGuruReviewer", HCLKeys: []string{"codegurureviewer"}}
+	serviceData[CodePipeline] = &ServiceDatum{AWSClientName: "CodePipeline", AWSServiceName: codepipeline.ServiceName, AWSEndpointsID: codepipeline.EndpointsID, AWSServiceID: codepipeline.ServiceID, ProviderNameUpper: "CodePipeline", HCLKeys: []string{"codepipeline"}}
+	serviceData[CodeStar] = &ServiceDatum{AWSClientName: "CodeStar", AWSServiceName: codestar.ServiceName, AWSEndpointsID: codestar.EndpointsID, AWSServiceID: codestar.ServiceID, ProviderNameUpper: "CodeStar", HCLKeys: []string{"codestar"}}
+	serviceData[CodeStarConnections] = &ServiceDatum{AWSClientName: "CodeStarConnections", AWSServiceName: codestarconnections.ServiceName, AWSEndpointsID: codestarconnections.EndpointsID, AWSServiceID: codestarconnections.ServiceID, ProviderNameUpper: "CodeStarConnections", HCLKeys: []string{"codestarconnections"}}
+	serviceData[CodeStarNotifications] = &ServiceDatum{AWSClientName: "CodeStarNotifications", AWSServiceName: codestarnotifications.ServiceName, AWSEndpointsID: codestarnotifications.EndpointsID, AWSServiceID: codestarnotifications.ServiceID, ProviderNameUpper: "CodeStarNotifications", HCLKeys: []string{"codestarnotifications"}}
+	serviceData[CognitoIdentity] = &ServiceDatum{AWSClientName: "CognitoIdentity", AWSServiceName: cognitoidentity.ServiceName, AWSEndpointsID: cognitoidentity.EndpointsID, AWSServiceID: cognitoidentity.ServiceID, ProviderNameUpper: "CognitoIdentity", HCLKeys: []string{"cognitoidentity"}}
+	serviceData[CognitoIDP] = &ServiceDatum{AWSClientName: "CognitoIdentityProvider", AWSServiceName: cognitoidentityprovider.ServiceName, AWSEndpointsID: cognitoidentityprovider.EndpointsID, AWSServiceID: cognitoidentityprovider.ServiceID, ProviderNameUpper: "CognitoIDP", HCLKeys: []string{"cognitoidp", "cognitoidentityprovider"}}
+	serviceData[CognitoSync] = &ServiceDatum{AWSClientName: "CognitoSync", AWSServiceName: cognitosync.ServiceName, AWSEndpointsID: cognitosync.EndpointsID, AWSServiceID: cognitosync.ServiceID, ProviderNameUpper: "CognitoSync", HCLKeys: []string{"cognitosync"}}
+	serviceData[Comprehend] = &ServiceDatum{AWSClientName: "Comprehend", AWSServiceName: comprehend.ServiceName, AWSEndpointsID: comprehend.EndpointsID, AWSServiceID: comprehend.ServiceID, ProviderNameUpper: "Comprehend", HCLKeys: []string{"comprehend"}}
+	serviceData[ComprehendMedical] = &ServiceDatum{AWSClientName: "ComprehendMedical", AWSServiceName: comprehendmedical.ServiceName, AWSEndpointsID: comprehendmedical.EndpointsID, AWSServiceID: comprehendmedical.ServiceID, ProviderNameUpper: "ComprehendMedical", HCLKeys: []string{"comprehendmedical"}}
+	serviceData[ConfigService] = &ServiceDatum{AWSClientName: "ConfigService", AWSServiceName: configservice.ServiceName, AWSEndpointsID: configservice.EndpointsID, AWSServiceID: configservice.ServiceID, ProviderNameUpper: "ConfigService", HCLKeys: []string{"configservice", "config"}}
+	serviceData[Connect] = &ServiceDatum{AWSClientName: "Connect", AWSServiceName: connect.ServiceName, AWSEndpointsID: connect.EndpointsID, AWSServiceID: connect.ServiceID, ProviderNameUpper: "Connect", HCLKeys: []string{"connect"}}
+	serviceData[ConnectContactLens] = &ServiceDatum{AWSClientName: "ConnectContactLens", AWSServiceName: connectcontactlens.ServiceName, AWSEndpointsID: connectcontactlens.EndpointsID, AWSServiceID: connectcontactlens.ServiceID, ProviderNameUpper: "ConnectContactLens", HCLKeys: []string{"connectcontactlens"}}
+	serviceData[ConnectParticipant] = &ServiceDatum{AWSClientName: "ConnectParticipant", AWSServiceName: connectparticipant.ServiceName, AWSEndpointsID: connectparticipant.EndpointsID, AWSServiceID: connectparticipant.ServiceID, ProviderNameUpper: "ConnectParticipant", HCLKeys: []string{"connectparticipant"}}
+	serviceData[CostExplorer] = &ServiceDatum{AWSClientName: "CostExplorer", AWSServiceName: costexplorer.ServiceName, AWSEndpointsID: costexplorer.EndpointsID, AWSServiceID: costexplorer.ServiceID, ProviderNameUpper: "CostExplorer", HCLKeys: []string{"costexplorer"}}
+	serviceData[CUR] = &ServiceDatum{AWSClientName: "CostandUsageReportService", AWSServiceName: costandusagereportservice.ServiceName, AWSEndpointsID: costandusagereportservice.EndpointsID, AWSServiceID: costandusagereportservice.ServiceID, ProviderNameUpper: "CUR", HCLKeys: []string{"cur", "costandusagereportservice"}}
+	serviceData[DataExchange] = &ServiceDatum{AWSClientName: "DataExchange", AWSServiceName: dataexchange.ServiceName, AWSEndpointsID: dataexchange.EndpointsID, AWSServiceID: dataexchange.ServiceID, ProviderNameUpper: "DataExchange", HCLKeys: []string{"dataexchange"}}
+	serviceData[DataPipeline] = &ServiceDatum{AWSClientName: "DataPipeline", AWSServiceName: datapipeline.ServiceName, AWSEndpointsID: datapipeline.EndpointsID, AWSServiceID: datapipeline.ServiceID, ProviderNameUpper: "DataPipeline", HCLKeys: []string{"datapipeline"}}
+	serviceData[DataSync] = &ServiceDatum{AWSClientName: "DataSync", AWSServiceName: datasync.ServiceName, AWSEndpointsID: datasync.EndpointsID, AWSServiceID: datasync.ServiceID, ProviderNameUpper: "DataSync", HCLKeys: []string{"datasync"}}
+	serviceData[DAX] = &ServiceDatum{AWSClientName: "DAX", AWSServiceName: dax.ServiceName, AWSEndpointsID: dax.EndpointsID, AWSServiceID: dax.ServiceID, ProviderNameUpper: "DAX", HCLKeys: []string{"dax"}}
+	serviceData[Detective] = &ServiceDatum{AWSClientName: "Detective", AWSServiceName: detective.ServiceName, AWSEndpointsID: detective.EndpointsID, AWSServiceID: detective.ServiceID, ProviderNameUpper: "Detective", HCLKeys: []string{"detective"}}
+	serviceData[DeviceFarm] = &ServiceDatum{AWSClientName: "DeviceFarm", AWSServiceName: devicefarm.ServiceName, AWSEndpointsID: devicefarm.EndpointsID, AWSServiceID: devicefarm.ServiceID, ProviderNameUpper: "DeviceFarm", HCLKeys: []string{"devicefarm"}}
+	serviceData[DevOpsGuru] = &ServiceDatum{AWSClientName: "DevOpsGuru", AWSServiceName: devopsguru.ServiceName, AWSEndpointsID: devopsguru.EndpointsID, AWSServiceID: devopsguru.ServiceID, ProviderNameUpper: "DevOpsGuru", HCLKeys: []string{"devopsguru"}}
+	serviceData[DirectConnect] = &ServiceDatum{AWSClientName: "DirectConnect", AWSServiceName: directconnect.ServiceName, AWSEndpointsID: directconnect.EndpointsID, AWSServiceID: directconnect.ServiceID, ProviderNameUpper: "DirectConnect", HCLKeys: []string{"directconnect"}}
+	serviceData[DLM] = &ServiceDatum{AWSClientName: "DLM", AWSServiceName: dlm.ServiceName, AWSEndpointsID: dlm.EndpointsID, AWSServiceID: dlm.ServiceID, ProviderNameUpper: "DLM", HCLKeys: []string{"dlm"}}
+	serviceData[DMS] = &ServiceDatum{AWSClientName: "DatabaseMigrationService", AWSServiceName: databasemigrationservice.ServiceName, AWSEndpointsID: databasemigrationservice.EndpointsID, AWSServiceID: databasemigrationservice.ServiceID, ProviderNameUpper: "DMS", HCLKeys: []string{"dms", "databasemigration", "databasemigrationservice"}}
+	serviceData[DocDB] = &ServiceDatum{AWSClientName: "DocDB", AWSServiceName: docdb.ServiceName, AWSEndpointsID: docdb.EndpointsID, AWSServiceID: docdb.ServiceID, ProviderNameUpper: "DocDB", HCLKeys: []string{"docdb"}}
+	serviceData[DS] = &ServiceDatum{AWSClientName: "DirectoryService", AWSServiceName: directoryservice.ServiceName, AWSEndpointsID: directoryservice.EndpointsID, AWSServiceID: directoryservice.ServiceID, ProviderNameUpper: "DS", HCLKeys: []string{"ds"}}
+	serviceData[DynamoDB] = &ServiceDatum{AWSClientName: "DynamoDB", AWSServiceName: dynamodb.ServiceName, AWSEndpointsID: dynamodb.EndpointsID, AWSServiceID: dynamodb.ServiceID, ProviderNameUpper: "DynamoDB", HCLKeys: []string{"dynamodb"}, EnvVar: "TF_AWS_DYNAMODB_ENDPOINT", DeprecatedEnvVar: "AWS_DYNAMODB_ENDPOINT"}
+	serviceData[DynamoDBStreams] = &ServiceDatum{AWSClientName: "DynamoDBStreams", AWSServiceName: dynamodbstreams.ServiceName, AWSEndpointsID: dynamodbstreams.EndpointsID, AWSServiceID: dynamodbstreams.ServiceID, ProviderNameUpper: "DynamoDBStreams", HCLKeys: []string{"dynamodbstreams"}}
+	serviceData[EC2] = &ServiceDatum{AWSClientName: "EC2", AWSServiceName: ec2.ServiceName, AWSEndpointsID: ec2.EndpointsID, AWSServiceID: ec2.ServiceID, ProviderNameUpper: "EC2", HCLKeys: []string{"ec2"}}
+	serviceData[EC2InstanceConnect] = &ServiceDatum{AWSClientName: "EC2InstanceConnect", AWSServiceName: ec2instanceconnect.ServiceName, AWSEndpointsID: ec2instanceconnect.EndpointsID, AWSServiceID: ec2instanceconnect.ServiceID, ProviderNameUpper: "EC2InstanceConnect", HCLKeys: []string{"ec2instanceconnect"}}
+	serviceData[ECR] = &ServiceDatum{AWSClientName: "ECR", AWSServiceName: ecr.ServiceName, AWSEndpointsID: ecr.EndpointsID, AWSServiceID: ecr.ServiceID, ProviderNameUpper: "ECR", HCLKeys: []string{"ecr"}}
+	serviceData[ECRPublic] = &ServiceDatum{AWSClientName: "ECRPublic", AWSServiceName: ecrpublic.ServiceName, AWSEndpointsID: ecrpublic.EndpointsID, AWSServiceID: ecrpublic.ServiceID, ProviderNameUpper: "ECRPublic", HCLKeys: []string{"ecrpublic"}}
+	serviceData[ECS] = &ServiceDatum{AWSClientName: "ECS", AWSServiceName: ecs.ServiceName, AWSEndpointsID: ecs.EndpointsID, AWSServiceID: ecs.ServiceID, ProviderNameUpper: "ECS", HCLKeys: []string{"ecs"}}
+	serviceData[EFS] = &ServiceDatum{AWSClientName: "EFS", AWSServiceName: efs.ServiceName, AWSEndpointsID: efs.EndpointsID, AWSServiceID: efs.ServiceID, ProviderNameUpper: "EFS", HCLKeys: []string{"efs"}}
+	serviceData[EKS] = &ServiceDatum{AWSClientName: "EKS", AWSServiceName: eks.ServiceName, AWSEndpointsID: eks.EndpointsID, AWSServiceID: eks.ServiceID, ProviderNameUpper: "EKS", HCLKeys: []string{"eks"}}
+	serviceData[ElastiCache] = &ServiceDatum{AWSClientName: "ElastiCache", AWSServiceName: elasticache.ServiceName, AWSEndpointsID: elasticache.EndpointsID, AWSServiceID: elasticache.ServiceID, ProviderNameUpper: "ElastiCache", HCLKeys: []string{"elasticache"}}
+	serviceData[ElasticBeanstalk] = &ServiceDatum{AWSClientName: "ElasticBeanstalk", AWSServiceName: elasticbeanstalk.ServiceName, AWSEndpointsID: elasticbeanstalk.EndpointsID, AWSServiceID: elasticbeanstalk.ServiceID, ProviderNameUpper: "ElasticBeanstalk", HCLKeys: []string{"elasticbeanstalk"}}
+	serviceData[ElasticInference] = &ServiceDatum{AWSClientName: "ElasticInference", AWSServiceName: elasticinference.ServiceName, AWSEndpointsID: elasticinference.EndpointsID, AWSServiceID: elasticinference.ServiceID, ProviderNameUpper: "ElasticInference", HCLKeys: []string{"elasticinference"}}
+	serviceData[Elasticsearch] = &ServiceDatum{AWSClientName: "ElasticsearchService", AWSServiceName: elasticsearch.ServiceName, AWSEndpointsID: elasticsearch.EndpointsID, AWSServiceID: elasticsearch.ServiceID, ProviderNameUpper: "Elasticsearch", HCLKeys: []string{"es", "elasticsearch", "elasticsearchservice"}}
+	serviceData[ElasticTranscoder] = &ServiceDatum{AWSClientName: "ElasticTranscoder", AWSServiceName: elastictranscoder.ServiceName, AWSEndpointsID: elastictranscoder.EndpointsID, AWSServiceID: elastictranscoder.ServiceID, ProviderNameUpper: "ElasticTranscoder", HCLKeys: []string{"elastictranscoder"}}
+	serviceData[ELB] = &ServiceDatum{AWSClientName: "ELB", AWSServiceName: elb.ServiceName, AWSEndpointsID: elb.EndpointsID, AWSServiceID: elb.ServiceID, ProviderNameUpper: "ELB", HCLKeys: []string{"elb"}}
+	serviceData[ELBV2] = &ServiceDatum{AWSClientName: "ELBV2", AWSServiceName: elbv2.ServiceName, AWSEndpointsID: elbv2.EndpointsID, AWSServiceID: elbv2.ServiceID, ProviderNameUpper: "ELBV2", HCLKeys: []string{"elbv2"}}
+	serviceData[EMR] = &ServiceDatum{AWSClientName: "EMR", AWSServiceName: emr.ServiceName, AWSEndpointsID: emr.EndpointsID, AWSServiceID: emr.ServiceID, ProviderNameUpper: "EMR", HCLKeys: []string{"emr"}}
+	serviceData[EMRContainers] = &ServiceDatum{AWSClientName: "EMRContainers", AWSServiceName: emrcontainers.ServiceName, AWSEndpointsID: emrcontainers.EndpointsID, AWSServiceID: emrcontainers.ServiceID, ProviderNameUpper: "EMRContainers", HCLKeys: []string{"emrcontainers"}}
+	serviceData[Events] = &ServiceDatum{AWSClientName: "EventBridge", AWSServiceName: eventbridge.ServiceName, AWSEndpointsID: eventbridge.EndpointsID, AWSServiceID: eventbridge.ServiceID, ProviderNameUpper: "Events", HCLKeys: []string{"eventbridge", "cloudwatchevents", "events"}}
+	serviceData[FinSpace] = &ServiceDatum{AWSClientName: "Finspace", AWSServiceName: finspace.ServiceName, AWSEndpointsID: finspace.EndpointsID, AWSServiceID: finspace.ServiceID, ProviderNameUpper: "FinSpace", HCLKeys: []string{"finspace"}}
+	serviceData[FinSpaceData] = &ServiceDatum{AWSClientName: "FinSpaceData", AWSServiceName: finspacedata.ServiceName, AWSEndpointsID: finspacedata.EndpointsID, AWSServiceID: finspacedata.ServiceID, ProviderNameUpper: "FinSpaceData", HCLKeys: []string{"finspacedata"}}
+	serviceData[Firehose] = &ServiceDatum{AWSClientName: "Firehose", AWSServiceName: firehose.ServiceName, AWSEndpointsID: firehose.EndpointsID, AWSServiceID: firehose.ServiceID, ProviderNameUpper: "Firehose", HCLKeys: []string{"firehose"}}
+	serviceData[FIS] = &ServiceDatum{AWSClientName: "FIS", AWSServiceName: fis.ServiceName, AWSEndpointsID: fis.EndpointsID, AWSServiceID: fis.ServiceID, ProviderNameUpper: "FIS", HCLKeys: []string{"fis"}}
+	serviceData[FMS] = &ServiceDatum{AWSClientName: "FMS", AWSServiceName: fms.ServiceName, AWSEndpointsID: fms.EndpointsID, AWSServiceID: fms.ServiceID, ProviderNameUpper: "FMS", HCLKeys: []string{"fms"}}
+	serviceData[Forecast] = &ServiceDatum{AWSClientName: "ForecastService", AWSServiceName: forecastservice.ServiceName, AWSEndpointsID: forecastservice.EndpointsID, AWSServiceID: forecastservice.ServiceID, ProviderNameUpper: "Forecast", HCLKeys: []string{"forecast", "forecastservice"}}
+	serviceData[ForecastQuery] = &ServiceDatum{AWSClientName: "ForecastQueryService", AWSServiceName: forecastqueryservice.ServiceName, AWSEndpointsID: forecastqueryservice.EndpointsID, AWSServiceID: forecastqueryservice.ServiceID, ProviderNameUpper: "ForecastQuery", HCLKeys: []string{"forecastquery", "forecastqueryservice"}}
+	serviceData[FraudDetector] = &ServiceDatum{AWSClientName: "FraudDetector", AWSServiceName: frauddetector.ServiceName, AWSEndpointsID: frauddetector.EndpointsID, AWSServiceID: frauddetector.ServiceID, ProviderNameUpper: "FraudDetector", HCLKeys: []string{"frauddetector"}}
+	serviceData[FSx] = &ServiceDatum{AWSClientName: "FSx", AWSServiceName: fsx.ServiceName, AWSEndpointsID: fsx.EndpointsID, AWSServiceID: fsx.ServiceID, ProviderNameUpper: "FSx", HCLKeys: []string{"fsx"}}
+	serviceData[GameLift] = &ServiceDatum{AWSClientName: "GameLift", AWSServiceName: gamelift.ServiceName, AWSEndpointsID: gamelift.EndpointsID, AWSServiceID: gamelift.ServiceID, ProviderNameUpper: "GameLift", HCLKeys: []string{"gamelift"}}
+	serviceData[Glacier] = &ServiceDatum{AWSClientName: "Glacier", AWSServiceName: glacier.ServiceName, AWSEndpointsID: glacier.EndpointsID, AWSServiceID: glacier.ServiceID, ProviderNameUpper: "Glacier", HCLKeys: []string{"glacier"}}
+	serviceData[GlobalAccelerator] = &ServiceDatum{AWSClientName: "GlobalAccelerator", AWSServiceName: globalaccelerator.ServiceName, AWSEndpointsID: globalaccelerator.EndpointsID, AWSServiceID: globalaccelerator.ServiceID, ProviderNameUpper: "GlobalAccelerator", HCLKeys: []string{"globalaccelerator"}}
+	serviceData[Glue] = &ServiceDatum{AWSClientName: "Glue", AWSServiceName: glue.ServiceName, AWSEndpointsID: glue.EndpointsID, AWSServiceID: glue.ServiceID, ProviderNameUpper: "Glue", HCLKeys: []string{"glue"}}
+	serviceData[GlueDataBrew] = &ServiceDatum{AWSClientName: "GlueDataBrew", AWSServiceName: gluedatabrew.ServiceName, AWSEndpointsID: gluedatabrew.EndpointsID, AWSServiceID: gluedatabrew.ServiceID, ProviderNameUpper: "GlueDataBrew", HCLKeys: []string{"gluedatabrew"}}
+	serviceData[Grafana] = &ServiceDatum{AWSClientName: "Grafana", AWSServiceName: managedgrafana.ServiceName, AWSEndpointsID: managedgrafana.EndpointsID, AWSServiceID: managedgrafana.ServiceID, ProviderNameUpper: "Grafana", HCLKeys: []string{"grafana", "managedgrafana", "amg"}}
+	serviceData[Greengrass] = &ServiceDatum{AWSClientName: "Greengrass", AWSServiceName: greengrass.ServiceName, AWSEndpointsID: greengrass.EndpointsID, AWSServiceID: greengrass.ServiceID, ProviderNameUpper: "Greengrass", HCLKeys: []string{"greengrass"}}
+	serviceData[GreengrassV2] = &ServiceDatum{AWSClientName: "GreengrassV2", AWSServiceName: greengrassv2.ServiceName, AWSEndpointsID: greengrassv2.EndpointsID, AWSServiceID: greengrassv2.ServiceID, ProviderNameUpper: "GreengrassV2", HCLKeys: []string{"greengrassv2"}}
+	serviceData[GroundStation] = &ServiceDatum{AWSClientName: "GroundStation", AWSServiceName: groundstation.ServiceName, AWSEndpointsID: groundstation.EndpointsID, AWSServiceID: groundstation.ServiceID, ProviderNameUpper: "GroundStation", HCLKeys: []string{"groundstation"}}
+	serviceData[GuardDuty] = &ServiceDatum{AWSClientName: "GuardDuty", AWSServiceName: guardduty.ServiceName, AWSEndpointsID: guardduty.EndpointsID, AWSServiceID: guardduty.ServiceID, ProviderNameUpper: "GuardDuty", HCLKeys: []string{"guardduty"}}
+	serviceData[Health] = &ServiceDatum{AWSClientName: "Health", AWSServiceName: health.ServiceName, AWSEndpointsID: health.EndpointsID, AWSServiceID: health.ServiceID, ProviderNameUpper: "Health", HCLKeys: []string{"health"}}
+	serviceData[HealthLake] = &ServiceDatum{AWSClientName: "HealthLake", AWSServiceName: healthlake.ServiceName, AWSEndpointsID: healthlake.EndpointsID, AWSServiceID: healthlake.ServiceID, ProviderNameUpper: "HealthLake", HCLKeys: []string{"healthlake"}}
+	serviceData[Honeycode] = &ServiceDatum{AWSClientName: "Honeycode", AWSServiceName: honeycode.ServiceName, AWSEndpointsID: honeycode.EndpointsID, AWSServiceID: honeycode.ServiceID, ProviderNameUpper: "Honeycode", HCLKeys: []string{"honeycode"}}
+	serviceData[IAM] = &ServiceDatum{AWSClientName: "IAM", AWSServiceName: iam.ServiceName, AWSEndpointsID: iam.EndpointsID, AWSServiceID: iam.ServiceID, ProviderNameUpper: "IAM", HCLKeys: []string{"iam"}, EnvVar: "TF_AWS_IAM_ENDPOINT", DeprecatedEnvVar: "AWS_IAM_ENDPOINT"}
+	serviceData[IdentityStore] = &ServiceDatum{AWSClientName: "IdentityStore", AWSServiceName: identitystore.ServiceName, AWSEndpointsID: identitystore.EndpointsID, AWSServiceID: identitystore.ServiceID, ProviderNameUpper: "IdentityStore", HCLKeys: []string{"identitystore"}}
+	serviceData[ImageBuilder] = &ServiceDatum{AWSClientName: "ImageBuilder", AWSServiceName: imagebuilder.ServiceName, AWSEndpointsID: imagebuilder.EndpointsID, AWSServiceID: imagebuilder.ServiceID, ProviderNameUpper: "ImageBuilder", HCLKeys: []string{"imagebuilder"}}
+	serviceData[Inspector] = &ServiceDatum{AWSClientName: "Inspector", AWSServiceName: inspector.ServiceName, AWSEndpointsID: inspector.EndpointsID, AWSServiceID: inspector.ServiceID, ProviderNameUpper: "Inspector", HCLKeys: []string{"inspector"}}
+	serviceData[IoT] = &ServiceDatum{AWSClientName: "IoT", AWSServiceName: iot.ServiceName, AWSEndpointsID: iot.EndpointsID, AWSServiceID: iot.ServiceID, ProviderNameUpper: "IoT", HCLKeys: []string{"iot"}}
+	serviceData[IoT1ClickDevices] = &ServiceDatum{AWSClientName: "IoT1ClickDevicesService", AWSServiceName: iot1clickdevicesservice.ServiceName, AWSEndpointsID: iot1clickdevicesservice.EndpointsID, AWSServiceID: iot1clickdevicesservice.ServiceID, ProviderNameUpper: "IoT1ClickDevices", HCLKeys: []string{"iot1clickdevices", "iot1clickdevicesservice"}}
+	serviceData[IoT1ClickProjects] = &ServiceDatum{AWSClientName: "IoT1ClickProjects", AWSServiceName: iot1clickprojects.ServiceName, AWSEndpointsID: iot1clickprojects.EndpointsID, AWSServiceID: iot1clickprojects.ServiceID, ProviderNameUpper: "IoT1ClickProjects", HCLKeys: []string{"iot1clickprojects"}}
+	serviceData[IoTAnalytics] = &ServiceDatum{AWSClientName: "IoTAnalytics", AWSServiceName: iotanalytics.ServiceName, AWSEndpointsID: iotanalytics.EndpointsID, AWSServiceID: iotanalytics.ServiceID, ProviderNameUpper: "IoTAnalytics", HCLKeys: []string{"iotanalytics"}}
+	serviceData[IoTDataPlane] = &ServiceDatum{AWSClientName: "IoTDataPlane", AWSServiceName: iotdataplane.ServiceName, AWSEndpointsID: iotdataplane.EndpointsID, AWSServiceID: iotdataplane.ServiceID, ProviderNameUpper: "IoTDataPlane", HCLKeys: []string{"iotdataplane"}}
+	serviceData[IoTDeviceAdvisor] = &ServiceDatum{AWSClientName: "IoTDeviceAdvisor", AWSServiceName: iotdeviceadvisor.ServiceName, AWSEndpointsID: iotdeviceadvisor.EndpointsID, AWSServiceID: iotdeviceadvisor.ServiceID, ProviderNameUpper: "IoTDeviceAdvisor", HCLKeys: []string{"iotdeviceadvisor"}}
+	serviceData[IoTEvents] = &ServiceDatum{AWSClientName: "IoTEvents", AWSServiceName: iotevents.ServiceName, AWSEndpointsID: iotevents.EndpointsID, AWSServiceID: iotevents.ServiceID, ProviderNameUpper: "IoTEvents", HCLKeys: []string{"iotevents"}}
+	serviceData[IoTEventsData] = &ServiceDatum{AWSClientName: "IoTEventsData", AWSServiceName: ioteventsdata.ServiceName, AWSEndpointsID: ioteventsdata.EndpointsID, AWSServiceID: ioteventsdata.ServiceID, ProviderNameUpper: "IoTEventsData", HCLKeys: []string{"ioteventsdata"}}
+	serviceData[IoTFleetHub] = &ServiceDatum{AWSClientName: "IoTFleetHub", AWSServiceName: iotfleethub.ServiceName, AWSEndpointsID: iotfleethub.EndpointsID, AWSServiceID: iotfleethub.ServiceID, ProviderNameUpper: "IoTFleetHub", HCLKeys: []string{"iotfleethub"}}
+	serviceData[IoTJobsDataPlane] = &ServiceDatum{AWSClientName: "IoTJobsDataPlane", AWSServiceName: iotjobsdataplane.ServiceName, AWSEndpointsID: iotjobsdataplane.EndpointsID, AWSServiceID: iotjobsdataplane.ServiceID, ProviderNameUpper: "IoTJobsDataPlane", HCLKeys: []string{"iotjobsdataplane"}}
+	serviceData[IoTSecureTunneling] = &ServiceDatum{AWSClientName: "IoTSecureTunneling", AWSServiceName: iotsecuretunneling.ServiceName, AWSEndpointsID: iotsecuretunneling.EndpointsID, AWSServiceID: iotsecuretunneling.ServiceID, ProviderNameUpper: "IoTSecureTunneling", HCLKeys: []string{"iotsecuretunneling"}}
+	serviceData[IoTSiteWise] = &ServiceDatum{AWSClientName: "IoTSiteWise", AWSServiceName: iotsitewise.ServiceName, AWSEndpointsID: iotsitewise.EndpointsID, AWSServiceID: iotsitewise.ServiceID, ProviderNameUpper: "IoTSiteWise", HCLKeys: []string{"iotsitewise"}}
+	serviceData[IoTThingsGraph] = &ServiceDatum{AWSClientName: "IoTThingsGraph", AWSServiceName: iotthingsgraph.ServiceName, AWSEndpointsID: iotthingsgraph.EndpointsID, AWSServiceID: iotthingsgraph.ServiceID, ProviderNameUpper: "IoTThingsGraph", HCLKeys: []string{"iotthingsgraph"}}
+	serviceData[IoTWireless] = &ServiceDatum{AWSClientName: "IoTWireless", AWSServiceName: iotwireless.ServiceName, AWSEndpointsID: iotwireless.EndpointsID, AWSServiceID: iotwireless.ServiceID, ProviderNameUpper: "IoTWireless", HCLKeys: []string{"iotwireless"}}
+	serviceData[Kafka] = &ServiceDatum{AWSClientName: "Kafka", AWSServiceName: kafka.ServiceName, AWSEndpointsID: kafka.EndpointsID, AWSServiceID: kafka.ServiceID, ProviderNameUpper: "Kafka", HCLKeys: []string{"kafka"}}
+	serviceData[KafkaConnect] = &ServiceDatum{AWSClientName: "KafkaConnect", AWSServiceName: kafkaconnect.ServiceName, AWSEndpointsID: kafkaconnect.EndpointsID, AWSServiceID: kafkaconnect.ServiceID, ProviderNameUpper: "KafkaConnect", HCLKeys: []string{"kafkaconnect"}}
+	serviceData[Kendra] = &ServiceDatum{AWSClientName: "Kendra", AWSServiceName: kendra.ServiceName, AWSEndpointsID: kendra.EndpointsID, AWSServiceID: kendra.ServiceID, ProviderNameUpper: "Kendra", HCLKeys: []string{"kendra"}}
+	serviceData[Keyspaces] = &ServiceDatum{AWSClientName: "Keyspaces", AWSServiceName: keyspaces.ServiceName, AWSEndpointsID: keyspaces.EndpointsID, AWSServiceID: keyspaces.ServiceID, ProviderNameUpper: "Keyspaces", HCLKeys: []string{"keyspaces"}}
+	serviceData[Kinesis] = &ServiceDatum{AWSClientName: "Kinesis", AWSServiceName: kinesis.ServiceName, AWSEndpointsID: kinesis.EndpointsID, AWSServiceID: kinesis.ServiceID, ProviderNameUpper: "Kinesis", HCLKeys: []string{"kinesis"}}
+	serviceData[KinesisAnalytics] = &ServiceDatum{AWSClientName: "KinesisAnalytics", AWSServiceName: kinesisanalytics.ServiceName, AWSEndpointsID: kinesisanalytics.EndpointsID, AWSServiceID: kinesisanalytics.ServiceID, ProviderNameUpper: "KinesisAnalytics", HCLKeys: []string{"kinesisanalytics"}}
+	serviceData[KinesisAnalyticsV2] = &ServiceDatum{AWSClientName: "KinesisAnalyticsV2", AWSServiceName: kinesisanalyticsv2.ServiceName, AWSEndpointsID: kinesisanalyticsv2.EndpointsID, AWSServiceID: kinesisanalyticsv2.ServiceID, ProviderNameUpper: "KinesisAnalyticsV2", HCLKeys: []string{"kinesisanalyticsv2"}}
+	serviceData[KinesisVideo] = &ServiceDatum{AWSClientName: "KinesisVideo", AWSServiceName: kinesisvideo.ServiceName, AWSEndpointsID: kinesisvideo.EndpointsID, AWSServiceID: kinesisvideo.ServiceID, ProviderNameUpper: "KinesisVideo", HCLKeys: []string{"kinesisvideo"}}
+	serviceData[KinesisVideoArchivedMedia] = &ServiceDatum{AWSClientName: "KinesisVideoArchivedMedia", AWSServiceName: kinesisvideoarchivedmedia.ServiceName, AWSEndpointsID: kinesisvideoarchivedmedia.EndpointsID, AWSServiceID: kinesisvideoarchivedmedia.ServiceID, ProviderNameUpper: "KinesisVideoArchivedMedia", HCLKeys: []string{"kinesisvideoarchivedmedia"}}
+	serviceData[KinesisVideoMedia] = &ServiceDatum{AWSClientName: "KinesisVideoMedia", AWSServiceName: kinesisvideomedia.ServiceName, AWSEndpointsID: kinesisvideomedia.EndpointsID, AWSServiceID: kinesisvideomedia.ServiceID, ProviderNameUpper: "KinesisVideoMedia", HCLKeys: []string{"kinesisvideomedia"}}
+	serviceData[KinesisVideoSignalingChannels] = &ServiceDatum{AWSClientName: "KinesisVideoSignalingChannels", AWSServiceName: kinesisvideosignalingchannels.ServiceName, AWSEndpointsID: kinesisvideosignalingchannels.EndpointsID, AWSServiceID: kinesisvideosignalingchannels.ServiceID, ProviderNameUpper: "KinesisVideoSignalingChannels", HCLKeys: []string{"kinesisvideosignalingchannels"}}
+	serviceData[KMS] = &ServiceDatum{AWSClientName: "KMS", AWSServiceName: kms.ServiceName, AWSEndpointsID: kms.EndpointsID, AWSServiceID: kms.ServiceID, ProviderNameUpper: "KMS", HCLKeys: []string{"kms"}}
+	serviceData[LakeFormation] = &ServiceDatum{AWSClientName: "LakeFormation", AWSServiceName: lakeformation.ServiceName, AWSEndpointsID: lakeformation.EndpointsID, AWSServiceID: lakeformation.ServiceID, ProviderNameUpper: "LakeFormation", HCLKeys: []string{"lakeformation"}}
+	serviceData[Lambda] = &ServiceDatum{AWSClientName: "Lambda", AWSServiceName: lambda.ServiceName, AWSEndpointsID: lambda.EndpointsID, AWSServiceID: lambda.ServiceID, ProviderNameUpper: "Lambda", HCLKeys: []string{"lambda"}}
+	serviceData[LexModels] = &ServiceDatum{AWSClientName: "LexModelBuildingService", AWSServiceName: lexmodelbuildingservice.ServiceName, AWSEndpointsID: lexmodelbuildingservice.EndpointsID, AWSServiceID: lexmodelbuildingservice.ServiceID, ProviderNameUpper: "LexModels", HCLKeys: []string{"lexmodels", "lexmodelbuilding", "lexmodelbuildingservice"}}
+	serviceData[LexModelsV2] = &ServiceDatum{AWSClientName: "LexModelsV2", AWSServiceName: lexmodelsv2.ServiceName, AWSEndpointsID: lexmodelsv2.EndpointsID, AWSServiceID: lexmodelsv2.ServiceID, ProviderNameUpper: "LexModelsV2", HCLKeys: []string{"lexmodelsv2"}}
+	serviceData[LexRuntime] = &ServiceDatum{AWSClientName: "LexRuntimeService", AWSServiceName: lexruntimeservice.ServiceName, AWSEndpointsID: lexruntimeservice.EndpointsID, AWSServiceID: lexruntimeservice.ServiceID, ProviderNameUpper: "LexRuntime", HCLKeys: []string{"lexruntime", "lexruntimeservice"}}
+	serviceData[LexRuntimeV2] = &ServiceDatum{AWSClientName: "LexRuntimeV2", AWSServiceName: lexruntimev2.ServiceName, AWSEndpointsID: lexruntimev2.EndpointsID, AWSServiceID: lexruntimev2.ServiceID, ProviderNameUpper: "LexRuntimeV2", HCLKeys: []string{"lexruntimev2"}}
+	serviceData[LicenseManager] = &ServiceDatum{AWSClientName: "LicenseManager", AWSServiceName: licensemanager.ServiceName, AWSEndpointsID: licensemanager.EndpointsID, AWSServiceID: licensemanager.ServiceID, ProviderNameUpper: "LicenseManager", HCLKeys: []string{"licensemanager"}}
+	serviceData[Lightsail] = &ServiceDatum{AWSClientName: "Lightsail", AWSServiceName: lightsail.ServiceName, AWSEndpointsID: lightsail.EndpointsID, AWSServiceID: lightsail.ServiceID, ProviderNameUpper: "Lightsail", HCLKeys: []string{"lightsail"}}
+	serviceData[Location] = &ServiceDatum{AWSClientName: "LocationService", AWSServiceName: locationservice.ServiceName, AWSEndpointsID: locationservice.EndpointsID, AWSServiceID: locationservice.ServiceID, ProviderNameUpper: "Location", HCLKeys: []string{"location"}}
+	serviceData[LookoutEquipment] = &ServiceDatum{AWSClientName: "LookoutEquipment", AWSServiceName: lookoutequipment.ServiceName, AWSEndpointsID: lookoutequipment.EndpointsID, AWSServiceID: lookoutequipment.ServiceID, ProviderNameUpper: "LookoutEquipment", HCLKeys: []string{"lookoutequipment"}}
+	serviceData[LookoutForVision] = &ServiceDatum{AWSClientName: "LookoutForVision", AWSServiceName: lookoutforvision.ServiceName, AWSEndpointsID: lookoutforvision.EndpointsID, AWSServiceID: lookoutforvision.ServiceID, ProviderNameUpper: "LookoutForVision", HCLKeys: []string{"lookoutforvision"}}
+	serviceData[LookoutMetrics] = &ServiceDatum{AWSClientName: "LookoutMetrics", AWSServiceName: lookoutmetrics.ServiceName, AWSEndpointsID: lookoutmetrics.EndpointsID, AWSServiceID: lookoutmetrics.ServiceID, ProviderNameUpper: "LookoutMetrics", HCLKeys: []string{"lookoutmetrics"}}
+	serviceData[MachineLearning] = &ServiceDatum{AWSClientName: "MachineLearning", AWSServiceName: machinelearning.ServiceName, AWSEndpointsID: machinelearning.EndpointsID, AWSServiceID: machinelearning.ServiceID, ProviderNameUpper: "MachineLearning", HCLKeys: []string{"machinelearning"}}
+	serviceData[Macie] = &ServiceDatum{AWSClientName: "Macie", AWSServiceName: macie.ServiceName, AWSEndpointsID: macie.EndpointsID, AWSServiceID: macie.ServiceID, ProviderNameUpper: "Macie", HCLKeys: []string{"macie"}}
+	serviceData[Macie2] = &ServiceDatum{AWSClientName: "Macie2", AWSServiceName: macie2.ServiceName, AWSEndpointsID: macie2.EndpointsID, AWSServiceID: macie2.ServiceID, ProviderNameUpper: "Macie2", HCLKeys: []string{"macie2"}}
+	serviceData[ManagedBlockchain] = &ServiceDatum{AWSClientName: "ManagedBlockchain", AWSServiceName: managedblockchain.ServiceName, AWSEndpointsID: managedblockchain.EndpointsID, AWSServiceID: managedblockchain.ServiceID, ProviderNameUpper: "ManagedBlockchain", HCLKeys: []string{"managedblockchain"}}
+	serviceData[MarketplaceCatalog] = &ServiceDatum{AWSClientName: "MarketplaceCatalog", AWSServiceName: marketplacecatalog.ServiceName, AWSEndpointsID: marketplacecatalog.EndpointsID, AWSServiceID: marketplacecatalog.ServiceID, ProviderNameUpper: "MarketplaceCatalog", HCLKeys: []string{"marketplacecatalog"}}
+	serviceData[MarketplaceCommerceAnalytics] = &ServiceDatum{AWSClientName: "MarketplaceCommerceAnalytics", AWSServiceName: marketplacecommerceanalytics.ServiceName, AWSEndpointsID: marketplacecommerceanalytics.EndpointsID, AWSServiceID: marketplacecommerceanalytics.ServiceID, ProviderNameUpper: "MarketplaceCommerceAnalytics", HCLKeys: []string{"marketplacecommerceanalytics"}}
+	serviceData[MarketplaceEntitlement] = &ServiceDatum{AWSClientName: "MarketplaceEntitlementService", AWSServiceName: marketplaceentitlementservice.ServiceName, AWSEndpointsID: marketplaceentitlementservice.EndpointsID, AWSServiceID: marketplaceentitlementservice.ServiceID, ProviderNameUpper: "MarketplaceEntitlement", HCLKeys: []string{"marketplaceentitlement", "marketplaceentitlementservice"}}
+	serviceData[MarketplaceMetering] = &ServiceDatum{AWSClientName: "MarketplaceMetering", AWSServiceName: marketplacemetering.ServiceName, AWSEndpointsID: marketplacemetering.EndpointsID, AWSServiceID: marketplacemetering.ServiceID, ProviderNameUpper: "MarketplaceMetering", HCLKeys: []string{"marketplacemetering"}}
+	serviceData[MediaConnect] = &ServiceDatum{AWSClientName: "MediaConnect", AWSServiceName: mediaconnect.ServiceName, AWSEndpointsID: mediaconnect.EndpointsID, AWSServiceID: mediaconnect.ServiceID, ProviderNameUpper: "MediaConnect", HCLKeys: []string{"mediaconnect"}}
+	serviceData[MediaConvert] = &ServiceDatum{AWSClientName: "MediaConvert", AWSServiceName: mediaconvert.ServiceName, AWSEndpointsID: mediaconvert.EndpointsID, AWSServiceID: mediaconvert.ServiceID, ProviderNameUpper: "MediaConvert", HCLKeys: []string{"mediaconvert"}}
+	serviceData[MediaLive] = &ServiceDatum{AWSClientName: "MediaLive", AWSServiceName: medialive.ServiceName, AWSEndpointsID: medialive.EndpointsID, AWSServiceID: medialive.ServiceID, ProviderNameUpper: "MediaLive", HCLKeys: []string{"medialive"}}
+	serviceData[MediaPackage] = &ServiceDatum{AWSClientName: "MediaPackage", AWSServiceName: mediapackage.ServiceName, AWSEndpointsID: mediapackage.EndpointsID, AWSServiceID: mediapackage.ServiceID, ProviderNameUpper: "MediaPackage", HCLKeys: []string{"mediapackage"}}
+	serviceData[MediaPackageVOD] = &ServiceDatum{AWSClientName: "MediaPackageVOD", AWSServiceName: mediapackagevod.ServiceName, AWSEndpointsID: mediapackagevod.EndpointsID, AWSServiceID: mediapackagevod.ServiceID, ProviderNameUpper: "MediaPackageVOD", HCLKeys: []string{"mediapackagevod"}}
+	serviceData[MediaStore] = &ServiceDatum{AWSClientName: "MediaStore", AWSServiceName: mediastore.ServiceName, AWSEndpointsID: mediastore.EndpointsID, AWSServiceID: mediastore.ServiceID, ProviderNameUpper: "MediaStore", HCLKeys: []string{"mediastore"}}
+	serviceData[MediaStoreData] = &ServiceDatum{AWSClientName: "MediaStoreData", AWSServiceName: mediastoredata.ServiceName, AWSEndpointsID: mediastoredata.EndpointsID, AWSServiceID: mediastoredata.ServiceID, ProviderNameUpper: "MediaStoreData", HCLKeys: []string{"mediastoredata"}}
+	serviceData[MediaTailor] = &ServiceDatum{AWSClientName: "MediaTailor", AWSServiceName: mediatailor.ServiceName, AWSEndpointsID: mediatailor.EndpointsID, AWSServiceID: mediatailor.ServiceID, ProviderNameUpper: "MediaTailor", HCLKeys: []string{"mediatailor"}}
+	serviceData[MemoryDB] = &ServiceDatum{AWSClientName: "MemoryDB", AWSServiceName: memorydb.ServiceName, AWSEndpointsID: memorydb.EndpointsID, AWSServiceID: memorydb.ServiceID, ProviderNameUpper: "MemoryDB", HCLKeys: []string{"memorydb"}}
+	serviceData[Mgn] = &ServiceDatum{AWSClientName: "Mgn", AWSServiceName: mgn.ServiceName, AWSEndpointsID: mgn.EndpointsID, AWSServiceID: mgn.ServiceID, ProviderNameUpper: "Mgn", HCLKeys: []string{"mgn"}}
+	serviceData[MigrationHub] = &ServiceDatum{AWSClientName: "MigrationHub", AWSServiceName: migrationhub.ServiceName, AWSEndpointsID: migrationhub.EndpointsID, AWSServiceID: migrationhub.ServiceID, ProviderNameUpper: "MigrationHub", HCLKeys: []string{"migrationhub"}}
+	serviceData[MigrationHubConfig] = &ServiceDatum{AWSClientName: "MigrationHubConfig", AWSServiceName: migrationhubconfig.ServiceName, AWSEndpointsID: migrationhubconfig.EndpointsID, AWSServiceID: migrationhubconfig.ServiceID, ProviderNameUpper: "MigrationHubConfig", HCLKeys: []string{"migrationhubconfig"}}
+	serviceData[Mobile] = &ServiceDatum{AWSClientName: "Mobile", AWSServiceName: mobile.ServiceName, AWSEndpointsID: mobile.EndpointsID, AWSServiceID: mobile.ServiceID, ProviderNameUpper: "Mobile", HCLKeys: []string{"mobile"}}
+	serviceData[MobileAnalytics] = &ServiceDatum{AWSClientName: "MobileAnalytics", AWSServiceName: mobileanalytics.ServiceName, AWSEndpointsID: mobileanalytics.EndpointsID, AWSServiceID: mobileanalytics.ServiceID, ProviderNameUpper: "MobileAnalytics", HCLKeys: []string{"mobileanalytics"}}
+	serviceData[MQ] = &ServiceDatum{AWSClientName: "MQ", AWSServiceName: mq.ServiceName, AWSEndpointsID: mq.EndpointsID, AWSServiceID: mq.ServiceID, ProviderNameUpper: "MQ", HCLKeys: []string{"mq"}}
+	serviceData[MTurk] = &ServiceDatum{AWSClientName: "MTurk", AWSServiceName: mturk.ServiceName, AWSEndpointsID: mturk.EndpointsID, AWSServiceID: mturk.ServiceID, ProviderNameUpper: "MTurk", HCLKeys: []string{"mturk"}}
+	serviceData[MWAA] = &ServiceDatum{AWSClientName: "MWAA", AWSServiceName: mwaa.ServiceName, AWSEndpointsID: mwaa.EndpointsID, AWSServiceID: mwaa.ServiceID, ProviderNameUpper: "MWAA", HCLKeys: []string{"mwaa"}}
+	serviceData[Neptune] = &ServiceDatum{AWSClientName: "Neptune", AWSServiceName: neptune.ServiceName, AWSEndpointsID: neptune.EndpointsID, AWSServiceID: neptune.ServiceID, ProviderNameUpper: "Neptune", HCLKeys: []string{"neptune"}}
+	serviceData[NetworkFirewall] = &ServiceDatum{AWSClientName: "NetworkFirewall", AWSServiceName: networkfirewall.ServiceName, AWSEndpointsID: networkfirewall.EndpointsID, AWSServiceID: networkfirewall.ServiceID, ProviderNameUpper: "NetworkFirewall", HCLKeys: []string{"networkfirewall"}}
+	serviceData[NetworkManager] = &ServiceDatum{AWSClientName: "NetworkManager", AWSServiceName: networkmanager.ServiceName, AWSEndpointsID: networkmanager.EndpointsID, AWSServiceID: networkmanager.ServiceID, ProviderNameUpper: "NetworkManager", HCLKeys: []string{"networkmanager"}}
+	serviceData[NimbleStudio] = &ServiceDatum{AWSClientName: "NimbleStudio", AWSServiceName: nimblestudio.ServiceName, AWSEndpointsID: nimblestudio.EndpointsID, AWSServiceID: nimblestudio.ServiceID, ProviderNameUpper: "NimbleStudio", HCLKeys: []string{"nimblestudio"}}
+	serviceData[OpsWorks] = &ServiceDatum{AWSClientName: "OpsWorks", AWSServiceName: opsworks.ServiceName, AWSEndpointsID: opsworks.EndpointsID, AWSServiceID: opsworks.ServiceID, ProviderNameUpper: "OpsWorks", HCLKeys: []string{"opsworks"}}
+	serviceData[OpsWorksCM] = &ServiceDatum{AWSClientName: "OpsWorksCM", AWSServiceName: opsworkscm.ServiceName, AWSEndpointsID: opsworkscm.EndpointsID, AWSServiceID: opsworkscm.ServiceID, ProviderNameUpper: "OpsWorksCM", HCLKeys: []string{"opsworkscm"}}
+	serviceData[Organizations] = &ServiceDatum{AWSClientName: "Organizations", AWSServiceName: organizations.ServiceName, AWSEndpointsID: organizations.EndpointsID, AWSServiceID: organizations.ServiceID, ProviderNameUpper: "Organizations", HCLKeys: []string{"organizations"}}
+	serviceData[Outposts] = &ServiceDatum{AWSClientName: "Outposts", AWSServiceName: outposts.ServiceName, AWSEndpointsID: outposts.EndpointsID, AWSServiceID: outposts.ServiceID, ProviderNameUpper: "Outposts", HCLKeys: []string{"outposts"}}
+	serviceData[Personalize] = &ServiceDatum{AWSClientName: "Personalize", AWSServiceName: personalize.ServiceName, AWSEndpointsID: personalize.EndpointsID, AWSServiceID: personalize.ServiceID, ProviderNameUpper: "Personalize", HCLKeys: []string{"personalize"}}
+	serviceData[PersonalizeEvents] = &ServiceDatum{AWSClientName: "PersonalizeEvents", AWSServiceName: personalizeevents.ServiceName, AWSEndpointsID: personalizeevents.EndpointsID, AWSServiceID: personalizeevents.ServiceID, ProviderNameUpper: "PersonalizeEvents", HCLKeys: []string{"personalizeevents"}}
+	serviceData[PersonalizeRuntime] = &ServiceDatum{AWSClientName: "PersonalizeRuntime", AWSServiceName: personalizeruntime.ServiceName, AWSEndpointsID: personalizeruntime.EndpointsID, AWSServiceID: personalizeruntime.ServiceID, ProviderNameUpper: "PersonalizeRuntime", HCLKeys: []string{"personalizeruntime"}}
+	serviceData[PI] = &ServiceDatum{AWSClientName: "PI", AWSServiceName: pi.ServiceName, AWSEndpointsID: pi.EndpointsID, AWSServiceID: pi.ServiceID, ProviderNameUpper: "PI", HCLKeys: []string{"pi"}}
+	serviceData[Pinpoint] = &ServiceDatum{AWSClientName: "Pinpoint", AWSServiceName: pinpoint.ServiceName, AWSEndpointsID: pinpoint.EndpointsID, AWSServiceID: pinpoint.ServiceID, ProviderNameUpper: "Pinpoint", HCLKeys: []string{"pinpoint"}}
+	serviceData[PinpointEmail] = &ServiceDatum{AWSClientName: "PinpointEmail", AWSServiceName: pinpointemail.ServiceName, AWSEndpointsID: pinpointemail.EndpointsID, AWSServiceID: pinpointemail.ServiceID, ProviderNameUpper: "PinpointEmail", HCLKeys: []string{"pinpointemail"}}
+	serviceData[PinpointSMSVoice] = &ServiceDatum{AWSClientName: "PinpointSMSVoice", AWSServiceName: pinpointsmsvoice.ServiceName, AWSEndpointsID: pinpointsmsvoice.EndpointsID, AWSServiceID: pinpointsmsvoice.ServiceID, ProviderNameUpper: "PinpointSMSVoice", HCLKeys: []string{"pinpointsmsvoice"}}
+	serviceData[Polly] = &ServiceDatum{AWSClientName: "Polly", AWSServiceName: polly.ServiceName, AWSEndpointsID: polly.EndpointsID, AWSServiceID: polly.ServiceID, ProviderNameUpper: "Polly", HCLKeys: []string{"polly"}}
+	serviceData[Pricing] = &ServiceDatum{AWSClientName: "Pricing", AWSServiceName: pricing.ServiceName, AWSEndpointsID: pricing.EndpointsID, AWSServiceID: pricing.ServiceID, ProviderNameUpper: "Pricing", HCLKeys: []string{"pricing"}}
+	serviceData[Proton] = &ServiceDatum{AWSClientName: "Proton", AWSServiceName: proton.ServiceName, AWSEndpointsID: proton.EndpointsID, AWSServiceID: proton.ServiceID, ProviderNameUpper: "Proton", HCLKeys: []string{"proton"}}
+	serviceData[QLDB] = &ServiceDatum{AWSClientName: "QLDB", AWSServiceName: qldb.ServiceName, AWSEndpointsID: qldb.EndpointsID, AWSServiceID: qldb.ServiceID, ProviderNameUpper: "QLDB", HCLKeys: []string{"qldb"}}
+	serviceData[QLDBSession] = &ServiceDatum{AWSClientName: "QLDBSession", AWSServiceName: qldbsession.ServiceName, AWSEndpointsID: qldbsession.EndpointsID, AWSServiceID: qldbsession.ServiceID, ProviderNameUpper: "QLDBSession", HCLKeys: []string{"qldbsession"}}
+	serviceData[QuickSight] = &ServiceDatum{AWSClientName: "QuickSight", AWSServiceName: quicksight.ServiceName, AWSEndpointsID: quicksight.EndpointsID, AWSServiceID: quicksight.ServiceID, ProviderNameUpper: "QuickSight", HCLKeys: []string{"quicksight"}}
+	serviceData[RAM] = &ServiceDatum{AWSClientName: "RAM", AWSServiceName: ram.ServiceName, AWSEndpointsID: ram.EndpointsID, AWSServiceID: ram.ServiceID, ProviderNameUpper: "RAM", HCLKeys: []string{"ram"}}
+	serviceData[RDS] = &ServiceDatum{AWSClientName: "RDS", AWSServiceName: rds.ServiceName, AWSEndpointsID: rds.EndpointsID, AWSServiceID: rds.ServiceID, ProviderNameUpper: "RDS", HCLKeys: []string{"rds"}}
+	serviceData[RDSData] = &ServiceDatum{AWSClientName: "RDSDataService", AWSServiceName: rdsdataservice.ServiceName, AWSEndpointsID: rdsdataservice.EndpointsID, AWSServiceID: rdsdataservice.ServiceID, ProviderNameUpper: "RDSData", HCLKeys: []string{"rdsdata", "rdsdataservice"}}
+	serviceData[Redshift] = &ServiceDatum{AWSClientName: "Redshift", AWSServiceName: redshift.ServiceName, AWSEndpointsID: redshift.EndpointsID, AWSServiceID: redshift.ServiceID, ProviderNameUpper: "Redshift", HCLKeys: []string{"redshift"}}
+	serviceData[RedshiftData] = &ServiceDatum{AWSClientName: "RedshiftData", AWSServiceName: redshiftdataapiservice.ServiceName, AWSEndpointsID: redshiftdataapiservice.EndpointsID, AWSServiceID: redshiftdataapiservice.ServiceID, ProviderNameUpper: "RedshiftData", HCLKeys: []string{"redshiftdata"}}
+	serviceData[Rekognition] = &ServiceDatum{AWSClientName: "Rekognition", AWSServiceName: rekognition.ServiceName, AWSEndpointsID: rekognition.EndpointsID, AWSServiceID: rekognition.ServiceID, ProviderNameUpper: "Rekognition", HCLKeys: []string{"rekognition"}}
+	serviceData[ResourceGroups] = &ServiceDatum{AWSClientName: "ResourceGroups", AWSServiceName: resourcegroups.ServiceName, AWSEndpointsID: resourcegroups.EndpointsID, AWSServiceID: resourcegroups.ServiceID, ProviderNameUpper: "ResourceGroups", HCLKeys: []string{"resourcegroups"}}
+	serviceData[ResourceGroupsTaggingAPI] = &ServiceDatum{AWSClientName: "ResourceGroupsTaggingAPI", AWSServiceName: resourcegroupstaggingapi.ServiceName, AWSEndpointsID: resourcegroupstaggingapi.EndpointsID, AWSServiceID: resourcegroupstaggingapi.ServiceID, ProviderNameUpper: "ResourceGroupsTaggingAPI", HCLKeys: []string{"resourcegroupstaggingapi", "resourcegroupstagging"}}
+	serviceData[RoboMaker] = &ServiceDatum{AWSClientName: "RoboMaker", AWSServiceName: robomaker.ServiceName, AWSEndpointsID: robomaker.EndpointsID, AWSServiceID: robomaker.ServiceID, ProviderNameUpper: "RoboMaker", HCLKeys: []string{"robomaker"}}
+	serviceData[Route53] = &ServiceDatum{AWSClientName: "Route53", AWSServiceName: route53.ServiceName, AWSEndpointsID: route53.EndpointsID, AWSServiceID: route53.ServiceID, ProviderNameUpper: "Route53", HCLKeys: []string{"route53"}}
+	serviceData[Route53Domains] = &ServiceDatum{AWSClientName: "Route53Domains", AWSServiceName: Route53DomainsServiceName, AWSEndpointsID: Route53DomainsEndpointID, AWSServiceID: route53domains.ServiceID, ProviderNameUpper: "Route53Domains", HCLKeys: []string{"route53domains"}}
+	serviceData[Route53RecoveryControlConfig] = &ServiceDatum{AWSClientName: "Route53RecoveryControlConfig", AWSServiceName: route53recoverycontrolconfig.ServiceName, AWSEndpointsID: route53recoverycontrolconfig.EndpointsID, AWSServiceID: route53recoverycontrolconfig.ServiceID, ProviderNameUpper: "Route53RecoveryControlConfig", HCLKeys: []string{"route53recoverycontrolconfig"}}
+	serviceData[Route53RecoveryReadiness] = &ServiceDatum{AWSClientName: "Route53RecoveryReadiness", AWSServiceName: route53recoveryreadiness.ServiceName, AWSEndpointsID: route53recoveryreadiness.EndpointsID, AWSServiceID: route53recoveryreadiness.ServiceID, ProviderNameUpper: "Route53RecoveryReadiness", HCLKeys: []string{"route53recoveryreadiness"}}
+	serviceData[Route53Resolver] = &ServiceDatum{AWSClientName: "Route53Resolver", AWSServiceName: route53resolver.ServiceName, AWSEndpointsID: route53resolver.EndpointsID, AWSServiceID: route53resolver.ServiceID, ProviderNameUpper: "Route53Resolver", HCLKeys: []string{"route53resolver"}}
+	serviceData[S3] = &ServiceDatum{AWSClientName: "S3", AWSServiceName: s3.ServiceName, AWSEndpointsID: s3.EndpointsID, AWSServiceID: s3.ServiceID, ProviderNameUpper: "S3", HCLKeys: []string{"s3"}, EnvVar: "TF_AWS_S3_ENDPOINT", DeprecatedEnvVar: "AWS_S3_ENDPOINT"}
+	serviceData[S3Control] = &ServiceDatum{AWSClientName: "S3Control", AWSServiceName: s3control.ServiceName, AWSEndpointsID: s3control.EndpointsID, AWSServiceID: s3control.ServiceID, ProviderNameUpper: "S3Control", HCLKeys: []string{"s3control"}}
+	serviceData[S3Outposts] = &ServiceDatum{AWSClientName: "S3Outposts", AWSServiceName: s3outposts.ServiceName, AWSEndpointsID: s3outposts.EndpointsID, AWSServiceID: s3outposts.ServiceID, ProviderNameUpper: "S3Outposts", HCLKeys: []string{"s3outposts"}}
+	serviceData[SageMaker] = &ServiceDatum{AWSClientName: "SageMaker", AWSServiceName: sagemaker.ServiceName, AWSEndpointsID: sagemaker.EndpointsID, AWSServiceID: sagemaker.ServiceID, ProviderNameUpper: "SageMaker", HCLKeys: []string{"sagemaker"}}
+	serviceData[SageMakerEdgeManager] = &ServiceDatum{AWSClientName: "SagemakerEdgeManager", AWSServiceName: sagemakeredgemanager.ServiceName, AWSEndpointsID: sagemakeredgemanager.EndpointsID, AWSServiceID: sagemakeredgemanager.ServiceID, ProviderNameUpper: "SageMakerEdgeManager", HCLKeys: []string{"sagemakeredgemanager"}}
+	serviceData[SageMakerFeatureStoreRuntime] = &ServiceDatum{AWSClientName: "SageMakerFeatureStoreRuntime", AWSServiceName: sagemakerfeaturestoreruntime.ServiceName, AWSEndpointsID: sagemakerfeaturestoreruntime.EndpointsID, AWSServiceID: sagemakerfeaturestoreruntime.ServiceID, ProviderNameUpper: "SageMakerFeatureStoreRuntime", HCLKeys: []string{"sagemakerfeaturestoreruntime"}}
+	serviceData[SageMakerRuntime] = &ServiceDatum{AWSClientName: "SageMakerRuntime", AWSServiceName: sagemakerruntime.ServiceName, AWSEndpointsID: sagemakerruntime.EndpointsID, AWSServiceID: sagemakerruntime.ServiceID, ProviderNameUpper: "SageMakerRuntime", HCLKeys: []string{"sagemakerruntime"}}
+	serviceData[SavingsPlans] = &ServiceDatum{AWSClientName: "SavingsPlans", AWSServiceName: savingsplans.ServiceName, AWSEndpointsID: savingsplans.EndpointsID, AWSServiceID: savingsplans.ServiceID, ProviderNameUpper: "SavingsPlans", HCLKeys: []string{"savingsplans"}}
+	serviceData[Schemas] = &ServiceDatum{AWSClientName: "Schemas", AWSServiceName: schemas.ServiceName, AWSEndpointsID: schemas.EndpointsID, AWSServiceID: schemas.ServiceID, ProviderNameUpper: "Schemas", HCLKeys: []string{"schemas"}}
+	serviceData[SecretsManager] = &ServiceDatum{AWSClientName: "SecretsManager", AWSServiceName: secretsmanager.ServiceName, AWSEndpointsID: secretsmanager.EndpointsID, AWSServiceID: secretsmanager.ServiceID, ProviderNameUpper: "SecretsManager", HCLKeys: []string{"secretsmanager"}}
+	serviceData[SecurityHub] = &ServiceDatum{AWSClientName: "SecurityHub", AWSServiceName: securityhub.ServiceName, AWSEndpointsID: securityhub.EndpointsID, AWSServiceID: securityhub.ServiceID, ProviderNameUpper: "SecurityHub", HCLKeys: []string{"securityhub"}}
+	serviceData[ServerlessRepo] = &ServiceDatum{AWSClientName: "ServerlessApplicationRepository", AWSServiceName: serverlessapplicationrepository.ServiceName, AWSEndpointsID: serverlessapplicationrepository.EndpointsID, AWSServiceID: serverlessapplicationrepository.ServiceID, ProviderNameUpper: "ServerlessRepo", HCLKeys: []string{"serverlessrepo", "serverlessapprepo", "serverlessapplicationrepository"}}
+	serviceData[ServiceCatalog] = &ServiceDatum{AWSClientName: "ServiceCatalog", AWSServiceName: servicecatalog.ServiceName, AWSEndpointsID: servicecatalog.EndpointsID, AWSServiceID: servicecatalog.ServiceID, ProviderNameUpper: "ServiceCatalog", HCLKeys: []string{"servicecatalog"}}
+	serviceData[ServiceDiscovery] = &ServiceDatum{AWSClientName: "ServiceDiscovery", AWSServiceName: servicediscovery.ServiceName, AWSEndpointsID: servicediscovery.EndpointsID, AWSServiceID: servicediscovery.ServiceID, ProviderNameUpper: "ServiceDiscovery", HCLKeys: []string{"servicediscovery"}}
+	serviceData[ServiceQuotas] = &ServiceDatum{AWSClientName: "ServiceQuotas", AWSServiceName: servicequotas.ServiceName, AWSEndpointsID: servicequotas.EndpointsID, AWSServiceID: servicequotas.ServiceID, ProviderNameUpper: "ServiceQuotas", HCLKeys: []string{"servicequotas"}}
+	serviceData[SES] = &ServiceDatum{AWSClientName: "SES", AWSServiceName: ses.ServiceName, AWSEndpointsID: ses.EndpointsID, AWSServiceID: ses.ServiceID, ProviderNameUpper: "SES", HCLKeys: []string{"ses"}}
+	serviceData[SESV2] = &ServiceDatum{AWSClientName: "SESV2", AWSServiceName: sesv2.ServiceName, AWSEndpointsID: sesv2.EndpointsID, AWSServiceID: sesv2.ServiceID, ProviderNameUpper: "SESV2", HCLKeys: []string{"sesv2"}}
+	serviceData[SFN] = &ServiceDatum{AWSClientName: "SFN", AWSServiceName: sfn.ServiceName, AWSEndpointsID: sfn.EndpointsID, AWSServiceID: sfn.ServiceID, ProviderNameUpper: "SFN", HCLKeys: []string{"stepfunctions", "sfn"}}
+	serviceData[Shield] = &ServiceDatum{AWSClientName: "Shield", AWSServiceName: shield.ServiceName, AWSEndpointsID: shield.EndpointsID, AWSServiceID: shield.ServiceID, ProviderNameUpper: "Shield", HCLKeys: []string{"shield"}}
+	serviceData[Signer] = &ServiceDatum{AWSClientName: "Signer", AWSServiceName: signer.ServiceName, AWSEndpointsID: signer.EndpointsID, AWSServiceID: signer.ServiceID, ProviderNameUpper: "Signer", HCLKeys: []string{"signer"}}
+	serviceData[SimpleDB] = &ServiceDatum{AWSClientName: "SimpleDB", AWSServiceName: simpledb.ServiceName, AWSEndpointsID: simpledb.EndpointsID, AWSServiceID: simpledb.ServiceID, ProviderNameUpper: "SimpleDB", HCLKeys: []string{"sdb", "simpledb"}}
+	serviceData[SMS] = &ServiceDatum{AWSClientName: "SMS", AWSServiceName: sms.ServiceName, AWSEndpointsID: sms.EndpointsID, AWSServiceID: sms.ServiceID, ProviderNameUpper: "SMS", HCLKeys: []string{"sms"}}
+	serviceData[Snowball] = &ServiceDatum{AWSClientName: "Snowball", AWSServiceName: snowball.ServiceName, AWSEndpointsID: snowball.EndpointsID, AWSServiceID: snowball.ServiceID, ProviderNameUpper: "Snowball", HCLKeys: []string{"snowball"}}
+	serviceData[SNS] = &ServiceDatum{AWSClientName: "SNS", AWSServiceName: sns.ServiceName, AWSEndpointsID: sns.EndpointsID, AWSServiceID: sns.ServiceID, ProviderNameUpper: "SNS", HCLKeys: []string{"sns"}}
+	serviceData[SQS] = &ServiceDatum{AWSClientName: "SQS", AWSServiceName: sqs.ServiceName, AWSEndpointsID: sqs.EndpointsID, AWSServiceID: sqs.ServiceID, ProviderNameUpper: "SQS", HCLKeys: []string{"sqs"}}
+	serviceData[SSM] = &ServiceDatum{AWSClientName: "SSM", AWSServiceName: ssm.ServiceName, AWSEndpointsID: ssm.EndpointsID, AWSServiceID: ssm.ServiceID, ProviderNameUpper: "SSM", HCLKeys: []string{"ssm"}}
+	serviceData[SSMContacts] = &ServiceDatum{AWSClientName: "SSMContacts", AWSServiceName: ssmcontacts.ServiceName, AWSEndpointsID: ssmcontacts.EndpointsID, AWSServiceID: ssmcontacts.ServiceID, ProviderNameUpper: "SSMContacts", HCLKeys: []string{"ssmcontacts"}}
+	serviceData[SSMIncidents] = &ServiceDatum{AWSClientName: "SSMIncidents", AWSServiceName: ssmincidents.ServiceName, AWSEndpointsID: ssmincidents.EndpointsID, AWSServiceID: ssmincidents.ServiceID, ProviderNameUpper: "SSMIncidents", HCLKeys: []string{"ssmincidents"}}
+	serviceData[SSO] = &ServiceDatum{AWSClientName: "SSO", AWSServiceName: sso.ServiceName, AWSEndpointsID: sso.EndpointsID, AWSServiceID: sso.ServiceID, ProviderNameUpper: "SSO", HCLKeys: []string{"sso"}}
+	serviceData[SSOAdmin] = &ServiceDatum{AWSClientName: "SSOAdmin", AWSServiceName: ssoadmin.ServiceName, AWSEndpointsID: ssoadmin.EndpointsID, AWSServiceID: ssoadmin.ServiceID, ProviderNameUpper: "SSOAdmin", HCLKeys: []string{"ssoadmin"}}
+	serviceData[SSOOIDC] = &ServiceDatum{AWSClientName: "SSOOIDC", AWSServiceName: ssooidc.ServiceName, AWSEndpointsID: ssooidc.EndpointsID, AWSServiceID: ssooidc.ServiceID, ProviderNameUpper: "SSOOIDC", HCLKeys: []string{"ssooidc"}}
+	serviceData[StorageGateway] = &ServiceDatum{AWSClientName: "StorageGateway", AWSServiceName: storagegateway.ServiceName, AWSEndpointsID: storagegateway.EndpointsID, AWSServiceID: storagegateway.ServiceID, ProviderNameUpper: "StorageGateway", HCLKeys: []string{"storagegateway"}}
+	serviceData[STS] = &ServiceDatum{AWSClientName: "STS", AWSServiceName: sts.ServiceName, AWSEndpointsID: sts.EndpointsID, AWSServiceID: sts.ServiceID, ProviderNameUpper: "STS", HCLKeys: []string{"sts"}, EnvVar: "TF_AWS_STS_ENDPOINT", DeprecatedEnvVar: "AWS_STS_ENDPOINT"}
+	serviceData[Support] = &ServiceDatum{AWSClientName: "Support", AWSServiceName: support.ServiceName, AWSEndpointsID: support.EndpointsID, AWSServiceID: support.ServiceID, ProviderNameUpper: "Support", HCLKeys: []string{"support"}}
+	serviceData[SWF] = &ServiceDatum{AWSClientName: "SWF", AWSServiceName: swf.ServiceName, AWSEndpointsID: swf.EndpointsID, AWSServiceID: swf.ServiceID, ProviderNameUpper: "SWF", HCLKeys: []string{"swf"}}
+	serviceData[Synthetics] = &ServiceDatum{AWSClientName: "Synthetics", AWSServiceName: synthetics.ServiceName, AWSEndpointsID: synthetics.EndpointsID, AWSServiceID: synthetics.ServiceID, ProviderNameUpper: "Synthetics", HCLKeys: []string{"synthetics"}}
+	serviceData[Textract] = &ServiceDatum{AWSClientName: "Textract", AWSServiceName: textract.ServiceName, AWSEndpointsID: textract.EndpointsID, AWSServiceID: textract.ServiceID, ProviderNameUpper: "Textract", HCLKeys: []string{"textract"}}
+	serviceData[TimestreamQuery] = &ServiceDatum{AWSClientName: "TimestreamQuery", AWSServiceName: timestreamquery.ServiceName, AWSEndpointsID: timestreamquery.EndpointsID, AWSServiceID: timestreamquery.ServiceID, ProviderNameUpper: "TimestreamQuery", HCLKeys: []string{"timestreamquery"}}
+	serviceData[TimestreamWrite] = &ServiceDatum{AWSClientName: "TimestreamWrite", AWSServiceName: timestreamwrite.ServiceName, AWSEndpointsID: timestreamwrite.EndpointsID, AWSServiceID: timestreamwrite.ServiceID, ProviderNameUpper: "TimestreamWrite", HCLKeys: []string{"timestreamwrite"}}
+	serviceData[Transcribe] = &ServiceDatum{AWSClientName: "TranscribeService", AWSServiceName: transcribeservice.ServiceName, AWSEndpointsID: transcribeservice.EndpointsID, AWSServiceID: transcribeservice.ServiceID, ProviderNameUpper: "Transcribe", HCLKeys: []string{"transcribe", "transcribeservice"}}
+	serviceData[TranscribeStreaming] = &ServiceDatum{AWSClientName: "TranscribeStreamingService", AWSServiceName: transcribestreamingservice.ServiceName, AWSEndpointsID: transcribestreamingservice.EndpointsID, AWSServiceID: transcribestreamingservice.ServiceID, ProviderNameUpper: "TranscribeStreaming", HCLKeys: []string{"transcribestreaming", "transcribestreamingservice"}}
+	serviceData[Transfer] = &ServiceDatum{AWSClientName: "Transfer", AWSServiceName: transfer.ServiceName, AWSEndpointsID: transfer.EndpointsID, AWSServiceID: transfer.ServiceID, ProviderNameUpper: "Transfer", HCLKeys: []string{"transfer"}}
+	serviceData[Translate] = &ServiceDatum{AWSClientName: "Translate", AWSServiceName: translate.ServiceName, AWSEndpointsID: translate.EndpointsID, AWSServiceID: translate.ServiceID, ProviderNameUpper: "Translate", HCLKeys: []string{"translate"}}
+	serviceData[WAF] = &ServiceDatum{AWSClientName: "WAF", AWSServiceName: waf.ServiceName, AWSEndpointsID: waf.EndpointsID, AWSServiceID: waf.ServiceID, ProviderNameUpper: "WAF", HCLKeys: []string{"waf"}}
+	serviceData[WAFRegional] = &ServiceDatum{AWSClientName: "WAFRegional", AWSServiceName: wafregional.ServiceName, AWSEndpointsID: wafregional.EndpointsID, AWSServiceID: wafregional.ServiceID, ProviderNameUpper: "WAFRegional", HCLKeys: []string{"wafregional"}}
+	serviceData[WAFV2] = &ServiceDatum{AWSClientName: "WAFV2", AWSServiceName: wafv2.ServiceName, AWSEndpointsID: wafv2.EndpointsID, AWSServiceID: wafv2.ServiceID, ProviderNameUpper: "WAFV2", HCLKeys: []string{"wafv2"}}
+	serviceData[WellArchitected] = &ServiceDatum{AWSClientName: "WellArchitected", AWSServiceName: wellarchitected.ServiceName, AWSEndpointsID: wellarchitected.EndpointsID, AWSServiceID: wellarchitected.ServiceID, ProviderNameUpper: "WellArchitected", HCLKeys: []string{"wellarchitected"}}
+	serviceData[WorkDocs] = &ServiceDatum{AWSClientName: "WorkDocs", AWSServiceName: workdocs.ServiceName, AWSEndpointsID: workdocs.EndpointsID, AWSServiceID: workdocs.ServiceID, ProviderNameUpper: "WorkDocs", HCLKeys: []string{"workdocs"}}
+	serviceData[WorkLink] = &ServiceDatum{AWSClientName: "WorkLink", AWSServiceName: worklink.ServiceName, AWSEndpointsID: worklink.EndpointsID, AWSServiceID: worklink.ServiceID, ProviderNameUpper: "WorkLink", HCLKeys: []string{"worklink"}}
+	serviceData[WorkMail] = &ServiceDatum{AWSClientName: "WorkMail", AWSServiceName: workmail.ServiceName, AWSEndpointsID: workmail.EndpointsID, AWSServiceID: workmail.ServiceID, ProviderNameUpper: "WorkMail", HCLKeys: []string{"workmail"}}
+	serviceData[WorkMailMessageFlow] = &ServiceDatum{AWSClientName: "WorkMailMessageFlow", AWSServiceName: workmailmessageflow.ServiceName, AWSEndpointsID: workmailmessageflow.EndpointsID, AWSServiceID: workmailmessageflow.ServiceID, ProviderNameUpper: "WorkMailMessageFlow", HCLKeys: []string{"workmailmessageflow"}}
+	serviceData[WorkSpaces] = &ServiceDatum{AWSClientName: "WorkSpaces", AWSServiceName: workspaces.ServiceName, AWSEndpointsID: workspaces.EndpointsID, AWSServiceID: workspaces.ServiceID, ProviderNameUpper: "WorkSpaces", HCLKeys: []string{"workspaces"}}
+	serviceData[XRay] = &ServiceDatum{AWSClientName: "XRay", AWSServiceName: xray.ServiceName, AWSEndpointsID: xray.EndpointsID, AWSServiceID: xray.ServiceID, ProviderNameUpper: "XRay", HCLKeys: []string{"xray"}}
+}
+
+func ServiceForHCLKey(s string) (string, error) {
+	for k, v := range serviceData {
+		for _, hclKey := range v.HCLKeys {
+			if s == hclKey {
+				return k, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("unable to find service for HCL key %s", s)
+}
+
+func ServiceKeys() []string {
+	keys := make([]string, len(serviceData))
+
+	i := 0
+	for k := range serviceData {
+		keys[i] = k
+		i++
+	}
+
+	return keys
+}
+
+func HCLKeys() []string {
+	keys := make([]string, 0)
+
+	for _, v := range serviceData {
+		keys = append(keys, v.HCLKeys...)
+	}
+
+	return keys
+}
+
+func ServiceProviderNameUpper(key string) (string, error) {
+	if v, ok := serviceData[key]; ok {
+		return v.ProviderNameUpper, nil
+	}
+
+	return "", fmt.Errorf("no service data found for %s", key)
+}
+
+func ServiceDeprecatedEnvVar(key string) string {
+	if v, ok := serviceData[key]; ok {
+		return v.DeprecatedEnvVar
+	}
+
+	return ""
+}
+
+func ServiceEnvVar(key string) string {
+	if v, ok := serviceData[key]; ok {
+		return v.EnvVar
+	}
+
+	return ""
+}

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -1,0 +1,242 @@
+package names
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestServiceForHCLKey(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "alternate",
+			Input:    "transcribeservice",
+			Expected: Transcribe,
+			Error:    false,
+		},
+		{
+			TestName: "primary",
+			Input:    "cognitoidp",
+			Expected: CognitoIDP,
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := ServiceForHCLKey(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestServicesForDirectories(t *testing.T) {
+	nonExisting := []string{
+		"alexaforbusiness",
+		"amplifybackend",
+		"appflow",
+		"appintegrations",
+		"applicationcostprofiler",
+		"applicationdiscovery",
+		"applicationinsights",
+		"appregistry",
+		"auditmanager",
+		"augmentedairuntime",
+		"braket",
+		"clouddirectory",
+		"cloudsearchdomain",
+		"cloudwatchrum",
+		"codeguruprofiler",
+		"codegurureviewer",
+		"codestar",
+		"cognitosync",
+		"comprehend",
+		"comprehendmedical",
+		"connectcontactlens",
+		"connectparticipant",
+		"costexplorer",
+		"devopsguru",
+		"dynamodbstreams",
+		"ec2instanceconnect",
+		"elasticinference",
+		"emrcontainers",
+		"finspace",
+		"finspacedata",
+		"fis",
+		"forecast",
+		"forecastquery",
+		"frauddetector",
+		"gluedatabrew",
+		"greengrassv2",
+		"groundstation",
+		"health",
+		"healthlake",
+		"honeycode",
+		"iot1clickdevices",
+		"iot1clickprojects",
+		"iotdataplane",
+		"iotdeviceadvisor",
+		"ioteventsdata",
+		"iotfleethub",
+		"iotjobsdataplane",
+		"iotsecuretunneling",
+		"iotsitewise",
+		"iotthingsgraph",
+		"iotwireless",
+		"kendra",
+		"kinesisvideoarchivedmedia",
+		"kinesisvideomedia",
+		"kinesisvideosignalingchannels",
+		"lexmodelsv2",
+		"lexruntime",
+		"lexruntimev2",
+		"location",
+		"lookoutequipment",
+		"lookoutforvision",
+		"lookoutmetrics",
+		"machinelearning",
+		"managedblockchain",
+		"marketplacecatalog",
+		"marketplacecommerceanalytics",
+		"marketplaceentitlement",
+		"marketplacemetering",
+		"mediapackagevod",
+		"mediastoredata",
+		"mediatailor",
+		"mgn",
+		"migrationhub",
+		"migrationhubconfig",
+		"mobile",
+		"mobileanalytics",
+		"mturk",
+		"nimblestudio",
+		"opsworkscm",
+		"personalize",
+		"personalizeevents",
+		"personalizeruntime",
+		"pi",
+		"pinpointemail",
+		"pinpointsmsvoice",
+		"polly",
+		"proton",
+		"qldbsession",
+		"rdsdata",
+		"redshiftdata",
+		"rekognition",
+		"robomaker",
+		"sagemakeredgemanager",
+		"sagemakerfeaturestoreruntime",
+		"sagemakerruntime",
+		"savingsplans",
+		"sesv2",
+		"sms",
+		"snowball",
+		"ssmcontacts",
+		"ssmincidents",
+		"sso",
+		"ssooidc",
+		"support",
+		"textract",
+		"timestreamquery",
+		"transcribe",
+		"transcribestreaming",
+		"translate",
+		"wellarchitected",
+		"workdocs",
+		"workmail",
+		"workmailmessageflow",
+	}
+
+	for _, testCase := range ServiceKeys() {
+		t.Run(testCase, func(t *testing.T) {
+			wd, err := os.Getwd()
+			if err != nil {
+				t.Errorf("error reading working directory: %s", err)
+			}
+
+			if _, err := os.Stat(fmt.Sprintf("%s/../internal/service/%s", wd, testCase)); os.IsNotExist(err) {
+				for _, service := range nonExisting {
+					if service == testCase {
+						t.Skipf("skipping %s because not yet implemented", testCase)
+						break
+					}
+				}
+				t.Errorf("expected %s/../internal/service/%s to exist %s", wd, testCase, err)
+			}
+		})
+	}
+}
+
+func TestServiceProviderNameUpper(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: Transcribe,
+			Input:    Transcribe,
+			Expected: "Transcribe",
+			Error:    false,
+		},
+		{
+			TestName: Route53Domains,
+			Input:    Route53Domains,
+			Expected: "Route53Domains",
+			Error:    false,
+		},
+		{
+			TestName: "doesnotexist",
+			Input:    "doesnotexist",
+			Expected: "",
+			Error:    true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := ServiceProviderNameUpper(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23794

Output from testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% go test ./...
?   	github.com/hashicorp/terraform-provider-aws	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	6.626s
?   	github.com/hashicorp/terraform-provider-aws/internal/attrmap	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/conns	1.329s
ok  	github.com/hashicorp/terraform-provider-aws/internal/create	1.889s
ok  	github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable	0.731s
?   	github.com/hashicorp/terraform-provider-aws/internal/experimental/sync	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/flex	1.585s
ok  	github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters	6.216s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider	0.511s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer	9.772s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	6.250s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acm	6.376s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	12.469s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	9.286s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	7.628s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	13.411s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	11.589s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling	12.179s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appconfig	13.656s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appmesh	15.079s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apprunner	7.712s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	6.148s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appsync	3.319s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/athena	9.822s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	12.019s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans	7.971s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	14.644s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	15.805s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/budgets	8.733s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	9.616s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloud9	10.552s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol	12.356s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	13.438s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	16.301s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2	13.435s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	15.553s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail	13.352s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	18.635s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs	17.765s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	4.248s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	6.017s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codecommit	2.975s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codedeploy	7.832s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline	12.112s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections	10.653s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications	14.714s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity	17.300s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	10.924s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	15.337s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	16.163s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cur	16.605s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange	2.721s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline	5.680s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	8.767s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	2.756s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/detective	6.019s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm	3.802s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	11.081s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dlm	7.320s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	11.772s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	13.080s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	14.147s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	10.134s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	22.087s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	12.715s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic	11.256s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	6.811s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	4.052s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	10.326s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	9.178s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	4.299s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	8.501s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder	10.928s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	12.634s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	14.277s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emr	13.190s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	14.562s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	10.272s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fms	9.187s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	8.741s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/gamelift	8.328s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	5.866s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	7.822s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	10.237s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/grafana	3.796s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/greengrass	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/guardduty	6.168s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	9.996s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	3.644s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	5.867s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector	3.356s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	4.904s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotevents	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	7.243s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	3.592s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces	5.083s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesis	12.498s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics	8.266s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	6.273s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo	5.303s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	7.610s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	10.125s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	5.963s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels	6.305s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager	9.319s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	10.037s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie	11.106s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie2	11.954s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert	3.490s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage	4.052s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediastore	11.769s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	12.779s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	7.349s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	8.782s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	10.159s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/neptune	15.819s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	14.055s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	17.173s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	15.389s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/organizations	16.997s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/outposts	5.786s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint	14.326s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pricing	4.513s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/qldb	3.891s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	5.227s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	9.286s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	14.118s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	8.305s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups	3.605s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi	4.139s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	10.364s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	7.432s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	5.935s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	11.186s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver	9.494s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	10.189s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	7.826s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts	8.232s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	6.672s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/schemas	4.376s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	11.454s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	5.651s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	7.584s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	13.288s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	14.291s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	12.721s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	11.218s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	14.890s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	10.951s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/signer	9.222s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/simpledb	11.716s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	13.097s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	4.573s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	9.344s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	12.291s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	13.630s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	6.079s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/swf	6.291s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	10.653s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite	8.009s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	13.429s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/waf	13.291s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	14.389s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	16.092s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/worklink	2.661s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/workspaces	14.738s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	16.019s
ok  	github.com/hashicorp/terraform-provider-aws/internal/tags	2.144s
ok  	github.com/hashicorp/terraform-provider-aws/internal/tfresource	33.409s
ok  	github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys	2.308s
ok  	github.com/hashicorp/terraform-provider-aws/internal/vault/sdk/helper/jsonutil	0.640s
ok  	github.com/hashicorp/terraform-provider-aws/internal/verify	0.358s
?   	github.com/hashicorp/terraform-provider-aws/names	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/version	[no test files]
% go test ./names/... -v -count 1 -parallel 2 -run='Test' -timeout 180m
--- PASS: TestServiceForHCLKey (0.00s)
    --- PASS: TestServiceForHCLKey/empty (0.00s)
    --- PASS: TestServiceForHCLKey/alternate (0.00s)
    --- PASS: TestServiceForHCLKey/primary (0.00s)
--- PASS: TestServicesForDirectories (0.01s)
    --- PASS: TestServicesForDirectories/amplify (0.00s)
    --- PASS: TestServicesForDirectories/dlm (0.00s)
    --- SKIP: TestServicesForDirectories/redshiftdata (0.00s)
    --- PASS: TestServicesForDirectories/cur (0.00s)
    --- SKIP: TestServicesForDirectories/kendra (0.00s)
    --- PASS: TestServicesForDirectories/amp (0.00s)
    --- SKIP: TestServicesForDirectories/appregistry (0.00s)
    --- PASS: TestServicesForDirectories/mq (0.00s)
    --- SKIP: TestServicesForDirectories/rdsdata (0.00s)
    --- SKIP: TestServicesForDirectories/snowball (0.00s)
    --- SKIP: TestServicesForDirectories/sso (0.00s)
    --- SKIP: TestServicesForDirectories/iotwireless (0.00s)
    --- PASS: TestServicesForDirectories/s3 (0.00s)
    --- PASS: TestServicesForDirectories/ds (0.00s)
    --- SKIP: TestServicesForDirectories/iotdataplane (0.00s)
    --- SKIP: TestServicesForDirectories/managedblockchain (0.00s)
    --- PASS: TestServicesForDirectories/neptune (0.00s)
    --- SKIP: TestServicesForDirectories/personalize (0.00s)
    --- PASS: TestServicesForDirectories/servicequotas (0.00s)
    --- SKIP: TestServicesForDirectories/healthlake (0.00s)
    --- PASS: TestServicesForDirectories/imagebuilder (0.00s)
    --- PASS: TestServicesForDirectories/route53 (0.00s)
    --- SKIP: TestServicesForDirectories/textract (0.00s)
    --- PASS: TestServicesForDirectories/timestreamwrite (0.00s)
    --- SKIP: TestServicesForDirectories/translate (0.00s)
    --- PASS: TestServicesForDirectories/account (0.00s)
    --- PASS: TestServicesForDirectories/grafana (0.00s)
    --- SKIP: TestServicesForDirectories/braket (0.00s)
    --- PASS: TestServicesForDirectories/kafkaconnect (0.00s)
    --- PASS: TestServicesForDirectories/lexmodels (0.00s)
    --- PASS: TestServicesForDirectories/lightsail (0.00s)
    --- PASS: TestServicesForDirectories/mwaa (0.00s)
    --- SKIP: TestServicesForDirectories/augmentedairuntime (0.00s)
    --- SKIP: TestServicesForDirectories/cloudsearchdomain (0.00s)
    --- PASS: TestServicesForDirectories/resourcegroups (0.00s)
    --- PASS: TestServicesForDirectories/simpledb (0.00s)
    --- PASS: TestServicesForDirectories/dms (0.00s)
    --- PASS: TestServicesForDirectories/inspector (0.00s)
    --- SKIP: TestServicesForDirectories/kinesisvideomedia (0.00s)
    --- SKIP: TestServicesForDirectories/lookoutmetrics (0.00s)
    --- PASS: TestServicesForDirectories/transfer (0.00s)
    --- PASS: TestServicesForDirectories/cloudwatchlogs (0.00s)
    --- PASS: TestServicesForDirectories/ec2 (0.00s)
    --- SKIP: TestServicesForDirectories/pi (0.00s)
    --- PASS: TestServicesForDirectories/sqs (0.00s)
    --- SKIP: TestServicesForDirectories/codestar (0.00s)
    --- SKIP: TestServicesForDirectories/connectparticipant (0.00s)
    --- PASS: TestServicesForDirectories/backup (0.00s)
    --- PASS: TestServicesForDirectories/cloudcontrol (0.00s)
    --- SKIP: TestServicesForDirectories/clouddirectory (0.00s)
    --- PASS: TestServicesForDirectories/cloudfront (0.00s)
    --- SKIP: TestServicesForDirectories/cloudwatchrum (0.00s)
    --- PASS: TestServicesForDirectories/codepipeline (0.00s)
    --- SKIP: TestServicesForDirectories/dynamodbstreams (0.00s)
    --- SKIP: TestServicesForDirectories/machinelearning (0.00s)
    --- SKIP: TestServicesForDirectories/marketplaceentitlement (0.00s)
    --- SKIP: TestServicesForDirectories/pinpointemail (0.00s)
    --- PASS: TestServicesForDirectories/worklink (0.00s)
    --- SKIP: TestServicesForDirectories/applicationinsights (0.00s)
    --- SKIP: TestServicesForDirectories/cognitosync (0.00s)
    --- PASS: TestServicesForDirectories/organizations (0.00s)
    --- PASS: TestServicesForDirectories/outposts (0.00s)
    --- PASS: TestServicesForDirectories/s3control (0.00s)
    --- SKIP: TestServicesForDirectories/finspace (0.00s)
    --- PASS: TestServicesForDirectories/appsync (0.00s)
    --- PASS: TestServicesForDirectories/codedeploy (0.00s)
    --- SKIP: TestServicesForDirectories/nimblestudio (0.00s)
    --- PASS: TestServicesForDirectories/memorydb (0.00s)
    --- SKIP: TestServicesForDirectories/applicationcostprofiler (0.00s)
    --- PASS: TestServicesForDirectories/codestarconnections (0.00s)
    --- SKIP: TestServicesForDirectories/costexplorer (0.00s)
    --- PASS: TestServicesForDirectories/datasync (0.00s)
    --- SKIP: TestServicesForDirectories/emrcontainers (0.00s)
    --- PASS: TestServicesForDirectories/licensemanager (0.00s)
    --- PASS: TestServicesForDirectories/kinesisvideo (0.00s)
    --- SKIP: TestServicesForDirectories/savingsplans (0.00s)
    --- PASS: TestServicesForDirectories/codestarnotifications (0.00s)
    --- PASS: TestServicesForDirectories/mediaconnect (0.00s)
    --- PASS: TestServicesForDirectories/cloudformation (0.00s)
    --- PASS: TestServicesForDirectories/datapipeline (0.00s)
    --- PASS: TestServicesForDirectories/pricing (0.00s)
    --- SKIP: TestServicesForDirectories/appintegrations (0.00s)
    --- SKIP: TestServicesForDirectories/codegurureviewer (0.00s)
    --- PASS: TestServicesForDirectories/route53domains (0.00s)
    --- PASS: TestServicesForDirectories/ecs (0.00s)
    --- PASS: TestServicesForDirectories/serverlessrepo (0.00s)
    --- PASS: TestServicesForDirectories/cognitoidentity (0.00s)
    --- PASS: TestServicesForDirectories/dynamodb (0.00s)
    --- SKIP: TestServicesForDirectories/forecast (0.00s)
    --- PASS: TestServicesForDirectories/servicecatalog (0.00s)
    --- SKIP: TestServicesForDirectories/sms (0.00s)
    --- SKIP: TestServicesForDirectories/comprehend (0.00s)
    --- PASS: TestServicesForDirectories/greengrass (0.00s)
    --- SKIP: TestServicesForDirectories/mediastoredata (0.00s)
    --- PASS: TestServicesForDirectories/codebuild (0.00s)
    --- SKIP: TestServicesForDirectories/mobile (0.00s)
    --- PASS: TestServicesForDirectories/resourcegroupstaggingapi (0.00s)
    --- PASS: TestServicesForDirectories/workspaces (0.00s)
    --- SKIP: TestServicesForDirectories/frauddetector (0.00s)
    --- SKIP: TestServicesForDirectories/honeycode (0.00s)
    --- SKIP: TestServicesForDirectories/iotdeviceadvisor (0.00s)
    --- SKIP: TestServicesForDirectories/personalizeruntime (0.00s)
    --- PASS: TestServicesForDirectories/storagegateway (0.00s)
    --- PASS: TestServicesForDirectories/swf (0.00s)
    --- PASS: TestServicesForDirectories/iotevents (0.00s)
    --- PASS: TestServicesForDirectories/macie2 (0.00s)
    --- PASS: TestServicesForDirectories/qldb (0.00s)
    --- PASS: TestServicesForDirectories/ses (0.00s)
    --- PASS: TestServicesForDirectories/sns (0.00s)
    --- PASS: TestServicesForDirectories/sts (0.00s)
    --- PASS: TestServicesForDirectories/efs (0.00s)
    --- PASS: TestServicesForDirectories/identitystore (0.00s)
    --- PASS: TestServicesForDirectories/mediaconvert (0.00s)
    --- PASS: TestServicesForDirectories/wafv2 (0.00s)
    --- SKIP: TestServicesForDirectories/workdocs (0.00s)
    --- PASS: TestServicesForDirectories/batch (0.00s)
    --- PASS: TestServicesForDirectories/elastictranscoder (0.00s)
    --- SKIP: TestServicesForDirectories/opsworkscm (0.00s)
    --- SKIP: TestServicesForDirectories/workmailmessageflow (0.00s)
    --- PASS: TestServicesForDirectories/elasticsearch (0.00s)
    --- SKIP: TestServicesForDirectories/gluedatabrew (0.00s)
    --- SKIP: TestServicesForDirectories/fis (0.00s)
    --- PASS: TestServicesForDirectories/kinesisanalytics (0.00s)
    --- SKIP: TestServicesForDirectories/sagemakerruntime (0.00s)
    --- PASS: TestServicesForDirectories/ecrpublic (0.00s)
    --- SKIP: TestServicesForDirectories/groundstation (0.00s)
    --- PASS: TestServicesForDirectories/waf (0.00s)
    --- PASS: TestServicesForDirectories/iot (0.00s)
    --- SKIP: TestServicesForDirectories/iotfleethub (0.00s)
    --- SKIP: TestServicesForDirectories/iotjobsdataplane (0.00s)
    --- SKIP: TestServicesForDirectories/marketplacecatalog (0.00s)
    --- PASS: TestServicesForDirectories/servicediscovery (0.00s)
    --- PASS: TestServicesForDirectories/autoscalingplans (0.00s)
    --- PASS: TestServicesForDirectories/chime (0.00s)
    --- PASS: TestServicesForDirectories/cloudtrail (0.00s)
    --- SKIP: TestServicesForDirectories/transcribe (0.00s)
    --- SKIP: TestServicesForDirectories/wellarchitected (0.00s)
    --- PASS: TestServicesForDirectories/apprunner (0.00s)
    --- PASS: TestServicesForDirectories/autoscaling (0.00s)
    --- SKIP: TestServicesForDirectories/migrationhub (0.00s)
    --- PASS: TestServicesForDirectories/detective (0.00s)
    --- PASS: TestServicesForDirectories/fms (0.00s)
    --- SKIP: TestServicesForDirectories/forecastquery (0.00s)
    --- PASS: TestServicesForDirectories/networkfirewall (0.00s)
    --- SKIP: TestServicesForDirectories/support (0.00s)
    --- SKIP: TestServicesForDirectories/transcribestreaming (0.00s)
    --- PASS: TestServicesForDirectories/signer (0.00s)
    --- SKIP: TestServicesForDirectories/ssmincidents (0.00s)
    --- SKIP: TestServicesForDirectories/amplifybackend (0.00s)
    --- PASS: TestServicesForDirectories/gamelift (0.00s)
    --- PASS: TestServicesForDirectories/glue (0.00s)
    --- PASS: TestServicesForDirectories/redshift (0.00s)
    --- PASS: TestServicesForDirectories/route53recoverycontrolconfig (0.00s)
    --- PASS: TestServicesForDirectories/s3outposts (0.00s)
    --- PASS: TestServicesForDirectories/appmesh (0.00s)
    --- PASS: TestServicesForDirectories/kms (0.00s)
    --- PASS: TestServicesForDirectories/route53resolver (0.00s)
    --- SKIP: TestServicesForDirectories/location (0.00s)
    --- PASS: TestServicesForDirectories/medialive (0.00s)
    --- SKIP: TestServicesForDirectories/proton (0.00s)
    --- SKIP: TestServicesForDirectories/mobileanalytics (0.00s)
    --- PASS: TestServicesForDirectories/networkmanager (0.00s)
    --- PASS: TestServicesForDirectories/cognitoidp (0.00s)
    --- PASS: TestServicesForDirectories/configservice (0.00s)
    --- PASS: TestServicesForDirectories/elbv2 (0.00s)
    --- PASS: TestServicesForDirectories/keyspaces (0.00s)
    --- SKIP: TestServicesForDirectories/lexruntimev2 (0.00s)
    --- SKIP: TestServicesForDirectories/marketplacecommerceanalytics (0.00s)
    --- PASS: TestServicesForDirectories/quicksight (0.00s)
    --- SKIP: TestServicesForDirectories/rekognition (0.00s)
    --- SKIP: TestServicesForDirectories/sesv2 (0.00s)
    --- PASS: TestServicesForDirectories/wafregional (0.00s)
    --- PASS: TestServicesForDirectories/appautoscaling (0.00s)
    --- PASS: TestServicesForDirectories/cloudsearch (0.00s)
    --- SKIP: TestServicesForDirectories/sagemakeredgemanager (0.00s)
    --- SKIP: TestServicesForDirectories/codeguruprofiler (0.00s)
    --- SKIP: TestServicesForDirectories/devopsguru (0.00s)
    --- PASS: TestServicesForDirectories/guardduty (0.00s)
    --- SKIP: TestServicesForDirectories/personalizeevents (0.00s)
    --- PASS: TestServicesForDirectories/dax (0.00s)
    --- PASS: TestServicesForDirectories/iam (0.00s)
    --- SKIP: TestServicesForDirectories/lookoutequipment (0.00s)
    --- PASS: TestServicesForDirectories/sagemaker (0.00s)
    --- SKIP: TestServicesForDirectories/iot1clickdevices (0.00s)
    --- PASS: TestServicesForDirectories/mediastore (0.00s)
    --- SKIP: TestServicesForDirectories/mgn (0.00s)
    --- SKIP: TestServicesForDirectories/migrationhubconfig (0.00s)
    --- SKIP: TestServicesForDirectories/comprehendmedical (0.00s)
    --- SKIP: TestServicesForDirectories/connectcontactlens (0.00s)
    --- PASS: TestServicesForDirectories/eks (0.00s)
    --- PASS: TestServicesForDirectories/codecommit (0.00s)
    --- SKIP: TestServicesForDirectories/ec2instanceconnect (0.00s)
    --- PASS: TestServicesForDirectories/iotanalytics (0.00s)
    --- SKIP: TestServicesForDirectories/mturk (0.00s)
    --- PASS: TestServicesForDirectories/pinpoint (0.00s)
    --- PASS: TestServicesForDirectories/acmpca (0.00s)
    --- PASS: TestServicesForDirectories/cloudhsmv2 (0.00s)
    --- PASS: TestServicesForDirectories/ecr (0.00s)
    --- PASS: TestServicesForDirectories/securityhub (0.00s)
    --- PASS: TestServicesForDirectories/emr (0.00s)
    --- SKIP: TestServicesForDirectories/greengrassv2 (0.00s)
    --- SKIP: TestServicesForDirectories/ioteventsdata (0.00s)
    --- PASS: TestServicesForDirectories/ram (0.00s)
    --- PASS: TestServicesForDirectories/sfn (0.00s)
    --- PASS: TestServicesForDirectories/synthetics (0.00s)
    --- PASS: TestServicesForDirectories/mediapackage (0.00s)
    --- SKIP: TestServicesForDirectories/ssooidc (0.00s)
    --- PASS: TestServicesForDirectories/cloud9 (0.00s)
    --- PASS: TestServicesForDirectories/globalaccelerator (0.00s)
    --- SKIP: TestServicesForDirectories/health (0.00s)
    --- SKIP: TestServicesForDirectories/kinesisvideosignalingchannels (0.00s)
    --- SKIP: TestServicesForDirectories/robomaker (0.00s)
    --- PASS: TestServicesForDirectories/accessanalyzer (0.00s)
    --- SKIP: TestServicesForDirectories/applicationdiscovery (0.00s)
    --- PASS: TestServicesForDirectories/devicefarm (0.00s)
    --- SKIP: TestServicesForDirectories/iot1clickprojects (0.00s)
    --- PASS: TestServicesForDirectories/opsworks (0.00s)
    --- PASS: TestServicesForDirectories/ssoadmin (0.00s)
    --- PASS: TestServicesForDirectories/cloudwatch (0.00s)
    --- PASS: TestServicesForDirectories/directconnect (0.00s)
    --- SKIP: TestServicesForDirectories/kinesisvideoarchivedmedia (0.00s)
    --- SKIP: TestServicesForDirectories/mediatailor (0.00s)
    --- SKIP: TestServicesForDirectories/polly (0.00s)
    --- PASS: TestServicesForDirectories/apigateway (0.00s)
    --- PASS: TestServicesForDirectories/glacier (0.00s)
    --- PASS: TestServicesForDirectories/kafka (0.00s)
    --- SKIP: TestServicesForDirectories/lexruntime (0.00s)
    --- PASS: TestServicesForDirectories/xray (0.00s)
    --- PASS: TestServicesForDirectories/route53recoveryreadiness (0.00s)
    --- PASS: TestServicesForDirectories/appconfig (0.00s)
    --- PASS: TestServicesForDirectories/athena (0.00s)
    --- PASS: TestServicesForDirectories/docdb (0.00s)
    --- PASS: TestServicesForDirectories/elasticache (0.00s)
    --- SKIP: TestServicesForDirectories/pinpointsmsvoice (0.00s)
    --- PASS: TestServicesForDirectories/rds (0.00s)
    --- SKIP: TestServicesForDirectories/alexaforbusiness (0.00s)
    --- SKIP: TestServicesForDirectories/finspacedata (0.00s)
    --- PASS: TestServicesForDirectories/fsx (0.00s)
    --- SKIP: TestServicesForDirectories/iotsitewise (0.00s)
    --- PASS: TestServicesForDirectories/lambda (0.00s)
    --- PASS: TestServicesForDirectories/ssm (0.00s)
    --- PASS: TestServicesForDirectories/kinesisanalyticsv2 (0.00s)
    --- PASS: TestServicesForDirectories/lakeformation (0.00s)
    --- PASS: TestServicesForDirectories/acm (0.00s)
    --- PASS: TestServicesForDirectories/appstream (0.00s)
    --- PASS: TestServicesForDirectories/dataexchange (0.00s)
    --- SKIP: TestServicesForDirectories/elasticinference (0.00s)
    --- PASS: TestServicesForDirectories/elb (0.00s)
    --- SKIP: TestServicesForDirectories/iotthingsgraph (0.00s)
    --- PASS: TestServicesForDirectories/macie (0.00s)
    --- PASS: TestServicesForDirectories/schemas (0.00s)
    --- PASS: TestServicesForDirectories/apigatewayv2 (0.00s)
    --- PASS: TestServicesForDirectories/budgets (0.00s)
    --- PASS: TestServicesForDirectories/connect (0.00s)
    --- SKIP: TestServicesForDirectories/marketplacemetering (0.00s)
    --- SKIP: TestServicesForDirectories/appflow (0.00s)
    --- SKIP: TestServicesForDirectories/auditmanager (0.00s)
    --- PASS: TestServicesForDirectories/codeartifact (0.00s)
    --- SKIP: TestServicesForDirectories/lexmodelsv2 (0.00s)
    --- SKIP: TestServicesForDirectories/mediapackagevod (0.00s)
    --- SKIP: TestServicesForDirectories/sagemakerfeaturestoreruntime (0.00s)
    --- PASS: TestServicesForDirectories/events (0.00s)
    --- PASS: TestServicesForDirectories/firehose (0.00s)
    --- PASS: TestServicesForDirectories/kinesis (0.00s)
    --- PASS: TestServicesForDirectories/shield (0.00s)
    --- SKIP: TestServicesForDirectories/ssmcontacts (0.00s)
    --- SKIP: TestServicesForDirectories/qldbsession (0.00s)
    --- PASS: TestServicesForDirectories/secretsmanager (0.00s)
    --- SKIP: TestServicesForDirectories/timestreamquery (0.00s)
    --- SKIP: TestServicesForDirectories/workmail (0.00s)
    --- PASS: TestServicesForDirectories/elasticbeanstalk (0.00s)
    --- SKIP: TestServicesForDirectories/iotsecuretunneling (0.00s)
    --- SKIP: TestServicesForDirectories/lookoutforvision (0.00s)
--- PASS: TestServiceProviderNameUpper (0.00s)
    --- PASS: TestServiceProviderNameUpper/empty (0.00s)
    --- PASS: TestServiceProviderNameUpper/transcribe (0.00s)
    --- PASS: TestServiceProviderNameUpper/route53domains (0.00s)
    --- PASS: TestServiceProviderNameUpper/doesnotexist (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/names	0.250s
```
