### PR TITLE
r/s3_bucket: make `logging` configurable

### DIFF
--- a/.changelog/23819.txt
+++ b/.changelog/23819.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Update `logging` parameter to be configurable. Please refer to the documentation for details on drift detection and potential conflicts when configuring this parameter with the standalone `aws_s3_bucket_logging` resource.
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106 
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23758

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3Bucket_Security_logging (25.98s)

--- SKIP: TestAccS3BucketLogging_TargetGrantByEmail (0.00s)
--- PASS: TestAccS3BucketLogging_disappears (24.19s)
--- PASS: TestAccS3BucketLogging_basic (28.36s)
--- PASS: TestAccS3BucketLogging_migrate_loggingNoChange (46.11s)
--- PASS: TestAccS3BucketLogging_migrate_loggingWithChange (46.23s)
--- PASS: TestAccS3BucketLogging_TargetGrantByGroup (63.53s)
--- PASS: TestAccS3BucketLogging_TargetGrantByID (64.80s)
--- PASS: TestAccS3BucketLogging_update (64.95s)

```
