### PR TITLE
test/backup: Fix `TestAccBackupRegionSettings_basic` and `TestAccBackupReportPlan_basic`

### DIFF
--- a/internal/service/backup/region_settings.go
+++ b/internal/service/backup/region_settings.go
@@ -52,7 +52,7 @@ func resourceRegionSettingsUpdate(d *schema.ResourceData, meta interface{}) erro
 	_, err := conn.UpdateRegionSettings(input)
 
 	if err != nil {
-		return fmt.Errorf("error setting Backup Region Settings (%s): %w", d.Id(), err)
+		return fmt.Errorf("error updating Backup Region Settings (%s): %w", d.Id(), err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
@@ -63,14 +63,14 @@ func resourceRegionSettingsUpdate(d *schema.ResourceData, meta interface{}) erro
 func resourceRegionSettingsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).BackupConn
 
-	resp, err := conn.DescribeRegionSettings(&backup.DescribeRegionSettingsInput{})
+	output, err := conn.DescribeRegionSettings(&backup.DescribeRegionSettingsInput{})
 
 	if err != nil {
 		return fmt.Errorf("error reading Backup Region Settings (%s): %w", d.Id(), err)
 	}
 
-	d.Set("resource_type_opt_in_preference", aws.BoolValueMap(resp.ResourceTypeOptInPreference))
-	d.Set("resource_type_management_preference", aws.BoolValueMap(resp.ResourceTypeManagementPreference))
+	d.Set("resource_type_opt_in_preference", aws.BoolValueMap(output.ResourceTypeOptInPreference))
+	d.Set("resource_type_management_preference", aws.BoolValueMap(output.ResourceTypeManagementPreference))
 
 	return nil
 }

--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -26,10 +26,10 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupRegionSettingsConfig1(),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccRegionSettings1Config(),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "12"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
@@ -39,6 +39,7 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.S3", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
@@ -52,10 +53,10 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupRegionSettingsConfig2(),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccRegionSettings2Config(),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "12"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "false"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
@@ -65,6 +66,7 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.S3", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
@@ -73,10 +75,10 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupRegionSettingsConfig3(),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccRegionSettings3Config(),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "12"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "false"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
@@ -86,6 +88,7 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.S3", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "false"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
@@ -97,22 +100,23 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckRegionSettingsExists(settings *backup.DescribeRegionSettingsOutput) resource.TestCheckFunc {
+func testAccCheckRegionSettingsExists(v *backup.DescribeRegionSettingsOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
-		resp, err := conn.DescribeRegionSettings(&backup.DescribeRegionSettingsInput{})
+
+		output, err := conn.DescribeRegionSettings(&backup.DescribeRegionSettingsInput{})
+
 		if err != nil {
 			return err
 		}
 
-		*settings = *resp
+		*v = *output
 
 		return nil
 	}
 }
 
