### PR TITLE
IoT Authorizer HTTP caching support

### DIFF
--- a/.changelog/23993.txt
+++ b/.changelog/23993.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_authorizer: Add `enable_caching_for_http` argument
+```

--- a/internal/service/iot/authorizer.go
+++ b/internal/service/iot/authorizer.go
@@ -54,6 +54,11 @@ func ResourceAuthorizer() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"enable_http_caching": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"status": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -87,6 +92,7 @@ func resourceAuthorizerCreate(d *schema.ResourceData, meta interface{}) error {
 		AuthorizerName:        aws.String(name),
 		SigningDisabled:       aws.Bool(d.Get("signing_disabled").(bool)),
 		Status:                aws.String(d.Get("status").(string)),
+		EnableCachingForHttp:  aws.Bool(d.Get("enable_http_caching").(bool)),
 	}
 
 	if v, ok := d.GetOk("token_key_name"); ok {
@@ -131,6 +137,7 @@ func resourceAuthorizerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", authorizer.Status)
 	d.Set("token_key_name", authorizer.TokenKeyName)
 	d.Set("token_signing_public_keys", aws.StringValueMap(authorizer.TokenSigningPublicKeys))
+	d.Set("enable_http_caching", authorizer.EnableCachingForHttp)
 
 	return nil
 }
@@ -156,6 +163,10 @@ func resourceAuthorizerUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("token_signing_public_keys") {
 		input.TokenSigningPublicKeys = flex.ExpandStringMap(d.Get("token_signing_public_keys").(map[string]interface{}))
+	}
+
+	if d.HasChange("enable_http_caching") {
+		input.EnableCachingForHttp = aws.Bool(d.Get("enable_http_caching").(bool))
 	}
 
 	log.Printf("[INFO] Updating IoT Authorizer: %s", input)

--- a/internal/service/iot/authorizer_test.go
+++ b/internal/service/iot/authorizer_test.go
@@ -30,13 +30,13 @@ func TestAccIoTAuthorizer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthorizerExists(resourceName, &conf),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("authorizer/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "enable_caching_for_http", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "signing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(resourceName, "token_key_name", "Token-Header-1"),
 					resource.TestCheckResourceAttr(resourceName, "token_signing_public_keys.%", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key1"),
-					resource.TestCheckResourceAttr(resourceName, "enable_http_caching", "true"),
 				),
 			},
 			{
@@ -119,13 +119,13 @@ func TestAccIoTAuthorizer_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthorizerExists(resourceName, &conf),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("authorizer/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "enable_caching_for_http", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "signing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(resourceName, "token_key_name", "Token-Header-1"),
 					resource.TestCheckResourceAttr(resourceName, "token_signing_public_keys.%", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key1"),
-					resource.TestCheckResourceAttr(resourceName, "enable_http_caching", "true"),
 				),
 			},
 			{
@@ -133,6 +133,7 @@ func TestAccIoTAuthorizer_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthorizerExists(resourceName, &conf),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("authorizer/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "enable_caching_for_http", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "signing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INACTIVE"),
@@ -140,7 +141,6 @@ func TestAccIoTAuthorizer_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_signing_public_keys.%", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key1"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key2"),
-					resource.TestCheckResourceAttr(resourceName, "enable_http_caching", "false"),
 				),
 			},
 		},
@@ -235,7 +235,6 @@ resource "aws_iot_authorizer" "test" {
   name                    = %[1]q
   authorizer_function_arn = aws_lambda_function.test.arn
   token_key_name          = "Token-Header-1"
-  enable_http_caching     = true
 
   token_signing_public_keys = {
     Key1 = "${file("test-fixtures/iot-authorizer-signing-key.pem")}"
@@ -252,7 +251,7 @@ resource "aws_iot_authorizer" "test" {
   signing_disabled        = false
   token_key_name          = "Token-Header-2"
   status                  = "INACTIVE"
-  enable_http_caching     = false
+  enable_caching_for_http = true
 
   token_signing_public_keys = {
     Key1 = "${file("test-fixtures/iot-authorizer-signing-key.pem")}"

--- a/internal/service/iot/authorizer_test.go
+++ b/internal/service/iot/authorizer_test.go
@@ -36,6 +36,7 @@ func TestAccIoTAuthorizer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_key_name", "Token-Header-1"),
 					resource.TestCheckResourceAttr(resourceName, "token_signing_public_keys.%", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key1"),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_caching", "true"),
 				),
 			},
 			{
@@ -124,6 +125,7 @@ func TestAccIoTAuthorizer_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_key_name", "Token-Header-1"),
 					resource.TestCheckResourceAttr(resourceName, "token_signing_public_keys.%", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key1"),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_caching", "true"),
 				),
 			},
 			{
@@ -138,6 +140,7 @@ func TestAccIoTAuthorizer_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_signing_public_keys.%", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key1"),
 					resource.TestCheckResourceAttrSet(resourceName, "token_signing_public_keys.Key2"),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_caching", "false"),
 				),
 			},
 		},
@@ -232,6 +235,7 @@ resource "aws_iot_authorizer" "test" {
   name                    = %[1]q
   authorizer_function_arn = aws_lambda_function.test.arn
   token_key_name          = "Token-Header-1"
+  enable_http_caching     = true
 
   token_signing_public_keys = {
     Key1 = "${file("test-fixtures/iot-authorizer-signing-key.pem")}"
@@ -248,6 +252,7 @@ resource "aws_iot_authorizer" "test" {
   signing_disabled        = false
   token_key_name          = "Token-Header-2"
   status                  = "INACTIVE"
+  enable_http_caching     = false
 
   token_signing_public_keys = {
     Key1 = "${file("test-fixtures/iot-authorizer-signing-key.pem")}"

--- a/website/docs/r/iot_authorizer.html.markdown
+++ b/website/docs/r/iot_authorizer.html.markdown
@@ -29,10 +29,10 @@ resource "aws_iot_authorizer" "example" {
 ## Argument Reference
 
 * `authorizer_function_arn` - (Required) The ARN of the authorizer's Lambda function.
+* `enable_caching_for_http`  - (Optional) Specifies whether the HTTP caching is enabled or not. Default: `false`.
 * `name` - (Required) The name of the authorizer.
 * `signing_disabled` - (Optional) Specifies whether AWS IoT validates the token signature in an authorization request. Default: `false`.
 * `status` - (Optional) The status of Authorizer request at creation. Valid values: `ACTIVE`, `INACTIVE`. Default: `ACTIVE`.
-* `enable_http_caching`  - (Optional) Specifies whether the HTTP caching is enabled or not. Default: `false`.
 * `token_key_name` - (Optional) The name of the token key used to extract the token from the HTTP headers. This value is required if signing is enabled in your authorizer.
 * `token_signing_public_keys` - (Optional) The public keys used to verify the digital signature returned by your custom authentication service. This value is required if signing is enabled in your authorizer.
 

--- a/website/docs/r/iot_authorizer.html.markdown
+++ b/website/docs/r/iot_authorizer.html.markdown
@@ -32,6 +32,7 @@ resource "aws_iot_authorizer" "example" {
 * `name` - (Required) The name of the authorizer.
 * `signing_disabled` - (Optional) Specifies whether AWS IoT validates the token signature in an authorization request. Default: `false`.
 * `status` - (Optional) The status of Authorizer request at creation. Valid values: `ACTIVE`, `INACTIVE`. Default: `ACTIVE`.
+* `enable_http_caching`  - (Optional) Specifies whether the HTTP caching is enabled or not. Default: `false`.
 * `token_key_name` - (Optional) The name of the token key used to extract the token from the HTTP headers. This value is required if signing is enabled in your authorizer.
 * `token_signing_public_keys` - (Optional) The public keys used to verify the digital signature returned by your custom authentication service. This value is required if signing is enabled in your authorizer.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->
Adds support for HTTP caching on an IoT authorizer.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_PROFILE=default make testacc TESTARGS='-run=TestAccIoTAuthorizer_basic' PKG_NAME=internal/service/iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20  -run=TestAccIoTAuthorizer_basic -timeout 180m
=== RUN   TestAccIoTAuthorizer_basic
=== PAUSE TestAccIoTAuthorizer_basic
=== CONT  TestAccIoTAuthorizer_basic
--- PASS: TestAccIoTAuthorizer_basic (55.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	55.317s

...
```
