### PR TITLE
Add note about filename

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -44,6 +44,8 @@ EOF
 }
 
 resource "aws_lambda_function" "test_lambda" {
+  # If the file is not in the current working directory you will need to include a 
+  # path.module in the filename.
   filename      = "lambda_function_payload.zip"
   function_name = "lambda_function_name"
   role          = aws_iam_role.iam_for_lambda.arn


### PR DESCRIPTION
**Reasoning for Change:**

I tend to look at example code first (because it's at the top of the page) and this example can be a bit misleading if the resource is in a module. Especially because it says "filename" which, given the example, leads me to believe it doesn't need a path.

**Prefer AWS Documentation:**

N/A

**Large Example Configurations:**

N/A

**Terraform Configuration Language Features:**

N/A


This recently bit me. Took me a bit to figure it out. Maybe I'm dumb ¯\\\_(ツ)\_/¯

I had a lambda resource in a module. Based on the sample I thought I had done everything right. Then I realized that because this was a module I needed to specify more than just the filename. 

I think where I get screwed up is that filename, to me, means just the name of the file but in reality this is path and filename.

I also didn't see this the first time around:

```
* `filename` - (Optional) Path to the function's deployment package within the local filesystem. Conflicts with `image_uri`, `s3_bucket`, `s3_key`, and `s3_object_version`.
```

Still feels really nuanced? Feel free to close if this is just me not RTFM'ing enough.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
