### PR TITLE
r/s3_bucket: make `versioning` configurable

### DIFF
--- a/.changelog/23820.txt
+++ b/.changelog/23820.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Update `versioning` parameter to be configurable. Please refer to the documentation for details on drift detection and potential conflicts when configuring this parameter with the standalone `aws_s3_bucket_versioning` resource.
+```

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -135,6 +135,163 @@ func TestAccS3BucketVersioning_MFADelete(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketVersioning_migrate_versioningDisabledNoChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withVersioning(bucketName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.0.enabled", "false"),
+				),
+			},
+			{
+				Config: testAccBucketVersioning_Migrate_VersioningEnabledConfig(bucketName, tfs3.BucketVersioningStatusDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", tfs3.BucketVersioningStatusDisabled),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_migrate_versioningDisabledWithChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withVersioning(bucketName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.0.enabled", "false"),
+				),
+			},
+			{
+				Config: testAccBucketVersioning_Migrate_VersioningEnabledConfig(bucketName, s3.BucketVersioningStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusEnabled),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_migrate_versioningEnabledNoChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withVersioning(bucketName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.0.enabled", "true"),
+				),
+			},
+			{
+				Config: testAccBucketVersioning_Migrate_VersioningEnabledConfig(bucketName, s3.BucketVersioningStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusEnabled),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketVersioning_migrate_versioningEnabledWithChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withVersioning(bucketName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.0.enabled", "true"),
+				),
+			},
+			{
+				Config: testAccBucketVersioning_Migrate_VersioningEnabledConfig(bucketName, s3.BucketVersioningStatusSuspended),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", s3.BucketVersioningStatusSuspended),
+				),
+			},
+		},
+	})
+}
+
+// TestAccS3BucketVersioning_migrate_mfaDeleteNoChange can only test for a "Disabled"
+// mfa_delete configuration as the "mfa" argument is required if it's enabled
+func TestAccS3BucketVersioning_migrate_mfaDeleteNoChange(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withVersioningMfaDelete(bucketName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "versioning.0.mfa_delete", "false"),
+				),
+			},
+			{
+				Config: testAccBucketVersioning_Migrate_MfaDeleteConfig(bucketName, s3.MFADeleteDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.mfa_delete", s3.MFADeleteDisabled),
+				),
+			},
+		},
+	})
+}
+
 func TestAccS3BucketVersioning_Status_disabled(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_versioning.test"
@@ -374,6 +531,37 @@ resource "aws_s3_bucket" "test" {
 resource "aws_s3_bucket_acl" "test" {
   bucket = aws_s3_bucket.test.id
   acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    mfa_delete = %[2]q
+    status     = "Enabled"
+  }
+}
+`, rName, mfaDelete)
+}
+
+func testAccBucketVersioning_Migrate_VersioningEnabledConfig(rName, status string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = %[2]q
+  }
+}
+`, rName, status)
+}
+
+func testAccBucketVersioning_Migrate_MfaDeleteConfig(rName, mfaDelete string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
 resource "aws_s3_bucket_versioning" "test" {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -36,6 +36,10 @@ Configuring with both will cause inconsistencies and may overwrite configuration
 or with the deprecated parameter `logging` in the resource `aws_s3_bucket`.
 Configuring with both will cause inconsistencies and may overwrite configuration.
 
+~> **NOTE on S3 Bucket Versioning Configuration:** S3 Bucket versioning can be configured in either the standalone resource [`aws_s3_bucket_versioning`](s3_bucket_versioning.html.markdown)
+or with the deprecated parameter `versioning` in the resource `aws_s3_bucket`.
+Configuring with both will cause inconsistencies and may overwrite configuration.
+
 ## Example Usage
 
 ### Private Bucket w/ Tags
@@ -83,8 +87,19 @@ resource "aws_s3_bucket" "b" {
 
 ### Using versioning
 
-The `versioning` argument is read-only as of version 4.0 of the Terraform AWS Provider.
-See the [`aws_s3_bucket_versioning` resource](s3_bucket_versioning.html.markdown) for configuration details.
+-> **NOTE:** The parameter `versioning` is deprecated.
+Use the resource [`aws_s3_bucket_versioning`](s3_bucket_versioning.html.markdown) instead.
+
+```terraform
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+}
+```
 
 ### Enable Logging
 
@@ -244,6 +259,7 @@ The following arguments are supported:
   Use the resource [`aws_s3_bucket_logging`](s3_bucket_logging.html.markdown) instead.
 * `object_lock_enabled` - (Optional, Default:`false`, Forces new resource) Indicates whether this bucket has an Object Lock configuration enabled.
 * `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). See [Object Lock Configuration](#object-lock-configuration) below.
+* `versioning` - (Optional, **Deprecated**) A configuration of the [S3 bucket versioning state](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html). See [Versioning](#versioning) below for details. Terraform will only perform drift detection if a configuration value is provided. Use the resource [`aws_s3_bucket_versioning`](s3_bucket_versioning.html.markdown) instead.
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### CORS Rule
@@ -336,6 +352,15 @@ The `object_lock_configuration` configuration block supports the following argum
 
 * `object_lock_enabled` - (Optional, **Deprecated**) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`. Use the top-level argument `object_lock_enabled` instead.
 
+### Versioning
+
+~> **NOTE:** Currently, changes to the `versioning` configuration of _existing_ resources cannot be automatically detected by Terraform. To manage changes of versioning state to an S3 bucket, use the `aws_s3_bucket_versioning` resource instead. If you use `versioning` on an `aws_s3_bucket`, Terraform will assume management over the versioning state of the S3 bucket, treating additional versioning state changes as drift. For this reason, `versioning` cannot be mixed with the external `aws_s3_bucket_versioning` resource for a given S3 bucket.
+
+The `versioning` configuration block supports the following arguments:
+
+* `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
+* `mfa_delete` - (Optional) Enable MFA delete for either `Change the versioning state of your bucket` or `Permanently delete an object version`. Default is `false`. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -388,9 +413,6 @@ In addition to all arguments above, the following attributes are exported:
             * `sse_algorithm` - (required) The server-side encryption algorithm used.
         * `bucket_key_enabled` - (Optional) Whether an [Amazon S3 Bucket Key](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) is used for SSE-KMS.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
-* `versioning` - The [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) state of the bucket.
-    * `enabled` - Whether versioning is enabled.
-    * `mfa_delete` - Whether MFA delete is enabled.
 * `website` - The website configuration, if configured.
     * `error_document` - The name of the error document for the website.
     * `index_document` - The name of the index document for the website.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (62.15s)
--- PASS: TestAccS3Bucket_Manage_objectLock (63.65s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (63.92s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (77.82s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (77.82s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (78.65s)
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (78.98s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (80.11s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (80.20s)
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (95.26s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (97.87s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (120.17s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (121.01s)
--- PASS: TestAccS3Bucket_Manage_versioning (127.39s)

--- PASS: TestAccS3BucketVersioning_disappears (38.93s)
--- PASS: TestAccS3BucketVersioning_Status_disabled (42.60s)
--- PASS: TestAccS3BucketVersioning_basic (43.66s)
--- PASS: TestAccS3BucketVersioning_MFADelete (43.66s)
--- PASS: TestAccS3BucketVersioning_Status_enabledToDisabled (44.44s)
--- PASS: TestAccS3BucketVersioning_Status_suspendedToDisabled (44.79s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledNoChange (56.81s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledWithChange (57.07s)
--- PASS: TestAccS3BucketVersioning_migrate_mfaDeleteNoChange (57.07s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledWithChange (57.16s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToEnabled (66.21s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToSuspended (66.49s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledNoChange (73.05s)
--- PASS: TestAccS3BucketVersioning_update (85.82s)
```
