### PR TITLE
r/aws_dynamo_contributor_insights: Add new resource

### DIFF
--- a/.changelog/23947.txt
+++ b/.changelog/23947.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_dynamodb_contributor_insights
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1195,6 +1195,7 @@ func Provider() *schema.Provider {
 			"aws_directory_service_directory":             ds.ResourceDirectory(),
 			"aws_directory_service_log_subscription":      ds.ResourceLogSubscription(),
 
+			"aws_dynamodb_contributor_insights":          dynamodb.ResourceContributorInsights(),
 			"aws_dynamodb_global_table":                  dynamodb.ResourceGlobalTable(),
 			"aws_dynamodb_kinesis_streaming_destination": dynamodb.ResourceKinesisStreamingDestination(),
 			"aws_dynamodb_table":                         dynamodb.ResourceTable(),

--- a/internal/service/dynamodb/contributor_insights.go
+++ b/internal/service/dynamodb/contributor_insights.go
@@ -107,16 +107,17 @@ func resourceContributorInsightsDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[INFO] Deleting DynamoDB ContributorInsights %s", d.Id())
 
-	var indexName string
-	if v, ok := d.GetOk("index_name"); ok {
-		indexName = v.(string)
-	}
-
 	in := &dynamodb.UpdateContributorInsightsInput{
 		ContributorInsightsAction: aws.String(dynamodb.ContributorInsightsActionDisable),
 		TableName:                 aws.String(d.Id()),
-		IndexName:                 aws.String(indexName),
 	}
+
+	var indexName string
+	if v, ok := d.GetOk("index_name"); ok {
+		indexName = v.(string)
+		in.IndexName = aws.String(v.(string))
+	}
+
 	_, err := conn.UpdateContributorInsightsWithContext(ctx, in)
 
 	if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {

--- a/internal/service/dynamodb/contributor_insights.go
+++ b/internal/service/dynamodb/contributor_insights.go
@@ -81,12 +81,7 @@ func resourceContributorInsightsCreate(ctx context.Context, d *schema.ResourceDa
 func resourceContributorInsightsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).DynamoDBConn
 
-	var indexName string
-	if v, ok := d.GetOk("index_name"); ok {
-		indexName = v.(string)
-	}
-
-	tableName, indexName, _, err := decodeContributorInsightsID(d.Id())
+	tableName, indexName, err := decodeContributorInsightsID(d.Id())
 	if err != nil {
 		return diag.Errorf("unable to decode ContributorInsights ID (%s): %s", d.Id(), err)
 	}
@@ -115,7 +110,7 @@ func resourceContributorInsightsDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[INFO] Deleting DynamoDB ContributorInsights %s", d.Id())
 
-	tableName, indexName, _, err := decodeContributorInsightsID(d.Id())
+	tableName, indexName, err := decodeContributorInsightsID(d.Id())
 	if err != nil {
 		return diag.Errorf("unable to decode DynamoDB ContributorInsights ID (%s): %s", d.Id(), err)
 	}
@@ -154,25 +149,23 @@ func encodeContributorInsightsID(tableName, indexName, accountID string) string 
 	return fmt.Sprintf("%s/%s", tableName, accountID)
 }
 
-func decodeContributorInsightsID(id string) (string, string, string, error) {
+func decodeContributorInsightsID(id string) (string, string, error) {
 	idParts := strings.Split(id, "/")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		return "", "", "", fmt.Errorf("expected ID in the form of table_name/account_id, given: %q", id)
+		return "", "", fmt.Errorf("expected ID in the form of table_name/account_id, given: %q", id)
 	}
 
-	var tableName, indexName, accountID string
+	var tableName, indexName string
 
 	tableName = idParts[0]
 	if strings.Contains(tableName, "-") {
 		parts := strings.Split(tableName, "-")
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return "", "", "", fmt.Errorf("expected ID in the form of table_name-index_name, given: %q", id)
+			return "", "", fmt.Errorf("expected ID in the form of table_name-index_name, given: %q", id)
 		}
 		tableName = parts[0]
 		indexName = parts[1]
 	}
 
-	accountID = idParts[1]
-
-	return tableName, indexName, accountID, nil
+	return tableName, indexName, nil
 }

