### PR TITLE
Fix skaff importlint error

### DIFF
--- a/skaff/cmd/resource.go
+++ b/skaff/cmd/resource.go
@@ -1,9 +1,8 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/hashicorp/terraform-provider-aws/skaff/resource"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/skaff/go.mod
+++ b/skaff/go.mod
@@ -18,3 +18,5 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
+
+replace github.com/hashicorp/terraform-provider-aws => ../

--- a/skaff/go.sum
+++ b/skaff/go.sum
@@ -130,8 +130,6 @@ github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9E
 github.com/hashicorp/terraform-plugin-go v0.8.0/go.mod h1:E3GuvfX0Pz2Azcl6BegD6t51StXsVZMOYQoGO8mkHM0=
 github.com/hashicorp/terraform-plugin-log v0.3.0/go.mod h1:EjueSP/HjlyFAsDqt+okpCPjkT4NDynAe32AeDC4vps=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.12.0/go.mod h1:TPjMXvpPNWagHzYOmVPzzRRIBTuaLVukR+esL08tgzg=
-github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220322001452-8f7a597d0c24 h1:KCl/FUv9snI6GzVfySGbMz+esNTtSTjKnrCPsmS/Ssc=
-github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220322001452-8f7a597d0c24/go.mod h1:zsp20C5nEOBuHBF+D22DrzMsQp3EPUcCcw+M/Vv9EHc=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Fix **importlint** error:

```
Run impi --local . --scheme stdThirdPartyLocal ./...
Error: skaff/cmd/resource.go: Import groups are not in the proper order: ["Third party" "Third party"]

impi verification failed: Found 1 errors
```

Plus, use local file path to import `terraform-provider-aws`.