### PR TITLE
Improve formatting for ses_identity_notification_topic doc

### DIFF
--- a/website/docs/r/ses_identity_notification_topic.markdown
+++ b/website/docs/r/ses_identity_notification_topic.markdown
@@ -25,10 +25,10 @@ resource "aws_ses_identity_notification_topic" "test" {
 
 The following arguments are supported:
 
-* `topic_arn` - (Optional) The Amazon Resource Name (ARN) of the Amazon SNS topic. Can be set to "" (an empty string) to disable publishing.
-* `notification_type` - (Required) The type of notifications that will be published to the specified Amazon SNS topic. Valid Values: *Bounce*, *Complaint* or *Delivery*.
+* `topic_arn` - (Optional) The Amazon Resource Name (ARN) of the Amazon SNS topic. Can be set to ``""`` (an empty string) to disable publishing.
+* `notification_type` - (Required) The type of notifications that will be published to the specified Amazon SNS topic. Valid Values: ``Bounce``, ``Complaint`` or ``Delivery``.
 * `identity` - (Required) The identity for which the Amazon SNS topic will be set. You can specify an identity by using its name or by using its Amazon Resource Name (ARN).
-* `include_original_headers` - (Optional) Whether SES should include original email headers in SNS notifications of this type. *false* by default.
+* `include_original_headers` - (Optional) Whether SES should include original email headers in SNS notifications of this type. ``false`` by default.
 
 ## Attributes Reference
 
@@ -36,7 +36,7 @@ No additional attributes are exported.
 
 ## Import
 
-Identity Notification Topics can be imported using ID of the record. The ID is made up as IDENTITY|TYPE where IDENTITY is the SES Identity and TYPE is the Notification Type.
+Identity Notification Topics can be imported using the ID of the record. The ID is made up as ``IDENTITY|TYPE`` where ``IDENTITY`` is the SES Identity and ``TYPE`` is the Notification Type.
 
 ```
 $ terraform import aws_ses_identity_notification_topic.test 'example.com|Bounce'

--- a/website/docs/r/ses_identity_notification_topic.markdown
+++ b/website/docs/r/ses_identity_notification_topic.markdown
@@ -25,10 +25,10 @@ resource "aws_ses_identity_notification_topic" "test" {
 
 The following arguments are supported:
 
-* `topic_arn` - (Optional) The Amazon Resource Name (ARN) of the Amazon SNS topic. Can be set to ``""`` (an empty string) to disable publishing.
-* `notification_type` - (Required) The type of notifications that will be published to the specified Amazon SNS topic. Valid Values: ``Bounce``, ``Complaint`` or ``Delivery``.
+* `topic_arn` - (Optional) The Amazon Resource Name (ARN) of the Amazon SNS topic. Can be set to `""` (an empty string) to disable publishing.
+* `notification_type` - (Required) The type of notifications that will be published to the specified Amazon SNS topic. Valid Values: `Bounce`, `Complaint` or `Delivery`.
 * `identity` - (Required) The identity for which the Amazon SNS topic will be set. You can specify an identity by using its name or by using its Amazon Resource Name (ARN).
-* `include_original_headers` - (Optional) Whether SES should include original email headers in SNS notifications of this type. ``false`` by default.
+* `include_original_headers` - (Optional) Whether SES should include original email headers in SNS notifications of this type. `false` by default.
 
 ## Attributes Reference
 
@@ -36,7 +36,7 @@ No additional attributes are exported.
 
 ## Import
 
-Identity Notification Topics can be imported using the ID of the record. The ID is made up as ``IDENTITY|TYPE`` where ``IDENTITY`` is the SES Identity and ``TYPE`` is the Notification Type.
+Identity Notification Topics can be imported using the ID of the record. The ID is made up as `IDENTITY|TYPE` where `IDENTITY` is the SES Identity and `TYPE` is the Notification Type.
 
 ```
 $ terraform import aws_ses_identity_notification_topic.test 'example.com|Bounce'


### PR DESCRIPTION
This pull request improves slightly the rendering of [the `aws_ses_identity_notification_topic` resource's documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic).

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->