--- a/internal/service/dynamodb/contributor_insights.go
+++ b/internal/service/dynamodb/contributor_insights.go
@@ -28,10 +28,12 @@ func ResourceContributorInsights() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"index_name": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Optional: true,
 			},
 			"table_name": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Required: true,
 			},
 			"status": {

--- a/internal/service/dynamodb/contributor_insights.go
+++ b/internal/service/dynamodb/contributor_insights.go
@@ -1,0 +1,133 @@
+package dynamodb
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceContributorInsights() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceContributorInsightsCreate,
+		ReadWithoutTimeout:   resourceContributorInsightsRead,
+		DeleteWithoutTimeout: resourceContributorInsightsDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"index_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceContributorInsightsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+
+	in := &dynamodb.UpdateContributorInsightsInput{
+		ContributorInsightsAction: aws.String(dynamodb.ContributorInsightsActionEnable),
+	}
+
+	if v, ok := d.GetOk("table_name"); ok {
+		in.TableName = aws.String(v.(string))
+	}
+
+	var indexName string
+	if v, ok := d.GetOk("index_name"); ok {
+		in.IndexName = aws.String(v.(string))
+		indexName = v.(string)
+	}
+
+	out, err := conn.UpdateContributorInsightsWithContext(ctx, in)
+	if err != nil {
+		return diag.Errorf("creating dynamodb ContributorInsights for table (%s): %s", d.Get("table_name").(string), err)
+	}
+
+	d.SetId(aws.StringValue(out.TableName))
+
+	if err := waitContributorInsightsCreated(ctx, conn, d.Id(), indexName, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("waiting for dynamodb ContributorInsights (%s) create: %s", d.Id(), err)
+	}
+
+	return resourceContributorInsightsRead(ctx, d, meta)
+}
+
+func resourceContributorInsightsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+
+	var indexName string
+	if v, ok := d.GetOk("index_name"); ok {
+		indexName = v.(string)
+	}
+
+	out, err := FindContributorInsights(ctx, conn, d.Id(), indexName)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DynamoDB ContributorInsights (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("reading DynamoDB ContributorInsights (%s): %s", d.Id(), err)
+	}
+
+	d.Set("index_name", out.IndexName)
+	d.Set("table_name", out.TableName)
+	d.Set("status", out.ContributorInsightsStatus)
+
+	return nil
+}
+
+func resourceContributorInsightsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+
+	log.Printf("[INFO] Deleting DynamoDB ContributorInsights %s", d.Id())
+
+	var indexName string
+	if v, ok := d.GetOk("index_name"); ok {
+		indexName = v.(string)
+	}
+
+	in := &dynamodb.UpdateContributorInsightsInput{
+		ContributorInsightsAction: aws.String(dynamodb.ContributorInsightsActionDisable),
+		TableName:                 aws.String(d.Id()),
+		IndexName:                 aws.String(indexName),
+	}
+	_, err := conn.UpdateContributorInsightsWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("deleting DynamoDB ContributorInsights (%s): %s", d.Id(), err)
+	}
+
+	if err := waitContributorInsightsDeleted(ctx, conn, d.Id(), indexName, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("waiting for DynamoDB ContributorInsights (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/dynamodb/contributor_insights_test.go
+++ b/internal/service/dynamodb/contributor_insights_test.go
@@ -1,0 +1,154 @@
+package dynamodb_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdynamodb "github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb"
+)
+
+func TestAccContributorInsights_basic(t *testing.T) {
+	var conf dynamodb.DescribeContributorInsightsOutput
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	indexName := fmt.Sprintf("%s-index", rName)
+	resourceName := "aws_dynamodb_contributor_insights.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckContributorInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContributorInsightsBasicConfig(rName, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckContributorInsightsExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "table_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContributorInsightsBasicConfig(rName, indexName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckContributorInsightsExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "index_name", indexName),
+				),
+			},
+		},
+	})
+}
+
+func testAccContributorInsightsBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 2
+  write_capacity = 2
+  hash_key       = %[1]q
+
+  attribute {
+    name = %[1]q
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "%[1]s-index"
+    hash_key        = %[1]q
+    projection_type = "ALL"
+    read_capacity   = 1
+    write_capacity  = 1
+  }
+}
+`, rName)
+}
+
+func testAccContributorInsightsBasicConfig(rName, indexName string) string {
+	return acctest.ConfigCompose(testAccContributorInsightsBaseConfig(rName), fmt.Sprintf(`
+resource "aws_dynamodb_contributor_insights" "test" {
+  table_name = aws_dynamodb_table.test.name
+  index_name = %[2]q
+}
+`, rName, indexName))
+}
+
+func testAccCheckContributorInsightsExists(n string, ci *dynamodb.DescribeContributorInsightsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no DynamodDB Contributor Insights ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn
+
+		tableName, indexName, err := tfdynamodb.DecodeContributorInsightsID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		output, err := tfdynamodb.FindContributorInsights(context.Background(), conn, tableName, indexName)
+		if err != nil {
+			return err
+		}
+
+		ci = output
+
+		return nil
+	}
+}
+
+func testAccCheckContributorInsightsDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dynamodb_contributor_insights" {
+			continue
+		}
+
+		log.Printf("[DEBUG] Checking if DynamoDB Contributor Insights %s exists", rs.Primary.ID)
+
+		tableName, indexName, err := tfdynamodb.DecodeContributorInsightsID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		in := &dynamodb.DescribeContributorInsightsInput{
+			TableName: aws.String(tableName),
+		}
+
+		if indexName != "" {
+			in.IndexName = aws.String(indexName)
+		}
+
+		_, err = conn.DescribeContributorInsightsWithContext(context.Background(), in)
+		if err == nil {
+			return fmt.Errorf("the DynamoDB Contributor Insights %s still exists. Failing", rs.Primary.ID)
+		}
+
+		// Verify the error is what we want
+		if dbErr, ok := err.(awserr.Error); ok && dbErr.Code() == "ResourceNotFoundException" {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/internal/service/dynamodb/contributor_insights_test.go
+++ b/internal/service/dynamodb/contributor_insights_test.go
@@ -3,11 +3,11 @@ package dynamodb_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -69,6 +69,7 @@ func TestAccContributorInsights_disappears(t *testing.T) {
 					testAccCheckContributorInsightsExists(resourceName, &conf),
 					acctest.CheckResourceDisappears(acctest.Provider, tfdynamodb.ResourceContributorInsights(), resourceName),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -159,13 +160,13 @@ func testAccCheckContributorInsightsDestroy(s *terraform.State) error {
 			in.IndexName = aws.String(indexName)
 		}
 
-		_, err = conn.DescribeContributorInsightsWithContext(context.Background(), in)
+		_, err = tfdynamodb.FindContributorInsights(context.Background(), conn, tableName, indexName)
 		if err == nil {
 			return fmt.Errorf("the DynamoDB Contributor Insights %s still exists. Failing", rs.Primary.ID)
 		}
 
 		// Verify the error is what we want
-		if dbErr, ok := err.(awserr.Error); ok && dbErr.Code() == "ResourceNotFoundException" {
+		if tfresource.NotFound(err) {
 			return nil
 		}
 

--- a/internal/service/dynamodb/contributor_insights_test.go
+++ b/internal/service/dynamodb/contributor_insights_test.go
@@ -3,7 +3,6 @@ package dynamodb_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"log"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfdynamodb "github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccContributorInsights_basic(t *testing.T) {

--- a/internal/service/dynamodb/contributor_insights_test.go
+++ b/internal/service/dynamodb/contributor_insights_test.go
@@ -52,6 +52,28 @@ func TestAccContributorInsights_basic(t *testing.T) {
 	})
 }
 
+func TestAccContributorInsights_disappears(t *testing.T) {
+	var conf dynamodb.DescribeContributorInsightsOutput
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	resourceName := "aws_dynamodb_contributor_insights.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckContributorInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContributorInsightsBasicConfig(rName, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckContributorInsightsExists(resourceName, &conf),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdynamodb.ResourceContributorInsights(), resourceName),
+				),
+			},
+		},
+	})
+}
+
 func testAccContributorInsightsBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "test" {

--- a/internal/service/dynamodb/find.go
+++ b/internal/service/dynamodb/find.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func FindDynamoDBKinesisDataStreamDestination(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) (*dynamodb.KinesisDataStreamDestination, error) {
@@ -130,8 +133,27 @@ func FindContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, table
 	}
 
 	output, err := conn.DescribeContributorInsightsWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
+	}
+
+	if status := aws.StringValue(output.ContributorInsightsStatus); status == dynamodb.ContributorInsightsStatusDisabled {
+		return nil, &resource.NotFoundError{
+			Message:     status,
+			LastRequest: input,
+		}
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/internal/service/dynamodb/find.go
+++ b/internal/service/dynamodb/find.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )

--- a/internal/service/dynamodb/find.go
+++ b/internal/service/dynamodb/find.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"context"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
@@ -118,4 +117,21 @@ func FindDynamoDBTTLRDescriptionByTableName(conn *dynamodb.DynamoDB, tableName s
 	}
 
 	return output.TimeToLiveDescription, nil
+}
+
+func FindContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string) (*dynamodb.DescribeContributorInsightsOutput, error) {
+	input := &dynamodb.DescribeContributorInsightsInput{
+		TableName: aws.String(tableName),
+	}
+
+	if indexName != "" {
+		input.IndexName = aws.String(indexName)
+	}
+
+	output, err := conn.DescribeContributorInsightsWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }

--- a/internal/service/dynamodb/status.go
+++ b/internal/service/dynamodb/status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func statusDynamoDBKinesisStreamingDestination(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) resource.StateRefreshFunc {
@@ -189,7 +190,7 @@ func statusContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, tab
 	return func() (interface{}, string, error) {
 		insight, err := FindContributorInsights(ctx, conn, tableName, indexName)
 
-		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
+		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
 

--- a/internal/service/dynamodb/status.go
+++ b/internal/service/dynamodb/status.go
@@ -184,3 +184,23 @@ func statusDynamoDBTableSES(conn *dynamodb.DynamoDB, tableName string) resource.
 		return table, aws.StringValue(table.SSEDescription.Status), nil
 	}
 }
+
+func statusContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		insight, err := FindContributorInsights(ctx, conn, tableName, indexName)
+
+		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if insight == nil {
+			return nil, "", nil
+		}
+
+		return insight, aws.StringValue(insight.ContributorInsightsStatus), nil
+	}
+}

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -275,7 +275,7 @@ func waitContributorInsightsCreated(ctx context.Context, conn *dynamodb.DynamoDB
 func waitContributorInsightsDeleted(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{dynamodb.ContributorInsightsStatusDisabling},
-		Target:  []string{dynamodb.ContributorInsightsStatusDisabled},
+		Target:  []string{},
 		Timeout: timeout,
 		Refresh: statusContributorInsights(ctx, conn, tableName, indexName),
 	}

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -19,7 +19,6 @@ const (
 	deleteTableTimeout                         = 10 * time.Minute
 	pitrUpdateTimeout                          = 30 * time.Second
 	ttlUpdateTimeout                           = 30 * time.Second
-	updateContributorInsightsTimeout           = 5 * time.Minute
 )
 
 func waitDynamoDBKinesisStreamingDestinationActive(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) error {

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -260,11 +260,11 @@ func waitDynamoDBSSEUpdated(conn *dynamodb.DynamoDB, tableName string) (*dynamod
 	return nil, err
 }
 
-func waitContributorInsightsCreated(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string) error {
+func waitContributorInsightsCreated(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{dynamodb.ContributorInsightsStatusEnabling},
 		Target:  []string{dynamodb.ContributorInsightsStatusEnabled},
-		Timeout: updateContributorInsightsTimeout,
+		Timeout: timeout,
 		Refresh: statusContributorInsights(ctx, conn, tableName, indexName),
 	}
 
@@ -273,11 +273,11 @@ func waitContributorInsightsCreated(ctx context.Context, conn *dynamodb.DynamoDB
 	return err
 }
 
-func waitContributorInsightsDeleted(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string) error {
+func waitContributorInsightsDeleted(ctx context.Context, conn *dynamodb.DynamoDB, tableName, indexName string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{dynamodb.ContributorInsightsStatusDisabling},
 		Target:  []string{dynamodb.ContributorInsightsStatusDisabled},
-		Timeout: updateContributorInsightsTimeout,
+		Timeout: timeout,
 		Refresh: statusContributorInsights(ctx, conn, tableName, indexName),
 	}
 

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -18,14 +18,14 @@ resource "aws_dynamodb_contributor_insights" "test" {
 }
 ```
 
