### PR TITLE
d/aws_memorydb_parameter_group: new data source

### DIFF
--- a/.changelog/23814.txt
+++ b/.changelog/23814.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_memorydb_parameter_group
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -716,7 +716,8 @@ func Provider() *schema.Provider {
 			"aws_regions":                 meta.DataSourceRegions(),
 			"aws_service":                 meta.DataSourceService(),
 
-			"aws_memorydb_subnet_group": memorydb.DataSourceSubnetGroup(),
+			"aws_memorydb_parameter_group": memorydb.DataSourceParameterGroup(),
+			"aws_memorydb_subnet_group":    memorydb.DataSourceSubnetGroup(),
 
 			"aws_mq_broker": mq.DataSourceBroker(),
 

--- a/internal/service/memorydb/parameter_group_data_source.go
+++ b/internal/service/memorydb/parameter_group_data_source.go
@@ -1,0 +1,98 @@
+package memorydb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func DataSourceParameterGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceParameterGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"family": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"parameter": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: ParameterHash,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	name := d.Get("name").(string)
+
+	group, err := FindParameterGroupByName(ctx, conn, name)
+
+	if err != nil {
+		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB Parameter Group", err))
+	}
+
+	d.SetId(aws.StringValue(group.Name))
+
+	d.Set("arn", group.ARN)
+	d.Set("description", group.Description)
+	d.Set("family", group.Family)
+	d.Set("name", group.Name)
+
+	userDefinedParameters := createUserDefinedParameterMap(d)
+
+	parameters, err := listParameterGroupParameters(ctx, conn, d.Get("family").(string), d.Id(), userDefinedParameters)
+	if err != nil {
+		return diag.Errorf("error listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("parameter", flattenParameters(parameters)); err != nil {
+		return diag.Errorf("failed to set parameter: %s", err)
+	}
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/memorydb/parameter_group_data_source_test.go
+++ b/internal/service/memorydb/parameter_group_data_source_test.go
@@ -1,0 +1,74 @@
+package memorydb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccMemoryDBParameterGroupDataSource_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_parameter_group.test"
+	dataSourceName := "data.aws_memorydb_parameter_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterGroupDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "family", resourceName, "family"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "parameter.*", map[string]string{
+						"name":  "active-defrag-cycle-max",
+						"value": "70",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "parameter.*", map[string]string{
+						"name":  "active-defrag-cycle-min",
+						"value": "10",
+					}),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Test", resourceName, "tags.Test"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccParameterGroupDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_parameter_group" "test" {
+  name   = %[1]q
+  family = "memorydb_redis6"
+
+  parameter {
+    name  = "active-defrag-cycle-max"
+    value = "70"
+  }
+
+  parameter {
+    name  = "active-defrag-cycle-min"
+    value = "10"
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+
+data "aws_memorydb_parameter_group" "test" {
+  name = aws_memorydb_parameter_group.test.name
+}
+`, rName)
+}

--- a/website/docs/d/memorydb_parameter_group.html.markdown
+++ b/website/docs/d/memorydb_parameter_group.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_parameter_group"
+description: |-
+  Provides information about a MemoryDB Parameter Group.
+---
+
+# Resource: aws_memorydb_parameter_group
+
+Provides information about a MemoryDB Parameter Group.
+
+## Example Usage
+
+```terraform
+data "aws_memorydb_parameter_group" "example" {
+  name = "my-parameter-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the parameter group.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `id` - Name of the parameter group.
+* `arn` - ARN of the parameter group.
+* `description` - Description of the parameter group.
+* `family` - The engine version that the parameter group can be used with.
+* `parameter` - Set of user-defined MemoryDB parameters applied by the parameter group.
+    * `name` - Name of the parameter.
+    * `value` - Value of the parameter.
+* `tags` - A map of tags assigned to the parameter group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23795

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccMemoryDBParameterGroupDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBParameterGroupDataSource_'  -timeout 180m
=== RUN   TestAccMemoryDBParameterGroupDataSource_basic
=== PAUSE TestAccMemoryDBParameterGroupDataSource_basic
=== CONT  TestAccMemoryDBParameterGroupDataSource_basic
--- PASS: TestAccMemoryDBParameterGroupDataSource_basic (8.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   10.389s
```
