### PR TITLE
r/glue_catalog_table: Note on partition_index

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -104,6 +104,10 @@ The follow arguments are optional:
 
 ### partition_index
 
+~> **NOTE:** A `partition_index` cannot be added to an existing `glue_catalog_table`.
+This will destroy and recreate the table, possibly resulting in data loss.
+To add an index to an existing table, see the [`glue_partition_index` resource](/docs/providers/aws/r/glue_partition_index.html) for configuration details.
+
 * `index_name` - (Required) Name of the partition index.
 * `keys` - (Required) Keys for the partition index.
 


### PR DESCRIPTION
Add a note to the update partition_index information with a note that it only works for new tables; existing tables should use the glue_partition_index resource. I used the notes on s3_bucket as a template.

Closes #23929

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
