### PR TITLE
r/s3_bucket_lifecycle_configuration: use custom `DiffSuppressFunc` on `rule.filter` parameter

### DIFF
--- a/.changelog/23893.txt
+++ b/.changelog/23893.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Prevent `MalformedXML` errors when handling diffs in `rule.filter`
+```

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -843,6 +843,42 @@ func TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions(t *tes
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23884
+func TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanAndPrefixConfig(rName, "prefix1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.0.and.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.0.and.0.object_size_greater_than", "300"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.0.and.0.prefix", "prefix1"),
+				),
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_Filter_PrefixConfig(rName, "prefix2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.0.and.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.0.prefix", "prefix2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBucketLifecycleConfigurationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
 
@@ -1583,4 +1619,67 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
   }
 }
 `, rName, date, sizeGreaterThan, sizeLessThan)
+}
+
+func testAccBucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanAndPrefixConfig(rName, prefix string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    id = %[1]q
+
+    expiration {
+      days = 90
+    }
+
+    filter {
+      and {
+        object_size_greater_than = 300
+        prefix                   = %[2]q
+      }
+    }
+
+    status = "Enabled"
+  }
+}`, rName, prefix)
+}
+
+func testAccBucketLifecycleConfiguration_Filter_PrefixConfig(rName, prefix string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    id = %[1]q
+
+    expiration {
+      days = 90
+    }
+
+    filter {
+      prefix = %[2]q
+    }
+
+    status = "Enabled"
+  }
+}`, rName, prefix)
 }


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23884
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23883

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccS3BucketLifecycleConfiguration_' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketLifecycleConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_disappears
=== PAUSE TestAccS3BucketLifecycleConfiguration_disappears
=== RUN   TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_disableRule
=== PAUSE TestAccS3BucketLifecycleConfiguration_disableRule
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== RUN   TestAccS3BucketLifecycleConfiguration_prefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_prefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_prefix
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (194.43s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (194.44s)
=== CONT  TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (204.72s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (205.27s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (205.30s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_Tag
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (191.84s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (192.75s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (192.17s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (270.72s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (271.15s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (192.00s)
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (192.25s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (192.93s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (53.55s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (246.38s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (191.94s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (325.21s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (191.80s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (271.75s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (203.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (192.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (214.94s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (202.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (325.06s)
```
