### PR TITLE
r/aws_wafv2_rule_group: Increase nested statement limit

### DIFF
--- a/.changelog/23813.txt
+++ b/.changelog/23813.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Increase limit on nested `statement` blocks from 3 to 7
+```

--- a/internal/service/wafv2/consts.go
+++ b/internal/service/wafv2/consts.go
@@ -1,6 +1,6 @@
 package wafv2
 
 const (
-	rootStatementSchemaLevel       = 3
-	webACLRootStatementSchemaLevel = 3
+	rootStatementSchemaLevel       = 7
+	webACLRootStatementSchemaLevel = 7
 )

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -372,7 +372,7 @@ Each block supports the following arguments:
 
 The processing guidance for a Rule, used by AWS WAF to determine whether a web request matches the rule. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html) for more information.
 
--> **NOTE:** Although the `statement` block is recursive, currently only 3 levels are supported.
+-> **NOTE:** Although the `statement` block is recursive, currently only 7 levels are supported.
 
 The `statement` block supports the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #23812 
Relates to #14377

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Output from acceptance testing:
```
$ make testacc TESTS=TestAccWAFV2RuleGroup_ PKG=wafv2

--- PASS: TestAccWAFV2RuleGroup_disappears (1594.88s)
=== CONT  TestAccWAFV2RuleGroup_changeCapacityForceNew
--- PASS: TestAccWAFV2RuleGroup_minimal (1855.28s)
=== CONT  TestAccWAFV2RuleGroup_changeNameForceNew
--- PASS: TestAccWAFV2RuleGroup_basic (2054.41s)
=== CONT  TestAccWAFV2RuleGroup_updateRuleProperties
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (2102.63s)
=== CONT  TestAccWAFV2RuleGroup_byteMatchStatement
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (2102.99s)
=== CONT  TestAccWAFV2RuleGroup_updateRule
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (3462.78s)
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (3726.34s)
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (3728.37s)
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (3729.21s)
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (3733.92s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (3744.52s)
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (3745.02s)
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (3749.28s)
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (3752.77s)
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (2467.76s)
--- PASS: TestAccWAFV2RuleGroup_tags (4097.57s)
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (2265.45s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (4133.68s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (4134.65s)
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (4188.26s)
--- PASS: TestAccWAFV2RuleGroup_updateRule (2098.71s)
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (2105.78s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (4325.71s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (2329.68s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (4752.15s)
PASS
```

Terraform config with 7 nested statements
```hcl
resource "aws_wafv2_rule_group" "example" {
  name        = "complex-example"
  description = "An rule group containing 7 nested statements"
  scope       = "REGIONAL"
  capacity    = 500

  rule {
    name     = "rule-1"
    priority = 1

    action {
      block {}
    }

    statement {
      or_statement {
        statement {
          geo_match_statement {
              country_codes = ["US"]
          }
        }

        statement {
          geo_match_statement {
              country_codes = ["EE"]
          }
        }

        statement {
          and_statement {
              statement {
                geo_match_statement {
                  country_codes = ["US"]
                }
              }
              statement {
                geo_match_statement {
                  country_codes = ["EE"]
               }
              }
              statement {
                or_statement {
                    statement {
                  and_statement {
                      statement {
                          geo_match_statement {
                              country_codes = ["US"]
                          }
                      }
                      statement {
                          or_statement {
                              statement {
                                  and_statement {
                                      statement {
                                        geo_match_statement {
                                            country_codes = ["US"]
                                        }
                                      }
                                      statement {
                                        geo_match_statement {
                                            country_codes = ["EE"]
                                        }
                                      }
                                  }
                              }
                              statement {
                                  geo_match_statement {
                                      country_codes = ["US"]
                                  }
                              }
                          }
                      }
                  } 
                    }
                  statement {
                    geo_match_statement {
                        country_codes = ["US"]
                    }
                  }
                }
              }
          }
        }
      }
    }

    visibility_config {
      cloudwatch_metrics_enabled = false
      metric_name                = "rule-1"
      sampled_requests_enabled   = false
    }
  }

    visibility_config {
    cloudwatch_metrics_enabled = false
    metric_name                = "friendly-metric-name"
    sampled_requests_enabled   = false
  }
}

...
```
