### PR TITLE
d/aws_memorydb_user: new data source

### DIFF
--- a/.changelog/23890.txt
+++ b/.changelog/23890.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_memorydb_user
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -719,6 +719,7 @@ func Provider() *schema.Provider {
 
 			"aws_memorydb_parameter_group": memorydb.DataSourceParameterGroup(),
 			"aws_memorydb_subnet_group":    memorydb.DataSourceSubnetGroup(),
+			"aws_memorydb_user":            memorydb.DataSourceUser(),
 
 			"aws_mq_broker": mq.DataSourceBroker(),
 

--- a/internal/service/memorydb/user_data_source.go
+++ b/internal/service/memorydb/user_data_source.go
@@ -1,0 +1,98 @@
+package memorydb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func DataSourceUser() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"access_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authentication_mode": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"password_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"minimum_engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	userName := d.Get("user_name").(string)
+
+	user, err := FindUserByName(ctx, conn, userName)
+
+	if err != nil {
+		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB User", err))
+	}
+
+	d.SetId(aws.StringValue(user.Name))
+
+	d.Set("access_string", user.AccessString)
+	d.Set("arn", user.ARN)
+
+	if v := user.Authentication; v != nil {
+		authenticationMode := map[string]interface{}{
+			"password_count": aws.Int64Value(v.PasswordCount),
+			"type":           aws.StringValue(v.Type),
+		}
+
+		if err := d.Set("authentication_mode", []interface{}{authenticationMode}); err != nil {
+			return diag.Errorf("failed to set authentication_mode of MemoryDB User (%s): %s", d.Id(), err)
+		}
+	}
+
+	d.Set("minimum_engine_version", user.MinimumEngineVersion)
+	d.Set("user_name", user.Name)
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB User (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/memorydb/user_data_source_test.go
+++ b/internal/service/memorydb/user_data_source_test.go
@@ -1,0 +1,60 @@
+package memorydb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccMemoryDBUserDataSource_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_user.test"
+	dataSourceName := "data.aws_memorydb_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "access_string", resourceName, "access_string"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "authentication_mode.0.password_count", resourceName, "authentication_mode.0.password_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "authentication_mode.0.type", resourceName, "authentication_mode.0.type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "minimum_engine_version", resourceName, "minimum_engine_version"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Test", resourceName, "tags.Test"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "user_name", resourceName, "user_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = ["aaaaaaaaaaaaaaaa"]
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+
+data "aws_memorydb_user" "test" {
+  user_name = aws_memorydb_user.test.user_name
+}
+`, rName)
+}

--- a/website/docs/d/memorydb_user.html.markdown
+++ b/website/docs/d/memorydb_user.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_user"
+description: |-
+  Provides information about a MemoryDB User.
+---
+
+# Resource: aws_memorydb_user
+
+Provides information about a MemoryDB User.
+
+## Example Usage
+
+```terraform
+data "aws_memorydb_user" "example" {
+  user_name = "my-user"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `user_name` - (Required) Name of the user.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `id` - Name of the user.
+* `access_string` - The access permissions string used for this user.
+* `arn` - ARN of the user.
+* `authentication_mode` - Denotes the user's authentication properties.
+    * `password_count` - The number of passwords belonging to the user.
+    * `type` - Indicates whether the user requires a password to authenticate.
+* `minimum_engine_version` - The minimum engine version supported for the user.
+* `tags` - A map of tags assigned to the subnet group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23795

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccMemoryDBUserDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBUserDataSource_'  -timeout 180m
=== RUN   TestAccMemoryDBUserDataSource_basic
=== PAUSE TestAccMemoryDBUserDataSource_basic
=== CONT  TestAccMemoryDBUserDataSource_basic
--- PASS: TestAccMemoryDBUserDataSource_basic (42.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   44.415s
```
