### PR TITLE
d/aws_memorydb_acl: new data source

### DIFF
--- a/.changelog/23891.txt
+++ b/.changelog/23891.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_memorydb_acl
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -717,6 +717,7 @@ func Provider() *schema.Provider {
 			"aws_regions":                 meta.DataSourceRegions(),
 			"aws_service":                 meta.DataSourceService(),
 
+			"aws_memorydb_acl":             memorydb.DataSourceACL(),
 			"aws_memorydb_parameter_group": memorydb.DataSourceParameterGroup(),
 			"aws_memorydb_subnet_group":    memorydb.DataSourceSubnetGroup(),
 

--- a/internal/service/memorydb/acl_data_source.go
+++ b/internal/service/memorydb/acl_data_source.go
@@ -1,0 +1,72 @@
+package memorydb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func DataSourceACL() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceACLRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"minimum_engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"user_names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	name := d.Get("name").(string)
+
+	acl, err := FindACLByName(ctx, conn, name)
+
+	if err != nil {
+		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB ACL", err))
+	}
+
+	d.SetId(aws.StringValue(acl.Name))
+
+	d.Set("arn", acl.ARN)
+	d.Set("minimum_engine_version", acl.MinimumEngineVersion)
+	d.Set("name", acl.Name)
+	d.Set("user_names", flex.FlattenStringSet(acl.UserNames))
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB ACL (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/memorydb/acl_data_source_test.go
+++ b/internal/service/memorydb/acl_data_source_test.go
@@ -1,0 +1,62 @@
+package memorydb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccMemoryDBACLDataSource_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_acl.test"
+	dataSourceName := "data.aws_memorydb_acl.test"
+	userName1 := "tf-" + sdkacctest.RandString(8)
+	userName2 := "tf-" + sdkacctest.RandString(8)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACLDataSourceConfig(rName, userName1, userName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "minimum_engine_version", resourceName, "minimum_engine_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttr(dataSourceName, "user_names.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "user_names.*", resourceName, "user_names.0"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "user_names.*", resourceName, "user_names.1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Test", resourceName, "tags.Test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccACLDataSourceConfig(rName, userName1, userName2 string) string {
+	return acctest.ConfigCompose(
+		testAccACLConfigUsers(userName1, userName2),
+		fmt.Sprintf(`
+resource "aws_memorydb_acl" "test" {
+  depends_on = [aws_memorydb_user.test]
+
+  name       = %[1]q
+  user_names = [%[2]q, %[3]q]
+
+  tags = {
+    Test = "test"
+  }
+}
+
+data "aws_memorydb_acl" "test" {
+  name = aws_memorydb_acl.test.name
+}
+`, rName, userName1, userName2),
+	)
+}

--- a/website/docs/d/memorydb_acl.html.markdown
+++ b/website/docs/d/memorydb_acl.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_acl"
+description: |-
+  Provides information about a MemoryDB ACL.
+---
+
+# Resource: aws_memorydb_acl
+
+Provides information about a MemoryDB ACL.
+
+## Example Usage
+
+```terraform
+data "aws_memorydb_acl" "example" {
+  name = "my-acl"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the ACL.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `id` - Name of the ACL.
+* `arn` - ARN of the ACL.
+* `minimum_engine_version` - The minimum engine version supported by the ACL.
+* `tags` - A map of tags assigned to the ACL.
+* `user_names` - Set of MemoryDB user names included in this ACL.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23795

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccMemoryDBACLDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBACLDataSource_'  -timeout 180m
=== RUN   TestAccMemoryDBACLDataSource_basic
=== PAUSE TestAccMemoryDBACLDataSource_basic
=== CONT  TestAccMemoryDBACLDataSource_basic
--- PASS: TestAccMemoryDBACLDataSource_basic (152.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   154.379s

```
