### PR TITLE
Removing unnecessarily insecure S3 ACL from GuardDuty IPSet example

### DIFF
--- a/website/docs/r/guardduty_ipset.html.markdown
+++ b/website/docs/r/guardduty_ipset.html.markdown
@@ -36,7 +36,6 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
 }
 
 resource "aws_s3_object" "MyIPSet" {
-  acl     = "public-read"
   content = "10.0.0.0/8\n"
   bucket  = aws_s3_bucket.bucket.id
   key     = "MyIPSet"


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Notes

* Removed `public-read` acl from example as it's not required due to Guard Duty automatically updating its own service role permissions to access the object when referencing it for use in an IP list. Given the sensitive nature of this files contents, I thought it best to encourage best practice and keep the file secured by default if someone copies and pastes the example.