### PR TITLE
Add support for operation_preferences in stackset update

### DIFF
--- a/.changelog/23908.txt
+++ b/.changelog/23908.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudformation_stack_set: Add `operation_preferences` argument
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ BUG FIXES:
 
 * resource/aws_cloudformation_stack_set: Consider `QUEUED` a valid pending state for resource creation ([#22160](https://github.com/hashicorp/terraform-provider-aws/issues/22160))
 * resource/aws_dynamodb_table_item: Allow `item` names to still succeed if they include non-letters ([#14075](https://github.com/hashicorp/terraform-provider-aws/issues/14075))
+* resource/aws_elasticsearch_domain_saml_option: Fix difference caused by `subject_key` default not matching AWS default; old and new defaults are equivalent ([#20892](https://github.com/hashicorp/terraform-provider-aws/issues/20892))
+* resource/aws_s3_bucket_lifecycle_configuration: Prevent `MalformedXML` errors when handling diffs in `rule.filter` ([#23893](https://github.com/hashicorp/terraform-provider-aws/issues/23893))
 
 ## 4.8.0 (March 25, 2022)
 

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -337,7 +337,7 @@ func resourceStackSetUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.OperationPreferences = expandCloudFormationOperationPreferences(d)
+		input.OperationPreferences = expandCloudFormationOperationPreferences(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -102,6 +102,53 @@ func ResourceStackSet() *schema.Resource {
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-]+$`), "must contain only alphanumeric and hyphen characters"),
 				),
 			},
+			"operation_preferences": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_tolerance_count": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ValidateFunc:  validation.IntAtLeast(0),
+							ConflictsWith: []string{"operation_preferences.0.failure_tolerance_percentage"},
+						},
+						"failure_tolerance_percentage": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ValidateFunc:  validation.IntBetween(0, 100),
+							ConflictsWith: []string{"operation_preferences.0.failure_tolerance_count"},
+						},
+						"max_concurrent_count": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ValidateFunc:  validation.IntAtLeast(1),
+							ConflictsWith: []string{"operation_preferences.0.max_concurrent_percentage"},
+						},
+						"max_concurrent_percentage": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ValidateFunc:  validation.IntBetween(1, 100),
+							ConflictsWith: []string{"operation_preferences.0.max_concurrent_count"},
+						},
+						"region_concurrency_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(cloudformation.RegionConcurrencyType_Values(), false),
+						},
+						"region_order": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-]{1,128}$`), ""),
+							},
+						},
+					},
+				},
+			},
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -287,6 +334,10 @@ func resourceStackSetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("execution_role_name"); ok {
 		input.ExecutionRoleName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.OperationPreferences = expandCloudFormationOperationPreferences(d)
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -425,29 +425,3 @@ func expandCloudFormationDeploymentTargets(l []interface{}) *cloudformation.Depl
 
 	return dt
 }
-
-func expandCloudFormationOperationPreferences(d *schema.ResourceData) *cloudformation.StackSetOperationPreferences {
-
-	operationPreferences := &cloudformation.StackSetOperationPreferences{}
-
-	if v, ok := d.GetOk("operation_preferences.0.failure_tolerance_count"); ok {
-		operationPreferences.FailureToleranceCount = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.failure_tolerance_percentage"); ok {
-		operationPreferences.FailureTolerancePercentage = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.max_concurrent_count"); ok {
-		operationPreferences.MaxConcurrentCount = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.max_concurrent_percentage"); ok {
-		operationPreferences.MaxConcurrentPercentage = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.region_concurrency_type"); ok {
-		operationPreferences.RegionConcurrencyType = aws.String(v.(string))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.region_order"); ok {
-		operationPreferences.RegionOrder = flex.ExpandStringSet(v.(*schema.Set))
-	}
-
-	return operationPreferences
-}

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -190,7 +190,7 @@ func resourceStackSetInstanceCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.OperationPreferences = expandCloudFormationOperationPreferences(d)
+		input.OperationPreferences = expandCloudFormationOperationPreferences(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating CloudFormation StackSet Instance: %s", input)
@@ -339,7 +339,7 @@ func resourceStackSetInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.OperationPreferences = expandCloudFormationOperationPreferences(d)
+			input.OperationPreferences = expandCloudFormationOperationPreferences(v.([]interface{})[0].(map[string]interface{}))
 		}
 
 		log.Printf("[DEBUG] Updating CloudFormation StackSet Instance: %s", input)

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -40,18 +40,13 @@ func TestAccCloudFormationStackSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "execution_role_name", "AWSCloudFormationStackSetExecutionRole"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "permission_model", "SELF_MANAGED"),
 					resource.TestMatchResourceAttr(resourceName, "stack_set_id", regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_body", testAccStackSetTemplateBodyVPC(rName)+"\n"),
 					resource.TestCheckNoResourceAttr(resourceName, "template_url"),
-					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "0"),
-					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "0"),
-					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "0"),
-					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "0"),
-					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
 				),
 			},
 			{
@@ -61,7 +56,6 @@ func TestAccCloudFormationStackSet_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 		},
@@ -118,7 +112,6 @@ func TestAccCloudFormationStackSet_administrationRoleARN(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -158,7 +151,6 @@ func TestAccCloudFormationStackSet_description(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -198,7 +190,6 @@ func TestAccCloudFormationStackSet_executionRoleName(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -255,7 +246,6 @@ func TestAccCloudFormationStackSet_name(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -333,7 +323,6 @@ func TestAccCloudFormationStackSet_parameters(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -395,7 +384,6 @@ func TestAccCloudFormationStackSet_Parameters_default(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -449,7 +437,6 @@ func TestAccCloudFormationStackSet_Parameters_noEcho(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -501,7 +488,6 @@ func TestAccCloudFormationStackSet_PermissionModel_serviceManaged(t *testing.T) 
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 		},
@@ -534,7 +520,6 @@ func TestAccCloudFormationStackSet_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -591,7 +576,6 @@ func TestAccCloudFormationStackSet_templateBody(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{
@@ -632,7 +616,6 @@ func TestAccCloudFormationStackSet_templateURL(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"call_as",
 					"template_url",
-					"operation_preferences",
 				},
 			},
 			{

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -270,7 +270,7 @@ func TestAccCloudFormationStackSet_name(t *testing.T) {
 	})
 }
 
-func testAccCloudFormationStackSetInstance_operationPreferences(t *testing.T) {
+func TestAccCloudFormationStackSetInstance_operationPreferences(t *testing.T) {
 	var stackSet cloudformation.StackSet
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudformation_stack_set.test"

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -270,7 +270,7 @@ func TestAccCloudFormationStackSet_name(t *testing.T) {
 	})
 }
 
-func TestAccCloudFormationStackSetInstance_operationPreferences(t *testing.T) {
+func TestAccCloudFormationStackSet_operationPreferences(t *testing.T) {
 	var stackSet cloudformation.StackSet
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudformation_stack_set.test"

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -313,30 +313,33 @@ func expandCloudformationLoggingConfig(tfMap map[string]interface{}) *cloudforma
 	return apiObject
 }
 
-func expandCloudFormationOperationPreferences(d *schema.ResourceData) *cloudformation.StackSetOperationPreferences {
-
-	operationPreferences := &cloudformation.StackSetOperationPreferences{}
-
-	if v, ok := d.GetOk("operation_preferences.0.failure_tolerance_count"); ok {
-		operationPreferences.FailureToleranceCount = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.failure_tolerance_percentage"); ok {
-		operationPreferences.FailureTolerancePercentage = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.max_concurrent_count"); ok {
-		operationPreferences.MaxConcurrentCount = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.max_concurrent_percentage"); ok {
-		operationPreferences.MaxConcurrentPercentage = aws.Int64(int64(v.(int)))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.region_concurrency_type"); ok {
-		operationPreferences.RegionConcurrencyType = aws.String(v.(string))
-	}
-	if v, ok := d.GetOk("operation_preferences.0.region_order"); ok {
-		operationPreferences.RegionOrder = flex.ExpandStringSet(v.(*schema.Set))
+func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *cloudformation.StackSetOperationPreferences {
+	if tfMap == nil {
+		return nil
 	}
 
-	return operationPreferences
+	apiObject := &cloudformation.StackSetOperationPreferences{}
+
+	if v, ok := tfMap["failure_tolerance_count"].(int); ok {
+		apiObject.FailureToleranceCount = aws.Int64(int64(v))
+	}
+	if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
+		apiObject.FailureTolerancePercentage = aws.Int64(int64(v))
+	}
+	if v, ok := tfMap["max_concurrent_count"].(int); ok {
+		apiObject.MaxConcurrentCount = aws.Int64(int64(v))
+	}
+	if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
+		apiObject.MaxConcurrentPercentage = aws.Int64(int64(v))
+	}
+	if v, ok := tfMap["region_concurrency_type"].(string); ok && v != "" {
+		apiObject.RegionConcurrencyType = aws.String(v)
+	}
+	if v, ok := tfMap["region_order"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.RegionOrder = flex.ExpandStringSet(v)
+	}
+
+	return apiObject
 }
 
 func flattenCloudformationLoggingConfig(apiObject *cloudformation.LoggingConfig) map[string]interface{} {

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -310,6 +311,32 @@ func expandCloudformationLoggingConfig(tfMap map[string]interface{}) *cloudforma
 	}
 
 	return apiObject
+}
+
+func expandCloudFormationOperationPreferences(d *schema.ResourceData) *cloudformation.StackSetOperationPreferences {
+
+	operationPreferences := &cloudformation.StackSetOperationPreferences{}
+
+	if v, ok := d.GetOk("operation_preferences.0.failure_tolerance_count"); ok {
+		operationPreferences.FailureToleranceCount = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("operation_preferences.0.failure_tolerance_percentage"); ok {
+		operationPreferences.FailureTolerancePercentage = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("operation_preferences.0.max_concurrent_count"); ok {
+		operationPreferences.MaxConcurrentCount = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("operation_preferences.0.max_concurrent_percentage"); ok {
+		operationPreferences.MaxConcurrentPercentage = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("operation_preferences.0.region_concurrency_type"); ok {
+		operationPreferences.RegionConcurrencyType = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("operation_preferences.0.region_order"); ok {
+		operationPreferences.RegionOrder = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	return operationPreferences
 }
 
 func flattenCloudformationLoggingConfig(apiObject *cloudformation.LoggingConfig) map[string]interface{} {

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -91,6 +91,7 @@ The following arguments are supported:
     * `retain_stacks_on_account_removal` - (Optional) Whether or not to retain stacks when the account is removed.
 * `name` - (Required) Name of the StackSet. The name must be unique in the region where you create your StackSet. The name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.
 * `capabilities` - (Optional) A list of capabilities. Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, `CAPABILITY_AUTO_EXPAND`.
+* `operation_preferences` - (Optional) Preferences for how AWS CloudFormation performs a stack set update.
 * `description` - (Optional) Description of the StackSet.
 * `execution_role_name` - (Optional) Name of the IAM Role in all target accounts for StackSet operations. Defaults to `AWSCloudFormationStackSetExecutionRole` when using the `SELF_MANAGED` permission model. This should not be defined when using the `SERVICE_MANAGED` permission model.
 * `parameters` - (Optional) Key-value map of input parameters for the StackSet template. All template parameters, including those with a `Default`, must be configured or ignored with `lifecycle` configuration block `ignore_changes` argument. All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
@@ -99,6 +100,17 @@ The following arguments are supported:
 * `tags` - (Optional) Key-value map of tags to associate with this StackSet and the Stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the Stacks. A maximum number of 50 tags can be specified. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `template_body` - (Optional) String containing the CloudFormation template body. Maximum size: 51,200 bytes. Conflicts with `template_url`.
 * `template_url` - (Optional) String containing the location of a file containing the CloudFormation template body. The URL must point to a template that is located in an Amazon S3 bucket. Maximum location file size: 460,800 bytes. Conflicts with `template_body`.
+
+### `operation_preferences` Argument Reference
+
+The `operation_preferences` configuration block supports the following arguments:
+
+*`failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
+*`failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
+*`max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time.
+*`max_concurrent_percentage` - (Optional) The maximum percentage of accounts in which to perform this operation at one time.
+*`region_concurrency_type` - (Optional) The concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time.
+*`region_order` - (Optional) The order of the Regions in where you want to perform the stack operation.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release Note:
```
* resource/aws_cloudformation_stack_set: Add `operation_preferences` argument
```

Output from acceptance testing:

Could use some help from a maintainer to run acceptance tests, but all unit tests pass and I've done `go fmt`.

### Other Notes

I've mostly adapted the work done by @Popsiclestick here https://github.com/hashicorp/terraform-provider-aws/pull/23666. My org has a use case that needs this as well so I figured I'd just give it a go. Please let me know if the acceptance tests are sufficient.