### PR TITLE
d/aws_memorydb_snapshot: new data source

### DIFF
--- a/.changelog/23990.txt
+++ b/.changelog/23990.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_memorydb_snapshot
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -720,6 +720,7 @@ func Provider() *schema.Provider {
 
 			"aws_memorydb_acl":             memorydb.DataSourceACL(),
 			"aws_memorydb_parameter_group": memorydb.DataSourceParameterGroup(),
+			"aws_memorydb_snapshot":        memorydb.DataSourceSnapshot(),
 			"aws_memorydb_subnet_group":    memorydb.DataSourceSubnetGroup(),
 			"aws_memorydb_user":            memorydb.DataSourceUser(),
 

--- a/internal/service/memorydb/snapshot_data_source.go
+++ b/internal/service/memorydb/snapshot_data_source.go
@@ -1,0 +1,138 @@
+package memorydb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func DataSourceSnapshot() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceSnapshotRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"maintenance_window": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num_shards": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"parameter_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"snapshot_retention_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"snapshot_window": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	name := d.Get("name").(string)
+
+	snapshot, err := FindSnapshotByName(ctx, conn, name)
+
+	if err != nil {
+		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB Snapshot", err))
+	}
+
+	d.SetId(aws.StringValue(snapshot.Name))
+
+	d.Set("arn", snapshot.ARN)
+	if err := d.Set("cluster_configuration", flattenClusterConfiguration(snapshot.ClusterConfiguration)); err != nil {
+		return diag.Errorf("failed to set cluster_configuration for MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+	d.Set("cluster_name", snapshot.ClusterConfiguration.Name)
+	d.Set("kms_key_arn", snapshot.KmsKeyId)
+	d.Set("name", snapshot.Name)
+	d.Set("source", snapshot.Source)
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/memorydb/snapshot_data_source_test.go
+++ b/internal/service/memorydb/snapshot_data_source_test.go
@@ -1,0 +1,73 @@
+package memorydb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccMemoryDBSnapshotDataSource_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+	dataSourceName := "data.aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.description", resourceName, "cluster_configuration.0.description"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.engine_version", resourceName, "cluster_configuration.0.engine_version"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.maintenance_window", resourceName, "cluster_configuration.0.maintenance_window"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.name", resourceName, "cluster_configuration.0.name"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.node_type", resourceName, "cluster_configuration.0.node_type"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.num_shards", resourceName, "cluster_configuration.0.num_shards"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.parameter_group_name", resourceName, "cluster_configuration.0.parameter_group_name"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.port", resourceName, "cluster_configuration.0.port"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.snapshot_retention_limit", resourceName, "cluster_configuration.0.snapshot_retention_limit"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.snapshot_window", resourceName, "cluster_configuration.0.snapshot_window"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.subnet_group_name", resourceName, "cluster_configuration.0.subnet_group_name"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.vpc_id", resourceName, "cluster_configuration.0.vpc_id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_name", resourceName, "cluster_name"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "kms_key_arn", resourceName, "kms_key_arn"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "source", resourceName, "source"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.Test", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSnapshotDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  kms_key_arn  = aws_kms_key.test.arn
+  name         = %[1]q
+
+  tags = {
+    Test = "test"
+  }
+}
+
+data "aws_memorydb_snapshot" "test" {
+  name = aws_memorydb_snapshot.test.name
+}
+`, rName),
+	)
+}

--- a/website/docs/d/memorydb_snapshot.html.markdown
+++ b/website/docs/d/memorydb_snapshot.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_snapshot"
+description: |-
+  Provides information about a MemoryDB Snapshot.
+---
+
+# Resource: aws_memorydb_snapshot
+
+Provides information about a MemoryDB Snapshot.
+
+## Example Usage
+
+```terraform
+data "aws_memorydb_snapshot" "example" {
+  name = "my-snapshot"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the snapshot.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `id` - The name of the snapshot.
+* `arn` - The ARN of the snapshot.
+* `cluster_configuration` - The configuration of the cluster from which the snapshot was taken.
+    * `description` - Description for the cluster.
+    * `engine_version` - Version number of the Redis engine used by the cluster.
+    * `maintenance_window` - The weekly time range during which maintenance on the cluster is performed.
+    * `name` - Name of the cluster.
+    * `node_type` - Compute and memory capacity of the nodes in the cluster.
+    * `num_shards` - Number of shards in the cluster.
+    * `parameter_group_name` - Name of the parameter group associated with the cluster.
+    * `port` - Port number on which the cluster accepts connections.
+    * `snapshot_retention_limit` - Number of days for which MemoryDB retains automatic snapshots before deleting them.
+    * `snapshot_window` - The daily time range (in UTC) during which MemoryDB begins taking a daily snapshot of the shard.
+    * `subnet_group_name` - Name of the subnet group used by the cluster.
+    * `topic_arn` - ARN of the SNS topic to which cluster notifications are sent.
+    * `vpc_id` - The VPC in which the cluster exists.
+* `cluster_name` - Name of the MemoryDB cluster that this snapshot was taken from.
+* `kms_key_arn` - ARN of the KMS key used to encrypt the snapshot at rest.
+* `source` - Indicates whether the snapshot is from an automatic backup (`automated`) or was created manually (`manual`).
+* `tags` - A map of tags assigned to the snapshot.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23795

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccMemoryDBSnapshotDataSource_ ACCTEST_TIMEOUT=600m
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBSnapshotDataSource_'  -timeout 600m
=== RUN   TestAccMemoryDBSnapshotDataSource_basic
=== PAUSE TestAccMemoryDBSnapshotDataSource_basic
=== CONT  TestAccMemoryDBSnapshotDataSource_basic
--- PASS: TestAccMemoryDBSnapshotDataSource_basic (2174.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   2176.587s
```
