### PR TITLE
r/aws_backup_report_plan: Wait for correct `DeploymentStatus` after lifecycle operations

### DIFF
--- a/.changelog/23967.txt
+++ b/.changelog/23967.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_backup_report_plan: Wait for asynchronous lifecycle operations to complete
+```

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -7,3 +7,15 @@ const (
 	frameworkStatusFailed             = "FAILED"
 	frameworkStatusUpdateInProgress   = "UPDATE_IN_PROGRESS"
 )
+
+const (
+	reportDeliveryFormatCSV  = "CSV"
+	reportDeliveryFormatJSON = "JSON"
+)
+
+func reportDeliveryFormat_Values() []string {
+	return []string{
+		reportDeliveryFormatCSV,
+		reportDeliveryFormatJSON,
+	}
+}

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -9,6 +9,13 @@ const (
 )
 
 const (
+	reportPlanDeploymentStatusCompleted        = "COMPLETED"
+	reportPlanDeploymentStatusCreateInProgress = "CREATE_IN_PROGRESS"
+	reportPlanDeploymentStatusDeleteInProgress = "DELETE_IN_PROGRESS"
+	reportPlanDeploymentStatusUpdateInProgress = "UPDATE_IN_PROGRESS"
+)
+
+const (
 	reportDeliveryChannelFormatCSV  = "CSV"
 	reportDeliveryChannelFormatJSON = "JSON"
 )

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -9,13 +9,13 @@ const (
 )
 
 const (
-	reportDeliveryFormatCSV  = "CSV"
-	reportDeliveryFormatJSON = "JSON"
+	reportDeliveryChannelFormatCSV  = "CSV"
+	reportDeliveryChannelFormatJSON = "JSON"
 )
 
-func reportDeliveryFormat_Values() []string {
+func reportDeliveryChannelFormat_Values() []string {
 	return []string{
-		reportDeliveryFormatCSV,
-		reportDeliveryFormatJSON,
+		reportDeliveryChannelFormatCSV,
+		reportDeliveryChannelFormatJSON,
 	}
 }

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -19,3 +19,21 @@ func reportDeliveryChannelFormat_Values() []string {
 		reportDeliveryChannelFormatJSON,
 	}
 }
+
+const (
+	reportSettingTemplateBackupJobReport          = "BACKUP_JOB_REPORT"
+	reportSettingTemplateControlComplianceReport  = "CONTROL_COMPLIANCE_REPORT"
+	reportSettingTemplateCopyJobReport            = "COPY_JOB_REPORT"
+	reportSettingTemplateResourceComplianceReport = "RESOURCE_COMPLIANCE_REPORT"
+	reportSettingTemplateRestoreJobReport         = "RESTORE_JOB_REPORT"
+)
+
+func reportSettingTemplate_Values() []string {
+	return []string{
+		reportSettingTemplateBackupJobReport,
+		reportSettingTemplateControlComplianceReport,
+		reportSettingTemplateCopyJobReport,
+		reportSettingTemplateResourceComplianceReport,
+		reportSettingTemplateRestoreJobReport,
+	}
+}

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -64,7 +64,7 @@ func ResourceReportPlan() *schema.Resource {
 							Optional: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice(reportDeliveryFormat_Values(), false),
+								ValidateFunc: validation.StringInSlice(reportDeliveryChannelFormat_Values(), false),
 							},
 						},
 						"s3_bucket_name": {

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -97,16 +97,10 @@ func ResourceReportPlan() *schema.Resource {
 						},
 						// A report plan template cannot be updated
 						"report_template": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"RESOURCE_COMPLIANCE_REPORT",
-								"CONTROL_COMPLIANCE_REPORT",
-								"BACKUP_JOB_REPORT",
-								"COPY_JOB_REPORT",
-								"RESTORE_JOB_REPORT",
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(reportSettingTemplate_Values(), false),
 						},
 					},
 				},

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -63,11 +63,8 @@ func ResourceReportPlan() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									"CSV",
-									"JSON",
-								}, false),
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice(reportDeliveryFormat_Values(), false),
 							},
 						},
 						"s3_bucket_name": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23966.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccBackupReportPlan_ PKG=backup ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 3 -run='TestAccBackupReportPlan_'  -timeout 180m
=== RUN   TestAccBackupReportPlan_basic
=== PAUSE TestAccBackupReportPlan_basic
=== RUN   TestAccBackupReportPlan_updateTags
=== PAUSE TestAccBackupReportPlan_updateTags
=== RUN   TestAccBackupReportPlan_updateReportDeliveryChannel
=== PAUSE TestAccBackupReportPlan_updateReportDeliveryChannel
=== RUN   TestAccBackupReportPlan_disappears
=== PAUSE TestAccBackupReportPlan_disappears
=== CONT  TestAccBackupReportPlan_basic
=== CONT  TestAccBackupReportPlan_updateReportDeliveryChannel
=== CONT  TestAccBackupReportPlan_disappears
--- PASS: TestAccBackupReportPlan_disappears (22.77s)
=== CONT  TestAccBackupReportPlan_updateTags
--- PASS: TestAccBackupReportPlan_updateReportDeliveryChannel (41.37s)
--- PASS: TestAccBackupReportPlan_basic (41.84s)
--- PASS: TestAccBackupReportPlan_updateTags (57.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	84.089s```
