### PR TITLE
f/aws_ssm_maintenance_windows: add new datasource

### DIFF
--- a/.changelog/24011.txt
+++ b/.changelog/24011.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ssm_maintenance_windows
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -827,11 +827,12 @@ func Provider() *schema.Provider {
 
 			"aws_sqs_queue": sqs.DataSourceQueue(),
 
-			"aws_ssm_document":           ssm.DataSourceDocument(),
-			"aws_ssm_instances":          ssm.DataSourceInstances(),
-			"aws_ssm_parameter":          ssm.DataSourceParameter(),
-			"aws_ssm_parameters_by_path": ssm.DataSourceParametersByPath(),
-			"aws_ssm_patch_baseline":     ssm.DataSourcePatchBaseline(),
+			"aws_ssm_document":            ssm.DataSourceDocument(),
+			"aws_ssm_instances":           ssm.DataSourceInstances(),
+			"aws_ssm_maintenance_windows": ssm.DataSourceMaintenanceWindows(),
+			"aws_ssm_parameter":           ssm.DataSourceParameter(),
+			"aws_ssm_parameters_by_path":  ssm.DataSourceParametersByPath(),
+			"aws_ssm_patch_baseline":      ssm.DataSourcePatchBaseline(),
 
 			"aws_ssoadmin_instances":      ssoadmin.DataSourceInstances(),
 			"aws_ssoadmin_permission_set": ssoadmin.DataSourcePermissionSet(),

--- a/internal/service/ssm/maintenance_windows_data_source.go
+++ b/internal/service/ssm/maintenance_windows_data_source.go
@@ -1,0 +1,129 @@
+package ssm
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+)
+
+func DataSourceMaintenanceWindows() *schema.Resource {
+	return &schema.Resource{
+		Read: dataMaintenanceWindowsRead,
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataMaintenanceWindowsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSMConn
+
+	input := &ssm.DescribeMaintenanceWindowsInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = expandMaintenanceWindowFilters(v.(*schema.Set).List())
+	}
+
+	var results []*ssm.MaintenanceWindowIdentity
+
+	err := conn.DescribeMaintenanceWindowsPages(input, func(page *ssm.DescribeMaintenanceWindowsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, windowIdentities := range page.WindowIdentities {
+			if windowIdentities == nil {
+				continue
+			}
+
+			results = append(results, windowIdentities)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading SSM maintenance windows: %w", err)
+	}
+
+	var windowIDs []string
+
+	for _, r := range results {
+		windowIDs = append(windowIDs, aws.StringValue(r.WindowId))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("ids", windowIDs)
+
+	return nil
+}
+
+func expandMaintenanceWindowFilters(tfList []interface{}) []*ssm.MaintenanceWindowFilter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*ssm.MaintenanceWindowFilter
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandMaintenanceWindowFilter(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandMaintenanceWindowFilter(tfMap map[string]interface{}) *ssm.MaintenanceWindowFilter {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &ssm.MaintenanceWindowFilter{}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		apiObject.Key = aws.String(v)
+	}
+
+	if v, ok := tfMap["values"].([]interface{}); ok && len(v) > 0 {
+		apiObject.Values = flex.ExpandStringList(v)
+	}
+
+	return apiObject
+}

--- a/internal/service/ssm/maintenance_windows_data_source.go
+++ b/internal/service/ssm/maintenance_windows_data_source.go
@@ -33,7 +33,7 @@ func DataSourceMaintenanceWindows() *schema.Resource {
 				},
 			},
 			"ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -69,7 +69,7 @@ func dataMaintenanceWindowsRead(d *schema.ResourceData, meta interface{}) error 
 	})
 
 	if err != nil {
-		return fmt.Errorf("error reading SSM maintenance windows: %w", err)
+		return fmt.Errorf("error reading SSM Maintenance Windows: %w", err)
 	}
 
 	var windowIDs []string

