### PR TITLE
Updates `aws-sdk-go-base` to `v2.0.0-beta.14` and `awsv1shim` to `v2/awsv1shim/v2.0.0-beta.15`

### DIFF
--- a/.changelog/24064.txt
+++ b/.changelog/24064.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add support for reading custom CA bundle setting from shared config files
+```

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/beevik/etree v1.1.0
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.16.0
-	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.13
-	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.14
+	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.14
+	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.15
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -134,10 +134,10 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.16.0 h1:r2RUzeK2gAitl0HY9SLH1axAEu+6aPBY20g1jOoBepM=
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.16.0/go.mod h1:C6GVuO9RWOrt6QCGTmLCOYuSHpkfQSBDuRqTteOlo0g=
-github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.13 h1:FIIkxL5+CHVt4TqwqY1pxG8k35ac8+vi3wGKpsRSTcI=
-github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.13/go.mod h1:QP/Uy/4K9XLzpwDSKX7fLGFuQfQq2Nz+OacCTbuaKKQ=
-github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.14 h1:Ar8qQRk0SomjSlmSr3oKzbt65/GtESrmwLGWS/9DI3M=
-github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.14/go.mod h1:WcbJAJErVMrVS/H7q57C83iFXFeay+xg29dxwQc/GqI=
+github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.14 h1:tZBIvSx7Ympn/tb8ti9spm6t5/aZGDYXgGqScTbi73E=
+github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.14/go.mod h1:QP/Uy/4K9XLzpwDSKX7fLGFuQfQq2Nz+OacCTbuaKKQ=
+github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.15 h1:5APIXK6BrpmZfN5zziM9QEfRPQlvipPAEL5kdP0/kmA=
+github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.15/go.mod h1:egFflsd1GSZDS/NvREHcsYAIxJVerRiFWDoWtP+YH0c=
 github.com/hashicorp/awspolicyequivalence v1.5.0 h1:tGw6h9qN1AWNBaUf4OUcdCyE/kqNBItTiyTPQeV/KUg=
 github.com/hashicorp/awspolicyequivalence v1.5.0/go.mod h1:9IOaIHx+a7C0NfUNk1A93M7kHd5rJ19aoUx37LZGC14=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -215,7 +215,7 @@ credential_process = custom-process --username jdoe
 |Secret Access Key|`secret_key`|`AWS_SECRET_ACCESS_KEY`|`aws_secret_access_key`|
 |Session Token|`token`|`AWS_SESSION_TOKEN`|`aws_session_token`|
 |Region|`region`|`AWS_REGION` or `AWS_DEFAULT_REGION`|`region`|
-|Custom CA Bundle |`custom_ca_bundle`|`AWS_CA_BUNDLE`|Not supported|
+|Custom CA Bundle |`custom_ca_bundle`|`AWS_CA_BUNDLE`|`ca_bundle`|
 |EC2 IMDS Endpoint |`ec2_metadata_service_endpoint`|`AWS_EC2_METADATA_SERVICE_ENDPOINT`|N/A|
 |EC2 IMDS Endpoint Mode|`ec2_metadata_service_endpoint_mode`|`AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE`|N/A|
 |Disable EC2 IMDS|`skip_metadata_api_check`|`AWS_EC2_METADATA_DISABLED`|N/A|


### PR DESCRIPTION
Adds support for reading custom CA bundle from shared config files.

Output from acceptance testing:

N/A