### PR TITLE
examples: configuration for intra-region Transit Gateway Peering

### DIFF
--- a/examples/transit-gateway-intra-region-peering/README.md
+++ b/examples/transit-gateway-intra-region-peering/README.md
@@ -1,0 +1,20 @@
+# EC2 Transit Gateway intra-region Peering
+
+This example demonstrates how to create two Transit Gateways in one AWS account and *same* region, attach a VPC each, and then create a Peering Attachment between the two Transit Gateways.
+
+See [more in the Transit Gateway intra-region Peering documentation](https://aws.amazon.com/it/blogs/networking-and-content-delivery/aws-transit-gateway-now-supports-intra-region-peering/).
+
+## Running this example
+
+Either `cp terraform.template.tfvars terraform.tfvars` and modify that new file accordingly or provide variables via CLI:
+
+```terrform
+terraform apply \
+	-var="aws_profile=aws-account" \
+	-var="aws_region=us-east-1" 
+```
+
+## Prerequisites
+
+- This example requires one AWS accounts within the same AWS Organizations Organization
+- Ensure Resource Access Manager is enabled in your organization. For more information, see the [Resource Access Manager User Guide](https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html).

--- a/examples/transit-gateway-intra-region-peering/README.md
+++ b/examples/transit-gateway-intra-region-peering/README.md
@@ -1,6 +1,6 @@
 # EC2 Transit Gateway intra-region Peering
 
-This example demonstrates how to create two Transit Gateways in one AWS account and *same* region, attach a VPC each, and then create a Peering Attachment between the two Transit Gateways.
+This example demonstrates how to create two Transit Gateways in one AWS account and the same region, attach a VPC each, and then create a Peering Attachment between the two Transit Gateways.
 
 See [more in the Transit Gateway intra-region Peering documentation](https://aws.amazon.com/it/blogs/networking-and-content-delivery/aws-transit-gateway-now-supports-intra-region-peering/).
 

--- a/examples/transit-gateway-intra-region-peering/main.tf
+++ b/examples/transit-gateway-intra-region-peering/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_version = ">= 0.14.9"
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+resource "aws_vpc" "example_vpc_1" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-example-vpc-1"
+  }
+}
+
+resource "aws_subnet" "example_subnet_1" {
+  cidr_block = "10.1.0.0/24"
+  vpc_id     = aws_vpc.example_vpc_1.id
+
+  tags = {
+    Name = "terraform-example-subnet-1"
+  }
+}
+
+resource "aws_vpc" "example_vpc_2" {
+  cidr_block = "10.2.0.0/16"
+
+  tags = {
+    Name = "terraform-example-vpc-2"
+  }
+}
+
+resource "aws_subnet" "example_subnet_2" {
+  cidr_block = "10.2.0.0/24"
+  vpc_id     = aws_vpc.example_vpc_2.id
+
+  tags = {
+    Name = "terraform-example-subnet-2"
+  }
+}
+
+# Create the first Transit Gateway.
+resource "aws_ec2_transit_gateway" "example_tgw_1" {
+  tags = {
+    Name = "terraform-example-tgw-1"
+  }
+}
+
+# Attach the first VPC to the first Transit Gateway.
+resource "aws_ec2_transit_gateway_vpc_attachment" "example_vpc_1_attachment" {
+  subnet_ids         = [aws_subnet.example_subnet_1.id]
+  transit_gateway_id = aws_ec2_transit_gateway.example_tgw_1.id
+  vpc_id             = aws_vpc.example_vpc_1.id
+
+  tags = {
+    Name = "terraform-example-vpc-attach-1"
+  }
+}
+
+# Create the second Transit Gateway in the same region.
+resource "aws_ec2_transit_gateway" "example_tgw_2" {
+  tags = {
+    Name = "terraform-example-tgw-2"
+  }
+}
+
+# Attach the second VPC to the second Transit Gateway.
+resource "aws_ec2_transit_gateway_vpc_attachment" "example_vpc_2_attachment" {
+  subnet_ids         = [aws_subnet.example_subnet_2.id]
+  transit_gateway_id = aws_ec2_transit_gateway.example_tgw_2.id
+  vpc_id             = aws_vpc.example_vpc_2.id
+
+  tags = {
+    Name = "terraform-example-vpc-attach-2"
+  }
+}
+
+# Create the intra-region Peering Attachment from Gateway 1 to Gateway 2.
+# Actually, this will create two peerings: one for Gateway 1 (Creator) 
+# and one for Gateway 2 (Acceptor).
+resource "aws_ec2_transit_gateway_peering_attachment" "example_source_peering" {
+  peer_region             = var.aws_region
+  transit_gateway_id      = aws_ec2_transit_gateway.example_tgw_1.id
+  peer_transit_gateway_id = aws_ec2_transit_gateway.example_tgw_2.id
+  tags = {
+    Name = "terraform-example-tgw-peering"
+    Side = "Creator"
+  }
+}
+
+# Transit Gateway 2's peering request needs to be accepted. 
+# So, we fetch the Peering Attachment that is created for the Gateway 2.
+data "aws_ec2_transit_gateway_peering_attachment" "example_acceptor_peering_data" {
+  depends_on = [aws_ec2_transit_gateway_peering_attachment.example_source_peering]
+  filter {
+    name   = "transit-gateway-id"
+    values = [aws_ec2_transit_gateway.example_tgw_2.id]
+  }
+}
+
+# Accept the Attachment Peering request.
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "example_accpeter" {
+  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.example_acceptor_peering_data.id
+  tags = {
+    Name = "terraform-example-tgw-peering-accepter"
+    Side = "Acceptor"
+  }
+}

