### PR TITLE
r/s3_bucket: make `server_side_encryption_configuration` configurable

### DIFF
--- a/.changelog/23822.txt
+++ b/.changelog/23822.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Update `server_side_encryption_configuration` parameter to be configurable. Please refer to the documentation for details on drift detection and potential conflicts when configuring this parameter with the standalone `aws_s3_bucket_server_side_encryption_configuration` resource.
+```

--- a/internal/service/s3/bucket_server_side_encryption_configuration_test.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_test.go
@@ -314,6 +314,80 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKe
 	})
 }
 
+func TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_server_side_encryption_configuration.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketServerSideEncryptionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withDefaultEncryption_defaultKey(rName, s3.ServerSideEncryptionAwsKms),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", s3.ServerSideEncryptionAwsKms),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.0.bucket_key_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccBucketServerSideEncryptionConfigurationConfig_migrate_noChange(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketServerSideEncryptionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", bucketResourceName, "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", s3.ServerSideEncryptionAwsKms),
+					resource.TestCheckNoResourceAttr(resourceName, "rule.0.bucket_key_enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_server_side_encryption_configuration.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketServerSideEncryptionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_withDefaultEncryption_defaultKey(rName, s3.ServerSideEncryptionAwsKms),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", s3.ServerSideEncryptionAwsKms),
+					resource.TestCheckResourceAttr(bucketResourceName, "server_side_encryption_configuration.0.rule.0.bucket_key_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccBucketServerSideEncryptionConfigurationConfig_ApplySSEByDefault_SSEAlgorithm(rName, s3.ServerSideEncryptionAes256),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketServerSideEncryptionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", bucketResourceName, "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", s3.ServerSideEncryptionAes256),
+					resource.TestCheckNoResourceAttr(resourceName, "rule.0.bucket_key_enabled"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBucketServerSideEncryptionConfigurationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
 
@@ -512,4 +586,22 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
   }
 }
 `, rName, enabled)
+}
+
+func testAccBucketServerSideEncryptionConfigurationConfig_migrate_noChange(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106 
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23758

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (22.69s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (23.25s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (25.17s)
--- PASS: TestAccS3Bucket_Basic_generatedName (25.21s)
--- PASS: TestAccS3Bucket_Basic_basic (25.22s)
--- PASS: TestAccS3Bucket_Basic_emptyString (25.52s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (26.02s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (27.02s)
--- PASS: TestAccS3Bucket_Basic_acceleration (41.26s)

--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (26.94s)
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (27.44s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (27.48s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (28.24s)
--- PASS: TestAccS3Bucket_Security_logging (30.35s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (39.33s)
--- PASS: TestAccS3Bucket_Security_grantToACL (39.55s)
--- PASS: TestAccS3Bucket_Security_corsDelete (39.96s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (40.03s)
--- PASS: TestAccS3Bucket_Security_updateACL (40.38s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (41.98s)
--- PASS: TestAccS3Bucket_Security_updateGrant (56.36s)

--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_disappears (55.65s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyArn (75.41s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_basic (90.53s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS (91.16s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256 (91.53s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID (91.71s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange (129.36s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange (142.84s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled (160.28s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm (172.14s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled (173.08s)
```
