### PR TITLE
Change the link provided to describe addons

### DIFF
--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -75,7 +75,7 @@ resource "aws_iam_role_policy_attachment" "example" {
 The following arguments are required:
 
 * `addon_name` – (Required) Name of the EKS add-on. The name must match one of
-  the names returned by [list-addon](https://docs.aws.amazon.com/cli/latest/reference/eks/list-addons.html).
+  the names returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 
 The following arguments are optional:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #23974

Output from acceptance testing: n/a, documentation

### Information

As called out in the linked issue, we previously linked to [list-addons](https://docs.aws.amazon.com/cli/latest/reference/eks/list-addons.html), however, according to the [API Documentation](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html#API_CreateAddon_RequestSyntax), the more effective link would be to [describe-addons-versions](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/eks/describe-addon-versions.html).