### PR TITLE
r/autoscaling_attachment.html.markdown: Don't use the deprecated parameter in the example

### DIFF
--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -33,7 +33,7 @@ resource "aws_autoscaling_attachment" "asg_attachment_bar" {
 # Create a new ALB Target Group attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
   autoscaling_group_name = aws_autoscaling_group.asg.id
-  alb_target_group_arn   = aws_lb_target_group.test.arn
+  lb_target_group_arn    = aws_lb_target_group.test.arn
 }
 ```
 


### PR DESCRIPTION
alb_target_group_arn is deprecated as stated in the reference, but was
still used in the example.
