### PR TITLE
r/s3_bucket: make `object_lock_configuration.rule` configurable

### DIFF
--- a/.changelog/23984.txt
+++ b/.changelog/23984.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Update `object_lock_configuration.rule` parameter to be configurable. Please refer to the documentation for details on drift detection and potential conflicts when configuring this parameter with the standalone `aws_s3_bucket_object_lock_configuration` resource.
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23106 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketObjectLockConfiguration_disappears (21.35s)
--- PASS: TestAccS3BucketObjectLockConfiguration_basic (23.82s)
--- PASS: TestAccS3BucketObjectLockConfiguration_migrate_withChange (34.92s)
--- PASS: TestAccS3BucketObjectLockConfiguration_migrate_noChange (35.52s)
--- PASS: TestAccS3BucketObjectLockConfiguration_update (36.76s)

--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (44.99s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (47.45s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (62.48s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (62.76s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (62.76s)
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (62.76s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (75.39s)
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (76.43s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (82.60s)
--- PASS: TestAccS3Bucket_Manage_objectLock (82.90s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (84.20s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (85.18s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (91.87s)
--- PASS: TestAccS3Bucket_Manage_versioning (92.60s)
```
