### PR TITLE
Add support for OperationPreferences to StackSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ BUG FIXES:
 * resource/aws_cloudformation_stack_set: Consider `QUEUED` a valid pending state for resource creation ([#22160](https://github.com/hashicorp/terraform-provider-aws/issues/22160))
 * resource/aws_dynamodb_table_item: Allow `item` names to still succeed if they include non-letters ([#14075](https://github.com/hashicorp/terraform-provider-aws/issues/14075))
 
+ENHANCEMENTS:
+
+* resource/aws_cloudformation_stack: add support for `operation_preferences`
+
 ## 4.8.0 (Unreleased)
 
 ENHANCEMENTS:

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -67,6 +67,41 @@ func ResourceStackSet() *schema.Resource {
 					},
 				},
 			},
+			"operation_preferences": {
+				Type:     schema.TypeList,
+				MinItems: 1,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_tolerance_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"failure_tolerance_percentage": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"max_concurrent_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"max_concurrent_percentage": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"region_concurrency_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"region_order": {
+							Type:     schema.TypeList,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"call_as": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -322,6 +357,10 @@ func resourceStackSetUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.AutoDeployment = expandAutoDeployment(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("operation_preferences"); ok {
+		input.OperationPreferences = expandOperationPreferences(v.([]interface{}))
+	}
+
 	log.Printf("[DEBUG] Updating CloudFormation StackSet: %s", input)
 	output, err := conn.UpdateStackSet(input)
 
@@ -374,6 +413,25 @@ func expandAutoDeployment(l []interface{}) *cloudformation.AutoDeployment {
 	}
 
 	return autoDeployment
+}
+
+func expandOperationPreferences(l []interface{}) *cloudformation.StackSetOperationPreferences {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	operationPreferences := &cloudformation.StackSetOperationPreferences{
+		FailureToleranceCount:      aws.Int64(m["failure_tolerance_count"].(int64)),
+		FailureTolerancePercentage: aws.Int64(m["failure_tolerance_percentage"].(int64)),
+		MaxConcurrentCount:         aws.Int64(m["max_concurrent_count"].(int64)),
+		MaxConcurrentPercentage:    aws.Int64(m["max_concurrent_percentage"].(int64)),
+		RegionConcurrencyType:      aws.String(m["region_concurrency_type"].(string)),
+		RegionOrder:                aws.StringSlice([]string{m["region_order"].(string)}),
+	}
+
+	return operationPreferences
 }
 
 func flattenStackSetAutoDeploymentResponse(autoDeployment *cloudformation.AutoDeployment) []map[string]interface{} {

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -89,6 +89,13 @@ The following arguments are supported:
 * `auto_deployment` - (Optional) Configuration block containing the auto-deployment model for your StackSet. This can only be defined when using the `SERVICE_MANAGED` permission model.
     * `enabled` - (Optional) Whether or not auto-deployment is enabled.
     * `retain_stacks_on_account_removal` - (Optional) Whether or not to retain stacks when the account is removed.
+* `operation_preferences` - (Optional) Configuration block containing the opertional-preferences model for your StackSet.
+    * `failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region. If the operation is stopped in a Region, AWS CloudFormation doesn't attempt the operation in any subsequent Regions.
+    * `failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region. If the operation is stopped in a Region, AWS CloudFormation doesn't attempt the operation in any subsequent Regions.
+    * `max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time. This is dependent on the value of FailureToleranceCount. MaxConcurrentCount is at most one more than the FailureToleranceCount.
+    * `max_concurrent_percentage` - (Optional) The maximum percentage of accounts in which to perform this operation at one time.
+    * `region_concurrency_type` - (Optional) The concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time.
+    * `region_order` - (Optional) The order of the Regions where you want to perform the stack operation.
 * `name` - (Required) Name of the StackSet. The name must be unique in the region where you create your StackSet. The name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.
 * `capabilities` - (Optional) A list of capabilities. Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, `CAPABILITY_AUTO_EXPAND`.
 * `description` - (Optional) Description of the StackSet.


### PR DESCRIPTION
The OperationPreferences enables the user to have control over
the way a deployment of a stack update should occur

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
