### PR TITLE
r/fsx_ontap_file_system - Support updating `storage_capacity`, `throughput_capacity`, `disk_iops_configuration`

### DIFF
--- a/.changelog/24002.txt
+++ b/.changelog/24002.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_fsx_ontap_file_system: Support updating `storage_capacity`, `thorughput_capacity`, and `disk_iops_configuration`.
+resource/aws_fsx_ontap_file_system: Support updating `storage_capacity`, `throughput_capacity`, and `disk_iops_configuration`.
 ```

--- a/.changelog/24002.txt
+++ b/.changelog/24002.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_ontap_file_system: Support updating `storage_capacity` and `thorughput_capacity`.
+```

--- a/.changelog/24002.txt
+++ b/.changelog/24002.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_fsx_ontap_file_system: Support updating `storage_capacity` and `thorughput_capacity`.
+resource/aws_fsx_ontap_file_system: Support updating `storage_capacity`, `thorughput_capacity`, and `disk_iops_configuration`.
 ```

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -414,6 +414,10 @@ func resourceOntapFileSystemUpdate(d *schema.ResourceData, meta interface{}) err
 			input.OntapConfiguration.ThroughputCapacity = aws.Int64(int64(d.Get("throughput_capacity").(int)))
 		}
 
+		if d.HasChange("disk_iops_configuration") {
+			input.OntapConfiguration.DiskIopsConfiguration = expandFsxOntapFileDiskIopsConfiguration(d.Get("disk_iops_configuration").([]interface{}))
+		}
+
 		_, err := conn.UpdateFileSystem(input)
 
 		if err != nil {

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -183,7 +183,6 @@ func ResourceOntapFileSystem() *schema.Resource {
 			"storage_capacity": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1024, 192*1024),
 			},
 			"storage_type": {
@@ -206,8 +205,7 @@ func ResourceOntapFileSystem() *schema.Resource {
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{128, 512, 1024, 2048}),
+				ValidateFunc: validation.IntInSlice([]int{128, 256, 512, 1024, 2048}),
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,
@@ -392,6 +390,10 @@ func resourceOntapFileSystemUpdate(d *schema.ResourceData, meta interface{}) err
 			OntapConfiguration: &fsx.UpdateFileSystemOntapConfiguration{},
 		}
 
+		if d.HasChange("storage_capacity") {
+			input.StorageCapacity = aws.Int64(int64(d.Get("storage_capacity").(int)))
+		}
+
 		if d.HasChange("automatic_backup_retention_days") {
 			input.OntapConfiguration.AutomaticBackupRetentionDays = aws.Int64(int64(d.Get("automatic_backup_retention_days").(int)))
 		}
@@ -406,6 +408,10 @@ func resourceOntapFileSystemUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if d.HasChange("weekly_maintenance_start_time") {
 			input.OntapConfiguration.WeeklyMaintenanceStartTime = aws.String(d.Get("weekly_maintenance_start_time").(string))
+		}
+
+		if d.HasChange("throughput_capacity") {
+			input.OntapConfiguration.ThroughputCapacity = aws.Int64(int64(d.Get("throughput_capacity").(int)))
 		}
 
 		_, err := conn.UpdateFileSystem(input)

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -427,6 +427,10 @@ func resourceOntapFileSystemUpdate(d *schema.ResourceData, meta interface{}) err
 		if _, err := waitFileSystemUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("error waiting for FSx ONTAP File System (%s) update: %w", d.Id(), err)
 		}
+
+		if _, err := waitAdministrativeActionCompleted(conn, d.Id(), fsx.AdministrativeActionTypeFileSystemUpdate, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error waiting for FSx ONTAP File System (%s) update: %w", d.Id(), err)
+		}
 	}
 
 	return resourceOntapFileSystemRead(d, meta)

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -446,7 +446,7 @@ func TestAccFSxOntapFileSystem_dailyAutomaticBackupStartTime(t *testing.T) {
 }
 
 func TestAccFSxOntapFileSystem_throughputCapacity(t *testing.T) {
-	var filesystem fsx.FileSystem
+	var filesystem1, filesystem2 fsx.FileSystem
 	resourceName := "aws_fsx_ontap_file_system.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -459,7 +459,7 @@ func TestAccFSxOntapFileSystem_throughputCapacity(t *testing.T) {
 			{
 				Config: testAccOntapFileSystemBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "128"),
 				),
 			},
@@ -472,7 +472,8 @@ func TestAccFSxOntapFileSystem_throughputCapacity(t *testing.T) {
 			{
 				Config: testAccOntapFileSystemThroughputCapacityConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem2),
+					testAccCheckFsxOntapFileSystemNotRecreated(&filesystem1, &filesystem2),
 					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "256"),
 				),
 			},
@@ -481,7 +482,7 @@ func TestAccFSxOntapFileSystem_throughputCapacity(t *testing.T) {
 }
 
 func TestAccFSxOntapFileSystem_storageCapacity(t *testing.T) {
-	var filesystem fsx.FileSystem
+	var filesystem1, filesystem2 fsx.FileSystem
 	resourceName := "aws_fsx_ontap_file_system.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -494,7 +495,7 @@ func TestAccFSxOntapFileSystem_storageCapacity(t *testing.T) {
 			{
 				Config: testAccOntapFileSystemBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "1024"),
 				),
 			},
@@ -507,7 +508,8 @@ func TestAccFSxOntapFileSystem_storageCapacity(t *testing.T) {
 			{
 				Config: testAccOntapFileSystemStorageCapacityConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem2),
+					testAccCheckFsxOntapFileSystemNotRecreated(&filesystem1, &filesystem2),
 					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "2048"),
 				),
 			},

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -148,7 +148,7 @@ func TestAccFSxOntapFileSystem_diskIops(t *testing.T) {
 		CheckDestroy: testAccCheckFsxOntapFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOntapFileSystemDiskIopsConfigurationConfig(rName),
+				Config: testAccOntapFileSystemDiskIopsConfigurationConfig(rName, 3072),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
 					resource.TestCheckResourceAttr(resourceName, "disk_iops_configuration.#", "1"),
@@ -161,6 +161,15 @@ func TestAccFSxOntapFileSystem_diskIops(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+			{
+				Config: testAccOntapFileSystemDiskIopsConfigurationConfig(rName, 4000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "disk_iops_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disk_iops_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "disk_iops_configuration.0.iops", "4000"),
+				),
 			},
 		},
 	})
@@ -661,7 +670,7 @@ resource "aws_fsx_ontap_file_system" "test" {
 `, rName))
 }
 
