### PR TITLE
r/cloudwatch_event_target - fix setting `path_parameter_values`

### DIFF
--- a/.changelog/23862.txt
+++ b/.changelog/23862.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Fix setting `path_parameter_values`.
+```

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -844,8 +844,8 @@ func expandTargetHTTPParameters(tfMap map[string]interface{}) *eventbridge.HttpP
 		apiObject.HeaderParameters = flex.ExpandStringMap(v)
 	}
 
-	if v, ok := tfMap["path_parameter_values"].(*schema.Set); ok && v.Len() > 0 {
-		apiObject.PathParameterValues = flex.ExpandStringSet(v)
+	if v, ok := tfMap["path_parameter_values"].([]interface{}); ok && len(v) > 0 {
+		apiObject.PathParameterValues = flex.ExpandStringList(v)
 	}
 
 	if v, ok := tfMap["query_string_parameters"].(map[string]interface{}); ok && len(v) > 0 {

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -368,6 +368,58 @@ func TestAccEventsTarget_http(t *testing.T) {
 	})
 }
 
+//https://github.com/hashicorp/terraform-provider-aws/issues/23805
+func TestAccEventsTarget_http_params(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
+
+	var v eventbridge.Target
+	rName := sdkacctest.RandomWithPrefix("tf_http_target")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, eventbridge.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetHTTPParameterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "http_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.path_parameter_values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.path_parameter_values.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.header_parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.header_parameters.X-Test", "test"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.query_string_parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.query_string_parameters.Env", "test"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.query_string_parameters.Path", "$.detail.path"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTargetHTTPParameterConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "http_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.path_parameter_values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.path_parameter_values.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.path_parameter_values.1", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.header_parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.header_parameters.X-Test", "test"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.query_string_parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.query_string_parameters.Env", "test"),
+					resource.TestCheckResourceAttr(resourceName, "http_target.0.query_string_parameters.Path", "$.detail.path"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEventsTarget_ecs(t *testing.T) {
 	resourceName := "aws_cloudwatch_event_target.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -1277,29 +1329,13 @@ data "aws_partition" "current" {}
 `, rName)
 }
 
-func testAccTargetHTTPConfig(rName string) string {
+func testAccTargetHTTPConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_rule" "test" {
   name        = %[1]q
   description = "schedule_http_test"
 
   schedule_expression = "rate(5 minutes)"
-}
-
-resource "aws_cloudwatch_event_target" "test" {
-  arn  = "${aws_api_gateway_stage.test.execution_arn}/GET"
-  rule = aws_cloudwatch_event_rule.test.id
-
-  http_target {
-    path_parameter_values = []
-    query_string_parameters = {
-      Env  = "test"
-      Path = "$.detail.path"
-    }
-    header_parameters = {
-      X-Test = "test"
-    }
-  }
 }
 
 resource "aws_api_gateway_rest_api" "test" {
@@ -1345,6 +1381,66 @@ resource "aws_api_gateway_stage" "test" {
 
 data "aws_partition" "current" {}
 `, rName)
+}
+
+func testAccTargetHTTPConfig(rName string) string {
+	return testAccTargetHTTPConfigBase(rName) + `
+resource "aws_cloudwatch_event_target" "test" {
+  arn  = "${aws_api_gateway_stage.test.execution_arn}/GET"
+  rule = aws_cloudwatch_event_rule.test.id
+
+  http_target {
+    path_parameter_values = []
+    query_string_parameters = {
+      Env  = "test"
+      Path = "$.detail.path"
+    }
+    header_parameters = {
+      X-Test = "test"
+    }
+  }
+}
+`
+}
+
+func testAccTargetHTTPParameterConfig(rName string) string {
+	return testAccTargetHTTPConfigBase(rName) + `
+resource "aws_cloudwatch_event_target" "test" {
+  arn  = "${aws_api_gateway_stage.test.execution_arn}/*/*/GET"
+  rule = aws_cloudwatch_event_rule.test.id
+
+  http_target {
+    path_parameter_values = ["test"]
+    query_string_parameters = {
+      Env  = "test"
+      Path = "$.detail.path"
+    }
+    header_parameters = {
+      X-Test = "test"
+    }
+  }
+}
+`
+}
+
+func testAccTargetHTTPParameterConfigUpdated(rName string) string {
+	return testAccTargetHTTPConfigBase(rName) + `
+resource "aws_cloudwatch_event_target" "test" {
+  arn  = "${aws_api_gateway_stage.test.execution_arn}/*/*/*/GET"
+  rule = aws_cloudwatch_event_rule.test.id
+
+  http_target {
+    path_parameter_values = ["test", "test2"]
+    query_string_parameters = {
+      Env  = "test"
+      Path = "$.detail.path"
+    }
+    header_parameters = {
+      X-Test = "test"
+    }
+  }
+}
+`
 }
 
 func testAccTargetECSBaseConfig(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23805

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEventsTarget_http PKG=events

--- PASS: TestAccEventsTarget_http (45.81s)
--- PASS: TestAccEventsTarget_http_params (86.56s)
```