-## ArgumentReference
+## Argument Reference
 
 The following arguments are supported:
 
 * `table_name` - (Required) The name of the table to attach contributor insight
 * `index_name` - (Optional) The global secondary index name
 
-## Attribute Reference
+## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -22,7 +22,7 @@ resource "aws_dynamodb_contributor_insights" "test" {
 
 The following arguments are supported:
 
-* `table_name` - (Required) The name of the table to attach contributor insight
+* `table_name` - (Required) The name of the table to enable contributor insights
 * `index_name` - (Optional) The global secondary index name
 
 ## Attributes Reference

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -33,8 +33,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_dynamodb_contributor_insights` can be imported using the `table_name`, or `table_name-index_name`, followed by the account number, e.g.,
+`aws_dynamodb_contributor_insights` can be imported using the format `name:table_name/index:index_name`, followed by the account number, e.g.,
 
 ```
-$ terraform import aws_dynamodb_contributor_insights.test ExampleTableName/123456789012
+$ terraform import aws_dynamodb_contributor_insights.test name:ExampleTableName/index:ExampleIndexName/123456789012
 ```

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_contributor_insights"
+description: |-
+  Provides a DynamoDB contributor insights resource
+---
+
+# Resource: aws_dynamodb_contributor_insights
+
+Provides a DynamoDB contributor insights resource
+
+## Example Usage
+
+```terraform
+resource "aws_dynamodb_contributor_insights" "test" {
+  table_name = "ExampleTableName"
+}
+```
+
+## ArgumentReference
+
+The following arguments are supported:
+
+* `table_name` - (Required) The name of the table to attach contributor insight
+* `index_name` - (Optional) The global secondary index name
+
+## Atrriibute Reference
+
+In addition to all arguments above, teh following attributes are exported:
+
+* `status` - The contributor insights status
+
+## Import
+
+`aws_dynamodb_contributor_insights` can be imported using the `table_name`, or `table_name-index_name`, followed by the account number, e.g.,
+
+```
+$ terraform import aws_dynamodb_contributor_insights.test ExampleTableName/123456789012
+```

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -25,12 +25,6 @@ The following arguments are supported:
 * `table_name` - (Required) The name of the table to enable contributor insights
 * `index_name` - (Optional) The global secondary index name
 
-## Attributes Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `status` - The contributor insights status
-
 ## Import
 
 `aws_dynamodb_contributor_insights` can be imported using the format `name:table_name/index:index_name`, followed by the account number, e.g.,

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -25,9 +25,9 @@ The following arguments are supported:
 * `table_name` - (Required) The name of the table to attach contributor insight
 * `index_name` - (Optional) The global secondary index name
 
-## Atrriibute Reference
+## Attribute Reference
 
-In addition to all arguments above, teh following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `status` - The contributor insights status
 

--- a/website/docs/r/dynamodb_contributor_insights.html.markdown
+++ b/website/docs/r/dynamodb_contributor_insights.html.markdown
@@ -25,6 +25,10 @@ The following arguments are supported:
 * `table_name` - (Required) The name of the table to enable contributor insights
 * `index_name` - (Optional) The global secondary index name
 
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
 ## Import
 
 `aws_dynamodb_contributor_insights` can be imported using the format `name:table_name/index:index_name`, followed by the account number, e.g.,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #13933

### Description

Creates new resource for `aws_dynamodb_contributor_insights`

```hcl
resource "aws_dynamodb_contributor_insights" "test" {
  table_name = "TestTableName"
}
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccContributorInsights_ PKG=dynamodb

=== RUN   TestAccContributorInsights_basic
=== PAUSE TestAccContributorInsights_basic
=== RUN   TestAccContributorInsights_disappears
=== PAUSE TestAccContributorInsights_disappears
=== CONT  TestAccContributorInsights_basic
=== CONT  TestAccContributorInsights_disappears
--- PASS: TestAccContributorInsights_disappears (32.56s)
--- PASS: TestAccContributorInsights_basic (56.66s)
PASS
...
```
