### PR TITLE
Update docs to refelect `PROTOBUF` as a supported `data_format` for the `aws_glue_schema` resource

### DIFF
--- a/.changelog/23815.txt
+++ b/.changelog/23815.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_schema: Update documentation to include [Protobuf data format support](https://aws.amazon.com/about-aws/whats-new/2022/02/aws-glue-schema-registry-protocol-buffers)
+```

--- a/website/docs/r/glue_schema.html.markdown
+++ b/website/docs/r/glue_schema.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 * `schema_name` – (Required) The Name of the schema.
 * `registry_arn` - (Required) The ARN of the Glue Registry to create the schema in.
-* `data_format` - (Required) The data format of the schema definition. Valid values are `AVRO` and `JSON`.
+* `data_format` - (Required) The data format of the schema definition. Valid values are `AVRO`, `JSON` and `PROTOBUF`.
 * `compatibility` - (Required) The compatibility mode of the schema. Values values are: `NONE`, `DISABLED`, `BACKWARD`, `BACKWARD_ALL`, `FORWARD`, `FORWARD_ALL`, `FULL`, and `FULL_ALL`.
 * `schema_definition` - (Required) The schema definition using the `data_format` setting for `schema_name`.
 * `description` – (Optional) A description of the schema.


### PR DESCRIPTION
…supported `data_format`

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23811

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccGlueSchema_protobuf PKG=glue             (base) 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueSchema_protobuf'  -timeout 180m
=== RUN   TestAccGlueSchema_protobuf
=== PAUSE TestAccGlueSchema_protobuf
=== CONT  TestAccGlueSchema_protobuf
--- PASS: TestAccGlueSchema_protobuf (34.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       34.495s
```
