### PR TITLE
Fixing duplicate id with same RT and CIDR but different vpc when using for_each

### DIFF
--- a/internal/service/ec2/transit_gateway_route.go
+++ b/internal/service/ec2/transit_gateway_route.go
@@ -58,8 +58,9 @@ func resourceTransitGatewayRouteCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	destination := d.Get("destination_cidr_block").(string)
+	TransitGatewayAttachmentID := d.Get("transit_gateway_attachment_id").(string)
 	transitGatewayRouteTableID := d.Get("transit_gateway_route_table_id").(string)
-	id := TransitGatewayRouteCreateResourceID(transitGatewayRouteTableID, destination)
+	id := TransitGatewayRouteCreateResourceID(transitGatewayRouteTableID, destination, TransitGatewayAttachmentID)
 	input := &ec2.CreateTransitGatewayRouteInput{
 		Blackhole:                  aws.Bool(d.Get("blackhole").(bool)),
 		DestinationCidrBlock:       aws.String(destination),
@@ -153,8 +154,8 @@ func resourceTransitGatewayRouteDelete(d *schema.ResourceData, meta interface{})
 
 const transitGatewayRouteIDSeparator = "_"
 
-func TransitGatewayRouteCreateResourceID(transitGatewayRouteTableID, destination string) string {
-	parts := []string{transitGatewayRouteTableID, destination}
+func TransitGatewayRouteCreateResourceID(transitGatewayRouteTableID, destination, TransitGatewayAttachmentID string) string {
+	parts := []string{transitGatewayRouteTableID, destination, TransitGatewayAttachmentID}
 	id := strings.Join(parts, transitGatewayRouteIDSeparator)
 
 	return id

--- a/website/docs/r/ec2_transit_gateway_route.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route.html.markdown
@@ -49,8 +49,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_ec2_transit_gateway_route` can be imported by using the EC2 Transit Gateway Route Table, an underscore, and the destination, e.g.,
+`aws_ec2_transit_gateway_route` can be imported by using the EC2 Transit Gateway Route Table, an underscore, and the destination, and the Transit Gateway Attachment e.g.,
 
 ```
-$ terraform import aws_ec2_transit_gateway_route.example tgw-rtb-12345678_0.0.0.0/0
+$ terraform import aws_ec2_transit_gateway_route.example tgw-rtb-12345678_0.0.0.0/0_tgw-attach-012345678abcdefg
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #24015 
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/71

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
#make testacc TESTS=testAccTransitGatewayRoute PKG=ec2           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='testAccTransitGatewayRoute'  -timeout 180m
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        2.772s [no tests to run]
...
```