-func testAccOntapFileSystemDiskIopsConfigurationConfig(rName string) string {
+func testAccOntapFileSystemDiskIopsConfigurationConfig(rName string, iops int) string {
 	return acctest.ConfigCompose(testAccOntapFileSystemBaseConfig(rName), fmt.Sprintf(`
 resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
@@ -672,14 +681,14 @@ resource "aws_fsx_ontap_file_system" "test" {
 
   disk_iops_configuration {
     mode = "USER_PROVISIONED"
-    iops = 3072
+    iops = %[2]d
   }
 
   tags = {
     Name = %[1]q
   }
 }
-`, rName))
+`, rName, iops))
 }
 
 func testAccOntapFileSystemRouteTableConfig(rName string) string {

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -470,10 +470,45 @@ func TestAccFSxOntapFileSystem_throughputCapacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"security_group_ids"},
 			},
 			{
-				Config: testAccOntapFileSystemBasicConfig(rName),
+				Config: testAccOntapFileSystemThroughputCapacityConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
 					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "256"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFSxOntapFileSystem_storageCapacity(t *testing.T) {
+	var filesystem fsx.FileSystem
+	resourceName := "aws_fsx_ontap_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, fsx.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFsxOntapFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOntapFileSystemBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "1024"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+			{
+				Config: testAccOntapFileSystemStorageCapacityConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxOntapFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "2048"),
 				),
 			},
 		},
@@ -900,6 +935,18 @@ resource "aws_fsx_ontap_file_system" "test" {
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
   throughput_capacity = 256
+  preferred_subnet_id = aws_subnet.test1.id
+}
+`)
+}
+
+func testAccOntapFileSystemStorageCapacityConfig(rName string) string {
+	return acctest.ConfigCompose(testAccOntapFileSystemBaseConfig(rName), `
+resource "aws_fsx_ontap_file_system" "test" {
+  storage_capacity    = 2048
+  subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
+  deployment_type     = "MULTI_AZ_1"
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 }
 `)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23983
Closes #23982
Closes #23861

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccFSxOntapFileSystem_ PKG=fsx

--- PASS: TestAccFSxOntapFileSystem_endpointIPAddressRange (2030.71s)
--- PASS: TestAccFSxOntapFileSystem_basic (2051.03s)
--- PASS: TestAccFSxOntapFileSystem_weeklyMaintenanceStartTime (2109.52s)
--- PASS: TestAccFSxOntapFileSystem_fsxAdminPassword (2173.09s)
--- PASS: TestAccFSxOntapFileSystem_disappears (2212.25s)
--- PASS: TestAccFSxOntapFileSystem_dailyAutomaticBackupStartTime (2234.94s)
--- PASS: TestAccFSxOntapFileSystem_storageCapacity (2235.10s)
--- PASS: TestAccFSxOntapFileSystem_routeTableIDs (2235.11s)
--- PASS: TestAccFSxOntapFileSystem_automaticBackupRetentionDays (2313.13s)
--- PASS: TestAccFSxOntapFileSystem_tags (2439.78s)
--- PASS: TestAccFSxOntapFileSystem_kmsKeyID (2477.77s)
--- PASS: TestAccFSxOntapFileSystem_diskIops (2174.13s)
--- PASS: TestAccFSxOntapFileSystem_throughputCapacity (3168.08s)
```
