### PR TITLE
r/aws_route: Call SetId before WaitRouteReady

### DIFF
--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_route: Ensure that resource ID is set in case of wait-for-creation time out
 ```
+
+```release-note:enhancement
+resource/aws_route: Add `core_network_arn` argument
+```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -5,3 +5,7 @@ resource/aws_route: Ensure that resource ID is set in case of wait-for-creation 
 ```release-note:enhancement
 resource/aws_route: Add `core_network_arn` argument
 ```
+
+```release-note:enhancement
+data-source/aws_route: Add `core_network_arn` argument
+```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route: Fix state leakage in case of wait-for-creation times out
+```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -21,3 +21,7 @@ data-source/aws_route_table: Add 'routes.core_network_arn' attribute'
 ```release-note:enhancement
 resource/aws_default_route_table: Add `core_network_arn` argument to the `route` configuration block
 ```
+
+```release-note:enhancement
+resource/aws_vpn_connection: Add `core_network_arn` and `core_network_attachment_arn` attributes
+```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -9,3 +9,7 @@ resource/aws_route: Add `core_network_arn` argument
 ```release-note:enhancement
 data-source/aws_route: Add `core_network_arn` argument
 ```
+
+```release-note:enhancement
+resource/aws_route_table: Add `core_network_arn` argument to the `route` configuration block
+```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_route: Fix state leakage in case of wait-for-creation times out
+resource/aws_route: Ensure that resource ID is set in case of wait-for-creation time out
 ```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -13,3 +13,7 @@ data-source/aws_route: Add `core_network_arn` argument
 ```release-note:enhancement
 resource/aws_route_table: Add `core_network_arn` argument to the `route` configuration block
 ```
+
+```release-note:enhancement
+data-source/aws_route_table: Add 'routes.core_network_arn' attribute'
+```

--- a/.changelog/24024.txt
+++ b/.changelog/24024.txt
@@ -17,3 +17,7 @@ resource/aws_route_table: Add `core_network_arn` argument to the `route` configu
 ```release-note:enhancement
 data-source/aws_route_table: Add 'routes.core_network_arn' attribute'
 ```
+
+```release-note:enhancement
+resource/aws_default_route_table: Add `core_network_arn` argument to the `route` configuration block
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 4.8.0 (Unreleased)
 
