### PR TITLE
github/workflows: change post_publish to workflow dependency and skip `changelog-newversion` if tag is from non-default branch

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -1,27 +1,41 @@
 name: Post Publish
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
 jobs:
-  tidy:
-    name: Tidy Asana
+  on-success:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: breathingdust/github-asana-tidy@v1
+      - uses: actions/download-artifact@v3
+        with:
+          name: release_tag
+          path: release_tag.data
+      - name: Output Release Tag
+        id: release-tag
+        run: |
+          value=`cat release_tag.data`
+          echo ::set-output name=tag_name::$value
+      - name: Tidy Asana
+        uses: breathingdust/github-asana-tidy@v1
         with:
           asana_pat: ${{ secrets.asana_pat }}
           asana_target_section_gid: '1141945723817371'
           asana_workspace_gid: '90955849329269'
           asana_project_gid: '632425409545160'
           asana_github_url_field_gid: '1134594824474912'
-          github_release_name: ${{ github.event.release.tag_name }}
+          github_release_name: ${{ steps.release-tag.outputs.tag_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  project-archive:
-    name: Archive Released Cards
-    runs-on: ubuntu-latest
-    steps:
-      - uses: breathingdust/github-project-archive@v1
+      - name: Archive Released Cards
+        uses: breathingdust/github-project-archive@v1
         with:
           github_done_column_id: 11513756
-          github_release_name: ${{ github.event.release.tag_name }}
+          github_release_name: ${{ steps.release-tag.outputs.tag_name }}
           github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Generate Release Notes
-        run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# \[$(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
+        run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
       - uses: actions/upload-artifact@v3
         with:
           name: release-notes
@@ -49,18 +49,37 @@ jobs:
       hc-releases-aws-role-duration-seconds: 7200
       release-notes: true
       setup-go-version: '${{ needs.go-version.outputs.version }}'
+  highest-version-tag:
+    needs: [ terraform-provider-release ]
+    runs-on: macos-latest
+    outputs:
+      tag: ${{ steps.highest-version-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v2
+        id: highest-version-tag
+        with:
+          # Allow tag to be fetched when ref is a commit
+          fetch-depth: 0
+      - run: |
+          HIGHEST=$(git tag | sort -V | tail -1)
+          echo ::set-output name=tag::$HIGHEST
   changelog-newversion:
-      needs: [terraform-provider-release]
+      needs: [terraform-provider-release, highest-version-tag]
+      # write new changelog header only if release tag is the $HIGHEST i.e. exists on main
+      # and not a backport release branch (e.g. release/3.x). This results in
+      # manually updating the CHANGELOG header if releasing from the non-default branch.
+      # TODO: find a more deterministic way to determine release branch from tag commit
+      if: github.ref_name == needs.highest-version-tag.outputs.tag
       runs-on: macos-latest
       steps:
         - uses: actions/checkout@v3
           with:
             fetch-depth: 0
+            ref: main
         - name: Update Changelog Header
-          id: changelog
           run: |
             CHANGELOG_FILE_NAME="CHANGELOG.md"
-            PREVIOUS_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
+            PREVIOUS_RELEASE_TAG=${{ github.ref_name }}
            
             # Add Release Date
             RELEASE_DATE=`date +%B' '%e', '%Y`
@@ -78,11 +97,19 @@ jobs:
             echo New minor version is: v$NEW_RELEASE_LINE
             
             echo -e "## $NEW_RELEASE_LINE (Unreleased)\n$(cat $CHANGELOG_FILE_NAME)" > $CHANGELOG_FILE_NAME
-            
-            echo ::set-output name=prev_release_tag::$PREVIOUS_RELEASE_TAG
         - run: |
               git config --local user.email changelogbot@hashicorp.com
               git config --local user.name changelogbot
               git add CHANGELOG.md
-              git commit -m "Update CHANGELOG.md after ${{ steps.changelog.outputs.prev_release_tag }}" 
+              git commit -m "Update CHANGELOG.md after ${{ github.ref_name }}" 
               git push
+  upload-tag-before-post-publish:
+    needs: [ terraform-provider-release ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save Release Tag
+        run: echo ${{ github.ref_name }} > release_tag.data
+      - uses: actions/upload-artifact@v2
+          with:
+            name: release_tag
+            path: release_tag.data


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Description
* This attempts to trigger the post_publish workflow based on the release workflow
* This attempts to fix the error seen on the `main` branch (can't commit changelog without branch) https://github.com/hashicorp/terraform-provider-aws/runs/5684880997?check_suite_focus=true

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/23854
Relates https://github.com/hashicorp/terraform-provider-aws/pull/23856
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23188

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
