### PR TITLE
t-aws_rds_activity_stream: Exclude regions that are not supported in test

### DIFF
--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -169,11 +169,7 @@ func testAccCheckClusterActivityStreamDestroyWithProvider(s *terraform.State, pr
 }
 
 func testAccClusterActivityStreamConfigBase(clusterName, instanceName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
@@ -196,13 +192,11 @@ resource "aws_rds_cluster_instance" "test" {
   engine             = aws_rds_cluster.test.engine
   instance_class     = "db.r6g.large"
 }
-`, clusterName, instanceName)
+`, clusterName, instanceName))
 }
 
 func testAccClusterActivityStreamConfig(clusterName, instanceName string) string {
-	return acctest.ConfigCompose(
-		testAccClusterActivityStreamConfigBase(clusterName, instanceName),
-		`
+	return acctest.ConfigCompose(testAccClusterActivityStreamConfigBase(clusterName, instanceName), `
 resource "aws_rds_cluster_activity_stream" "test" {
   resource_arn = aws_rds_cluster.test.arn
   kms_key_id   = aws_kms_key.test.key_id
@@ -210,5 +204,5 @@ resource "aws_rds_cluster_activity_stream" "test" {
 
   depends_on = [aws_rds_cluster_instance.test]
 }
-		`)
+`)
 }

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -2,11 +2,11 @@ package rds_test
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/rds"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -2,6 +2,7 @@ package rds_test
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"regexp"
 	"testing"
 
@@ -26,7 +27,10 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckRegionNot(t, endpoints.UsGovWest1RegionID, endpoints.UsGovEast1RegionID, endpoints.CnNorthwest1RegionID, endpoints.CnNorth1RegionID)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
@@ -60,7 +64,10 @@ func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckRegionNot(t, endpoints.UsGovWest1RegionID, endpoints.UsGovEast1RegionID, endpoints.CnNorthwest1RegionID, endpoints.CnNorth1RegionID)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -29,7 +29,7 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsGovWest1RegionID, endpoints.UsGovEast1RegionID, endpoints.CnNorthwest1RegionID, endpoints.CnNorth1RegionID)
+			acctest.PreCheckPartition(endpoints.AwsPartitionID, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
 		Providers:    acctest.Providers,
@@ -66,7 +66,7 @@ func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsGovWest1RegionID, endpoints.UsGovEast1RegionID, endpoints.CnNorthwest1RegionID, endpoints.CnNorth1RegionID)
+			acctest.PreCheckPartition(endpoints.AwsPartitionID, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
+func TestAccRDSClusterActivityStream_basic(t *testing.T) {
 	var dbCluster rds.DBCluster
 	clusterName := sdkacctest.RandomWithPrefix("tf-testacc-aurora-cluster")
 	instanceName := sdkacctest.RandomWithPrefix("tf-testacc-aurora-instance")
@@ -33,13 +33,13 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		CheckDestroy: testAccCheckClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
+				Config: testAccClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
-					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					testAccCheckClusterActivityStreamAttributes(&dbCluster),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+clusterName)),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", rdsClusterResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "key_id"),
@@ -57,7 +57,7 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
+func TestAccRDSClusterActivityStream_disappears(t *testing.T) {
 	var dbCluster rds.DBCluster
 	clusterName := sdkacctest.RandomWithPrefix("tf-testacc-aurora-cluster")
 	instanceName := sdkacctest.RandomWithPrefix("tf-testacc-aurora-instance")
@@ -70,10 +70,10 @@ func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		CheckDestroy: testAccCheckClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
+				Config: testAccClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					acctest.CheckResourceDisappears(acctest.Provider, tfrds.ResourceClusterActivityStream(), resourceName),
@@ -112,7 +112,7 @@ func testAccCheckAWSRDSClusterActivityStreamExistsWithProvider(resourceName stri
 	}
 }
 
-func testAccCheckAWSRDSClusterActivityStreamAttributes(v *rds.DBCluster) resource.TestCheckFunc {
+func testAccCheckClusterActivityStreamAttributes(v *rds.DBCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if aws.StringValue(v.DBClusterArn) == "" {
@@ -139,11 +139,11 @@ func testAccCheckAWSRDSClusterActivityStreamAttributes(v *rds.DBCluster) resourc
 	}
 }
 
-func testAccCheckAWSClusterActivityStreamDestroy(s *terraform.State) error {
-	return testAccCheckAWSClusterActivityStreamDestroyWithProvider(s, acctest.Provider)
+func testAccCheckClusterActivityStreamDestroy(s *terraform.State) error {
+	return testAccCheckClusterActivityStreamDestroyWithProvider(s, acctest.Provider)
 }
 
-func testAccCheckAWSClusterActivityStreamDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+func testAccCheckClusterActivityStreamDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
 	conn := provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -168,7 +168,7 @@ func testAccCheckAWSClusterActivityStreamDestroyWithProvider(s *terraform.State,
 	return nil
 }
 
-func testAccAWSClusterActivityStreamConfigBase(clusterName, instanceName string) string {
+func testAccClusterActivityStreamConfigBase(clusterName, instanceName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -199,9 +199,9 @@ resource "aws_rds_cluster_instance" "test" {
 `, clusterName, instanceName)
 }
 
-func testAccAWSClusterActivityStreamConfig(clusterName, instanceName string) string {
+func testAccClusterActivityStreamConfig(clusterName, instanceName string) string {
 	return acctest.ConfigCompose(
-		testAccAWSClusterActivityStreamConfigBase(clusterName, instanceName),
+		testAccClusterActivityStreamConfigBase(clusterName, instanceName),
 		`
 resource "aws_rds_cluster_activity_stream" "test" {
   resource_arn = aws_rds_cluster.test.arn


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Regions that are not supported can be found [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.Overview.html)

Closes #24160

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAWSRDSClusterActivityStream_ PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccAWSRDSClusterActivityStream_'  -timeout 180m
=== RUN   TestAccAWSRDSClusterActivityStream_basic
=== PAUSE TestAccAWSRDSClusterActivityStream_basic
=== RUN   TestAccAWSRDSClusterActivityStream_disappears
=== PAUSE TestAccAWSRDSClusterActivityStream_disappears
=== CONT  TestAccAWSRDSClusterActivityStream_basic
=== CONT  TestAccAWSRDSClusterActivityStream_disappears
=== CONT  TestAccAWSRDSClusterActivityStream_basic
    acctest.go:673: skipping tests; current partition (aws-us-gov) does not equal aws
--- SKIP: TestAccAWSRDSClusterActivityStream_basic (0.76s)
=== CONT  TestAccAWSRDSClusterActivityStream_disappears
    acctest.go:673: skipping tests; current partition (aws-us-gov) does not equal aws
--- SKIP: TestAccAWSRDSClusterActivityStream_disappears (0.76s)
PASS
...
```