-func testAccBackupRegionSettingsConfig1() string {
+func testAccRegionSettings1Config() string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
@@ -125,6 +129,7 @@ resource "aws_backup_region_settings" "test" {
     "FSx"             = true
     "Neptune"         = true
     "RDS"             = true
+    "S3"              = true
     "Storage Gateway" = true
     "VirtualMachine"  = true
   }
@@ -132,7 +137,7 @@ resource "aws_backup_region_settings" "test" {
 `
 }
 
-func testAccBackupRegionSettingsConfig2() string {
+func testAccRegionSettings2Config() string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
@@ -145,6 +150,7 @@ resource "aws_backup_region_settings" "test" {
     "FSx"             = true
     "Neptune"         = true
     "RDS"             = true
+    "S3"              = true
     "Storage Gateway" = true
     "VirtualMachine"  = true
   }
@@ -157,7 +163,7 @@ resource "aws_backup_region_settings" "test" {
 `
 }
 
-func testAccBackupRegionSettingsConfig3() string {
+func testAccRegionSettings3Config() string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
@@ -170,6 +176,7 @@ resource "aws_backup_region_settings" "test" {
     "FSx"             = true
     "Neptune"         = true
     "RDS"             = true
+    "S3"              = true
     "Storage Gateway" = true
     "VirtualMachine"  = false
   }

--- a/internal/service/backup/report_plan_data_source_test.go
+++ b/internal/service/backup/report_plan_data_source_test.go
@@ -23,11 +23,11 @@ func TestAccBackupReportPlanDataSource_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccReportPlanDataSourceConfig_nonExistent,
-				ExpectError: regexp.MustCompile(`Error getting Backup Report Plan`),
+				Config:      testAccReportPlanDataSourceNonExistentConfig,
+				ExpectError: regexp.MustCompile(`error reading Backup Report Plan`),
 			},
 			{
-				Config: testAccReportPlanDataSourceConfig_basic(rName, rName2),
+				Config: testAccReportPlanDataSourceConfig(rName, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "creation_time", resourceName, "creation_time"),
@@ -48,13 +48,13 @@ func TestAccBackupReportPlanDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccReportPlanDataSourceConfig_nonExistent = `
+const testAccReportPlanDataSourceNonExistentConfig = `
 data "aws_backup_report_plan" "test" {
   name = "tf_acc_test_does_not_exist"
 }
 `
 
-func testAccReportPlanDataSourceConfig_basic(rName, rName2 string) string {
+func testAccReportPlanDataSourceConfig(rName, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccBackupReportPlan_basic(t *testing.T) {
-	var reportPlan backup.DescribeReportPlanOutput
-
+	var reportPlan backup.ReportPlan
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	originalDescription := "original description"
@@ -30,7 +29,7 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 		CheckDestroy: testAccCheckReportPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupReportPlanConfig_basic(rName, rName2, originalDescription),
+				Config: testAccReportPlanConfig(rName, rName2, originalDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -53,7 +52,7 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupReportPlanConfig_basic(rName, rName2, updatedDescription),
+				Config: testAccReportPlanConfig(rName, rName2, updatedDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -75,8 +74,7 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 }
 
 func TestAccBackupReportPlan_updateTags(t *testing.T) {
-	var reportPlan backup.DescribeReportPlanOutput
-
+	var reportPlan backup.ReportPlan
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	description := "example description"
@@ -89,7 +87,7 @@ func TestAccBackupReportPlan_updateTags(t *testing.T) {
 		CheckDestroy: testAccCheckReportPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupReportPlanConfig_basic(rName, rName2, description),
+				Config: testAccReportPlanConfig(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -112,7 +110,7 @@ func TestAccBackupReportPlan_updateTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupReportPlanConfig_tags(rName, rName2, description),
+				Config: testAccReportPlanConfigTags1(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -136,7 +134,7 @@ func TestAccBackupReportPlan_updateTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupReportPlanConfig_tagsUpdated(rName, rName2, description),
+				Config: testAccReportPlanConfigTags2(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -160,8 +158,7 @@ func TestAccBackupReportPlan_updateTags(t *testing.T) {
 }
 
 func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
-	var reportPlan backup.DescribeReportPlanOutput
-
+	var reportPlan backup.ReportPlan
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	description := "example description"
@@ -174,7 +171,7 @@ func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
 		CheckDestroy: testAccCheckReportPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupReportPlanConfig_basic(rName, rName2, description),
+				Config: testAccReportPlanConfig(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -197,7 +194,7 @@ func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupReportPlanConfig_reportDeliveryChannel(rName, rName2, description),
+				Config: testAccReportPlanReportDeliveryChannelConfig(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -220,8 +217,7 @@ func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
 }
 
 func TestAccBackupReportPlan_disappears(t *testing.T) {
-	var reportPlan backup.DescribeReportPlanOutput
-
+	var reportPlan backup.ReportPlan
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
 	description := "disappears"
@@ -234,7 +230,7 @@ func TestAccBackupReportPlan_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckReportPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupReportPlanConfig_basic(rName, rName2, description),
+				Config: testAccReportPlanConfig(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(resourceName, &reportPlan),
 					acctest.CheckResourceDisappears(acctest.Provider, tfbackup.ResourceReportPlan(), resourceName),
@@ -261,52 +257,54 @@ func testAccReportPlanPreCheck(t *testing.T) {
 
 func testAccCheckReportPlanDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_backup_report_plan" {
 			continue
 		}
 
-		input := &backup.DescribeReportPlanInput{
-			ReportPlanName: aws.String(rs.Primary.ID),
+		_, err := tfbackup.FindReportPlanByName(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
-
-		resp, err := conn.DescribeReportPlan(input)
-
-		if err == nil {
-			if aws.StringValue(resp.ReportPlan.ReportPlanName) == rs.Primary.ID {
-				return fmt.Errorf("Backup Report Plan '%s' was not deleted properly", rs.Primary.ID)
-			}
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckReportPlanExists(name string, reportPlan *backup.DescribeReportPlanOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
-		input := &backup.DescribeReportPlanInput{
-			ReportPlanName: aws.String(rs.Primary.ID),
-		}
-		resp, err := conn.DescribeReportPlan(input)
 
 		if err != nil {
 			return err
 		}
 
-		*reportPlan = *resp
+		return fmt.Errorf("Backup Report Plan %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckReportPlanExists(n string, v *backup.ReportPlan) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Backup Report Plan ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+
+		output, err := tfbackup.FindReportPlanByName(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
 
 		return nil
 	}
 }
 
-func testAccBackupReportPlanBaseConfig(bucketName string) string {
+func testAccReportPlanBaseConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -322,10 +320,8 @@ resource "aws_s3_bucket_public_access_block" "test" {
 `, bucketName)
 }
 
