### PR TITLE
d/aws_memorydb_subnet_group: new data source

### DIFF
--- a/.changelog/23796.txt
+++ b/.changelog/23796.txt
@@ -1,0 +1,3 @@
+```new-data-source
+aws_memorydb_subnet_group
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -714,6 +714,8 @@ func Provider() *schema.Provider {
 			"aws_regions":                 meta.DataSourceRegions(),
 			"aws_service":                 meta.DataSourceService(),
 
+			"aws_memorydb_subnet_group": memorydb.DataSourceSubnetGroup(),
+
 			"aws_mq_broker": mq.DataSourceBroker(),
 
 			"aws_neptune_engine_version":        neptune.DataSourceEngineVersion(),

--- a/internal/service/memorydb/subnet_group_data_source.go
+++ b/internal/service/memorydb/subnet_group_data_source.go
@@ -1,0 +1,82 @@
+package memorydb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func DataSourceSubnetGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceSubnetGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	name := d.Get("name").(string)
+
+	group, err := FindSubnetGroupByName(ctx, conn, name)
+
+	if err != nil {
+		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB Subnet Group", err))
+	}
+
+	d.SetId(aws.StringValue(group.Name))
+
+	var subnetIds []*string
+	for _, subnet := range group.Subnets {
+		subnetIds = append(subnetIds, subnet.Identifier)
+	}
+
+	d.Set("arn", group.ARN)
+	d.Set("description", group.Description)
+	d.Set("subnet_ids", flex.FlattenStringSet(subnetIds))
+	d.Set("name", group.Name)
+	d.Set("vpc_id", group.VpcId)
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/memorydb/subnet_group_data_source_test.go
+++ b/internal/service/memorydb/subnet_group_data_source_test.go
@@ -1,0 +1,59 @@
+package memorydb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccMemoryDBSubnetGroupDataSource_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_subnet_group.test"
+	dataSourceName := "data.aws_memorydb_subnet_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubnetGroupDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_ids.#", resourceName, "subnet_ids.#"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "subnet_ids.*", resourceName, "subnet_ids.0"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "subnet_ids.*", resourceName, "subnet_ids.0"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Test", resourceName, "tags.Test"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSubnetGroupDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVpcWithSubnets(2),
+		fmt.Sprintf(`
+resource "aws_memorydb_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test.*.id
+
+  tags = {
+    Test = "test"
+  }
+}
+
+data "aws_memorydb_subnet_group" "test" {
+  name = aws_memorydb_subnet_group.test.name
+}
+`, rName),
+	)
+}

--- a/website/docs/d/memorydb_subnet_group.html.markdown
+++ b/website/docs/d/memorydb_subnet_group.html.markdown
@@ -1,0 +1,36 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_subnet_group"
+description: |-
+  Provides information about a MemoryDB Subnet Group.
+---
+
+# Resource: aws_memorydb_subnet_group
+
+Provides information about a MemoryDB Subnet Group.
+
+## Example Usage
+
+```terraform
+data "aws_memorydb_subnet_group" "example" {
+  name = "my-subnet-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the subnet group.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `id` - Name of the subnet group.
+* `arn` - ARN of the subnet group.
+* `description` - Description of the subnet group.
+* `subnet_ids` - Set of VPC Subnet ID-s of the subnet group.
+* `vpc_id` - The VPC in which the subnet group exists.
+* `tags` - A map of tags assigned to the subnet group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23795

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccMemoryDBSubnetGroupDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBSubnetGroupDataSource_'  -timeout 180m
=== RUN   TestAccMemoryDBSubnetGroupDataSource_basic
=== PAUSE TestAccMemoryDBSubnetGroupDataSource_basic
=== CONT  TestAccMemoryDBSubnetGroupDataSource_basic
--- PASS: TestAccMemoryDBSubnetGroupDataSource_basic (13.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   15.847s
```
