### PR TITLE
Add insights_configuration argument to aws_xray_group resource

### DIFF
--- a/.changelog/24028.txt
+++ b/.changelog/24028.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_xray_group: Add `insights_configuration` argument
+```

--- a/internal/service/xray/group.go
+++ b/internal/service/xray/group.go
@@ -69,19 +69,25 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).XRayConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	name := d.Get("group_name").(string)
 	input := &xray.CreateGroupInput{
-		GroupName:             aws.String(d.Get("group_name").(string)),
-		FilterExpression:      aws.String(d.Get("filter_expression").(string)),
-		InsightsConfiguration: expandInsightsConfig(d.Get("insights_configuration").([]interface{})),
-		Tags:                  Tags(tags.IgnoreAWS()),
+		GroupName:        aws.String(name),
+		FilterExpression: aws.String(d.Get("filter_expression").(string)),
+		Tags:             Tags(tags.IgnoreAWS()),
 	}
 
-	out, err := conn.CreateGroup(input)
+	if v, ok := d.GetOk("insights_configuration"); ok {
+		input.InsightsConfiguration = expandInsightsConfig(v.([]interface{}))
+	}
+
+	output, err := conn.CreateGroup(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating XRay Group: %w", err)
+		return fmt.Errorf("error creating XRay Group (%s): %w", name, err)
 	}
 
-	d.SetId(aws.StringValue(out.Group.GroupARN))
+	d.SetId(aws.StringValue(output.Group.GroupARN))
 
 	return resourceGroupRead(d, meta)
 }
@@ -97,12 +103,13 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	group, err := conn.GetGroup(input)
 
+	if tfawserr.ErrMessageContains(err, xray.ErrCodeInvalidRequestException, "Group not found") {
+		log.Printf("[WARN] XRay Group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, xray.ErrCodeInvalidRequestException, "Group not found") {
-			log.Printf("[WARN] XRay Group (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
 		return fmt.Errorf("error reading XRay Group (%s): %w", d.Id(), err)
 	}
 
@@ -110,12 +117,12 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", arn)
 	d.Set("group_name", group.Group.GroupName)
 	d.Set("filter_expression", group.Group.FilterExpression)
-
-	if config := flattenInsightsConfig(group.Group.InsightsConfiguration); config != nil {
-		d.Set("insights_configuration", config)
+	if err := d.Set("insights_configuration", flattenInsightsConfig(group.Group.InsightsConfiguration)); err != nil {
+		return fmt.Errorf("error setting insights_configuration: %w", err)
 	}
 
 	tags, err := ListTags(conn, arn)
+
 	if err != nil {
 		return fmt.Errorf("error listing tags for Xray Group (%q): %s", d.Id(), err)
 	}
@@ -143,11 +150,13 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("filter_expression"); ok {
 			input.FilterExpression = aws.String(v.(string))
 		}
+
 		if v, ok := d.GetOk("insights_configuration"); ok {
 			input.InsightsConfiguration = expandInsightsConfig(v.([]interface{}))
 		}
 
 		_, err := conn.UpdateGroup(input)
+
 		if err != nil {
 			return fmt.Errorf("error updating XRay Group (%s): %w", d.Id(), err)
 		}
@@ -155,6 +164,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
+
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %w", err)
 		}
@@ -167,11 +177,10 @@ func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).XRayConn
 
 	log.Printf("[INFO] Deleting XRay Group: %s", d.Id())
-
-	params := &xray.DeleteGroupInput{
+	_, err := conn.DeleteGroup(&xray.DeleteGroupInput{
 		GroupARN: aws.String(d.Id()),
-	}
-	_, err := conn.DeleteGroup(params)
+	})
+
 	if err != nil {
 		return fmt.Errorf("error deleting XRay Group (%s): %w", d.Id(), err)
 	}

--- a/internal/service/xray/group_test.go
+++ b/internal/service/xray/group_test.go
@@ -258,11 +258,12 @@ resource "aws_xray_group" "test" {
 func testAccGroupBasicInsightsConfig(rName, expression string, insightsEnabled bool, notificationsEnabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_xray_group" "test" {
-  group_name             = %[1]q
-  filter_expression      = %[2]q
+  group_name        = %[1]q
+  filter_expression = %[2]q
+
   insights_configuration {
-    insights_enabled     = %[3]t	
-    notifications_enabled = %[4]t	
+    insights_enabled      = %[3]t
+    notifications_enabled = %[4]t
   }
 }
 `, rName, expression, insightsEnabled, notificationsEnabled)

