### PR TITLE
Add `ephemeral_storage` attribute to Lambda function scheme

### DIFF
--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -208,6 +208,24 @@ func ResourceFunction() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(lambda.Runtime_Values(), false),
 			},
+			"ephemeral_storage": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"size": {
+							Type:     schema.TypeInt,
+							Required: true,
+							Default:  512,
+							ValidateFunc: validation.All(
+								validation.IntBetween(512, 10240),
+							),
+						},
+					},
+				},
+			},
 			"timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -378,6 +396,7 @@ func hasConfigChanges(d verify.ResourceDiffer) bool {
 		d.HasChange("layers") ||
 		d.HasChange("dead_letter_config") ||
 		d.HasChange("tracing_config") ||
+		d.HasChange("ephemeral_storage") ||
 		d.HasChange("vpc_config.0.security_group_ids") ||
 		d.HasChange("vpc_config.0.subnet_ids") ||
 		d.HasChange("runtime") ||
@@ -505,6 +524,14 @@ func resourceFunctionCreate(d *schema.ResourceData, meta interface{}) error {
 			Mode: aws.String(tracing["mode"].(string)),
 		}
 	}
+
+	// if v, ok := d.GetOk("ephemeral_storage"); ok {
+	// 	ephemeralStorageConfig := v.([]interface{})
+	// 	ephemeralStorage := ephemeralStorageConfig[0].(map[string]interface{})
+	// 	params.EphemeralStorage = &lambda.EphemeralStorage{
+	// 		Size: aws.Int64(int64(ephemeralStorage["size"].(int))),
+	// 	}
+	// }
 
 	if v, ok := d.GetOk("environment"); ok {
 		environments := v.([]interface{})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23860

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
