### PR TITLE
SES receipt rule resource: Fix `scope` definition inside `stop_action`.

### DIFF
--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -91,7 +91,7 @@ SNS actions support the following:
 
 Stop actions support the following:
 
-* `scope` - (Required) The scope to apply
+* `scope` - (Required) The scope to apply. The only acceptable value is `RuleSet`.
 * `topic_arn` - (Optional) The ARN of an SNS topic to notify
 * `position` - (Required) The position of the action in the receipt rule
 


### PR DESCRIPTION
From https://docs.aws.amazon.com/ses/latest/APIReference/API_StopAction.html

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->