--- a/internal/service/xray/group_test.go
+++ b/internal/service/xray/group_test.go
@@ -34,6 +34,7 @@ func TestAccXRayGroup_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "xray", regexp.MustCompile(`group/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression", "responsetime > 5"),
+					resource.TestCheckResourceAttr(resourceName, "insights_configuration.#", "1"), // Computed.
 				),
 			},
 			{
@@ -48,6 +49,7 @@ func TestAccXRayGroup_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "xray", regexp.MustCompile(`group/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression", "responsetime > 10"),
+					resource.TestCheckResourceAttr(resourceName, "insights_configuration.#", "1"),
 				),
 			},
 		},
@@ -69,6 +71,7 @@ func TestAccXRayGroup_insights(t *testing.T) {
 				Config: testAccGroupBasicInsightsConfig(rName, "responsetime > 5", true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckXrayGroupExists(resourceName, &Group),
+					resource.TestCheckResourceAttr(resourceName, "insights_configuration.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "insights_configuration.*", map[string]string{
 						"insights_enabled":      "true",
 						"notifications_enabled": "true",
@@ -84,6 +87,7 @@ func TestAccXRayGroup_insights(t *testing.T) {
 				Config: testAccGroupBasicInsightsConfig(rName, "responsetime > 10", false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckXrayGroupExists(resourceName, &Group),
+					resource.TestCheckResourceAttr(resourceName, "insights_configuration.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "insights_configuration.*", map[string]string{
 						"insights_enabled":      "false",
 						"notifications_enabled": "false",

--- a/website/docs/r/xray_group.html.markdown
+++ b/website/docs/r/xray_group.html.markdown
@@ -16,6 +16,11 @@ Creates and manages an AWS XRay Group.
 resource "aws_xray_group" "example" {
   group_name        = "example"
   filter_expression = "responsetime > 5"
+  
+  insights_configuration {
+    insights_enabled      = true
+    notifications_enabled = true
+  }
 }
 ```
 
@@ -23,7 +28,15 @@ resource "aws_xray_group" "example" {
 
 * `group_name` - (Required) The name of the group.
 * `filter_expression` - (Required) The filter expression defining criteria by which to group traces. more info can be found in official [docs](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html).
+* `insights_configuration` - (Optional) Configuration options for enabling insights.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Nested fields
+
+#### `insights_configuration`
+
+* `insights_enabled` - (Required) Specifies whether insights are enabled.
+* `notifications_enabled` - (Optional) Specifies whether insight notifications are enabled.
 
 ## Attributes Reference
 

--- a/website/docs/r/xray_group.html.markdown
+++ b/website/docs/r/xray_group.html.markdown
@@ -16,7 +16,7 @@ Creates and manages an AWS XRay Group.
 resource "aws_xray_group" "example" {
   group_name        = "example"
   filter_expression = "responsetime > 5"
-  
+
   insights_configuration {
     insights_enabled      = true
     notifications_enabled = true


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Adds support for `insights_configuration` to  `aws_xray_group`. See the [X-Ray Group API docs](https://docs.aws.amazon.com/xray/latest/api/API_Group.html) for more details.

Output from acceptance testing:
```
$ make testacc TESTS=TestAccXRayGroup PKG=xray
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/xray/... -v -count 1 -parallel 20 -run='TestAccXRayGroup'  -timeout 180m
=== RUN   TestAccXRayGroup_basic
=== PAUSE TestAccXRayGroup_basic
=== RUN   TestAccXRayGroup_insights
=== PAUSE TestAccXRayGroup_insights
=== RUN   TestAccXRayGroup_tags
=== PAUSE TestAccXRayGroup_tags
=== RUN   TestAccXRayGroup_disappears
=== PAUSE TestAccXRayGroup_disappears
=== CONT  TestAccXRayGroup_basic
=== CONT  TestAccXRayGroup_tags
=== CONT  TestAccXRayGroup_disappears
=== CONT  TestAccXRayGroup_insights
--- PASS: TestAccXRayGroup_disappears (18.81s)
--- PASS: TestAccXRayGroup_insights (43.69s)
--- PASS: TestAccXRayGroup_basic (43.70s)
--- PASS: TestAccXRayGroup_tags (59.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	59.516s
```
