### PR TITLE
aws_imagebuilder_distribution_configuration: Add Account ID to Launch Template Configuration

### DIFF
--- a/.changelog/23924.txt
+++ b/.changelog/23924.txt
@@ -3,5 +3,5 @@ resource/aws_imagebuilder_distribution_configuration: Add `account_id` argument 
 ```
 
 ```release-note:enhancement
-data-source/aws_imagebuilder_distribution_configuration: Add `account_id` argument to the `launch_template_configuration` attribute of the `distribution` configuration block
+data-source/aws_imagebuilder_distribution_configuration: Add `account_id` attribute to the `launch_template_configuration` attribute of the `distribution` configuration block
 ```

--- a/.changelog/23924.txt
+++ b/.changelog/23924.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_imagebuilder_distribution_configuration: Add `account_id` argument to the `launch_template_configuration` attribute of the `distribution` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_imagebuilder_distribution_configuration: Add `account_id` argument to the `launch_template_configuration` attribute of the `distribution` configuration block
+```

--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -174,6 +174,11 @@ func ResourceDistributionConfiguration() *schema.Resource {
 							MaxItems: 100,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"account_id": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidAccountID,
+									},
 									"default": {
 										Type:     schema.TypeBool,
 										Optional: true,
@@ -563,6 +568,10 @@ func expandLaunchTemplateConfiguration(tfMap map[string]interface{}) *imagebuild
 		apiObject.SetDefaultVersion = aws.Bool(v)
 	}
 
+	if v, ok := tfMap["account_id"].(string); ok && v != "" {
+		apiObject.AccountId = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -745,6 +754,10 @@ func flattenLaunchTemplateConfiguration(apiObject *imagebuilder.LaunchTemplateCo
 
 	if v := apiObject.SetDefaultVersion; v != nil {
 		tfMap["default"] = aws.BoolValue(v)
+	}
+
+	if v := apiObject.AccountId; v != nil {
+		tfMap["account_id"] = aws.StringValue(v)
 	}
 
 	return tfMap

--- a/internal/service/imagebuilder/distribution_configuration_data_source.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source.go
@@ -142,6 +142,10 @@ func DataSourceDistributionConfiguration() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"account_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"default": {
 										Type:     schema.TypeBool,
 										Computed: true,

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -51,6 +51,8 @@ func testAccDistributionConfigurationARNDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_launch_template" "test" {
   instance_type = "t2.micro"
   name          = %[1]q
@@ -72,7 +74,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     }
 
     launch_template_configuration {
-      account_id         = data.aws_caller_identity.member.account_id
+      account_id         = data.aws_caller_identity.current.account_id
       default            = false
       launch_template_id = aws_launch_template.test.id
     }

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -38,6 +38,7 @@ func TestAccImageBuilderDistributionConfigurationDataSource_arn(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.#", resourceName, "distribution.0.launch_template_configuration.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.default", resourceName, "distribution.0.launch_template_configuration.0.default"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.launch_template_id", resourceName, "distribution.0.launch_template_configuration.0.launch_template_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.account_id", resourceName, "distribution.0.launch_template_configuration.0.account_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),
@@ -71,6 +72,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     }
 
     launch_template_configuration {
+	  account_id         = data.aws_caller_identity.member.account_id
       default            = false
       launch_template_id = aws_launch_template.test.id
     }

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -72,7 +72,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     }
 
     launch_template_configuration {
-	  account_id         = data.aws_caller_identity.member.account_id
+      account_id         = data.aws_caller_identity.member.account_id
       default            = false
       launch_template_id = aws_launch_template.test.id
     }

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -1119,7 +1119,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     launch_template_configuration {
       default            = true
       launch_template_id = aws_launch_template.test.id
-	  account_id         = data.aws_caller_identity.current.account_id
+      account_id         = data.aws_caller_identity.current.account_id
     }
 
     region = data.aws_region.current.name

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -624,6 +624,18 @@ func TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateCon
 					resource.TestCheckResourceAttrPair(resourceName, "distribution.0.launch_template_configuration.0.launch_template_id", launchTemplateResourceName, "id"),
 				),
 			},
