### PR TITLE
Lambda Function URLs

### DIFF
--- a/.changelog/24053.txt
+++ b/.changelog/24053.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_lambda_function_url
+```
+
+```release-note:new-data-source
+aws_lambda_function_url
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -701,7 +701,7 @@ func Provider() *schema.Provider {
 
 			"aws_lambda_alias":               lambda.DataSourceAlias(),
 			"aws_lambda_code_signing_config": lambda.DataSourceCodeSigningConfig(),
-			"aws_lambda_function_url":        lambda.DataSourceFunctionUrl(),
+			"aws_lambda_function_url":        lambda.DataSourceFunctionURL(),
 			"aws_lambda_function":            lambda.DataSourceFunction(),
 			"aws_lambda_invocation":          lambda.DataSourceInvocation(),
 			"aws_lambda_layer_version":       lambda.DataSourceLayerVersion(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -702,6 +702,7 @@ func Provider() *schema.Provider {
 			"aws_lambda_alias":               lambda.DataSourceAlias(),
 			"aws_lambda_code_signing_config": lambda.DataSourceCodeSigningConfig(),
 			"aws_lambda_function":            lambda.DataSourceFunction(),
+			"aws_lambda_function_url":        lambda.DataSourceFunctionUrl(),
 			"aws_lambda_invocation":          lambda.DataSourceInvocation(),
 			"aws_lambda_layer_version":       lambda.DataSourceLayerVersion(),
 
@@ -1559,6 +1560,7 @@ func Provider() *schema.Provider {
 			"aws_lambda_event_source_mapping":           lambda.ResourceEventSourceMapping(),
 			"aws_lambda_function":                       lambda.ResourceFunction(),
 			"aws_lambda_function_event_invoke_config":   lambda.ResourceFunctionEventInvokeConfig(),
+			"aws_lambda_function_url":                   lambda.ResourceFunctionUrl(),
 			"aws_lambda_invocation":                     lambda.ResourceInvocation(),
 			"aws_lambda_layer_version":                  lambda.ResourceLayerVersion(),
 			"aws_lambda_layer_version_permission":       lambda.ResourceLayerVersionPermission(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -701,8 +701,8 @@ func Provider() *schema.Provider {
 
 			"aws_lambda_alias":               lambda.DataSourceAlias(),
 			"aws_lambda_code_signing_config": lambda.DataSourceCodeSigningConfig(),
-			"aws_lambda_function":            lambda.DataSourceFunction(),
 			"aws_lambda_function_url":        lambda.DataSourceFunctionUrl(),
+			"aws_lambda_function":            lambda.DataSourceFunction(),
 			"aws_lambda_invocation":          lambda.DataSourceInvocation(),
 			"aws_lambda_layer_version":       lambda.DataSourceLayerVersion(),
 

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -22,12 +22,13 @@ func ResourceFunctionUrl() *schema.Resource {
 		Read:   resourceFunctionUrlRead,
 		Update: resourceFunctionUrlUpdate,
 		Delete: resourceFunctionUrlDelete,
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-		},
 
 		Importer: &schema.ResourceImporter{
 			State: resourceFunctionUrlImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -74,6 +75,10 @@ func ResourceFunctionUrl() *schema.Resource {
 					},
 				},
 			},
+			"function_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"function_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -86,26 +91,14 @@ func ResourceFunctionUrl() *schema.Resource {
 					return (oldFunctionName == new && oldFunctionNameErr == nil) || (newFunctionName == old && newFunctionNameErr == nil)
 				},
 			},
-			"qualifier": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-			},
-			"creation_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"function_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"function_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"last_modified_time": {
+			"qualifier": {
 				Type:     schema.TypeString,
-				Computed: true,
+				ForceNew: true,
+				Optional: true,
 			},
 		},
 	}
@@ -183,16 +176,10 @@ func resourceFunctionUrlRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("cors", flattenFunctionUrlCorsConfigs(output.Cors)); err != nil {
 		return err
 	}
-	if err = d.Set("creation_time", output.CreationTime); err != nil {
-		return err
-	}
 	if err = d.Set("function_arn", output.FunctionArn); err != nil {
 		return err
 	}
 	if err = d.Set("function_url", output.FunctionUrl); err != nil {
-		return err
-	}
-	if err = d.Set("last_modified_time", output.LastModifiedTime); err != nil {
 		return err
 	}
 

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -19,10 +19,10 @@ import (
 
 func ResourceFunctionUrl() *schema.Resource {
 	return &schema.Resource{
-		CreateWithoutTimeout: resourceFunctionUrlCreate,
-		ReadWithoutTimeout:   resourceFunctionUrlRead,
-		UpdateWithoutTimeout: resourceFunctionUrlUpdate,
-		DeleteWithoutTimeout: resourceFunctionUrlDelete,
+		CreateWithoutTimeout: resourceFunctionURLCreate,
+		ReadWithoutTimeout:   resourceFunctionURLRead,
+		UpdateWithoutTimeout: resourceFunctionURLUpdate,
+		DeleteWithoutTimeout: resourceFunctionURLDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: resourceFunctionUrlImport,
@@ -105,7 +105,7 @@ func ResourceFunctionUrl() *schema.Resource {
 	}
 }
 
-func resourceFunctionUrlCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LambdaConn
 
 	params := &lambda.CreateFunctionUrlConfigInput{
@@ -146,10 +146,10 @@ func resourceFunctionUrlCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.StringValue(output.FunctionArn))
 
-	return resourceFunctionUrlRead(ctx, d, meta)
+	return resourceFunctionURLRead(ctx, d, meta)
 }
 
-func resourceFunctionUrlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LambdaConn
 
 	input := &lambda.GetFunctionUrlConfigInput{
@@ -179,7 +179,7 @@ func resourceFunctionUrlRead(ctx context.Context, d *schema.ResourceData, meta i
 	return nil
 }
 
-func resourceFunctionUrlUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LambdaConn
 
 	log.Printf("[DEBUG] Updating Lambda Function Url: %s", d.Id())
@@ -206,10 +206,10 @@ func resourceFunctionUrlUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error updating Lambda Function Url (%s): %s", d.Id(), err)
 	}
 
-	return resourceFunctionUrlRead(ctx, d, meta)
+	return resourceFunctionURLRead(ctx, d, meta)
 }
 
-func resourceFunctionUrlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LambdaConn
 
 	log.Printf("[INFO] Deleting Lambda Function Url: %s", d.Id())

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -187,28 +187,27 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LambdaConn
 
-	log.Printf("[DEBUG] Updating Lambda Function Url: %s", d.Id())
-
-	params := &lambda.UpdateFunctionUrlConfigInput{
+	input := &lambda.UpdateFunctionUrlConfigInput{
 		FunctionName: aws.String(d.Get("function_name").(string)),
 	}
 
-	if v, ok := d.GetOk("qualifier"); ok {
-		params.Qualifier = aws.String(v.(string))
-	}
-
 	if d.HasChange("authorization_type") {
-		params.AuthType = aws.String(d.Get("authorization_type").(string))
+		input.AuthType = aws.String(d.Get("authorization_type").(string))
 	}
 
 	if d.HasChange("cors") {
-		params.Cors = expandFunctionUrlCorsConfigs(d.Get("cors").([]interface{}))
+		input.Cors = expandFunctionUrlCorsConfigs(d.Get("cors").([]interface{}))
 	}
 
-	_, err := conn.UpdateFunctionUrlConfig(params)
+	if v, ok := d.GetOk("qualifier"); ok {
+		input.Qualifier = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Updating Lambda Function URL: %s", input)
+	_, err := conn.UpdateFunctionUrlConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating Lambda Function Url (%s): %s", d.Id(), err)
+		return diag.Errorf("error updating Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
 	return resourceFunctionURLRead(ctx, d, meta)

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -3,7 +3,6 @@ package lambda
 import (
 	"context"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -25,7 +24,11 @@ func ResourceFunctionUrl() *schema.Resource {
 		DeleteWithoutTimeout: resourceFunctionURLDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceFunctionUrlImport,
+			StateContext: func(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("function_name", d.Id())
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -275,17 +278,4 @@ func flattenFunctionUrlCorsConfigs(cors *lambda.Cors) []map[string]interface{} {
 	settings["max_age"] = cors.MaxAge
 
 	return []map[string]interface{}{settings}
-}
-
-func resourceFunctionUrlImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-
-	idSplit := strings.Split(d.Id(), ":")
-
-	functionName := idSplit[len(idSplit)-2]
-	qualifier := idSplit[len(idSplit)-1]
-
-	d.Set("function_name", functionName)
-	d.Set("qualifier", qualifier)
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -1,0 +1,293 @@
+package lambda
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"log"
+	"strings"
+	"time"
+)
+
+func ResourceFunctionUrl() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceFunctionUrlCreate,
+		Read:   resourceFunctionUrlRead,
+		Update: resourceFunctionUrlUpdate,
+		Delete: resourceFunctionUrlDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			State: resourceFunctionUrlImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"authorization_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(lambda.AuthorizationType_Values(), false),
+			},
+			"cors": {
+				Type:     schema.TypeList,
+				Optional: true,
+				//MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_credentials": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"allow_headers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"allow_methods": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"allow_origins": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"expose_headers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"max_age": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtMost(86400),
+						},
+					},
+				},
+			},
+			"function_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Using function name or ARN should not be shown as a diff.
+					// Try to convert the old and new values from ARN to function name
+					oldFunctionName, oldFunctionNameErr := GetFunctionNameFromARN(old)
+					newFunctionName, newFunctionNameErr := GetFunctionNameFromARN(new)
+					return (oldFunctionName == new && oldFunctionNameErr == nil) || (newFunctionName == old && newFunctionNameErr == nil)
+				},
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"function_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"function_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceFunctionUrlCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LambdaConn
+
+	params := &lambda.CreateFunctionUrlConfigInput{
+		FunctionName:      aws.String(d.Get("function_name").(string)),
+		AuthorizationType: aws.String(d.Get("authorization_type").(string)),
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		params.Qualifier = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("cors"); ok && len(v.([]interface{})) > 0 {
+		params.Cors = expandFunctionUrlCorsConfigs(v.([]interface{}))
+	}
+
+	output, err := conn.CreateFunctionUrlConfig(params)
+
+	if err != nil {
+		return fmt.Errorf("Error creating Lambda function url: %s", err)
+	}
+	log.Printf("[DEBUG] Creating Lambda Function Url Config Output: %s", output)
+
+	d.SetId(aws.StringValue(output.FunctionArn))
+
+	return resourceFunctionUrlRead(d, meta)
+}
+
+func resourceFunctionUrlRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LambdaConn
+
+	input := &lambda.GetFunctionUrlConfigInput{
+		FunctionName: aws.String(d.Get("function_name").(string)),
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		input.Qualifier = aws.String(v.(string))
+	}
+
+	output, err := conn.GetFunctionUrlConfig(input)
+	log.Printf("[DEBUG] Getting Lambda Function Url Config Output: %s", output)
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == lambda.ErrCodeResourceNotFoundException && !d.IsNewResource() {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error getting Lambda Function Url Config (%s): %w", d.Id(), err)
+	}
+
+	if err = d.Set("authorization_type", output.AuthorizationType); err != nil {
+		return err
+	}
+	if err = d.Set("cors", flattenFunctionUrlCorsConfigs(output.Cors)); err != nil {
+		return err
+	}
+	if err = d.Set("creation_time", output.CreationTime); err != nil {
+		return err
+	}
+	if err = d.Set("function_arn", output.FunctionArn); err != nil {
+		return err
+	}
+	if err = d.Set("function_url", output.FunctionUrl); err != nil {
+		return err
+	}
+	if err = d.Set("last_modified_time", output.LastModifiedTime); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceFunctionUrlUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LambdaConn
+
+	log.Printf("[DEBUG] Updating Lambda Function Url: %s", d.Id())
+
+	params := &lambda.UpdateFunctionUrlConfigInput{
+		FunctionName: aws.String(d.Get("function_name").(string)),
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		params.Qualifier = aws.String(v.(string))
+	}
+
+	if d.HasChange("authorization_type") {
+		params.AuthorizationType = aws.String(d.Get("authorization_type").(string))
+	}
+
+	if d.HasChange("cors") {
+		params.Cors = expandFunctionUrlCorsConfigs(d.Get("cors").([]interface{}))
+	}
+
+	_, err := conn.UpdateFunctionUrlConfig(params)
+
+	if err != nil {
+		return fmt.Errorf("error updating Lambda Function Url (%s): %w", d.Id(), err)
+	}
+
+	return resourceFunctionUrlRead(d, meta)
+}
+
+func resourceFunctionUrlDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LambdaConn
+
+	log.Printf("[INFO] Deleting Lambda Function Url: %s", d.Id())
+
+	params := &lambda.DeleteFunctionUrlConfigInput{
+		FunctionName: aws.String(d.Get("function_name").(string)),
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		params.Qualifier = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteFunctionUrlConfig(params)
+
+	if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Lambda Function Url (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandFunctionUrlCorsConfigs(urlConfigMap []interface{}) *lambda.Cors {
+	cors := &lambda.Cors{}
+	if len(urlConfigMap) == 1 && urlConfigMap[0] != nil {
+		config := urlConfigMap[0].(map[string]interface{})
+		cors.AllowCredentials = aws.Bool(config["allow_credentials"].(bool))
+		if len(config["allow_headers"].([]interface{})) > 0 {
+			cors.AllowHeaders = flex.ExpandStringList(config["allow_headers"].([]interface{}))
+		}
+		if len(config["allow_methods"].([]interface{})) > 0 {
+			cors.AllowMethods = flex.ExpandStringList(config["allow_methods"].([]interface{}))
+		}
+		if len(config["allow_origins"].([]interface{})) > 0 {
+			cors.AllowOrigins = flex.ExpandStringList(config["allow_origins"].([]interface{}))
+		}
+		if len(config["expose_headers"].([]interface{})) > 0 {
+			cors.ExposeHeaders = flex.ExpandStringList(config["expose_headers"].([]interface{}))
+		}
+		if config["max_age"].(int) > 0 {
+			cors.MaxAge = aws.Int64(int64(config["max_age"].(int)))
+		}
+	}
+	return cors
+}
+
+func flattenFunctionUrlCorsConfigs(cors *lambda.Cors) []map[string]interface{} {
+	settings := make(map[string]interface{})
+
+	if cors == nil {
+		return nil
+	}
+
+	settings["allow_credentials"] = cors.AllowCredentials
+	settings["allow_headers"] = cors.AllowHeaders
+	settings["allow_methods"] = cors.AllowMethods
+	settings["allow_origins"] = cors.AllowOrigins
+	settings["expose_headers"] = cors.ExposeHeaders
+	settings["max_age"] = cors.MaxAge
+
+	return []map[string]interface{}{settings}
+}
+
+func resourceFunctionUrlImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+
+	idSplit := strings.Split(d.Id(), ":")
+
+	functionName := idSplit[len(idSplit)-2]
+	qualifier := idSplit[len(idSplit)-1]
+
+	d.Set("function_name", functionName)
+	d.Set("qualifier", qualifier)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -173,7 +173,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Lambda Function URL (%s): %w", d.Id(), err)
+		return diag.Errorf("error reading Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
 	d.Set("authorization_type", output.AuthType)

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -1,0 +1,124 @@
+package lambda
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"log"
+)
+
+func DataSourceFunctionUrl() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFunctionUrlRead,
+
+		Schema: map[string]*schema.Schema{
+			"function_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"authorization_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_credentials": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"allow_headers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"allow_methods": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"allow_origins": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"expose_headers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"max_age": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"function_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"function_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceFunctionUrlRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LambdaConn
+
+	input := &lambda.GetFunctionUrlConfigInput{
+		FunctionName: aws.String(d.Get("function_name").(string)),
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		input.Qualifier = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Getting Lambda Function Url Config: %s", input)
+	output, err := conn.GetFunctionUrlConfig(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Lambda Function Url Config: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.FunctionArn))
+	if err = d.Set("authorization_type", output.AuthorizationType); err != nil {
+		return err
+	}
+	if err = d.Set("cors", flattenFunctionUrlCorsConfigs(output.Cors)); err != nil {
+		return err
+	}
+	if err = d.Set("creation_time", output.CreationTime); err != nil {
+		return err
+	}
+	if err = d.Set("function_arn", output.FunctionArn); err != nil {
+		return err
+	}
+	if err = d.Set("function_url", output.FunctionUrl); err != nil {
+		return err
+	}
+	if err = d.Set("last_modified_time", output.LastModifiedTime); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -90,7 +90,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	output, err := FindFunctionURLByNameAndQualifier(ctx, conn, name, qualifier)
 
 	if err != nil {
-		return diag.Errorf("error reading Lambda Function URL (%s): %w", id, err)
+		return diag.Errorf("error reading Lambda Function URL (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -104,8 +104,10 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	d.Set("creation_time", output.CreationTime)
 	d.Set("function_arn", output.FunctionArn)
+	d.Set("function_name", name)
 	d.Set("function_url", output.FunctionUrl)
 	d.Set("last_modified_time", output.LastModifiedTime)
+	d.Set("qualifier", qualifier)
 
 	return nil
 }

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -2,11 +2,12 @@ package lambda
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"log"
 )
 
 func DataSourceFunctionUrl() *schema.Resource {
@@ -101,7 +102,7 @@ func dataSourceFunctionUrlRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(aws.StringValue(output.FunctionArn))
-	if err = d.Set("authorization_type", output.AuthorizationType); err != nil {
+	if err = d.Set("authorization_type", output.AuthType); err != nil {
 		return err
 	}
 	if err = d.Set("cors", flattenFunctionUrlCorsConfigs(output.Cors)); err != nil {

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -37,6 +37,7 @@ func TestAccLambdaFunctionURLDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "function_url", resourceName, "function_url"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_time"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "qualifier", resourceName, "qualifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "url_id", resourceName, "url_id"),
 				),
 			},
 		},

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -2,17 +2,16 @@ package lambda_test
 
 import (
 	"fmt"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccLambdaFunctionUrlDataSource_basic(t *testing.T) {
+func TestAccLambdaFunctionURLDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
 	dataSourceName := "data.aws_lambda_function_url.test"
 	resourceName := "aws_lambda_function_url.test"
 
@@ -22,29 +21,29 @@ func TestAccLambdaFunctionUrlDataSource_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionUrlBasicDataSourceConfig(rName),
+				Config: testAccFunctionURLBasicDataSourceConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "function_name", resourceName, "function_name"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "qualifier", resourceName, "qualifier"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "authorization_type", resourceName, "authorization_type"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "function_arn", resourceName, "function_arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "function_url", resourceName, "function_url"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "creation_time", resourceName, "creation_time"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cors.#", resourceName, "cors.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_credentials", resourceName, "cors.0.allow_credentials"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_headers", resourceName, "cors.0.allow_headers"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_methods", resourceName, "cors.0.allow_methods"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_origins", resourceName, "cors.0.allow_origins"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.expose_headers", resourceName, "cors.0.expose_headers"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_headers.#", resourceName, "cors.0.allow_headers.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_methods.#", resourceName, "cors.0.allow_methods.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_origins.#", resourceName, "cors.0.allow_origins.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.expose_headers.#", resourceName, "cors.0.expose_headers.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.max_age", resourceName, "cors.0.max_age"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "creation_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "function_arn", resourceName, "function_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "function_name", resourceName, "function_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "function_url", resourceName, "function_url"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "qualifier", resourceName, "qualifier"),
 				),
 			},
 		},
 	})
 }
 
