### PR TITLE
d/eips - set `public_ips` for vpc as well as ec2 classic

### DIFF
--- a/.changelog/23859.txt
+++ b/.changelog/23859.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_eips: Set `public_ips` for VPC as well as ec2 classic.
+data-source/aws_eips: Set `public_ips` for VPC as well as EC2 Classic
 ```

--- a/.changelog/23859.txt
+++ b/.changelog/23859.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_eips: Set `public_ips` for VPC as well as ec2 classic.
+```

--- a/internal/service/ec2/eips_data_source.go
+++ b/internal/service/ec2/eips_data_source.go
@@ -61,10 +61,10 @@ func dataSourceEIPsRead(d *schema.ResourceData, meta interface{}) error {
 	var publicIPs []string
 
 	for _, v := range output {
+		publicIPs = append(publicIPs, aws.StringValue(v.PublicIp))
+
 		if aws.StringValue(v.Domain) == ec2.DomainTypeVpc {
 			allocationIDs = append(allocationIDs, aws.StringValue(v.AllocationId))
-		} else {
-			publicIPs = append(publicIPs, aws.StringValue(v.PublicIp))
 		}
 	}
 

--- a/internal/service/ec2/eips_data_source_test.go
+++ b/internal/service/ec2/eips_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccEC2EIPsDataSource_vpcDomain(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue("data.aws_eips.all", "allocation_ids.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_eips.by_tags", "allocation_ids.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_eips.by_tags", "public_ips.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_eips.by_tags", "public_ips.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_eips.none", "allocation_ids.#", "0"),
 					resource.TestCheckResourceAttr("data.aws_eips.none", "public_ips.#", "0"),
 				),

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -47,4 +47,4 @@ More complex filters can be expressed using one or more `filter` sub-blocks, whi
 
 * `id` - AWS Region.
 * `allocation_ids` - A list of all the allocation IDs for address for use with EC2-VPC.
-* `public_ips` - A list of all the Elastic IP addresses for use with EC2-Classic.
+* `public_ips` - A list of all the Elastic IP addresses.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23847

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ ake testacc TESTS=TestAccEC2EIPsDataSource_vpcDomain PKG=ec2

--- PASS: TestAccEC2EIPsDataSource_vpcDomain (30.42s)
```