--- a/internal/service/ssm/maintenance_windows_data_source_test.go
+++ b/internal/service/ssm/maintenance_windows_data_source_test.go
@@ -1,0 +1,107 @@
+package ssm_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ssm"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccSSMMaintenanceWindowsDataSource_filter(t *testing.T) {
+	dataSourceName := "data.aws_ssm_maintenance_windows.test"
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ssm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMaintenanceWindowsDataSourceConfig_filter_name(rName1, rName2, rName3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", "aws_ssm_maintenance_window.test2", "id"),
+				),
+			},
+			{
+				Config: testAccCheckMaintenanceWindowsDataSourceConfig_filter_enabled(rName1, rName2, rName3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", "aws_ssm_maintenance_window.test1", "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.1", "aws_ssm_maintenance_window.test2", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMaintenanceWindowsDataSourceConfig(rName1, rName2, rName3 string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test1" {
+  name     = "%[1]s"
+  duration = 1
+  cutoff   = 0
+  schedule = "cron(0 16 ? * TUE *)"
+}
+
+resource "aws_ssm_maintenance_window" "test2" {
+  name     = "%[2]s"
+  duration = 1
+  cutoff   = 0
+  schedule = "cron(0 16 ? * WED *)"
+}
+
+resource "aws_ssm_maintenance_window" "test3" {
+  name     = "%[3]s"
+  duration = 1
+  cutoff   = 0
+  schedule = "cron(0 16 ? * THU *)"
+
+  enabled  = false
+}
+`, rName1, rName2, rName3)
+}
+
+func testAccCheckMaintenanceWindowsDataSourceConfig_filter_name(rName1, rName2, rName3 string) string {
+	return acctest.ConfigCompose(
+		testAccCheckMaintenanceWindowsDataSourceConfig(rName1, rName2, rName3),
+		fmt.Sprintf(`
+data "aws_ssm_maintenance_windows" "test" {
+  filter {
+    name   = "Name"
+    values = ["%[1]s"]
+  }
+
+  depends_on = [
+    aws_ssm_maintenance_window.test1,
+    aws_ssm_maintenance_window.test2,
+    aws_ssm_maintenance_window.test3,
+  ]
+}
+`, rName2))
+}
+
+func testAccCheckMaintenanceWindowsDataSourceConfig_filter_enabled(rName1, rName2, rName3 string) string {
+	return acctest.ConfigCompose(
+		testAccCheckMaintenanceWindowsDataSourceConfig(rName1, rName2, rName3),
+		`
+data "aws_ssm_maintenance_windows" "test" {
+  filter {
+    name   = "Enabled"
+    values = ["true"]
+  }
+
+  depends_on = [
+    aws_ssm_maintenance_window.test1,
+    aws_ssm_maintenance_window.test2,
+    aws_ssm_maintenance_window.test3,
+  ]
+}
+`)
+}

--- a/internal/service/ssm/maintenance_windows_data_source_test.go
+++ b/internal/service/ssm/maintenance_windows_data_source_test.go
@@ -33,8 +33,6 @@ func TestAccSSMMaintenanceWindowsDataSource_filter(t *testing.T) {
 				Config: testAccCheckMaintenanceWindowsDataSourceConfig_filter_enabled(rName1, rName2, rName3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", "aws_ssm_maintenance_window.test1", "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "ids.1", "aws_ssm_maintenance_window.test2", "id"),
 				),
 			},
 		},

--- a/internal/service/ssm/maintenance_windows_data_source_test.go
+++ b/internal/service/ssm/maintenance_windows_data_source_test.go
@@ -32,7 +32,7 @@ func TestAccSSMMaintenanceWindowsDataSource_filter(t *testing.T) {
 			{
 				Config: testAccCheckMaintenanceWindowsDataSourceConfig_filter_enabled(rName1, rName2, rName3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ids.#", "1"),
 				),
 			},
 		},

--- a/internal/service/ssm/maintenance_windows_data_source_test.go
+++ b/internal/service/ssm/maintenance_windows_data_source_test.go
@@ -63,7 +63,7 @@ resource "aws_ssm_maintenance_window" "test3" {
   cutoff   = 0
   schedule = "cron(0 16 ? * THU *)"
 
-  enabled  = false
+  enabled = false
 }
 `, rName1, rName2, rName3)
 }

--- a/website/docs/d/ssm_maintenance_windows.html.markdown
+++ b/website/docs/d/ssm_maintenance_windows.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "SSM"
+layout: "aws"
+page_title: "AWS: aws_ssm_maintenance_windows"
+description: |-
+  Get information on SSM maintenance windows.
+---
+
+# Data Source: ssm_maintenance_windows
+
+Use this data source to get the window IDs of SSM maintenance windows.
+
+## Example Usage
+
+```terraform
+data "aws_ssm_maintenance_windows" "example" {
+  filter {
+    name   = "Enabled"
+    values = ["true"]
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [SSM DescribeMaintenanceWindows API Reference](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeMaintenanceWindows.html#API_DescribeMaintenanceWindows_RequestSyntax).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `ids` - Set of window IDs of the matched SSM maintenance windows.

--- a/website/docs/d/ssm_maintenance_windows.html.markdown
+++ b/website/docs/d/ssm_maintenance_windows.html.markdown
@@ -34,4 +34,4 @@ The following arguments are supported by the `filter` configuration block:
 
 ## Attributes Reference
 
-* `ids` - Set of window IDs of the matched SSM maintenance windows.
+* `ids` - List of window IDs of the matched SSM maintenance windows.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds a new datasource for fetching a list of maintenance window IDs based on the available filters (Name and Enabled) provided by the API.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSSMMaintenanceWindowsDataSource_filter PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMMaintenanceWindowsDataSource_filter'  -timeout 180m
=== RUN   TestAccSSMMaintenanceWindowsDataSource_filter
=== PAUSE TestAccSSMMaintenanceWindowsDataSource_filter
=== CONT  TestAccSSMMaintenanceWindowsDataSource_filter
--- PASS: TestAccSSMMaintenanceWindowsDataSource_filter (26.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	28.698s
...
```