-func testAccFunctionUrlDataSourceBaseConfig(rName string) string {
+func testAccFunctionURLDataSourceBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -112,6 +111,7 @@ resource "aws_lambda_function" "test" {
 resource "aws_lambda_function_url" "test" {
   function_name      = aws_lambda_function.test.arn
   authorization_type = "AWS_IAM"
+
   cors {
     allow_credentials = true
     allow_origins     = ["*"]
@@ -125,10 +125,10 @@ resource "aws_lambda_function_url" "test" {
 `, rName)
 }
 
-func testAccFunctionUrlBasicDataSourceConfig(rName string) string {
-	return testAccFunctionUrlDataSourceBaseConfig(rName) + `
+func testAccFunctionURLBasicDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(testAccFunctionURLDataSourceBaseConfig(rName), `
 data "aws_lambda_function_url" "test" {
   function_name = aws_lambda_function_url.test.function_name
 }
-`
+`)
 }

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -1,0 +1,134 @@
+package lambda_test
+
+import (
+	"fmt"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLambdaFunctionUrlDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	dataSourceName := "data.aws_lambda_function_url.test"
+	resourceName := "aws_lambda_function_url.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, lambda.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionUrlBasicDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "function_name", resourceName, "function_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "qualifier", resourceName, "qualifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "authorization_type", resourceName, "authorization_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "function_arn", resourceName, "function_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "function_url", resourceName, "function_url"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "creation_time", resourceName, "creation_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.#", resourceName, "cors.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_credentials", resourceName, "cors.0.allow_credentials"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_headers", resourceName, "cors.0.allow_headers"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_methods", resourceName, "cors.0.allow_methods"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.allow_origins", resourceName, "cors.0.allow_origins"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.expose_headers", resourceName, "cors.0.expose_headers"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cors.0.max_age", resourceName, "cors.0.max_age"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFunctionUrlDataSourceBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "lambda" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "lambda" {
+  name = %[1]q
+  role = aws_iam_role.lambda.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  role          = aws_iam_role.lambda.arn
+  runtime       = "nodejs14.x"
+}
+
+resource "aws_lambda_function_url" "test" {
+  function_name      = aws_lambda_function.test.arn
+  authorization_type = "AWS_IAM"
+  cors {
+    allow_credentials = true
+    allow_origins     = ["*"]
+    allow_methods     = ["*"]
+    allow_headers     = ["date", "keep-alive"]
+    expose_headers    = ["keep-alive", "date"]
+    max_age           = 86400
+  }
+}
+
+`, rName)
+}
+
+func testAccFunctionUrlBasicDataSourceConfig(rName string) string {
+	return testAccFunctionUrlDataSourceBaseConfig(rName) + `
+data "aws_lambda_function_url" "test" {
+  function_name = aws_lambda_function_url.test.function_name
+}
+`
+}

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccLambdaFunctionURLDataSource_basic(t *testing.T) {
 	resourceName := "aws_lambda_function_url.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { acctest.PreCheck(t) },
+		PreCheck:   func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, lambda.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -39,6 +39,7 @@ func TestAccLambdaFunctionURL_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "function_name", funcName),
 					resource.TestCheckResourceAttrSet(resourceName, "function_url"),
 					resource.TestCheckResourceAttr(resourceName, "qualifier", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "url_id"),
 				),
 			},
 			{

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,6 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func testAccFunctionURLPreCheck(t *testing.T) {
+	if got, want := acctest.Partition(), endpoints.AwsPartitionID; got != want {
+		t.Skipf("Lambda Function URLs are not supported in %s partition", got)
+	}
+}
+
 func TestAccLambdaFunctionURL_basic(t *testing.T) {
 	var conf lambda.GetFunctionUrlConfigOutput
 	resourceName := "aws_lambda_function_url.test"
@@ -24,7 +31,7 @@ func TestAccLambdaFunctionURL_basic(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, lambda.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckFunctionURLDestroy,
@@ -61,7 +68,7 @@ func TestAccLambdaFunctionURL_Cors(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, lambda.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckFunctionURLDestroy,
@@ -126,7 +133,7 @@ func TestAccLambdaFunctionURL_Alias(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, lambda.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckFunctionURLDestroy,

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -1,0 +1,317 @@
+package lambda_test
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflambda "github.com/hashicorp/terraform-provider-aws/internal/service/lambda"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLambdaFunctionUrl_basic(t *testing.T) {
+	var conf lambda.GetFunctionUrlConfigOutput
+	resourceName := "aws_lambda_function_url.test"
+
+	rString := sdkacctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_basic_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_basic_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, lambda.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionUrlBasicConfig(funcName, policyName, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionUrlExists(resourceName, funcName, nil, &conf),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.AuthorizationTypeNone),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "function_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, tflambda.FunctionVersionLatest)),
+					resource.TestCheckResourceAttr(resourceName, "cors.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"function_name", "qualifier"},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunctionUrl_Cors(t *testing.T) {
+	var conf lambda.GetFunctionUrlConfigOutput
+	resourceName := "aws_lambda_function_url.test"
+
+	rString := sdkacctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_basic_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_basic_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, lambda.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionUrlCoresConfig(funcName, policyName, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionUrlExists(resourceName, funcName, nil, &conf),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.AuthorizationTypeAwsIam),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "function_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, tflambda.FunctionVersionLatest)),
+					resource.TestCheckResourceAttr(resourceName, "cors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_credentials", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_headers.0", "date"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_headers.1", "keep-alive"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_methods.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_origins.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.expose_headers.0", "keep-alive"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.expose_headers.1", "date"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.max_age", "86400"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"function_name", "qualifier"},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunctionUrl_Alias(t *testing.T) {
+	var conf lambda.GetFunctionUrlConfigOutput
+	resourceName := "aws_lambda_function_url.test"
+
+	rString := sdkacctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_basic_%s", rString)
+	aliasName := "live"
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_basic_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, lambda.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionUrlAliasConfig(funcName, aliasName, policyName, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionUrlExists(resourceName, funcName, &aliasName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.AuthorizationTypeAwsIam),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "function_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, aliasName)),
+					resource.TestCheckResourceAttr(resourceName, "cors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_credentials", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_headers.0", "date"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_headers.1", "keep-alive"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_methods.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_origins.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.expose_headers.0", "keep-alive"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.expose_headers.1", "date"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.max_age", "86400"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"function_name", "qualifier"},
+			},
+		},
+	})
+}
+
+func testAccCheckFunctionUrlExists(res string, funcName string, qualifier *string, function *lambda.GetFunctionUrlConfigOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[res]
+		if !ok {
+			return fmt.Errorf("Lambda function url not found: %s", res)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Lambda function url ID not set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn
+
+		params := &lambda.GetFunctionUrlConfigInput{
+			FunctionName: aws.String(funcName),
+		}
+
+		if qualifier != nil {
+			params.Qualifier = qualifier
+		}
+
+		output, err := conn.GetFunctionUrlConfig(params)
+		if err != nil {
+			return err
+		}
+
+		*function = *output
+
+		return nil
+	}
+}
+
+func testAccFunctionUrlBaseConfig(policyName, roleName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role_policy" "iam_policy_for_lambda" {
+  name = "%s"
+  role = aws_iam_role.iam_for_lambda.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "SNS:Publish"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "xray:PutTraceSegments"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+`, policyName, roleName)
+}
+
+func testAccFunctionUrlBasicConfig(funcName, policyName, roleName string) string {
+	return fmt.Sprintf(testAccFunctionUrlBaseConfig(policyName, roleName)+`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs14.x"
+}
+
+resource "aws_lambda_function_url" "test" {
+  function_name      = aws_lambda_function.test.function_name
+  authorization_type = "NONE"
+}
+`, funcName)
+}
+
+func testAccFunctionUrlCoresConfig(funcName, policyName, roleName string) string {
+	return fmt.Sprintf(testAccFunctionUrlBaseConfig(policyName, roleName)+`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs14.x"
+}
+
+resource "aws_lambda_function_url" "test" {
+  function_name      = aws_lambda_function.test.function_name
+  authorization_type = "AWS_IAM"
+  cors {
+    allow_credentials = true
+    allow_origins     = ["*"]
+    allow_methods     = ["*"]
+    allow_headers     = ["date", "keep-alive"]
+    expose_headers    = ["keep-alive", "date"]
+    max_age           = 86400
+  }
+}
+`, funcName)
+}
+
+func testAccFunctionUrlAliasConfig(funcName, aliasName, policyName, roleName string) string {
+	return fmt.Sprintf(testAccFunctionUrlBaseConfig(policyName, roleName)+`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs14.x"
+  publish       = true
+}
+
+resource "aws_lambda_alias" "live" {
+  name             = %[2]q
+  description      = "a sample description"
+  function_name    = aws_lambda_function.test.function_name
+  function_version = "1"
+}
+
+resource "aws_lambda_function_url" "test" {
+  function_name      = aws_lambda_function.test.function_name
+  qualifier          = aws_lambda_alias.live.name
+  authorization_type = "AWS_IAM"
+  cors {
+    allow_credentials = true
+    allow_origins     = ["*"]
+    allow_methods     = ["*"]
+    allow_headers     = ["date", "keep-alive"]
+    expose_headers    = ["keep-alive", "date"]
+    max_age           = 86400
+  }
+}
+`, funcName, aliasName)
+}

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -32,7 +32,7 @@ func TestAccLambdaFunctionUrl_basic(t *testing.T) {
 				Config: testAccFunctionUrlBasicConfig(funcName, policyName, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFunctionUrlExists(resourceName, funcName, nil, &conf),
-					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.AuthorizationTypeNone),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "function_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, tflambda.FunctionVersionLatest)),
 					resource.TestCheckResourceAttr(resourceName, "cors.#", "0"),
 				),
@@ -65,7 +65,7 @@ func TestAccLambdaFunctionUrl_Cors(t *testing.T) {
 				Config: testAccFunctionUrlCoresConfig(funcName, policyName, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFunctionUrlExists(resourceName, funcName, nil, &conf),
-					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.AuthorizationTypeAwsIam),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.FunctionUrlAuthTypeAwsIam),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "function_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, tflambda.FunctionVersionLatest)),
 					resource.TestCheckResourceAttr(resourceName, "cors.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_credentials", "true"),
@@ -107,7 +107,7 @@ func TestAccLambdaFunctionUrl_Alias(t *testing.T) {
 				Config: testAccFunctionUrlAliasConfig(funcName, aliasName, policyName, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFunctionUrlExists(resourceName, funcName, &aliasName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.AuthorizationTypeAwsIam),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.FunctionUrlAuthTypeAwsIam),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "function_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, aliasName)),
 					resource.TestCheckResourceAttr(resourceName, "cors.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cors.0.allow_credentials", "true"),

--- a/website/docs/d/lambda_function_url.html.markdown
+++ b/website/docs/d/lambda_function_url.html.markdown
@@ -37,5 +37,6 @@ In addition to all arguments above, the following attributes are exported:
 * `cors` - The [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings for the function URL. See the [`aws_lambda_function_url` resource](/docs/providers/aws/r/lambda_function_url.html) documentation for more details.
 * `creation_time` - When the function URL was created, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
 * `function_arn` - The Amazon Resource Name (ARN) of the function.
-* `function_url` - The HTTP URL endpoint for the function.
+* `function_url` - The HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws`.
 * `last_modified_time` - When the function URL configuration was last updated, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
+* `url_id` - A generated ID for the endpoint.

--- a/website/docs/d/lambda_function_url.html.markdown
+++ b/website/docs/d/lambda_function_url.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Lambda"
+layout: "aws"
+page_title: "AWS: aws_lambda_function_url"
+description: |-
+  Provides a Lambda function url data source.
+---
+
+# aws_lambda_function_url
+
+Provides information about a Lambda function url.
+
+## Example Usage
+
+```terraform
+variable "function_name" {
+  type = string
+}
+
+data "aws_lambda_function_url" "existing" {
+  function_name = var.function_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `function_name` - (Required) Name of the lambda function.
+* `qualifier` - (Optional) Alias name or latest version of the lambda function E.g., `$LATEST`, or `my-alias`
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `authorization_type` - The authorization type for your function URL.
+* `cors` - Cross-Origin Resource Sharing configuration.
+* `function_arn` - Lambda Function full ARN which this URL points to.
+* `function_url` - The HTTPS endpoint of Lambda URL.
+* `creation_time` - The creation time.
+* `last_modified_time` - The last modified time.

--- a/website/docs/d/lambda_function_url.html.markdown
+++ b/website/docs/d/lambda_function_url.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Lambda"
 layout: "aws"
 page_title: "AWS: aws_lambda_function_url"
 description: |-
-  Provides a Lambda function url data source.
+  Provides a Lambda function URL data source.
 ---
 
 # aws_lambda_function_url
 
-Provides information about a Lambda function url.
+Provides information about a Lambda function URL.
 
 ## Example Usage
 
@@ -26,16 +26,16 @@ data "aws_lambda_function_url" "existing" {
 
 The following arguments are supported:
 
-* `function_name` - (Required) Name of the lambda function.
-* `qualifier` - (Optional) Alias name or latest version of the lambda function E.g., `$LATEST`, or `my-alias`
+* `function_name` - (Required) he name (or ARN) of the Lambda function.
+* `qualifier` - (Optional) The alias name or `"$LATEST"`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `authorization_type` - The authorization type for your function URL.
-* `cors` - Cross-Origin Resource Sharing configuration.
-* `function_arn` - Lambda Function full ARN which this URL points to.
-* `function_url` - The HTTPS endpoint of Lambda URL.
-* `creation_time` - The creation time.
-* `last_modified_time` - The last modified time.
+* `authorization_type` - The type of authentication that the function URL uses.
+* `cors` - The [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings for the function URL. See the [`aws_lambda_function_url` resource](/docs/providers/aws/r/lambda_function_url.html) documentation for more details.
+* `creation_time` - When the function URL was created, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
+* `function_arn` - The Amazon Resource Name (ARN) of the function.
+* `function_url` - The HTTP URL endpoint for the function.
+* `last_modified_time` - When the function URL configuration was last updated, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -3,27 +3,28 @@ subcategory: "Lambda"
 layout: "aws"
 page_title: "AWS: aws_lambda_function_url"
 description: |-
-  Creates a Lambda function URL.
+  Provides a Lambda function URL resource.
 ---
 
 # Resource: aws_lambda_function_url
 
-Creates a Lambda function URL, an HTTPS URL that points to the specified Lambda function alias or the latest version.
+Provides a Lambda function URL resource. A function URL is a dedicated HTTP(S) endpoint for a Lambda function.
 
-A function URL is a dedicated HTTP(S) endpoint for your function. For information about Lambda function url, see [CreateFunctionUrlConfig][1] in the API docs.
+See the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html) for more information.
 
 ## Example Usage
 
 ```terraform
 resource "aws_lambda_function_url" "test_latest" {
-  function_name    = aws_lambda_function.test.function_name
+  function_name      = aws_lambda_function.test.function_name
   authorization_type = "NONE"
 }
 
 resource "aws_lambda_function_url" "test_live" {
-  function_name    = aws_lambda_function.test.function_name
-  qualifier        = "my_alias"
+  function_name      = aws_lambda_function.test.function_name
+  qualifier          = "my_alias"
   authorization_type = "AWS_IAM"
+
   cors {
     allow_credentials = true
     allow_origins     = ["*"]
@@ -37,26 +38,32 @@ resource "aws_lambda_function_url" "test_live" {
 
 ## Argument Reference
 
-* `function_name` - (Required) Lambda Function name or ARN.
-* `qualifier` - (Optional) The Lambda alias name or '$LATEST'.
-* `authorization_type` - (Required) The authorization type for your function URL. Valid values are `"AWS_IAM"` and `"NONE"`.
-* `cors` - (Optional) Configure cross-origin resource sharing.
+* `authorization_type` - (Required) The type of authentication that the function URL uses. Set to `"AWS_IAM"` to restrict access to authenticated IAM users only. Set to `"NONE"` to bypass IAM authentication and create a public endpoint. See the [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html) for more details.
+* `cors` - (Optional) The [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings for the function URL. Documented below.
+* `function_name` - (Required) The name (or ARN) of the Lambda function.
+* `qualifier` - (Optional) The alias name or `"$LATEST"`.
 
 ### cors
 
-* `allow_credentials` - (Optional) allow cookies or other credentials in requests to your function URL.
-* `allow_origins` - (Optional) The origins that can access your function URL. You can list any number of specific origins. Alternatively, you can grant access to all origins with the wildcard character (*). For example: https://www.example.com, https://*, or *.
-* `allow_methods` - (Optional) The HTTP methods that are allowed when calling your function URL. For example: GET, POST, DELETE, *.
-* `allow_headers` - (Optional) The HTTP headers that origins can include in requests to your function URL. For example: Date, Keep-Alive, X-Custom-Header.
-* `expose_headers` - (Optional) The HTTP headers in your function response that you want to expose to origins that call your function URL. For example: Date, Keep-Alive, X-Custom-Header.
-* `max_age` - (Optional) The maximum amount of time (in seconds) that browsers can cache results of a preflight request. You cannot exceed 86400 seconds max age.
+This configuration block supports the following attributes:
 
+* `allow_credentials` - (Optional) Whether to allow cookies or other credentials in requests to the function URL. The default is `false`.
+* `allow_headers` - (Optional) The HTTP headers that origins can include in requests to the function URL. For example: `["date", "keep-alive", "x-custom-header"]`.
+* `allow_methods` - (Optional) The HTTP methods that are allowed when calling the function URL. For example: `["GET", "POST", "DELETE"]`, or the wildcard character (`["*"]`).
+* `allow_origins` - (Optional) The origins that can access the function URL. You can list any number of specific origins (or the wildcard character (`"*"`)), separated by a comma. For example: `["https://www.example.com", "http://localhost:60905"]`.
+* `expose_headers` - (Optional) The HTTP headers in your function response that you want to expose to origins that call the function URL.
+* `max_age` - (Optional) The maximum amount of time, in seconds, that web browsers can cache results of a preflight request. By default, this is set to `0`, which means that the browser doesn't cache results. The maximum value is `86400`.
 
-[1]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunctionUrlConfig.html
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `function_arn` - The Amazon Resource Name (ARN) of the function.
+* `function_url` - The HTTP URL endpoint for the function.
 
 ## Import
 
-Lambda Function URLs can be imported using the `function_name` or `function_name/qualifier`, e.g.,
+Lambda function URLs can be imported using the `function_name` or `function_name/qualifier`, e.g.,
 
 ```
 $ terraform import aws_lambda_function_url.test_lambda_url my_test_lambda_function

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -39,7 +39,7 @@ resource "aws_lambda_function_url" "test_live" {
 
 * `function_name` - (Required) Lambda Function name or ARN.
 * `qualifier` - (Optional) The Lambda alias name or '$LATEST'.
-* `authorization_type` - (Required) The authorization type for your function URL. Valid values are `["AWS_IAM"]` and `["NONE"]`.
+* `authorization_type` - (Required) The authorization type for your function URL. Valid values are `"AWS_IAM"` and `"NONE"`.
 * `cors` - (Optional) Configure cross-origin resource sharing.
 
 ### cors

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -56,7 +56,7 @@ resource "aws_lambda_function_url" "test_live" {
 
 ## Import
 
-Lambda Function URLs can be imported using the `function_name`, e.g.,
+Lambda Function URLs can be imported using the `function_name` or `function_name/qualifier`, e.g.,
 
 ```
 $ terraform import aws_lambda_function_url.test_lambda_url my_test_lambda_function

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -56,8 +56,8 @@ resource "aws_lambda_function_url" "test_live" {
 
 ## Import
 
-Lambda Function URLs can be imported using the `function_name/alias`, e.g.,
+Lambda Function URLs can be imported using the `function_name`, e.g.,
 
 ```
-$ terraform import aws_lambda_function_url.test_lambda_url my_test_lambda_function/my_alias
+$ terraform import aws_lambda_function_url.test_lambda_url my_test_lambda_function
 ```

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "Lambda"
+layout: "aws"
+page_title: "AWS: aws_lambda_function_url"
+description: |-
+  Creates a Lambda function URL.
+---
+
+# Resource: aws_lambda_function_url
+
+Creates a Lambda function URL. Creates a https url that points to the specified Lambda function alias or the latest version.
+
+A function URL is a dedicated HTTP(S) endpoint for your function. For information about Lambda function url, see [CreateFunctionUrlConfig][1] in the API docs.
+
+## Example Usage
+
+```terraform
+resource "aws_lambda_function_url" "test_latest" {
+  function_name    = aws_lambda_function.test.function_name
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_function_url" "test_live" {
+  function_name    = aws_lambda_function.test.function_name
+  qualifier        = "my_alias"
+  authorization_type = "AWS_IAM"
+  cors {
+    allow_credentials = true
+    allow_origins     = ["*"]
+    allow_methods     = ["*"]
+    allow_headers     = ["date", "keep-alive"]
+    expose_headers    = ["keep-alive", "date"]
+    max_age           = 86400
+  }
+}
+```
+
+## Argument Reference
+
+* `function_name` - (Required) Lambda Function name or ARN.
+* `qualifier` - (Optional) The Lambda alias name or '$LATEST'.
+* `authorization_type` - (Required) The authorization type for your function URL. Valid values are `["AWS_IAM"]` and `["NONE"]`.
+* `cors` - (Optional) Configure cross-origin resource sharing.
+
+### cors
+
+* `allow_credentials` - (Optional) allow cookies or other credentials in requests to your function URL.
+* `allow_origins` - (Optional) The origins that can access your function URL. You can list any number of specific origins. Alternatively, you can grant access to all origins with the wildcard character (*). For example: https://www.example.com, https://*, or *.
+* `allow_methods` - (Optional) The HTTP methods that are allowed when calling your function URL. For example: GET, POST, DELETE, *.
+* `allow_headers` - (Optional) The HTTP headers that origins can include in requests to your function URL. For example: Date, Keep-Alive, X-Custom-Header.
+* `expose_headers` - (Optional) The HTTP headers in your function response that you want to expose to origins that call your function URL. For example: Date, Keep-Alive, X-Custom-Header.
+* `max_age` - (Optional) The maximum amount of time (in seconds) that browsers can cache results of a preflight request. You cannot exceed 86400 seconds max age.
+
+
+[1]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunctionUrlConfig.html
+
+## Import
+
+Lambda Function Aliases can be imported using the `function_name/alias`, e.g.,
+
+```
+$ terraform import aws_lambda_function_url.test_lambda_url my_test_lambda_function/my_alias
+```

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_lambda_function_url
 
-Creates a Lambda function URL. Creates a https url that points to the specified Lambda function alias or the latest version.
+Creates a Lambda function URL, an HTTPS URL that points to the specified Lambda function alias or the latest version.
 
 A function URL is a dedicated HTTP(S) endpoint for your function. For information about Lambda function url, see [CreateFunctionUrlConfig][1] in the API docs.
 
@@ -56,7 +56,7 @@ resource "aws_lambda_function_url" "test_live" {
 
 ## Import
 
-Lambda Function Aliases can be imported using the `function_name/alias`, e.g.,
+Lambda Function URLs can be imported using the `function_name/alias`, e.g.,
 
 ```
 $ terraform import aws_lambda_function_url.test_lambda_url my_test_lambda_function/my_alias

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -59,7 +59,8 @@ This configuration block supports the following attributes:
 In addition to all arguments above, the following attributes are exported:
 
 * `function_arn` - The Amazon Resource Name (ARN) of the function.
-* `function_url` - The HTTP URL endpoint for the function.
+* `function_url` - The HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws`.
+* `url_id` - A generated ID for the endpoint.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #24050.

##### TODO

* [x] Review/edit documentation after looking at [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html)

#### AWS Commercial

```console
% make testacc TESTS=TestAccLambdaFunctionURL PKG=lambda ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 2 -run='TestAccLambdaFunctionURL'  -timeout 180m
=== RUN   TestAccLambdaFunctionURLDataSource_basic
=== PAUSE TestAccLambdaFunctionURLDataSource_basic
=== RUN   TestAccLambdaFunctionURL_basic
=== PAUSE TestAccLambdaFunctionURL_basic
=== RUN   TestAccLambdaFunctionURL_Cors
=== PAUSE TestAccLambdaFunctionURL_Cors
=== RUN   TestAccLambdaFunctionURL_Alias
=== PAUSE TestAccLambdaFunctionURL_Alias
=== CONT  TestAccLambdaFunctionURLDataSource_basic
=== CONT  TestAccLambdaFunctionURL_Cors
--- PASS: TestAccLambdaFunctionURLDataSource_basic (53.51s)
=== CONT  TestAccLambdaFunctionURL_basic
--- PASS: TestAccLambdaFunctionURL_Cors (67.94s)
=== CONT  TestAccLambdaFunctionURL_Alias
--- PASS: TestAccLambdaFunctionURL_basic (38.30s)
--- PASS: TestAccLambdaFunctionURL_Alias (45.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	123.047s
```

#### AWS GovCloud

```console
% make testacc TESTS=TestAccLambdaFunctionURL PKG=lambda ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 2 -run='TestAccLambdaFunctionURL'  -timeout 180m
=== RUN   TestAccLambdaFunctionURLDataSource_basic
=== PAUSE TestAccLambdaFunctionURLDataSource_basic
=== RUN   TestAccLambdaFunctionURL_basic
=== PAUSE TestAccLambdaFunctionURL_basic
=== RUN   TestAccLambdaFunctionURL_Cors
=== PAUSE TestAccLambdaFunctionURL_Cors
=== RUN   TestAccLambdaFunctionURL_Alias
=== PAUSE TestAccLambdaFunctionURL_Alias
=== CONT  TestAccLambdaFunctionURLDataSource_basic
=== CONT  TestAccLambdaFunctionURL_Cors
=== CONT  TestAccLambdaFunctionURLDataSource_basic
    function_url_test.go:21: Lambda Function URLs are not supported in aws-us-gov partition
--- SKIP: TestAccLambdaFunctionURLDataSource_basic (1.84s)
=== CONT  TestAccLambdaFunctionURL_Cors
    function_url_test.go:21: Lambda Function URLs are not supported in aws-us-gov partition
=== CONT  TestAccLambdaFunctionURL_Alias
--- SKIP: TestAccLambdaFunctionURL_Cors (1.84s)
=== CONT  TestAccLambdaFunctionURL_basic
=== CONT  TestAccLambdaFunctionURL_Alias
    function_url_test.go:21: Lambda Function URLs are not supported in aws-us-gov partition
=== CONT  TestAccLambdaFunctionURL_basic
    function_url_test.go:21: Lambda Function URLs are not supported in aws-us-gov partition
--- SKIP: TestAccLambdaFunctionURL_Alias (0.00s)
--- SKIP: TestAccLambdaFunctionURL_basic (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	9.231s
```