--- a/examples/transit-gateway-intra-region-peering/main.tf
+++ b/examples/transit-gateway-intra-region-peering/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.9"
+  required_version = ">= 0.12"
 }
 
 provider "aws" {

--- a/examples/transit-gateway-intra-region-peering/main.tf
+++ b/examples/transit-gateway-intra-region-peering/main.tf
@@ -78,7 +78,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "example_vpc_2_attachment" {
 }
 
 # Create the intra-region Peering Attachment from Gateway 1 to Gateway 2.
-# Actually, this will create two peerings: one for Gateway 1 (Creator) 
+# Actually, this will create two peerings: one for Gateway 1 (Creator)
 # and one for Gateway 2 (Acceptor).
 resource "aws_ec2_transit_gateway_peering_attachment" "example_source_peering" {
   peer_region             = var.aws_region
@@ -90,9 +90,9 @@ resource "aws_ec2_transit_gateway_peering_attachment" "example_source_peering" {
   }
 }
 
-# Transit Gateway 2's peering request needs to be accepted. 
+# Transit Gateway 2's peering request needs to be accepted.
 # So, we fetch the Peering Attachment that is created for the Gateway 2.
-data "aws_ec2_transit_gateway_peering_attachment" "example_acceptor_peering_data" {
+data "aws_ec2_transit_gateway_peering_attachment" "example_accepter_peering_data" {
   depends_on = [aws_ec2_transit_gateway_peering_attachment.example_source_peering]
   filter {
     name   = "transit-gateway-id"
@@ -101,8 +101,8 @@ data "aws_ec2_transit_gateway_peering_attachment" "example_acceptor_peering_data
 }
 
 # Accept the Attachment Peering request.
-resource "aws_ec2_transit_gateway_peering_attachment_accepter" "example_accpeter" {
-  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.example_acceptor_peering_data.id
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "example_accepter" {
+  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.example_accepter_peering_data.id
   tags = {
     Name = "terraform-example-tgw-peering-accepter"
     Side = "Acceptor"

--- a/examples/transit-gateway-intra-region-peering/terraform.template.tfvars
+++ b/examples/transit-gateway-intra-region-peering/terraform.template.tfvars
@@ -1,0 +1,5 @@
+# AWS Profile (type `aws configure`)
+aws_profile = "default"
+
+# AWS Region 
+aws_region = "us-east-1"

--- a/examples/transit-gateway-intra-region-peering/variables.tf
+++ b/examples/transit-gateway-intra-region-peering/variables.tf
@@ -1,0 +1,3 @@
+variable "aws_profile" {}
+
+variable "aws_region" {}


### PR DESCRIPTION
Issue #23828 made me think that the intra-region Peering use-case
is not straight forward. Operators might assume they need to
configure the Acceptor to the Peering Attachment that Terraform creates.
In fact, AWS creates two Peering Attachment resources, one for the
Creator side and one for the Acceptor side. So, the a Data Source
is needed to find the second Acceptor side's attachment and then
use it to configure the Acceptor resource.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23828

Output from acceptance testing: not needed as it's a new example config and not a code change.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

