### PR TITLE
r/lambda_function: add `ResourceConflictException` error handling on create and update

### DIFF
--- a/.changelog/23879.txt
+++ b/.changelog/23879.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Add error handling for `ResourceConflictException` errors on create and update
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -553,6 +553,11 @@ func resourceFunctionCreate(d *schema.ResourceData, meta interface{}) error {
 			return resource.RetryableError(err)
 		}
 
+		if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceConflictException) {
+			log.Printf("[DEBUG] Received %s, retrying CreateFunction", err)
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -1093,6 +1098,11 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 
 			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "Lambda was unable to configure access to your environment variables because the KMS key is invalid for CreateGrant") {
+				log.Printf("[DEBUG] Received %s, retrying UpdateFunctionConfiguration", err)
+				return resource.RetryableError(err)
+			}
+
+			if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceConflictException) {
 				log.Printf("[DEBUG] Received %s, retrying UpdateFunctionConfiguration", err)
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Continues the work in https://github.com/hashicorp/terraform-provider-aws/pull/10049
Relates https://github.com/hashicorp/terraform-provider-aws/issues/5154

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccLambdaFunction_basic (35.99s)
--- PASS: TestAccLambdaFunction_vpc (1575.70s)
--- PASS: TestAccLambdaFunction_disappears (206.83s)
```
