### PR TITLE
internal/conns: add retry handling for `InternalErrorException` when calling FMS `PutPolicy`

### DIFF
--- a/.changelog/23952.txt
+++ b/.changelog/23952.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fms_policy: Retry when `InternalErrorException` errors are returned from the AWS API
+```

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1232,6 +1232,13 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 			if tfawserr.ErrMessageContains(r.Error, fms.ErrCodeInvalidOperationException, "Your AWS Organization is currently onboarding with AWS Firewall Manager and cannot be offboarded.") {
 				r.Retryable = aws.Bool(true)
 			}
+		// System problems can arise during FMS policy updates (maybe also creation),
+		// so we set the following operation as retryable.
+		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23946
+		case "PutPolicy":
+			if tfawserr.ErrCodeEquals(r.Error, fms.ErrCodeInternalErrorException) {
+				r.Retryable = aws.Bool(true)
+			}
 		}
 	})
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23946

### Notes:
* Tests already passing in nightly CI so I only ran the `update` test since the error may not be apparent with our test configs

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccFMS_serial (1082.54s)
    --- PASS: TestAccFMS_serial/Policy (1082.54s)
        --- PASS: TestAccFMS_serial/Policy/update (1082.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fms	1086.300s
```
