### PR TITLE
r/s3_bucket: make `lifecycle_rule` configurable

### DIFF
--- a/.changelog/23818.txt
+++ b/.changelog/23818.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Update `lifecycle_rule` parameter to be configurable. Please refer to the documentation for details on drift detection and potential conflicts when configuring this parameter with the standalone `aws_s3_bucket_lifecycle_configuration` resource.
+```

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -305,7 +305,7 @@ func TestAccS3BucketAcl_disappears(t *testing.T) {
 
 func TestAccS3BucketAcl_migrate_aclNoChange(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	bucketResourceName := "aws_s3_bucket.bucket"
+	bucketResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_s3_bucket_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -334,7 +334,7 @@ func TestAccS3BucketAcl_migrate_aclNoChange(t *testing.T) {
 
 func TestAccS3BucketAcl_migrate_aclWithChange(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	bucketResourceName := "aws_s3_bucket.bucket"
+	bucketResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_s3_bucket_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -363,7 +363,7 @@ func TestAccS3BucketAcl_migrate_aclWithChange(t *testing.T) {
 
 func TestAccS3BucketAcl_migrate_grantsNoChange(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	bucketResourceName := "aws_s3_bucket.bucket"
+	bucketResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_s3_bucket_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -412,7 +412,7 @@ func TestAccS3BucketAcl_migrate_grantsNoChange(t *testing.T) {
 
 func TestAccS3BucketAcl_migrate_grantsWithChange(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	bucketResourceName := "aws_s3_bucket.bucket"
+	bucketResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_s3_bucket_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -755,12 +755,12 @@ resource "aws_s3_bucket_acl" "test" {
 
 func testAccBucketAcl_Migrate_AclConfig(rName, acl string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.test.id
   acl    = %[2]q
 }
 `, rName, acl)
