### PR TITLE
names: Add AWS service name getting

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -911,3 +911,11 @@ func ServiceEnvVar(key string) string {
 
 	return ""
 }
+
+func AWSServiceName(key string) (string, error) {
+	if v, ok := serviceData[key]; ok {
+		return v.AWSServiceName, nil
+	}
+
+	return "", fmt.Errorf("no service data found for %s", key)
+}

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -240,3 +240,55 @@ func TestServiceProviderNameUpper(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSServiceName(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: Transcribe,
+			Input:    Transcribe,
+			Expected: "Transcribe",
+			Error:    false,
+		},
+		{
+			TestName: AppAutoScaling,
+			Input:    AppAutoScaling,
+			Expected: "AppAutoScaling",
+			Error:    false,
+		},
+		{
+			TestName: DMS,
+			Input:    DMS,
+			Expected: "DMS",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := ServiceProviderNameUpper(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAWSServiceName (0.00s)
    --- PASS: TestAWSServiceName/empty (0.00s)
    --- PASS: TestAWSServiceName/transcribe (0.00s)
    --- PASS: TestAWSServiceName/appautoscaling (0.00s)
    --- PASS: TestAWSServiceName/dms (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/names	0.308s
```