-func testAccBackupReportPlanConfig_basic(rName, rName2, label string) string {
-	return acctest.ConfigCompose(
-		testAccBackupReportPlanBaseConfig(rName),
-		fmt.Sprintf(`
+func testAccReportPlanConfig(rName, rName2, label string) string {
+	return acctest.ConfigCompose(testAccReportPlanBaseConfig(rName), fmt.Sprintf(`
 resource "aws_backup_report_plan" "test" {
   name        = %[1]q
   description = %[2]q
@@ -348,10 +344,8 @@ resource "aws_backup_report_plan" "test" {
 `, rName2, label))
 }
 
-func testAccBackupReportPlanConfig_tags(rName, rName2, label string) string {
-	return acctest.ConfigCompose(
-		testAccBackupReportPlanBaseConfig(rName),
-		fmt.Sprintf(`
+func testAccReportPlanConfigTags1(rName, rName2, label string) string {
+	return acctest.ConfigCompose(testAccReportPlanBaseConfig(rName), fmt.Sprintf(`
 resource "aws_backup_report_plan" "test" {
   name        = %[1]q
   description = %[2]q
@@ -375,10 +369,8 @@ resource "aws_backup_report_plan" "test" {
 `, rName2, label))
 }
 
-func testAccBackupReportPlanConfig_tagsUpdated(rName, rName2, label string) string {
-	return acctest.ConfigCompose(
-		testAccBackupReportPlanBaseConfig(rName),
-		fmt.Sprintf(`
+func testAccReportPlanConfigTags2(rName, rName2, label string) string {
+	return acctest.ConfigCompose(testAccReportPlanBaseConfig(rName), fmt.Sprintf(`
 resource "aws_backup_report_plan" "test" {
   name        = %[1]q
   description = %[2]q
@@ -403,10 +395,8 @@ resource "aws_backup_report_plan" "test" {
 `, rName2, label))
 }
 
-func testAccBackupReportPlanConfig_reportDeliveryChannel(rName, rName2, label string) string {
-	return acctest.ConfigCompose(
-		testAccBackupReportPlanBaseConfig(rName),
-		fmt.Sprintf(`
+func testAccReportPlanReportDeliveryChannelConfig(rName, rName2, label string) string {
+	return acctest.ConfigCompose(testAccReportPlanBaseConfig(rName), fmt.Sprintf(`
 resource "aws_backup_report_plan" "test" {
   name        = %[1]q
   description = %[2]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23941.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBackupRegionSettings_ PKG=backup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 20 -run='TestAccBackupRegionSettings_'  -timeout 180m
=== RUN   TestAccBackupRegionSettings_basic
=== PAUSE TestAccBackupRegionSettings_basic
=== CONT  TestAccBackupRegionSettings_basic
--- PASS: TestAccBackupRegionSettings_basic (37.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	41.586s
% make testacc TESTS=TestAccBackupReportPlan PKG=backup ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 2 -run='TestAccBackupReportPlan'  -timeout 180m
=== RUN   TestAccBackupReportPlanDataSource_basic
=== PAUSE TestAccBackupReportPlanDataSource_basic
=== RUN   TestAccBackupReportPlan_basic
=== PAUSE TestAccBackupReportPlan_basic
=== RUN   TestAccBackupReportPlan_updateTags
=== PAUSE TestAccBackupReportPlan_updateTags
=== RUN   TestAccBackupReportPlan_updateReportDeliveryChannel
=== PAUSE TestAccBackupReportPlan_updateReportDeliveryChannel
=== RUN   TestAccBackupReportPlan_disappears
=== PAUSE TestAccBackupReportPlan_disappears
=== CONT  TestAccBackupReportPlanDataSource_basic
=== CONT  TestAccBackupReportPlan_updateReportDeliveryChannel
--- PASS: TestAccBackupReportPlanDataSource_basic (28.33s)
=== CONT  TestAccBackupReportPlan_updateTags
--- PASS: TestAccBackupReportPlan_updateReportDeliveryChannel (43.50s)
=== CONT  TestAccBackupReportPlan_basic
--- PASS: TestAccBackupReportPlan_basic (42.30s)
=== CONT  TestAccBackupReportPlan_disappears
--- PASS: TestAccBackupReportPlan_updateTags (63.07s)
--- PASS: TestAccBackupReportPlan_disappears (20.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	112.388s
```
