### PR TITLE
Add `access_type`, `customer_owned_ipv4_pool` arguments for aws_s3outposts_endpoint

### DIFF
--- a/internal/service/s3outposts/endpoint.go
+++ b/internal/service/s3outposts/endpoint.go
@@ -67,6 +67,22 @@ func ResourceEndpoint() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+			"access_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "Private",
+				ValidateFunc: validation.StringInSlice([]string{
+					"Private",
+					"CustomerOwnedIp",
+				}, false),
+			},
+			"customer_owned_ipv4_pool": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -78,6 +94,14 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		OutpostId:       aws.String(d.Get("outpost_id").(string)),
 		SecurityGroupId: aws.String(d.Get("security_group_id").(string)),
 		SubnetId:        aws.String(d.Get("subnet_id").(string)),
+	}
+
+	if v, ok := d.GetOk("access_type"); ok {
+		input.AccessType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("customer_owned_ipv4_pool"); ok {
+		input.CustomerOwnedIpv4Pool = aws.String(v.(string))
 	}
 
 	output, err := conn.CreateEndpoint(input)
@@ -130,6 +154,9 @@ func resourceEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("outpost_id", endpoint.OutpostsId)
+
+	d.Set("access_type", endpoint.AccessType)
+	d.Set("customer_owned_ipv4_pool", endpoint.CustomerOwnedIpv4Pool)
 
 	return nil
 }

--- a/internal/service/s3outposts/endpoint_test.go
+++ b/internal/service/s3outposts/endpoint_test.go
@@ -35,6 +35,76 @@ func TestAccS3OutpostsEndpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "outpost_id", "data.aws_outposts_outpost.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "aws_security_group.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "Private"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccEndpointImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3OutpostsEndpoint_private(t *testing.T) {
+	resourceName := "aws_s3outposts_endpoint.test"
+	rInt := sdkacctest.RandIntRange(0, 255)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3outposts.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointPrivateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "s3-outposts", regexp.MustCompile(`outpost/[^/]+/endpoint/[a-z0-9]+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrPair(resourceName, "cidr_block", "aws_vpc.test", "cidr_block"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "4"),
+					resource.TestCheckResourceAttrPair(resourceName, "outpost_id", "data.aws_outposts_outpost.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "aws_security_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "Private"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccEndpointImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool(t *testing.T) {
+	resourceName := "aws_s3outposts_endpoint.test"
+	rInt := sdkacctest.RandIntRange(0, 255)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3outposts.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointCustomerOwnedIPv4PoolConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "s3-outposts", regexp.MustCompile(`outpost/[^/]+/endpoint/[a-z0-9]+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrPair(resourceName, "cidr_block", "aws_vpc.test", "cidr_block"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "4"),
+					resource.TestCheckResourceAttrPair(resourceName, "outpost_id", "data.aws_outposts_outpost.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "aws_security_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "CustomerOwnedIp"),
+					resource.TestMatchResourceAttr(resourceName, "customer_owned_ipv4_pool", regexp.MustCompile(`^ipv4pool-coip-.+$`)),
 				),
 			},
 			{
@@ -156,6 +226,83 @@ resource "aws_s3outposts_endpoint" "test" {
   outpost_id        = data.aws_outposts_outpost.test.id
   security_group_id = aws_security_group.test.id
   subnet_id         = aws_subnet.test.id
+}
+`, rInt)
+}
+
+func testAccEndpointPrivateConfig(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.%[1]d.0.0/16"
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_outposts_outpost.test.availability_zone
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  outpost_arn       = data.aws_outposts_outpost.test.arn
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_s3outposts_endpoint" "test" {
+  outpost_id        = data.aws_outposts_outpost.test.id
+  security_group_id = aws_security_group.test.id
+  subnet_id         = aws_subnet.test.id
+  access_type       = "Private"
+}
+`, rInt)
+}
+
+func testAccEndpointCustomerOwnedIPv4PoolConfig(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+data "aws_ec2_coip_pools" "test" {}
+
+data "aws_ec2_local_gateway_route_table" "test" {
+  outpost_arn = data.aws_outposts_outpost.test.arn
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.%[1]d.0.0/16"
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
+  vpc_id                       = aws_vpc.test.id
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_outposts_outpost.test.availability_zone
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  outpost_arn       = data.aws_outposts_outpost.test.arn
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_s3outposts_endpoint" "test" {
+  depends_on = [ aws_ec2_local_gateway_route_table_vpc_association.test ]
+  outpost_id               = data.aws_outposts_outpost.test.id
+  security_group_id        = aws_security_group.test.id
+  subnet_id                = aws_subnet.test.id
+  access_type              = "CustomerOwnedIp"
+  customer_owned_ipv4_pool = tolist(data.aws_ec2_coip_pools.test.pool_ids)[0]
 }
 `, rInt)
 }

--- a/internal/service/s3outposts/find.go
+++ b/internal/service/s3outposts/find.go
@@ -16,7 +16,7 @@ func FindEndpoint(conn *s3outposts.S3Outposts, endpointArn string) (*s3outposts.
 		}
 
 		for _, endpoint := range page.Endpoints {
-			if aws.StringValue(endpoint.EndpointArn) == endpointArn {
+			if aws.StringValue(endpoint.EndpointArn) == endpointArn && aws.StringValue(endpoint.Status) != "Deleting" {
 				result = endpoint
 				return false
 			}

--- a/website/docs/r/s3outposts_endpoint.html.markdown
+++ b/website/docs/r/s3outposts_endpoint.html.markdown
@@ -27,6 +27,8 @@ The following arguments are required:
 * `outpost_id` - (Required) Identifier of the Outpost to contain this endpoint.
 * `security_group_id` - (Required) Identifier of the EC2 Security Group.
 * `subnet_id` - (Required) Identifier of the EC2 Subnet.
+* `access_type` - (Optional) Type of access for the network connectivity. Valid values are `Private` or `CustomerOwnedIp`.
+* `customer_owned_ipv4_pool` - The ID of a Customer Owned IP Pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23834

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```
$ make testacc TESTS=TestAccS3OutpostsEndpoint PKG=s3outposts
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3outposts/... -v -count 1 -parallel 20 -run='TestAccS3OutpostsEndpoint'  -timeout 180m
=== RUN   TestAccS3OutpostsEndpoint_basic
=== PAUSE TestAccS3OutpostsEndpoint_basic
=== RUN   TestAccS3OutpostsEndpoint_private
=== PAUSE TestAccS3OutpostsEndpoint_private
=== RUN   TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
=== PAUSE TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
=== RUN   TestAccS3OutpostsEndpoint_disappears
=== PAUSE TestAccS3OutpostsEndpoint_disappears
=== CONT  TestAccS3OutpostsEndpoint_basic
=== CONT  TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
=== CONT  TestAccS3OutpostsEndpoint_disappears
=== CONT  TestAccS3OutpostsEndpoint_private
--- PASS: TestAccS3OutpostsEndpoint_disappears (689.56s)
--- PASS: TestAccS3OutpostsEndpoint_basic (713.99s)
--- PASS: TestAccS3OutpostsEndpoint_private (728.08s)
--- PASS: TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool (732.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts 734.238s
```