+BUG FIXES:
+
+* resource/aws_cloudformation_stack_set: Consider `QUEUED` a valid pending state for resource creation ([#22160](https://github.com/hashicorp/terraform-provider-aws/issues/22160))
+* resource/aws_dynamodb_table_item: Allow `item` names to still succeed if they include non-letters ([#14075](https://github.com/hashicorp/terraform-provider-aws/issues/14075))
+
+## 4.8.0 (Unreleased)
+
 ENHANCEMENTS:
 
 * data-source/aws_eips: Set `public_ips` for VPC as well as EC2 Classic ([#23859](https://github.com/hashicorp/terraform-provider-aws/issues/23859))

--- a/internal/service/ec2/default_route_table.go
+++ b/internal/service/ec2/default_route_table.go
@@ -88,6 +88,10 @@ func ResourceDefaultRouteTable() *schema.Resource {
 						// These target attributes are a subset of the aws_route_table resource's target attributes
 						// as there are some targets that are not allowed in the default route table for a VPC.
 						//
+						"core_network_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"egress_only_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,

--- a/internal/service/ec2/route.go
+++ b/internal/service/ec2/route.go
@@ -295,7 +295,7 @@ func resourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("carrier_gateway_id", route.CarrierGatewayId)
-	d.Set("nat_gatcore_network_arneway_id", route.CoreNetworkArn)
+	d.Set("core_network_arn", route.CoreNetworkArn)
 	d.Set("destination_cidr_block", route.DestinationCidrBlock)
 	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
 	d.Set("destination_prefix_list_id", route.DestinationPrefixListId)

--- a/internal/service/ec2/route.go
+++ b/internal/service/ec2/route.go
@@ -23,6 +23,7 @@ var routeValidDestinations = []string{
 
 var routeValidTargets = []string{
 	"carrier_gateway_id",
+	"core_network_arn",
 	"egress_only_gateway_id",
 	"gateway_id",
 	"instance_id",
@@ -90,6 +91,11 @@ func ResourceRoute() *schema.Resource {
 				Optional:      true,
 				ExactlyOneOf:  routeValidTargets,
 				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
+			},
+			"core_network_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
 			},
 			"egress_only_gateway_id": {
 				Type:          schema.TypeString,
@@ -203,6 +209,8 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	switch target := aws.String(target); targetAttributeKey {
 	case "carrier_gateway_id":
 		input.CarrierGatewayId = target
+	case "core_network_arn":
+		input.CoreNetworkArn = target
 	case "egress_only_gateway_id":
 		input.EgressOnlyInternetGatewayId = target
 	case "gateway_id":
@@ -287,6 +295,7 @@ func resourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("carrier_gateway_id", route.CarrierGatewayId)
+	d.Set("nat_gatcore_network_arneway_id", route.CoreNetworkArn)
 	d.Set("destination_cidr_block", route.DestinationCidrBlock)
 	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
 	d.Set("destination_prefix_list_id", route.DestinationPrefixListId)
@@ -351,6 +360,8 @@ func resourceRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	switch target := aws.String(target); targetAttributeKey {
 	case "carrier_gateway_id":
 		input.CarrierGatewayId = target
+	case "core_network_arn":
+		input.CoreNetworkArn = target
 	case "egress_only_gateway_id":
 		input.EgressOnlyInternetGatewayId = target
 	case "gateway_id":

--- a/internal/service/ec2/route.go
+++ b/internal/service/ec2/route.go
@@ -239,13 +239,13 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error creating Route in Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
 	}
 
+	d.SetId(RouteCreateID(routeTableID, destination))
+
 	_, err = WaitRouteReady(conn, routeFinder, routeTableID, destination, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return fmt.Errorf("error waiting for Route in Route Table (%s) with destination (%s) to become available: %w", routeTableID, destination, err)
 	}
-
-	d.SetId(RouteCreateID(routeTableID, destination))
 
 	return resourceRouteRead(d, meta)
 }

--- a/internal/service/ec2/route_data_source.go
+++ b/internal/service/ec2/route_data_source.go
@@ -33,7 +33,6 @@ func DataSourceRoute() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
 			"destination_prefix_list_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -44,6 +43,11 @@ func DataSourceRoute() *schema.Resource {
 			// Targets.
 			//
 			"carrier_gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"core_network_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -132,6 +136,10 @@ func dataSourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 			continue
 		}
 
+		if v, ok := d.GetOk("core_network_arn"); ok && aws.StringValue(r.CoreNetworkArn) != v.(string) {
+			continue
+		}
+
 		if v, ok := d.GetOk("egress_only_gateway_id"); ok && aws.StringValue(r.EgressOnlyInternetGatewayId) != v.(string) {
 			continue
 		}
@@ -186,6 +194,7 @@ func dataSourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("carrier_gateway_id", route.CarrierGatewayId)
+	d.Set("core_network_arn", route.CoreNetworkArn)
 	d.Set("destination_cidr_block", route.DestinationCidrBlock)
 	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
 	d.Set("destination_prefix_list_id", route.DestinationPrefixListId)

--- a/internal/service/ec2/route_table.go
+++ b/internal/service/ec2/route_table.go
@@ -757,7 +757,7 @@ func expandEc2ReplaceRouteInput(tfMap map[string]interface{}) *ec2.ReplaceRouteI
 	}
 
 	if v, ok := tfMap["core_network_arn"].(string); ok && v != "" {
-		apiObject.CarrierGatewayId = aws.String(v)
+		apiObject.CoreNetworkArn = aws.String(v)
 	}
 
 	if v, ok := tfMap["egress_only_gateway_id"].(string); ok && v != "" {

--- a/internal/service/ec2/route_table.go
+++ b/internal/service/ec2/route_table.go
@@ -27,6 +27,7 @@ var routeTableValidDestinations = []string{
 
 var routeTableValidTargets = []string{
 	"carrier_gateway_id",
+	"core_network_arn",
 	"egress_only_gateway_id",
 	"gateway_id",
 	"instance_id",
@@ -102,6 +103,10 @@ func ResourceRouteTable() *schema.Resource {
 						// Targets.
 						//
 						"carrier_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"core_network_arn": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -429,6 +434,10 @@ func resourceRouteTableHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
+	if v, ok := m["core_network_arn"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
 	if v, ok := m["egress_only_gateway_id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
@@ -681,6 +690,10 @@ func expandEc2CreateRouteInput(tfMap map[string]interface{}) *ec2.CreateRouteInp
 		apiObject.CarrierGatewayId = aws.String(v)
 	}
 
+	if v, ok := tfMap["core_network_arn"].(string); ok && v != "" {
+		apiObject.CoreNetworkArn = aws.String(v)
+	}
+
 	if v, ok := tfMap["egress_only_gateway_id"].(string); ok && v != "" {
 		apiObject.EgressOnlyInternetGatewayId = aws.String(v)
 	}
@@ -740,6 +753,10 @@ func expandEc2ReplaceRouteInput(tfMap map[string]interface{}) *ec2.ReplaceRouteI
 	}
 
 	if v, ok := tfMap["carrier_gateway_id"].(string); ok && v != "" {
+		apiObject.CarrierGatewayId = aws.String(v)
+	}
+
+	if v, ok := tfMap["core_network_arn"].(string); ok && v != "" {
 		apiObject.CarrierGatewayId = aws.String(v)
 	}
 
@@ -803,6 +820,10 @@ func flattenEc2Route(apiObject *ec2.Route) map[string]interface{} {
 
 	if v := apiObject.CarrierGatewayId; v != nil {
 		tfMap["carrier_gateway_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.CoreNetworkArn; v != nil {
+		tfMap["core_network_arn"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.EgressOnlyInternetGatewayId; v != nil {

--- a/internal/service/ec2/route_table_data_source.go
+++ b/internal/service/ec2/route_table_data_source.go
@@ -71,6 +71,11 @@ func DataSourceRouteTable() *schema.Resource {
 							Computed: true,
 						},
 
+						"core_network_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"egress_only_gateway_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -284,6 +289,9 @@ func dataSourceRoutesRead(conn *ec2.EC2, ec2Routes []*ec2.Route) []map[string]in
 		}
 		if r.CarrierGatewayId != nil {
 			m["carrier_gateway_id"] = *r.CarrierGatewayId
+		}
+		if r.CoreNetworkArn != nil {
+			m["core_network_arn"] = *r.CoreNetworkArn
 		}
 		if r.EgressOnlyInternetGatewayId != nil {
 			m["egress_only_gateway_id"] = *r.EgressOnlyInternetGatewayId

--- a/internal/service/ec2/route_test.go
+++ b/internal/service/ec2/route_test.go
@@ -38,6 +38,7 @@ func TestAccEC2Route_basic(t *testing.T) {
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -132,6 +133,7 @@ func TestAccEC2Route_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -182,6 +184,7 @@ func TestAccEC2Route_ipv6ToInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -227,6 +230,7 @@ func TestAccEC2Route_ipv6ToInstance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -272,6 +276,7 @@ func TestAccEC2Route_IPv6ToNetworkInterface_unattached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -317,6 +322,7 @@ func TestAccEC2Route_ipv6ToVPCPeeringConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -362,6 +368,7 @@ func TestAccEC2Route_ipv6ToVPNGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -407,6 +414,7 @@ func TestAccEC2Route_ipv4ToVPNGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -452,6 +460,7 @@ func TestAccEC2Route_ipv4ToInstance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -497,6 +506,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_unattached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -543,6 +553,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_attached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -590,6 +601,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -612,6 +624,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -657,6 +670,7 @@ func TestAccEC2Route_ipv4ToVPCPeeringConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -702,6 +716,7 @@ func TestAccEC2Route_ipv4ToNatGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -747,6 +762,7 @@ func TestAccEC2Route_ipv6ToNatGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -827,6 +843,7 @@ func TestAccEC2Route_ipv4ToTransitGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -876,6 +893,7 @@ func TestAccEC2Route_ipv6ToTransitGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -921,6 +939,7 @@ func TestAccEC2Route_ipv4ToCarrierGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "carrier_gateway_id", cgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -966,6 +985,7 @@ func TestAccEC2Route_ipv4ToLocalGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1011,6 +1031,7 @@ func TestAccEC2Route_ipv6ToLocalGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1106,6 +1127,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1128,6 +1150,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1150,6 +1173,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1172,6 +1196,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1194,6 +1219,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1217,6 +1243,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1239,6 +1266,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1261,6 +1289,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1315,6 +1344,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1337,6 +1367,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1359,6 +1390,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1381,6 +1413,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1403,6 +1436,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1425,6 +1459,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1474,6 +1509,7 @@ func TestAccEC2Route_ipv4ToVPCEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -1559,6 +1595,7 @@ func TestAccEC2Route_prefixListToInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1604,6 +1641,7 @@ func TestAccEC2Route_prefixListToVPNGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1649,6 +1687,7 @@ func TestAccEC2Route_prefixListToInstance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1694,6 +1733,7 @@ func TestAccEC2Route_PrefixListToNetworkInterface_unattached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1740,6 +1780,7 @@ func TestAccEC2Route_PrefixListToNetworkInterface_attached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1785,6 +1826,7 @@ func TestAccEC2Route_prefixListToVPCPeeringConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1830,6 +1872,7 @@ func TestAccEC2Route_prefixListToNatGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1879,6 +1922,7 @@ func TestAccEC2Route_prefixListToTransitGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1928,6 +1972,7 @@ func TestAccEC2Route_prefixListToCarrierGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "carrier_gateway_id", cgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -1977,6 +2022,7 @@ func TestAccEC2Route_prefixListToLocalGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
@@ -2022,6 +2068,7 @@ func TestAccEC2Route_prefixListToEgressOnlyInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),

--- a/internal/service/ec2/vpn_connection.go
+++ b/internal/service/ec2/vpn_connection.go
@@ -37,6 +37,14 @@ func ResourceVPNConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"core_network_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"core_network_attachment_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"customer_gateway_configuration": {
 				Type:      schema.TypeString,
 				Sensitive: true,
@@ -633,6 +641,8 @@ func resourceVPNConnectionRead(d *schema.ResourceData, meta interface{}) error {
 		Resource:  fmt.Sprintf("vpn-connection/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)
+	d.Set("core_network_arn", vpnConnection.CoreNetworkArn)
+	d.Set("core_network_attachment_arn", vpnConnection.CoreNetworkAttachmentArn)
 	d.Set("customer_gateway_id", vpnConnection.CustomerGatewayId)
 	d.Set("type", vpnConnection.Type)
 	d.Set("vpn_gateway_id", vpnConnection.VpnGatewayId)

--- a/internal/service/ec2/vpn_connection_test.go
+++ b/internal/service/ec2/vpn_connection_test.go
@@ -163,6 +163,8 @@ func TestAccEC2VPNConnection_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpn-connection/vpn-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_attachment_arn", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_gateway_configuration"),
 					resource.TestCheckResourceAttr(resourceName, "enable_acceleration", "false"),
 					resource.TestCheckResourceAttr(resourceName, "local_ipv4_network_cidr", "0.0.0.0/0"),

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -44,6 +44,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `carrier_gateway_id` - (Optional) EC2 Carrier Gateway ID of the Route belonging to the Route Table.
+* `core_network_arn` - (Optional) Core network ARN of the Route belonging to the Route Table.
 * `destination_cidr_block` - (Optional) CIDR block of the Route belonging to the Route Table.
 * `destination_ipv6_cidr_block` - (Optional) IPv6 CIDR block of the Route belonging to the Route Table.
 * `destination_prefix_list_id` - (Optional) The ID of a [managed prefix list](ec2_managed_prefix_list.html) destination of the Route belonging to the Route Table.

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -74,6 +74,7 @@ For destinations:
 For targets:
 
 * `carrier_gateway_id` - ID of the Carrier Gateway.
+* `core_network_arn` - ARN of the core network.
 * `egress_only_gateway_id` - ID of the Egress Only Internet Gateway.
 * `gateway_id` - Internet Gateway ID.
 * `instance_id` - EC2 instance ID.

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -76,6 +76,7 @@ One of the following destination arguments must be supplied:
 
 One of the following target arguments must be supplied:
 
+* `core_network_arn` - (Optional) The Amazon Resource Name (ARN) of a core network.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -59,6 +59,7 @@ One of the following destination arguments must be supplied:
 One of the following target arguments must be supplied:
 
 * `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
+* `core_network_arn` - (Optional) The Amazon Resource Name (ARN) of a core network.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional, **Deprecated** use `network_interface_id` instead) Identifier of an EC2 instance.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -88,6 +88,7 @@ One of the following destination arguments must be supplied:
 One of the following target arguments must be supplied:
 
 * `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
+* `core_network_arn` - (Optional) The Amazon Resource Name (ARN) of a core network.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional, **Deprecated** use `network_interface_id` instead) Identifier of an EC2 instance.

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -127,6 +127,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the VPN Connection.
 * `id` - The amazon-assigned ID of the VPN connection.
+* `core_network_arn` - The ARN of the core network.
+* `core_network_attachment_arn` - The ARN of the core network attachment.
 * `customer_gateway_configuration` - The configuration information for the VPN connection's customer gateway (in the native XML format).
 * `customer_gateway_id` - The ID of the customer gateway to which the connection is attached.
 * `routes` - The static routes associated with the VPN connection. Detailed below.


### PR DESCRIPTION
### Issue:
When the route's wait-for-creation operation times out, its state is leaked as `d.SetId(...)` is called after the `WaitRouteReady(...)`. So, the next time the configuration is applied, the Terraform engine tries to create the same route again, getting duplication error from AWS.

### Fix:
Call `d.SetId(...)` before `WaitRouteReady(...)`.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes  #23827

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2Route_ PKG=ec2 ACCTEST_PARALLELISM=2 ACCTEST_TIMEOUT=300m

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2 -run='TestAccEC2Route_'  -timeout 300m
=== RUN   TestAccEC2Route_basic
=== PAUSE TestAccEC2Route_basic
=== RUN   TestAccEC2Route_disappears
=== PAUSE TestAccEC2Route_disappears
=== RUN   TestAccEC2Route_Disappears_routeTable
=== PAUSE TestAccEC2Route_Disappears_routeTable
=== RUN   TestAccEC2Route_ipv6ToEgressOnlyInternetGateway
=== PAUSE TestAccEC2Route_ipv6ToEgressOnlyInternetGateway
=== RUN   TestAccEC2Route_ipv6ToInternetGateway
=== PAUSE TestAccEC2Route_ipv6ToInternetGateway
=== RUN   TestAccEC2Route_ipv6ToInstance
=== PAUSE TestAccEC2Route_ipv6ToInstance
=== RUN   TestAccEC2Route_IPv6ToNetworkInterface_unattached
=== PAUSE TestAccEC2Route_IPv6ToNetworkInterface_unattached
=== RUN   TestAccEC2Route_ipv6ToVPCPeeringConnection
=== PAUSE TestAccEC2Route_ipv6ToVPCPeeringConnection
=== RUN   TestAccEC2Route_ipv6ToVPNGateway
=== PAUSE TestAccEC2Route_ipv6ToVPNGateway
=== RUN   TestAccEC2Route_ipv4ToVPNGateway
=== PAUSE TestAccEC2Route_ipv4ToVPNGateway
=== RUN   TestAccEC2Route_ipv4ToInstance
=== PAUSE TestAccEC2Route_ipv4ToInstance
=== RUN   TestAccEC2Route_IPv4ToNetworkInterface_unattached
=== PAUSE TestAccEC2Route_IPv4ToNetworkInterface_unattached
=== RUN   TestAccEC2Route_IPv4ToNetworkInterface_attached
=== PAUSE TestAccEC2Route_IPv4ToNetworkInterface_attached
=== RUN   TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments
=== PAUSE TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments
=== RUN   TestAccEC2Route_ipv4ToVPCPeeringConnection
=== PAUSE TestAccEC2Route_ipv4ToVPCPeeringConnection
=== RUN   TestAccEC2Route_ipv4ToNatGateway
=== PAUSE TestAccEC2Route_ipv4ToNatGateway
=== RUN   TestAccEC2Route_ipv6ToNatGateway
=== PAUSE TestAccEC2Route_ipv6ToNatGateway
=== RUN   TestAccEC2Route_doesNotCrashWithVPCEndpoint
=== PAUSE TestAccEC2Route_doesNotCrashWithVPCEndpoint
=== RUN   TestAccEC2Route_ipv4ToTransitGateway
=== PAUSE TestAccEC2Route_ipv4ToTransitGateway
=== RUN   TestAccEC2Route_ipv6ToTransitGateway
=== PAUSE TestAccEC2Route_ipv6ToTransitGateway
=== RUN   TestAccEC2Route_ipv4ToCarrierGateway
=== PAUSE TestAccEC2Route_ipv4ToCarrierGateway
=== RUN   TestAccEC2Route_ipv4ToLocalGateway
=== PAUSE TestAccEC2Route_ipv4ToLocalGateway
=== RUN   TestAccEC2Route_ipv6ToLocalGateway
=== PAUSE TestAccEC2Route_ipv6ToLocalGateway
=== RUN   TestAccEC2Route_conditionalCIDRBlock
=== PAUSE TestAccEC2Route_conditionalCIDRBlock
=== RUN   TestAccEC2Route_IPv4Update_target
=== PAUSE TestAccEC2Route_IPv4Update_target
=== RUN   TestAccEC2Route_IPv6Update_target
=== PAUSE TestAccEC2Route_IPv6Update_target
=== RUN   TestAccEC2Route_ipv4ToVPCEndpoint
=== PAUSE TestAccEC2Route_ipv4ToVPCEndpoint
=== RUN   TestAccEC2Route_localRoute
=== PAUSE TestAccEC2Route_localRoute
=== RUN   TestAccEC2Route_prefixListToInternetGateway
=== PAUSE TestAccEC2Route_prefixListToInternetGateway
=== RUN   TestAccEC2Route_prefixListToVPNGateway
=== PAUSE TestAccEC2Route_prefixListToVPNGateway
=== RUN   TestAccEC2Route_prefixListToInstance
=== PAUSE TestAccEC2Route_prefixListToInstance
=== RUN   TestAccEC2Route_PrefixListToNetworkInterface_unattached
=== PAUSE TestAccEC2Route_PrefixListToNetworkInterface_unattached
=== RUN   TestAccEC2Route_PrefixListToNetworkInterface_attached
=== PAUSE TestAccEC2Route_PrefixListToNetworkInterface_attached
=== RUN   TestAccEC2Route_prefixListToVPCPeeringConnection
=== PAUSE TestAccEC2Route_prefixListToVPCPeeringConnection
=== RUN   TestAccEC2Route_prefixListToNatGateway
=== PAUSE TestAccEC2Route_prefixListToNatGateway
=== RUN   TestAccEC2Route_prefixListToTransitGateway
=== PAUSE TestAccEC2Route_prefixListToTransitGateway
=== RUN   TestAccEC2Route_prefixListToCarrierGateway
=== PAUSE TestAccEC2Route_prefixListToCarrierGateway
=== RUN   TestAccEC2Route_prefixListToLocalGateway
=== PAUSE TestAccEC2Route_prefixListToLocalGateway
=== RUN   TestAccEC2Route_prefixListToEgressOnlyInternetGateway
=== PAUSE TestAccEC2Route_prefixListToEgressOnlyInternetGateway
=== CONT  TestAccEC2Route_basic
=== CONT  TestAccEC2Route_ipv4ToCarrierGateway
    carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccEC2Route_ipv4ToCarrierGateway (1.99s)
=== CONT  TestAccEC2Route_prefixListToInstance
--- PASS: TestAccEC2Route_basic (33.87s)
=== CONT  TestAccEC2Route_prefixListToEgressOnlyInternetGateway
--- PASS: TestAccEC2Route_prefixListToEgressOnlyInternetGateway (48.35s)
=== CONT  TestAccEC2Route_prefixListToLocalGateway
    acctest.go:1293: skipping since no Outposts found
--- SKIP: TestAccEC2Route_prefixListToLocalGateway (1.68s)
=== CONT  TestAccEC2Route_prefixListToCarrierGateway
    carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccEC2Route_prefixListToCarrierGateway (0.43s)
=== CONT  TestAccEC2Route_prefixListToTransitGateway
--- PASS: TestAccEC2Route_prefixListToInstance (120.54s)
=== CONT  TestAccEC2Route_prefixListToNatGateway
--- PASS: TestAccEC2Route_prefixListToNatGateway (211.02s)
=== CONT  TestAccEC2Route_prefixListToVPCPeeringConnection
--- PASS: TestAccEC2Route_prefixListToVPCPeeringConnection (36.26s)
=== CONT  TestAccEC2Route_PrefixListToNetworkInterface_attached
--- PASS: TestAccEC2Route_PrefixListToNetworkInterface_attached (130.43s)
=== CONT  TestAccEC2Route_PrefixListToNetworkInterface_unattached
--- PASS: TestAccEC2Route_prefixListToTransitGateway (417.66s)
=== CONT  TestAccEC2Route_ipv4ToInstance
--- PASS: TestAccEC2Route_PrefixListToNetworkInterface_unattached (40.69s)
=== CONT  TestAccEC2Route_ipv6ToTransitGateway
--- PASS: TestAccEC2Route_ipv4ToInstance (309.32s)
=== CONT  TestAccEC2Route_ipv4ToTransitGateway
--- PASS: TestAccEC2Route_ipv6ToTransitGateway (521.55s)
=== CONT  TestAccEC2Route_doesNotCrashWithVPCEndpoint
--- PASS: TestAccEC2Route_ipv4ToTransitGateway (364.33s)
=== CONT  TestAccEC2Route_ipv6ToNatGateway
--- PASS: TestAccEC2Route_doesNotCrashWithVPCEndpoint (130.58s)
=== CONT  TestAccEC2Route_ipv4ToNatGateway
--- PASS: TestAccEC2Route_ipv6ToNatGateway (212.96s)
=== CONT  TestAccEC2Route_ipv4ToVPCPeeringConnection
--- PASS: TestAccEC2Route_ipv4ToVPCPeeringConnection (29.68s)
=== CONT  TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments
--- PASS: TestAccEC2Route_ipv4ToNatGateway (265.18s)
=== CONT  TestAccEC2Route_IPv4ToNetworkInterface_attached
--- PASS: TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments (171.47s)
=== CONT  TestAccEC2Route_IPv4ToNetworkInterface_unattached
--- PASS: TestAccEC2Route_IPv4ToNetworkInterface_attached (146.81s)
=== CONT  TestAccEC2Route_ipv6ToInstance
--- PASS: TestAccEC2Route_IPv4ToNetworkInterface_unattached (32.67s)
=== CONT  TestAccEC2Route_ipv4ToVPNGateway
--- PASS: TestAccEC2Route_ipv4ToVPNGateway (70.56s)
=== CONT  TestAccEC2Route_ipv6ToVPNGateway
--- PASS: TestAccEC2Route_ipv6ToInstance (145.06s)
=== CONT  TestAccEC2Route_ipv6ToVPCPeeringConnection
--- PASS: TestAccEC2Route_ipv6ToVPNGateway (83.95s)
=== CONT  TestAccEC2Route_IPv6ToNetworkInterface_unattached
--- PASS: TestAccEC2Route_ipv6ToVPCPeeringConnection (41.92s)
=== CONT  TestAccEC2Route_ipv6ToEgressOnlyInternetGateway
--- PASS: TestAccEC2Route_IPv6ToNetworkInterface_unattached (42.87s)
=== CONT  TestAccEC2Route_ipv6ToInternetGateway
--- PASS: TestAccEC2Route_ipv6ToEgressOnlyInternetGateway (65.80s)
=== CONT  TestAccEC2Route_IPv6Update_target
--- PASS: TestAccEC2Route_ipv6ToInternetGateway (39.42s)
=== CONT  TestAccEC2Route_prefixListToVPNGateway
--- PASS: TestAccEC2Route_prefixListToVPNGateway (108.96s)
=== CONT  TestAccEC2Route_prefixListToInternetGateway
--- PASS: TestAccEC2Route_prefixListToInternetGateway (70.81s)
=== CONT  TestAccEC2Route_localRoute
--- PASS: TestAccEC2Route_localRoute (26.27s)
=== CONT  TestAccEC2Route_ipv4ToVPCEndpoint
--- PASS: TestAccEC2Route_IPv6Update_target (251.31s)
=== CONT  TestAccEC2Route_IPv4Update_target
--- PASS: TestAccEC2Route_ipv4ToVPCEndpoint (309.01s)
=== CONT  TestAccEC2Route_ipv6ToLocalGateway
    acctest.go:1293: skipping since no Outposts found
--- SKIP: TestAccEC2Route_ipv6ToLocalGateway (0.93s)
=== CONT  TestAccEC2Route_ipv4ToLocalGateway
    acctest.go:1293: skipping since no Outposts found
--- SKIP: TestAccEC2Route_ipv4ToLocalGateway (0.26s)
=== CONT  TestAccEC2Route_Disappears_routeTable
--- PASS: TestAccEC2Route_Disappears_routeTable (25.97s)
=== CONT  TestAccEC2Route_disappears
--- PASS: TestAccEC2Route_disappears (45.74s)
=== CONT  TestAccEC2Route_conditionalCIDRBlock
--- PASS: TestAccEC2Route_conditionalCIDRBlock (73.05s)
--- PASS: TestAccEC2Route_IPv4Update_target (688.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	2800.264s

```