@@ -770,12 +770,12 @@ func testAccBucketAcl_Migrate_GrantsNoChangeConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_canonical_user_id" "current" {}
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.test.id
   access_control_policy {
     grant {
       grantee {
@@ -807,12 +807,12 @@ data "aws_canonical_user_id" "current" {}
 
 data "aws_partition" "current" {}
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.test.id
   access_control_policy {
     grant {
       grantee {

--- a/internal/service/s3/validate.go
+++ b/internal/service/s3/validate.go
@@ -1,0 +1,55 @@
+package s3
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+// ValidBucketName validates any S3 bucket name that is not inside the us-east-1 region.
+// Buckets outside of this region have to be DNS-compliant. After the same restrictions are
+// applied to buckets in the us-east-1 region, this function can be refactored as a SchemaValidateFunc
+func ValidBucketName(value string, region string) error {
+	if region != endpoints.UsEast1RegionID {
+		if (len(value) < 3) || (len(value) > 63) {
+			return fmt.Errorf("%q must contain from 3 to 63 characters", value)
+		}
+		if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
+			return fmt.Errorf("only lowercase alphanumeric characters and hyphens allowed in %q", value)
+		}
+		if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
+			return fmt.Errorf("%q must not be formatted as an IP address", value)
+		}
+		if strings.HasPrefix(value, `.`) {
+			return fmt.Errorf("%q cannot start with a period", value)
+		}
+		if strings.HasSuffix(value, `.`) {
+			return fmt.Errorf("%q cannot end with a period", value)
+		}
+		if strings.Contains(value, `..`) {
+			return fmt.Errorf("%q can be only one period between labels", value)
+		}
+	} else {
+		if len(value) > 255 {
+			return fmt.Errorf("%q must contain less than 256 characters", value)
+		}
+		if !regexp.MustCompile(`^[0-9a-zA-Z-._]+$`).MatchString(value) {
+			return fmt.Errorf("only alphanumeric characters, hyphens, periods, and underscores allowed in %q", value)
+		}
+	}
+	return nil
+}
+
+func validBucketLifecycleTimestamp(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be parsed as RFC3339 Timestamp Format", value))
+	}
+
+	return
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106 
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23758

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccS3BucketLifecycleConfiguration_' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketLifecycleConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_disappears
=== PAUSE TestAccS3BucketLifecycleConfiguration_disappears
=== RUN   TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_disableRule
=== PAUSE TestAccS3BucketLifecycleConfiguration_disableRule
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== RUN   TestAccS3BucketLifecycleConfiguration_prefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_prefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_noChange
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (193.63s)
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (194.63s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (195.07s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (204.03s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (337.91s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (193.14s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (194.00s)
=== CONT  TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (194.27s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (329.81s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (203.56s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (194.28s)
=== CONT  TestAccS3BucketLifecycleConfiguration_prefix
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (193.97s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (275.59s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (192.68s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (193.12s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (193.64s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (283.00s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (194.18s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (193.11s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (192.51s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (192.95s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (191.98s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (55.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (194.47s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (273.79s)

$ make testacc TESTARGS='-run=TestAccS3Bucket_' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3Bucket_ -timeout 180m
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Basic_emptyString
=== PAUSE TestAccS3Bucket_Basic_emptyString
=== RUN   TestAccS3Bucket_Basic_generatedName
=== PAUSE TestAccS3Bucket_Basic_generatedName
=== RUN   TestAccS3Bucket_Basic_namePrefix
=== PAUSE TestAccS3Bucket_Basic_namePrefix
=== RUN   TestAccS3Bucket_Basic_forceDestroy
=== PAUSE TestAccS3Bucket_Basic_forceDestroy
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== RUN   TestAccS3Bucket_Basic_acceleration
=== PAUSE TestAccS3Bucket_Basic_acceleration
=== RUN   TestAccS3Bucket_disappears
=== PAUSE TestAccS3Bucket_disappears
=== RUN   TestAccS3Bucket_Tags_basic
=== PAUSE TestAccS3Bucket_Tags_basic
=== RUN   TestAccS3Bucket_Tags_withNoSystemTags
=== PAUSE TestAccS3Bucket_Tags_withNoSystemTags
=== RUN   TestAccS3Bucket_Tags_withSystemTags
=== PAUSE TestAccS3Bucket_Tags_withSystemTags
=== RUN   TestAccS3Bucket_Tags_ignoreTags
=== PAUSE TestAccS3Bucket_Tags_ignoreTags
=== RUN   TestAccS3Bucket_Manage_lifecycleBasic
=== PAUSE TestAccS3Bucket_Manage_lifecycleBasic
=== RUN   TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== PAUSE TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== RUN   TestAccS3Bucket_Manage_lifecycleRemove
=== PAUSE TestAccS3Bucket_Manage_lifecycleRemove
=== RUN   TestAccS3Bucket_Manage_objectLock
=== PAUSE TestAccS3Bucket_Manage_objectLock
=== RUN   TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_objectLock_migrate
=== PAUSE TestAccS3Bucket_Manage_objectLock_migrate
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== RUN   TestAccS3Bucket_Security_updateACL
=== PAUSE TestAccS3Bucket_Security_updateACL
=== RUN   TestAccS3Bucket_Security_updateGrant
=== PAUSE TestAccS3Bucket_Security_updateGrant
=== RUN   TestAccS3Bucket_Security_aclToGrant
=== PAUSE TestAccS3Bucket_Security_aclToGrant
=== RUN   TestAccS3Bucket_Security_grantToACL
=== PAUSE TestAccS3Bucket_Security_grantToACL
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Bucket_Security_corsDelete
=== PAUSE TestAccS3Bucket_Security_corsDelete
=== RUN   TestAccS3Bucket_Security_corsEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsEmptyOrigin
=== RUN   TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== CONT  TestAccS3Bucket_disappears
=== CONT  TestAccS3Bucket_Tags_ignoreTags
--- PASS: TestAccS3Bucket_disappears (14.54s)
=== CONT  TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (18.69s)
=== CONT  TestAccS3Bucket_Security_corsEmptyOrigin
--- PASS: TestAccS3Bucket_Basic_basic (21.43s)
=== CONT  TestAccS3Bucket_Security_corsDelete
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (22.10s)
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (19.75s)
=== CONT  TestAccS3Bucket_Security_grantToACL
--- PASS: TestAccS3Bucket_Tags_ignoreTags (35.54s)
=== CONT  TestAccS3Bucket_Security_aclToGrant
--- PASS: TestAccS3Bucket_Security_corsDelete (16.86s)
=== CONT  TestAccS3Bucket_Security_updateGrant
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (20.56s)
=== CONT  TestAccS3Bucket_Security_updateACL
--- PASS: TestAccS3Bucket_Security_corsUpdate (35.36s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
--- PASS: TestAccS3Bucket_Security_grantToACL (33.75s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning
--- PASS: TestAccS3Bucket_Security_aclToGrant (33.10s)
=== CONT  TestAccS3Bucket_Manage_objectLock_migrate
--- PASS: TestAccS3Bucket_Security_updateACL (34.21s)
=== CONT  TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (25.57s)
=== CONT  TestAccS3Bucket_Manage_objectLock
--- PASS: TestAccS3Bucket_Security_updateGrant (51.20s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRemove
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (24.62s)
=== CONT  TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (19.63s)
=== CONT  TestAccS3Bucket_Basic_forceDestroy
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (26.03s)
=== CONT  TestAccS3Bucket_Basic_acceleration
--- PASS: TestAccS3Bucket_Manage_objectLock (19.52s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
--- PASS: TestAccS3Bucket_Basic_forceDestroy (18.41s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (28.51s)
=== CONT  TestAccS3Bucket_Basic_generatedName
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (21.57s)
=== CONT  TestAccS3Bucket_Basic_namePrefix
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (32.01s)
=== CONT  TestAccS3Bucket_Manage_lifecycleBasic
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (18.64s)
=== CONT  TestAccS3Bucket_Tags_withNoSystemTags
--- PASS: TestAccS3Bucket_Basic_acceleration (40.69s)
=== CONT  TestAccS3Bucket_Tags_withSystemTags
--- PASS: TestAccS3Bucket_Basic_generatedName (19.97s)
=== CONT  TestAccS3Bucket_Tags_basic
--- PASS: TestAccS3Bucket_Basic_namePrefix (19.11s)
=== CONT  TestAccS3Bucket_Basic_emptyString
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (31.67s)
--- PASS: TestAccS3Bucket_Tags_basic (24.87s)
--- PASS: TestAccS3Bucket_Basic_emptyString (18.80s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (67.72s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (116.08s)

--- PASS: TestAccS3BucketAcl_disappears (20.99s)
--- PASS: TestAccS3BucketAcl_basic (28.77s)
--- PASS: TestAccS3BucketAcl_migrate_aclNoChange (42.66s)
--- PASS: TestAccS3BucketAcl_migrate_aclWithChange (42.76s)
--- PASS: TestAccS3BucketAcl_migrate_grantsWithChange (45.50s)
--- PASS: TestAccS3BucketAcl_migrate_grantsNoChange (45.65s)
--- PASS: TestAccS3BucketAcl_updateACL (46.70s)
--- PASS: TestAccS3BucketAcl_grantToACL (47.23s)
--- PASS: TestAccS3BucketAcl_ACLToGrant (47.87s)
--- PASS: TestAccS3BucketAcl_updateGrant (50.28s)
```