+			{
+				Config: testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDAccountIDConfig(rName, "111111111111"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.0.default", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "distribution.0.launch_template_configuration.0.launch_template_id", launchTemplateResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.0.account_id", "111111111111"),
+				),
+			},
 		},
 	})
 }
@@ -1093,6 +1105,8 @@ func testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaun
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_launch_template" "test" {
   instance_type = "t2.micro"
   name          = %[1]q
@@ -1105,6 +1119,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     launch_template_configuration {
       default            = true
       launch_template_id = aws_launch_template.test.id
+	  account_id         = data.aws_caller_identity.current.account_id
     }
 
     region = data.aws_region.current.name
@@ -1116,6 +1131,8 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
 func testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDNonDefaultConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
 
 resource "aws_launch_template" "test" {
   instance_type = "t2.micro"
@@ -1129,12 +1146,44 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     launch_template_configuration {
       default            = false
       launch_template_id = aws_launch_template.test.id
+	  account_id         = data.aws_caller_identity.current.account_id
     }
 
     region = data.aws_region.current.name
   }
 }
 `, rName)
+}
+
+func testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDAccountIDConfig(rName string, accountId string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_launch_template" "test" {
+  instance_type = "t2.micro"
+  name          = %[1]q
+}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+	name = %[1]q
+  
+	distribution {
+	  launch_template_configuration {
+		default            = false
+		launch_template_id = aws_launch_template.test.id
+		account_id         = %[2]q
+	  }
+
+    ami_distribution_configuration {
+      launch_permission {
+        user_ids = [%[2]q]
+      }
+    }
+  
+	  region = data.aws_region.current.name
+	}
+  }
+  `, rName, accountId)
 }
 
 func testAccDistributionConfigurationDistributionLicenseConfigurationARNs1Config(rName string) string {

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -1146,7 +1146,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     launch_template_configuration {
       default            = false
       launch_template_id = aws_launch_template.test.id
-	  account_id         = data.aws_caller_identity.current.account_id
+      account_id         = data.aws_caller_identity.current.account_id
     }
 
     region = data.aws_region.current.name
@@ -1165,24 +1165,24 @@ resource "aws_launch_template" "test" {
 }
 
 resource "aws_imagebuilder_distribution_configuration" "test" {
-	name = %[1]q
-  
-	distribution {
-	  launch_template_configuration {
-		default            = false
-		launch_template_id = aws_launch_template.test.id
-		account_id         = %[2]q
-	  }
+  name = %[1]q
+
+  distribution {
+    launch_template_configuration {
+      default            = false
+      launch_template_id = aws_launch_template.test.id
+      account_id         = %[2]q
+    }
 
     ami_distribution_configuration {
       launch_permission {
         user_ids = [%[2]q]
       }
     }
-  
-	  region = data.aws_region.current.name
-	}
+
+    region = data.aws_region.current.name
   }
+}
   `, rName, accountId)
 }
 

--- a/website/docs/d/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/d/imagebuilder_distribution_configuration.html.markdown
@@ -49,6 +49,7 @@ In addition to all arguments above, the following attributes are exported:
     * `launch_template_configuration` - Nested list of launch template configurations.
         * `default` - Indicates whether the specified Amazon EC2 launch template is set as the default launch template.
         * `launch_template_id` - ID of the Amazon EC2 launch template.
+        * `account_id` - The account ID that this configuration applies to.
     * `license_configuration_arns` - Set of Amazon Resource Names (ARNs) of License Manager License Configurations.
     * `region` - AWS Region of distribution.
 * `name` - Name of the distribution configuration.

--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -98,6 +98,7 @@ The following arguments are optional:
 ### launch_template_configuration
 
 * `default` - (Optional) Indicates whether to set the specified Amazon EC2 launch template as the default launch template. Defaults to `true`.
+* `account_id` - The account ID that this configuration applies to.
 * `launch_template_id` - (Required) The ID of the Amazon EC2 launch template to use.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23919 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration" PKG_NAME=internal/service/imagebuilder

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== PAUSE TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== CONT  TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
--- PASS: TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration (45.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       47.059s

...
```
