### PR TITLE
r/s3_bucket: make `cors_rule` configurable

### DIFF
--- a/.changelog/23817.txt
+++ b/.changelog/23817.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Update `cors_rule` parameter to be configurable. Please refer to the documentation for details on drift detection and potential conflicts when configuring this parameter with the standalone `aws_s3_bucket_cors_configuration` resource.
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106 
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23758

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3Bucket_Security_corsDelete (20.41s)
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (24.14s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (24.44s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (40.72s)

--- PASS: TestAccS3BucketCorsConfiguration_MultipleRules (22.63s)
--- PASS: TestAccS3BucketCorsConfiguration_SingleRule (22.76s)
--- PASS: TestAccS3BucketCorsConfiguration_basic (23.01s)
--- PASS: TestAccS3BucketCorsConfiguration_migrate_corsRuleNoChange (35.51s)
--- PASS: TestAccS3BucketCorsConfiguration_migrate_corsRuleWithChange (35.57s)
--- PASS: TestAccS3BucketCorsConfiguration_update (51.90s)
--- PASS: TestAccS3BucketCorsConfiguration_disappears (139.51s)
```
