### PR TITLE
elasticache/aws_elasticache_cluster: Enable `auto_minor_version_upgrade`

### DIFF
--- a/.changelog/23996.txt
+++ b/.changelog/23996.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_elasticache_cluster: Add `auto_minor_version_upgrade` argument
+```
+
+```release-note:bug
+resource/aws_elasticache_replication_group: Allow disabling `auto_minor_version_upgrade`
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -468,7 +468,6 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	if err := setFromCacheCluster(d, c); err != nil {
 		return err
 	}
-	d.Set("auto_minor_version_upgrade", strconv.FormatBool(aws.BoolValue(c.AutoMinorVersionUpgrade)))
 
 	d.Set("log_delivery_configuration", flattenLogDeliveryConfigurations(c.LogDeliveryConfigurations))
 	d.Set("snapshot_window", c.SnapshotWindow)
@@ -539,6 +538,7 @@ func setFromCacheCluster(d *schema.ResourceData, c *elasticache.CacheCluster) er
 	if err := setEngineVersionFromCacheCluster(d, c); err != nil {
 		return err
 	}
+	d.Set("auto_minor_version_upgrade", strconv.FormatBool(aws.BoolValue(c.AutoMinorVersionUpgrade)))
 
 	d.Set("subnet_group_name", c.CacheSubnetGroupName)
 	if err := d.Set("security_group_names", flattenSecurityGroupNames(c.CacheSecurityGroups)); err != nil {

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -52,6 +54,12 @@ func ResourceCluster() *schema.Resource {
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"auto_minor_version_upgrade": {
+				Type:         nullable.TypeNullableBool,
+				Optional:     true,
+				Default:      "true",
+				ValidateFunc: nullable.ValidateTypeStringNullableBool,
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
@@ -340,8 +348,16 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		req.Engine = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("engine_version"); ok {
-		req.EngineVersion = aws.String(v.(string))
+	version := d.Get("engine_version").(string)
+	if version != "" {
+		req.EngineVersion = aws.String(version)
+	}
+	if v, ok := d.GetOk("auto_minor_version_upgrade"); ok {
+		if v, null, _ := nullable.Bool(v.(string)).Value(); null {
+			req.AutoMinorVersionUpgrade = aws.Bool(true)
+		} else {
+			req.AutoMinorVersionUpgrade = aws.Bool(v)
+		}
 	}
 
 	if v, ok := d.GetOk("port"); ok {
@@ -453,6 +469,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	if err := setFromCacheCluster(d, c); err != nil {
 		return err
 	}
+	d.Set("auto_minor_version_upgrade", strconv.FormatBool(aws.BoolValue(c.AutoMinorVersionUpgrade)))
 
 	d.Set("log_delivery_configuration", flattenLogDeliveryConfigurations(c.LogDeliveryConfigurations))
 	d.Set("snapshot_window", c.SnapshotWindow)
@@ -594,7 +611,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		previousLogDeliveryConfig := oldLogDeliveryConfig.(*schema.Set).List()
 		for _, previous := range previousLogDeliveryConfig {
 			logDeliveryConfigurationRequest := expandEmptyLogDeliveryConfigurations(previous.(map[string]interface{}))
-			//if something was removed, send an empty request
+			// if something was removed, send an empty request
 			if !logTypesToSubmit[*logDeliveryConfigurationRequest.LogType] {
 				req.LogDeliveryConfigurations = append(req.LogDeliveryConfigurations, &logDeliveryConfigurationRequest)
 			}
@@ -620,6 +637,15 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("engine_version") {
 		req.EngineVersion = aws.String(d.Get("engine_version").(string))
+		requestUpdate = true
+	}
+	if d.HasChange("auto_minor_version_upgrade") {
+		v := d.Get("auto_minor_version_upgrade")
+		if v, null, _ := nullable.Bool(v.(string)).Value(); null {
+			req.AutoMinorVersionUpgrade = aws.Bool(true)
+		} else {
+			req.AutoMinorVersionUpgrade = aws.Bool(v)
+		}
 		requestUpdate = true
 	}
 

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -352,10 +352,9 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	if version != "" {
 		req.EngineVersion = aws.String(version)
 	}
+
 	if v, ok := d.GetOk("auto_minor_version_upgrade"); ok {
-		if v, null, _ := nullable.Bool(v.(string)).Value(); null {
-			req.AutoMinorVersionUpgrade = aws.Bool(true)
-		} else {
+		if v, null, _ := nullable.Bool(v.(string)).Value(); !null {
 			req.AutoMinorVersionUpgrade = aws.Bool(v)
 		}
 	}
@@ -639,11 +638,10 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		req.EngineVersion = aws.String(d.Get("engine_version").(string))
 		requestUpdate = true
 	}
+
 	if d.HasChange("auto_minor_version_upgrade") {
 		v := d.Get("auto_minor_version_upgrade")
-		if v, null, _ := nullable.Bool(v.(string)).Value(); null {
-			req.AutoMinorVersionUpgrade = aws.Bool(true)
-		} else {
+		if v, null, _ := nullable.Bool(v.(string)).Value(); !null {
 			req.AutoMinorVersionUpgrade = aws.Bool(v)
 		}
 		requestUpdate = true

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -43,7 +43,7 @@ func TestAccElastiCacheCluster_Engine_memcached(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_Engine_Memcached(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint"),
@@ -77,7 +77,7 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_Engine_Redis(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
@@ -115,6 +115,7 @@ func TestAccElastiCacheCluster_Engine_redis_v5(t *testing.T) {
 					testAccCheckClusterExists(resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
+					// Even though it is ignored, the API returns `true` in this case
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
 				),
 			},

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -59,9 +61,10 @@ func ResourceReplicationGroup() *schema.Resource {
 				ConflictsWith: []string{"user_group_ids"},
 			},
 			"auto_minor_version_upgrade": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:         nullable.TypeNullableBool,
+				Optional:     true,
+				Default:      "true",
+				ValidateFunc: nullable.ValidateTypeStringNullableBool,
 			},
 			"automatic_failover_enabled": {
 				Type:     schema.TypeBool,
@@ -407,8 +410,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	params := &elasticache.CreateReplicationGroupInput{
-		ReplicationGroupId:      aws.String(d.Get("replication_group_id").(string)),
-		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
+		ReplicationGroupId: aws.String(d.Get("replication_group_id").(string)),
 	}
 
 	if len(tags) > 0 {
@@ -441,6 +443,12 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("engine_version"); ok {
 		params.EngineVersion = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("auto_minor_version_upgrade"); ok {
+		if v, null, _ := nullable.Bool(v.(string)).Value(); !null {
+			params.AutoMinorVersionUpgrade = aws.Bool(v)
+		}
 	}
 
 	if preferredAZs, ok := d.GetOk("preferred_cache_cluster_azs"); ok {
@@ -705,7 +713,7 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 			return nil
 		}
 
-		cacheCluster := *rgp.NodeGroups[0].NodeGroupMembers[0] // nosemgrep: prefer-aws-go-sdk-pointer-conversion-assignment // false positive
+		cacheCluster := rgp.NodeGroups[0].NodeGroupMembers[0]
 
 		res, err := conn.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{
 			CacheClusterId:    cacheCluster.CacheClusterId,
@@ -724,6 +732,7 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 		if err := setFromCacheCluster(d, c); err != nil {
 			return err
 		}
+		d.Set("auto_minor_version_upgrade", strconv.FormatBool(aws.BoolValue(c.AutoMinorVersionUpgrade)))
 
 		d.Set("log_delivery_configuration", flattenLogDeliveryConfigurations(rgp.LogDeliveryConfigurations))
 		d.Set("snapshot_window", rgp.SnapshotWindow)
@@ -741,7 +750,6 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("user_group_ids", rgp.UserGroupIds)
 
 		d.Set("at_rest_encryption_enabled", c.AtRestEncryptionEnabled)
-		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)
 		d.Set("transit_encryption_enabled", c.TransitEncryptionEnabled)
 
 		if c.AuthTokenEnabled != nil && !aws.BoolValue(c.AuthTokenEnabled) {
@@ -800,7 +808,10 @@ func resourceReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("auto_minor_version_upgrade") {
-		params.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
+		v := d.Get("auto_minor_version_upgrade")
+		if v, null, _ := nullable.Bool(v.(string)).Value(); !null {
+			params.AutoMinorVersionUpgrade = aws.Bool(v)
+		}
 		requestUpdate = true
 	}
 

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -744,7 +743,6 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 		if err := setFromCacheCluster(d, c); err != nil {
 			return err
 		}
-		d.Set("auto_minor_version_upgrade", strconv.FormatBool(aws.BoolValue(c.AutoMinorVersionUpgrade)))
 
 		d.Set("at_rest_encryption_enabled", c.AtRestEncryptionEnabled)
 		d.Set("transit_encryption_enabled", c.TransitEncryptionEnabled)

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -46,7 +46,6 @@ func TestAccElastiCacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
@@ -54,6 +53,7 @@ func TestAccElastiCacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", "false"),
 				),
 			},
@@ -210,7 +210,6 @@ func TestAccElastiCacheReplicationGroup_updateDescription(t *testing.T) {
 					testAccCheckReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_group_description", "test description"),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 				),
 			},
 			{
@@ -225,7 +224,6 @@ func TestAccElastiCacheReplicationGroup_updateDescription(t *testing.T) {
 					testAccCheckReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_group_description", "updated description"),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
 				),
 			},
 		},
@@ -455,7 +453,6 @@ func TestAccElastiCacheReplicationGroup_vpc(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_cache_cluster_azs.#", "1"),
 				),
 			},
@@ -489,7 +486,6 @@ func TestAccElastiCacheReplicationGroup_depecatedAvailabilityZones_vpc(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "1"),
 				),
 			},
@@ -2379,7 +2375,6 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
   snapshot_window               = "01:00-02:00"
 }
@@ -2432,7 +2427,6 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
   snapshot_window               = "01:00-02:00"
   snapshot_retention_limit      = 2
@@ -2476,7 +2470,6 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = true
 }
 `, rName)
 }
@@ -2489,7 +2482,6 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = true
   maintenance_window            = "wed:03:00-wed:06:00"
   snapshot_window               = "01:00-02:00"
 }
@@ -2534,7 +2526,6 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
   snapshot_window               = "01:00-02:00"
   transit_encryption_enabled    = true
@@ -2557,7 +2548,6 @@ resource "aws_elasticache_replication_group" "test" {
   subnet_group_name             = aws_elasticache_subnet_group.test.name
   security_group_ids            = [aws_security_group.test.id]
   preferred_cache_cluster_azs   = [data.aws_availability_zones.available.names[0]]
-  auto_minor_version_upgrade    = false
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -2594,7 +2584,6 @@ resource "aws_elasticache_replication_group" "test" {
   subnet_group_name             = aws_elasticache_subnet_group.test.name
   security_group_ids            = [aws_security_group.test.id]
   availability_zones            = [data.aws_availability_zones.available.names[0]]
-  auto_minor_version_upgrade    = false
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3075,7 +3064,6 @@ resource "aws_elasticache_replication_group" "test" {
   number_cache_clusters         = %[2]d
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
   snapshot_window               = "01:00-02:00"
 
@@ -3099,7 +3087,6 @@ resource "aws_elasticache_replication_group" "test" {
   number_cache_clusters         = %[2]d
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
   snapshot_window               = "01:00-02:00"
 
@@ -3394,7 +3381,6 @@ resource "aws_elasticache_replication_group" "test" {
   port                          = 6379
   subnet_group_name             = aws_elasticache_subnet_group.test.name
   security_group_ids            = [aws_security_group.test.id]
-  auto_minor_version_upgrade    = false
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3508,7 +3494,6 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   port                          = 6379
   apply_immediately             = true
-  auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
   snapshot_window               = "01:00-02:00"
   parameter_group_name          = tobool("%[2]t") ? "default.redis6.x.cluster.on" : "default.redis6.x"

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -3217,7 +3217,6 @@ resource "aws_elasticache_replication_group" "test" {
   replication_group_description = "test description"
   node_type                     = "cache.t3.small"
 
-//   apply_immediately          = true
   auto_minor_version_upgrade = %[2]t
 }
 `, rName, enable)

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -106,11 +106,15 @@ The following arguments are required:
 The following arguments are optional:
 
 * `apply_immediately` - (Optional) Whether any database modifications are applied immediately, or during the next maintenance window. Default is `false`. See [Amazon ElastiCache Documentation for more information.](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html).
+* `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
+  Only supported for engine type `"redis"` and if the engine version is 6 or higher.
+  Defaults to `true`.
 * `availability_zone` - (Optional) Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone. Changing this value will re-create the resource.
 * `az_mode` - (Optional, Memcached only) Whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are `single-az` or `cross-az`, default is `single-az`. If you want to choose `cross-az`, `num_cache_nodes` must be greater than `1`.
 * `engine_version` – (Optional) Version number of the cache engine to be used.
-See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html)
-in the AWS Documentation for supported versions. When `engine` is `redis` and the version is 6 or higher, only the major version can be set, e.g., `6.x`, otherwise, specify the full version desired, e.g., `5.0.6`. The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
+  If not set, defaults to the latest version.
+  See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html)
+  in the AWS Documentation for supported versions. When `engine` is `redis` and the version is 6 or higher, only the major version can be set, e.g., `6.x`, otherwise, specify the full version desired, e.g., `5.0.6`. The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 * `final_snapshot_identifier` - (Optional, Redis only) Name of your final cluster snapshot. If omitted, no final snapshot will be made.
 * `log_delivery_configuration` - (Optional, Redis only) Specifies the destination and format of Redis [SLOWLOG](https://redis.io/commands/slowlog) or Redis [Engine Log](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log). See the documentation on [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html). See [Log Delivery Configuration](#log-delivery-configuration) below for more details.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -106,7 +106,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `apply_immediately` - (Optional) Whether any database modifications are applied immediately, or during the next maintenance window. Default is `false`. See [Amazon ElastiCache Documentation for more information.](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html).
-* `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
+* `auto_minor_version_upgrade` - (Optional) Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
   Only supported for engine type `"redis"` and if the engine version is 6 or higher.
   Defaults to `true`.
 * `availability_zone` - (Optional) Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone. Changing this value will re-create the resource.

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -175,7 +175,9 @@ The following arguments are optional:
 * `apply_immediately` - (Optional) Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is `false`.
 * `at_rest_encryption_enabled` - (Optional) Whether to enable encryption at rest.
 * `auth_token` - (Optional) Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`.
-* `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. This parameter is currently not supported by the AWS API. Defaults to `true`.
+* `auto_minor_version_upgrade` - (Optional) Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
+  Only supported for engine type `"redis"` and if the engine version is 6 or higher.
+  Defaults to `true`.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `number_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
 * `availability_zones` - (Optional, **Deprecated** use `preferred_cache_cluster_azs` instead) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not considered.
 * `cluster_mode` - (Optional, **Deprecated** use root-level `num_node_groups` and `replicas_per_node_group` instead) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.


### PR DESCRIPTION
Enables `auto_minor_version_upgrade` for `aws_elasticache_cluster` and properly supports `auto_minor_version_upgrade` for `aws_elasticache_replication_group`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22385

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=elasticache TESTS='TestAccElastiCacheCluster_|TestAccElastiCacheReplicationGroup_'

--- PASS: TestAccElastiCacheClusterDataSource_Data_basic (497.16s)
--- PASS: TestAccElastiCacheClusterDataSource_Engine_Redis_LogDeliveryConfigurations (734.80s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (1624.58s)

--- PASS: TestAccElastiCacheReplicationGroupDataSource_nonExistent (2.56s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (786.95s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (879.79s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (858.93s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (921.96s)

--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (2.93s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (2.68s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (914.46s)
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (520.87s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (867.90s)
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (684.36s)
--- PASS: TestAccElastiCacheCluster_Engine_None (1.99s)
--- SKIP: TestAccElastiCacheCluster_SecurityGroup_ec2Classic (0.83s)
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (490.46s)
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (455.97s)
--- PASS: TestAccElastiCacheCluster_AZMode_redis (474.45s)
--- PASS: TestAccElastiCacheCluster_vpc (469.83s)
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (589.63s)
--- PASS: TestAccElastiCacheCluster_port (443.93s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1142.04s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1164.45s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1166.65s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1116.36s)
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (443.88s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (744.64s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (743.01s)
--- PASS: TestAccElastiCacheCluster_PortRedis_default (475.33s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (742.90s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1022.70s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (474.67s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (454.96s)
--- PASS: TestAccElastiCacheCluster_Engine_memcached (476.08s)

--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (23.04s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (665.09s)
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (808.11s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (880.98s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (903.66s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (944.20s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (1065.39s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (1150.83s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (3.34s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1353.02s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1396.59s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (1566.07s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1718.08s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1747.07s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (1791.61s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1901.71s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (2003.14s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1057.50s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (2176.43s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (2216.73s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (1286.22s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (902.17s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (693.33s)
--- PASS: TestAccElastiCacheReplicationGroup_depecatedAvailabilityZones_vpc (825.19s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (2635.99s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (1015.67s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (2027.60s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (840.63s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (2979.73s)
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (1128.17s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (848.78s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (837.94s)
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1084.96s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2644.73s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (1957.71s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (2157.46s)
--- PASS: TestAccElastiCacheReplicationGroup_basic_v5 (739.79s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzNotInVPC (2004.35s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (748.09s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (984.32s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1574.77s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2833.83s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (3283.54s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2938.46s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (5.08s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1229.57s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1226.76s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1167.68s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2388.68s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (3294.03s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2490.75s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3714.02s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3437.57s)
```
