### PR TITLE
Correct GameLift name

### DIFF
--- a/internal/service/gamelift/alias.go
+++ b/internal/service/gamelift/alias.go
@@ -79,7 +79,7 @@ func resourceAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	rs := expandGameliftRoutingStrategy(d.Get("routing_strategy").([]interface{}))
+	rs := expandRoutingStrategy(d.Get("routing_strategy").([]interface{}))
 	input := gamelift.CreateAliasInput{
 		Name:            aws.String(d.Get("name").(string)),
 		RoutingStrategy: rs,
@@ -88,7 +88,7 @@ func resourceAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
 	}
-	log.Printf("[INFO] Creating Gamelift Alias: %s", input)
+	log.Printf("[INFO] Creating GameLift Alias: %s", input)
 	out, err := conn.CreateAlias(&input)
 	if err != nil {
 		return err
@@ -104,14 +104,14 @@ func resourceAliasRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	log.Printf("[INFO] Describing Gamelift Alias: %s", d.Id())
+	log.Printf("[INFO] Describing GameLift Alias: %s", d.Id())
 	out, err := conn.DescribeAlias(&gamelift.DescribeAliasInput{
 		AliasId: aws.String(d.Id()),
 	})
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
 			d.SetId("")
-			log.Printf("[WARN] Gamelift Alias (%s) not found, removing from state", d.Id())
+			log.Printf("[WARN] GameLift Alias (%s) not found, removing from state", d.Id())
 			return nil
 		}
 		return err
@@ -122,7 +122,7 @@ func resourceAliasRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", arn)
 	d.Set("description", a.Description)
 	d.Set("name", a.Name)
-	d.Set("routing_strategy", flattenGameliftRoutingStrategy(a.RoutingStrategy))
+	d.Set("routing_strategy", flattenRoutingStrategy(a.RoutingStrategy))
 	tags, err := ListTags(conn, arn)
 
 	if err != nil {
@@ -146,12 +146,12 @@ func resourceAliasRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Updating Gamelift Alias: %s", d.Id())
+	log.Printf("[INFO] Updating GameLift Alias: %s", d.Id())
 	_, err := conn.UpdateAlias(&gamelift.UpdateAliasInput{
 		AliasId:         aws.String(d.Id()),
 		Name:            aws.String(d.Get("name").(string)),
 		Description:     aws.String(d.Get("description").(string)),
-		RoutingStrategy: expandGameliftRoutingStrategy(d.Get("routing_strategy").([]interface{})),
+		RoutingStrategy: expandRoutingStrategy(d.Get("routing_strategy").([]interface{})),
 	})
 	if err != nil {
 		return err
@@ -172,14 +172,14 @@ func resourceAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAliasDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Deleting Gamelift Alias: %s", d.Id())
+	log.Printf("[INFO] Deleting GameLift Alias: %s", d.Id())
 	_, err := conn.DeleteAlias(&gamelift.DeleteAliasInput{
 		AliasId: aws.String(d.Id()),
 	})
 	return err
 }
 
-func expandGameliftRoutingStrategy(cfg []interface{}) *gamelift.RoutingStrategy {
+func expandRoutingStrategy(cfg []interface{}) *gamelift.RoutingStrategy {
 	if len(cfg) < 1 {
 		return nil
 	}
@@ -200,7 +200,7 @@ func expandGameliftRoutingStrategy(cfg []interface{}) *gamelift.RoutingStrategy 
 	return &out
 }
 
-func flattenGameliftRoutingStrategy(rs *gamelift.RoutingStrategy) []interface{} {
+func flattenRoutingStrategy(rs *gamelift.RoutingStrategy) []interface{} {
 	if rs == nil {
 		return []interface{}{}
 	}

--- a/internal/service/gamelift/alias_test.go
+++ b/internal/service/gamelift/alias_test.go
@@ -126,6 +126,10 @@ func TestAccGameLiftAlias_tags(t *testing.T) {
 }
 
 func TestAccGameLiftAlias_fleetRouting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.Alias
 
 	rString := sdkacctest.RandString(8)

--- a/internal/service/gamelift/alias_test.go
+++ b/internal/service/gamelift/alias_test.go
@@ -238,7 +238,7 @@ func testAccCheckAliasExists(n string, res *gamelift.Alias) resource.TestCheckFu
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Gamelift Alias ID is set")
+			return fmt.Errorf("No GameLift Alias ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
@@ -252,7 +252,7 @@ func testAccCheckAliasExists(n string, res *gamelift.Alias) resource.TestCheckFu
 		a := out.Alias
 
 		if *a.AliasId != rs.Primary.ID {
-			return fmt.Errorf("Gamelift Alias not found")
+			return fmt.Errorf("GameLift Alias not found")
 		}
 
 		*res = *a
@@ -273,7 +273,7 @@ func testAccCheckAliasDestroy(s *terraform.State) error {
 			AliasId: aws.String(rs.Primary.ID),
 		})
 		if err == nil {
-			return fmt.Errorf("Gamelift Alias still exists")
+			return fmt.Errorf("GameLift Alias still exists")
 		}
 
 		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {

--- a/internal/service/gamelift/build.go
+++ b/internal/service/gamelift/build.go
@@ -95,7 +95,7 @@ func resourceBuildCreate(d *schema.ResourceData, meta interface{}) error {
 	input := gamelift.CreateBuildInput{
 		Name:            aws.String(d.Get("name").(string)),
 		OperatingSystem: aws.String(d.Get("operating_system").(string)),
-		StorageLocation: expandGameliftStorageLocation(d.Get("storage_location").([]interface{})),
+		StorageLocation: expandStorageLocation(d.Get("storage_location").([]interface{})),
 		Tags:            Tags(tags.IgnoreAWS()),
 	}
 
@@ -103,7 +103,7 @@ func resourceBuildCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Version = aws.String(v.(string))
 	}
 
-	log.Printf("[INFO] Creating Gamelift Build: %s", input)
+	log.Printf("[INFO] Creating GameLift Build: %s", input)
 	var out *gamelift.CreateBuildOutput
 	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
 		var err error
@@ -121,7 +121,7 @@ func resourceBuildCreate(d *schema.ResourceData, meta interface{}) error {
 		out, err = conn.CreateBuild(&input)
 	}
 	if err != nil {
-		return fmt.Errorf("Error creating Gamelift build client: %w", err)
+		return fmt.Errorf("Error creating GameLift build client: %w", err)
 	}
 
 	d.SetId(aws.StringValue(out.Build.BuildId))
@@ -138,7 +138,7 @@ func resourceBuildRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	log.Printf("[INFO] Reading Gamelift Build: %s", d.Id())
+	log.Printf("[INFO] Reading GameLift Build: %s", d.Id())
 	build, err := FindBuildByID(conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] GameLift Build (%s) not found, removing from state", d.Id())
@@ -180,7 +180,7 @@ func resourceBuildUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
 	if d.HasChangesExcept("tags", "tags_all") {
-		log.Printf("[INFO] Updating Gamelift Build: %s", d.Id())
+		log.Printf("[INFO] Updating GameLift Build: %s", d.Id())
 		input := gamelift.UpdateBuildInput{
 			BuildId: aws.String(d.Id()),
 			Name:    aws.String(d.Get("name").(string)),
@@ -191,7 +191,7 @@ func resourceBuildUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := conn.UpdateBuild(&input)
 		if err != nil {
-			return fmt.Errorf("Error updating Gamelift build client: %w", err)
+			return fmt.Errorf("Error updating GameLift build client: %w", err)
 		}
 	}
 
@@ -210,14 +210,14 @@ func resourceBuildUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceBuildDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Deleting Gamelift Build: %s", d.Id())
+	log.Printf("[INFO] Deleting GameLift Build: %s", d.Id())
 	_, err := conn.DeleteBuild(&gamelift.DeleteBuildInput{
 		BuildId: aws.String(d.Id()),
 	})
 	return err
 }
 
-func expandGameliftStorageLocation(cfg []interface{}) *gamelift.S3Location {
+func expandStorageLocation(cfg []interface{}) *gamelift.S3Location {
 	loc := cfg[0].(map[string]interface{})
 
 	location := &gamelift.S3Location{

--- a/internal/service/gamelift/build_test.go
+++ b/internal/service/gamelift/build_test.go
@@ -207,7 +207,7 @@ func testAccCheckBuildExists(n string, res *gamelift.Build) resource.TestCheckFu
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Gamelift Build ID is set")
+			return fmt.Errorf("No GameLift Build ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
@@ -218,7 +218,7 @@ func testAccCheckBuildExists(n string, res *gamelift.Build) resource.TestCheckFu
 		}
 
 		if aws.StringValue(build.BuildId) != rs.Primary.ID {
-			return fmt.Errorf("Gamelift Build not found")
+			return fmt.Errorf("GameLift Build not found")
 		}
 
 		*res = *build

--- a/internal/service/gamelift/fleet.go
+++ b/internal/service/gamelift/fleet.go
@@ -261,7 +261,7 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 		input.FleetType = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("ec2_inbound_permission"); ok {
-		input.EC2InboundPermissions = expandGameliftIpPermissions(v.(*schema.Set))
+		input.EC2InboundPermissions = expandIpPermissions(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("instance_role_arn"); ok {
@@ -275,17 +275,17 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 		input.NewGameSessionProtectionPolicy = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("resource_creation_limit_policy"); ok {
-		input.ResourceCreationLimitPolicy = expandGameliftResourceCreationLimitPolicy(v.([]interface{}))
+		input.ResourceCreationLimitPolicy = expandResourceCreationLimitPolicy(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("runtime_configuration"); ok {
-		input.RuntimeConfiguration = expandGameliftRuntimeConfiguration(v.([]interface{}))
+		input.RuntimeConfiguration = expandRuntimeConfiguration(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("certificate_configuration"); ok {
-		input.CertificateConfiguration = expandGameliftCertificateConfiguration(v.([]interface{}))
+		input.CertificateConfiguration = expandCertificateConfiguration(v.([]interface{}))
 	}
 
-	log.Printf("[INFO] Creating Gamelift Fleet: %s", input)
+	log.Printf("[INFO] Creating GameLift Fleet: %s", input)
 	var out *gamelift.CreateFleetOutput
 	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
 		var err error
@@ -324,7 +324,7 @@ func resourceFleetRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	log.Printf("[INFO] Describing Gamelift Fleet: %s", d.Id())
+	log.Printf("[INFO] Describing GameLift Fleet: %s", d.Id())
 	fleet, err := FindFleetByID(conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] GameLift Fleet (%s) not found, removing from state", d.Id())
@@ -352,11 +352,11 @@ func resourceFleetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("script_arn", fleet.ScriptArn)
 	d.Set("script_id", fleet.ScriptId)
 
-	if err := d.Set("certificate_configuration", flattenGameliftCertificateConfiguration(fleet.CertificateConfiguration)); err != nil {
+	if err := d.Set("certificate_configuration", flattenCertificateConfiguration(fleet.CertificateConfiguration)); err != nil {
 		return fmt.Errorf("error setting certificate_configuration: %w", err)
 	}
 
-	if err := d.Set("resource_creation_limit_policy", flattenGameliftResourceCreationLimitPolicy(fleet.ResourceCreationLimitPolicy)); err != nil {
+	if err := d.Set("resource_creation_limit_policy", flattenResourceCreationLimitPolicy(fleet.ResourceCreationLimitPolicy)); err != nil {
 		return fmt.Errorf("error setting resource_creation_limit_policy: %w", err)
 	}
 
@@ -369,7 +369,7 @@ func resourceFleetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading for GameLift Fleet ec2 inbound permission (%s): %w", d.Id(), err)
 	}
 
-	if err := d.Set("ec2_inbound_permission", flattenGameliftIpPermissions(portConfig.InboundPermissions)); err != nil {
+	if err := d.Set("ec2_inbound_permission", flattenIpPermissions(portConfig.InboundPermissions)); err != nil {
 		return fmt.Errorf("error setting ec2_inbound_permission: %w", err)
 	}
 
@@ -400,7 +400,7 @@ func resourceFleetRead(d *schema.ResourceData, meta interface{}) error {
 func resourceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Updating Gamelift Fleet: %s", d.Id())
+	log.Printf("[INFO] Updating GameLift Fleet: %s", d.Id())
 
 	if d.HasChanges("description", "metric_groups", "name", "new_game_session_protection_policy", "resource_creation_limit_policy") {
 		_, err := conn.UpdateFleetAttributes(&gamelift.UpdateFleetAttributesInput{
@@ -409,7 +409,7 @@ func resourceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 			MetricGroups:                   flex.ExpandStringList(d.Get("metric_groups").([]interface{})),
 			Name:                           aws.String(d.Get("name").(string)),
 			NewGameSessionProtectionPolicy: aws.String(d.Get("new_game_session_protection_policy").(string)),
-			ResourceCreationLimitPolicy:    expandGameliftResourceCreationLimitPolicy(d.Get("resource_creation_limit_policy").([]interface{})),
+			ResourceCreationLimitPolicy:    expandResourceCreationLimitPolicy(d.Get("resource_creation_limit_policy").([]interface{})),
 		})
 		if err != nil {
 			return fmt.Errorf("error updating for GameLift Fleet attributes (%s): %w", d.Id(), err)
@@ -433,7 +433,7 @@ func resourceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("runtime_configuration") {
 		_, err := conn.UpdateRuntimeConfiguration(&gamelift.UpdateRuntimeConfigurationInput{
 			FleetId:              aws.String(d.Id()),
-			RuntimeConfiguration: expandGameliftRuntimeConfiguration(d.Get("runtime_configuration").([]interface{})),
+			RuntimeConfiguration: expandRuntimeConfiguration(d.Get("runtime_configuration").([]interface{})),
 		})
 		if err != nil {
 			return fmt.Errorf("error updating for GameLift Fleet runtime configuration (%s): %w", d.Id(), err)
@@ -455,8 +455,8 @@ func resourceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceFleetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Deleting Gamelift Fleet: %s", d.Id())
-	// It can take ~ 1 hr as Gamelift will keep retrying on errors like
+	log.Printf("[INFO] Deleting GameLift Fleet: %s", d.Id())
+	// It can take ~ 1 hr as GameLift will keep retrying on errors like
 	// invalid launch path and remain in state when it can't be deleted :/
 	input := &gamelift.DeleteFleetInput{
 		FleetId: aws.String(d.Id()),
@@ -479,7 +479,7 @@ func resourceFleetDelete(d *schema.ResourceData, meta interface{}) error {
 		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Gamelift fleet: %w", err)
+		return fmt.Errorf("Error deleting GameLift fleet: %w", err)
 	}
 
 	if _, err := waitFleetTerminated(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
@@ -489,7 +489,7 @@ func resourceFleetDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandGameliftIpPermissions(cfgs *schema.Set) []*gamelift.IpPermission {
+func expandIpPermissions(cfgs *schema.Set) []*gamelift.IpPermission {
 	if cfgs.Len() < 1 {
 		return []*gamelift.IpPermission{}
 	}
@@ -497,12 +497,12 @@ func expandGameliftIpPermissions(cfgs *schema.Set) []*gamelift.IpPermission {
 	perms := make([]*gamelift.IpPermission, cfgs.Len())
 	for i, rawCfg := range cfgs.List() {
 		cfg := rawCfg.(map[string]interface{})
-		perms[i] = expandGameliftIpPermission(cfg)
+		perms[i] = expandIpPermission(cfg)
 	}
 	return perms
 }
 
-func expandGameliftIpPermission(cfg map[string]interface{}) *gamelift.IpPermission {
+func expandIpPermission(cfg map[string]interface{}) *gamelift.IpPermission {
 	return &gamelift.IpPermission{
 		FromPort: aws.Int64(int64(cfg["from_port"].(int))),
 		IpRange:  aws.String(cfg["ip_range"].(string)),
@@ -511,7 +511,7 @@ func expandGameliftIpPermission(cfg map[string]interface{}) *gamelift.IpPermissi
 	}
 }
 
-func flattenGameliftIpPermissions(apiObjects []*gamelift.IpPermission) []interface{} {
+func flattenIpPermissions(apiObjects []*gamelift.IpPermission) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -522,7 +522,7 @@ func flattenGameliftIpPermissions(apiObjects []*gamelift.IpPermission) []interfa
 			continue
 		}
 
-		if v := flattenGameliftIpPermission(apiObject); len(v) > 0 {
+		if v := flattenIpPermission(apiObject); len(v) > 0 {
 			tfList = append(tfList, v)
 		}
 	}
@@ -530,7 +530,7 @@ func flattenGameliftIpPermissions(apiObjects []*gamelift.IpPermission) []interfa
 	return tfList
 }
 
-func flattenGameliftIpPermission(apiObject *gamelift.IpPermission) map[string]interface{} {
+func flattenIpPermission(apiObject *gamelift.IpPermission) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -545,7 +545,7 @@ func flattenGameliftIpPermission(apiObject *gamelift.IpPermission) map[string]in
 	return tfMap
 }
 
-func expandGameliftResourceCreationLimitPolicy(cfg []interface{}) *gamelift.ResourceCreationLimitPolicy {
+func expandResourceCreationLimitPolicy(cfg []interface{}) *gamelift.ResourceCreationLimitPolicy {
 	if len(cfg) < 1 {
 		return nil
 	}
@@ -562,7 +562,7 @@ func expandGameliftResourceCreationLimitPolicy(cfg []interface{}) *gamelift.Reso
 	return &out
 }
 
-func flattenGameliftResourceCreationLimitPolicy(policy *gamelift.ResourceCreationLimitPolicy) []interface{} {
+func flattenResourceCreationLimitPolicy(policy *gamelift.ResourceCreationLimitPolicy) []interface{} {
 	if policy == nil {
 		return []interface{}{}
 	}
@@ -574,7 +574,7 @@ func flattenGameliftResourceCreationLimitPolicy(policy *gamelift.ResourceCreatio
 	return []interface{}{m}
 }
 
-func expandGameliftRuntimeConfiguration(cfg []interface{}) *gamelift.RuntimeConfiguration {
+func expandRuntimeConfiguration(cfg []interface{}) *gamelift.RuntimeConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
@@ -588,13 +588,13 @@ func expandGameliftRuntimeConfiguration(cfg []interface{}) *gamelift.RuntimeConf
 		out.MaxConcurrentGameSessionActivations = aws.Int64(int64(v))
 	}
 	if v, ok := m["server_process"]; ok {
-		out.ServerProcesses = expandGameliftServerProcesses(v.([]interface{}))
+		out.ServerProcesses = expandServerProcesses(v.([]interface{}))
 	}
 
 	return &out
 }
 
-func expandGameliftServerProcesses(cfgs []interface{}) []*gamelift.ServerProcess {
+func expandServerProcesses(cfgs []interface{}) []*gamelift.ServerProcess {
 	if len(cfgs) < 1 {
 		return []*gamelift.ServerProcess{}
 	}
@@ -614,7 +614,7 @@ func expandGameliftServerProcesses(cfgs []interface{}) []*gamelift.ServerProcess
 	return processes
 }
 
-func expandGameliftCertificateConfiguration(cfg []interface{}) *gamelift.CertificateConfiguration {
+func expandCertificateConfiguration(cfg []interface{}) *gamelift.CertificateConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
@@ -628,7 +628,7 @@ func expandGameliftCertificateConfiguration(cfg []interface{}) *gamelift.Certifi
 	return &out
 }
 
-func flattenGameliftCertificateConfiguration(config *gamelift.CertificateConfiguration) []interface{} {
+func flattenCertificateConfiguration(config *gamelift.CertificateConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -656,13 +656,13 @@ OUTER:
 		}
 
 		// Add what's left for revocation
-		r = append(r, expandGameliftIpPermission(oldPerm))
+		r = append(r, expandIpPermission(oldPerm))
 	}
 
 	for _, np := range newPerms {
 		newPerm := np.(map[string]interface{})
 		// Add what's left for authorization
-		a = append(a, expandGameliftIpPermission(newPerm))
+		a = append(a, expandIpPermission(newPerm))
 	}
 	return
 }

--- a/internal/service/gamelift/fleet_test.go
+++ b/internal/service/gamelift/fleet_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestDiffGameliftPortSettings(t *testing.T) {
+func TestDiffGameLiftPortSettings(t *testing.T) {
 	testCases := []struct {
 		Old           []interface{}
 		New           []interface{}
@@ -609,7 +609,7 @@ func testAccCheckFleetExists(n string, res *gamelift.FleetAttributes) resource.T
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Gamelift Fleet ID is set")
+			return fmt.Errorf("No GameLift Fleet ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
@@ -620,7 +620,7 @@ func testAccCheckFleetExists(n string, res *gamelift.FleetAttributes) resource.T
 		}
 
 		if aws.StringValue(fleet.FleetId) != rs.Primary.ID {
-			return fmt.Errorf("Gamelift Fleet not found")
+			return fmt.Errorf("GameLift Fleet not found")
 		}
 
 		*res = *fleet

--- a/internal/service/gamelift/fleet_test.go
+++ b/internal/service/gamelift/fleet_test.go
@@ -150,6 +150,10 @@ func TestDiffGameLiftPortSettings(t *testing.T) {
 }
 
 func TestAccGameLiftFleet_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.FleetAttributes
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -240,6 +244,10 @@ func TestAccGameLiftFleet_basic(t *testing.T) {
 }
 
 func TestAccGameLiftFleet_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.FleetAttributes
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -310,6 +318,10 @@ func TestAccGameLiftFleet_tags(t *testing.T) {
 }
 
 func TestAccGameLiftFleet_allFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.FleetAttributes
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -452,6 +464,10 @@ func TestAccGameLiftFleet_allFields(t *testing.T) {
 }
 
 func TestAccGameLiftFleet_cert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.FleetAttributes
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -505,6 +521,10 @@ func TestAccGameLiftFleet_cert(t *testing.T) {
 }
 
 func TestAccGameLiftFleet_script(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.FleetAttributes
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -554,6 +574,10 @@ func TestAccGameLiftFleet_script(t *testing.T) {
 }
 
 func TestAccGameLiftFleet_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf gamelift.FleetAttributes
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/gamelift/game_server_group.go
+++ b/internal/service/gamelift/game_server_group.go
@@ -191,8 +191,8 @@ func resourceGameServerGroupCreate(d *schema.ResourceData, meta interface{}) err
 
 	input := &gamelift.CreateGameServerGroupInput{
 		GameServerGroupName: aws.String(d.Get("game_server_group_name").(string)),
-		InstanceDefinitions: expandGameliftInstanceDefinitions(d.Get("instance_definition").(*schema.Set).List()),
-		LaunchTemplate:      expandGameliftLaunchTemplateSpecification(d.Get("launch_template").([]interface{})[0].(map[string]interface{})),
+		InstanceDefinitions: expandInstanceDefinitions(d.Get("instance_definition").(*schema.Set).List()),
+		LaunchTemplate:      expandLaunchTemplateSpecification(d.Get("launch_template").([]interface{})[0].(map[string]interface{})),
 		MaxSize:             aws.Int64(int64(d.Get("max_size").(int))),
 		MinSize:             aws.Int64(int64(d.Get("min_size").(int))),
 		RoleArn:             aws.String(d.Get("role_arn").(string)),
@@ -200,7 +200,7 @@ func resourceGameServerGroupCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if v, ok := d.GetOk("auto_scaling_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.AutoScalingPolicy = expandGameliftGameServerGroupAutoScalingPolicy(v.([]interface{})[0].(map[string]interface{}))
+		input.AutoScalingPolicy = expandGameServerGroupAutoScalingPolicy(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("balancing_strategy"); ok {
@@ -215,7 +215,7 @@ func resourceGameServerGroupCreate(d *schema.ResourceData, meta interface{}) err
 		input.VpcSubnets = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	log.Printf("[INFO] Creating Gamelift Game Server Group: %s", input)
+	log.Printf("[INFO] Creating GameLift Game Server Group: %s", input)
 	var out *gamelift.CreateGameServerGroupOutput
 	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
 		var err error
@@ -257,7 +257,7 @@ func resourceGameServerGroupRead(d *schema.ResourceData, meta interface{}) error
 
 	gameServerGroupName := d.Id()
 
-	log.Printf("[INFO] Describing Gamelift Game Server Group: %s", gameServerGroupName)
+	log.Printf("[INFO] Describing GameLift Game Server Group: %s", gameServerGroupName)
 	gameServerGroup, err := FindGameServerGroupByName(conn, gameServerGroupName)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] GameLift Game Server Group (%s) not found, removing from state", gameServerGroupName)
@@ -301,14 +301,14 @@ func resourceGameServerGroupRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("role_arn", gameServerGroup.RoleArn)
 
 	if len(describePoliciesOutput.ScalingPolicies) == 1 {
-		if err := d.Set("auto_scaling_policy", []interface{}{flattenGameliftGameServerGroupAutoScalingPolicy(describePoliciesOutput.ScalingPolicies[0])}); err != nil {
+		if err := d.Set("auto_scaling_policy", []interface{}{flattenGameServerGroupAutoScalingPolicy(describePoliciesOutput.ScalingPolicies[0])}); err != nil {
 			return fmt.Errorf("error setting auto_scaling_policy: %w", err)
 		}
 	} else {
 		d.Set("auto_scaling_policy", nil)
 	}
 
-	if err := d.Set("instance_definition", flattenGameliftInstanceDefinitions(gameServerGroup.InstanceDefinitions)); err != nil {
+	if err := d.Set("instance_definition", flattenInstanceDefinitions(gameServerGroup.InstanceDefinitions)); err != nil {
 		return fmt.Errorf("error setting instance_definition: %s", err)
 	}
 
@@ -343,12 +343,12 @@ func resourceGameServerGroupRead(d *schema.ResourceData, meta interface{}) error
 func resourceGameServerGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Updating Gamelift Game Server Group: %s", d.Id())
+	log.Printf("[INFO] Updating GameLift Game Server Group: %s", d.Id())
 
 	if d.HasChanges("balancing_strategy", "game_server_protection_policy", "instance_definition", "role_arn") {
 		input := gamelift.UpdateGameServerGroupInput{
 			GameServerGroupName: aws.String(d.Id()),
-			InstanceDefinitions: expandGameliftInstanceDefinitions(d.Get("instance_definition").(*schema.Set).List()),
+			InstanceDefinitions: expandInstanceDefinitions(d.Get("instance_definition").(*schema.Set).List()),
 			RoleArn:             aws.String(d.Get("role_arn").(string)),
 		}
 
@@ -381,7 +381,7 @@ func resourceGameServerGroupUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceGameServerGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Deleting Gamelift Game Server Group: %s", d.Id())
+	log.Printf("[INFO] Deleting GameLift Game Server Group: %s", d.Id())
 	input := &gamelift.DeleteGameServerGroupInput{
 		GameServerGroupName: aws.String(d.Id()),
 	}
@@ -403,7 +403,7 @@ func resourceGameServerGroupDelete(d *schema.ResourceData, meta interface{}) err
 		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Gamelift game server group: %w", err)
+		return fmt.Errorf("Error deleting GameLift game server group: %w", err)
 	}
 
 	if err := waitGameServerGroupTerminated(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
@@ -413,13 +413,13 @@ func resourceGameServerGroupDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func expandGameliftGameServerGroupAutoScalingPolicy(tfMap map[string]interface{}) *gamelift.GameServerGroupAutoScalingPolicy {
+func expandGameServerGroupAutoScalingPolicy(tfMap map[string]interface{}) *gamelift.GameServerGroupAutoScalingPolicy {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &gamelift.GameServerGroupAutoScalingPolicy{
-		TargetTrackingConfiguration: expandGameliftTargetTrackingConfiguration(tfMap["target_tracking_configuration"].([]interface{})[0].(map[string]interface{})),
+		TargetTrackingConfiguration: expandTargetTrackingConfiguration(tfMap["target_tracking_configuration"].([]interface{})[0].(map[string]interface{})),
 	}
 
 	if v, ok := tfMap["estimated_instance_warmup"].(int); ok && v != 0 {
@@ -429,7 +429,7 @@ func expandGameliftGameServerGroupAutoScalingPolicy(tfMap map[string]interface{}
 	return apiObject
 }
 
-func expandGameliftInstanceDefinition(tfMap map[string]interface{}) *gamelift.InstanceDefinition {
+func expandInstanceDefinition(tfMap map[string]interface{}) *gamelift.InstanceDefinition {
 	if tfMap == nil {
 		return nil
 	}
@@ -445,7 +445,7 @@ func expandGameliftInstanceDefinition(tfMap map[string]interface{}) *gamelift.In
 	return apiObject
 }
 
-func expandGameliftInstanceDefinitions(tfList []interface{}) []*gamelift.InstanceDefinition {
+func expandInstanceDefinitions(tfList []interface{}) []*gamelift.InstanceDefinition {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -459,7 +459,7 @@ func expandGameliftInstanceDefinitions(tfList []interface{}) []*gamelift.Instanc
 			continue
 		}
 
-		apiObject := expandGameliftInstanceDefinition(tfMap)
+		apiObject := expandInstanceDefinition(tfMap)
 
 		if apiObject == nil {
 			continue
@@ -471,7 +471,7 @@ func expandGameliftInstanceDefinitions(tfList []interface{}) []*gamelift.Instanc
 	return apiObjects
 }
 
-func expandGameliftLaunchTemplateSpecification(tfMap map[string]interface{}) *gamelift.LaunchTemplateSpecification {
+func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *gamelift.LaunchTemplateSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -493,7 +493,7 @@ func expandGameliftLaunchTemplateSpecification(tfMap map[string]interface{}) *ga
 	return apiObject
 }
 
-func expandGameliftTargetTrackingConfiguration(tfMap map[string]interface{}) *gamelift.TargetTrackingConfiguration {
+func expandTargetTrackingConfiguration(tfMap map[string]interface{}) *gamelift.TargetTrackingConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -505,13 +505,13 @@ func expandGameliftTargetTrackingConfiguration(tfMap map[string]interface{}) *ga
 	return apiObject
 }
 
-func flattenGameliftGameServerGroupAutoScalingPolicy(apiObject *autoscaling.ScalingPolicy) map[string]interface{} {
+func flattenGameServerGroupAutoScalingPolicy(apiObject *autoscaling.ScalingPolicy) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{
-		"target_tracking_configuration": []interface{}{flattenGameliftTargetTrackingConfiguration(apiObject.TargetTrackingConfiguration)},
+		"target_tracking_configuration": []interface{}{flattenTargetTrackingConfiguration(apiObject.TargetTrackingConfiguration)},
 	}
 
 	if v := apiObject.EstimatedInstanceWarmup; v != nil {
@@ -521,7 +521,7 @@ func flattenGameliftGameServerGroupAutoScalingPolicy(apiObject *autoscaling.Scal
 	return tfMap
 }
 
-func flattenGameliftInstanceDefinition(apiObject *gamelift.InstanceDefinition) map[string]interface{} {
+func flattenInstanceDefinition(apiObject *gamelift.InstanceDefinition) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -557,7 +557,7 @@ func flattenAutoscalingLaunchTemplateSpecification(apiObject *autoscaling.Launch
 	return []map[string]interface{}{tfMap}
 }
 
-func flattenGameliftInstanceDefinitions(apiObjects []*gamelift.InstanceDefinition) []interface{} {
+func flattenInstanceDefinitions(apiObjects []*gamelift.InstanceDefinition) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -569,13 +569,13 @@ func flattenGameliftInstanceDefinitions(apiObjects []*gamelift.InstanceDefinitio
 			continue
 		}
 
-		tfList = append(tfList, flattenGameliftInstanceDefinition(apiObject))
+		tfList = append(tfList, flattenInstanceDefinition(apiObject))
 	}
 
 	return tfList
 }
 
-func flattenGameliftTargetTrackingConfiguration(apiObject *autoscaling.TargetTrackingConfiguration) map[string]interface{} {
+func flattenTargetTrackingConfiguration(apiObject *autoscaling.TargetTrackingConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/gamelift/game_server_group_test.go
+++ b/internal/service/gamelift/game_server_group_test.go
@@ -148,6 +148,10 @@ func TestAccGameLiftGameServerGroup_BalancingStrategy(t *testing.T) {
 }
 
 func TestAccGameLiftGameServerGroup_GameServerGroupName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -396,6 +400,10 @@ func TestAccGameLiftGameServerGroup_GameServerProtectionPolicy(t *testing.T) {
 }
 
 func TestAccGameLiftGameServerGroup_MaxSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -434,6 +442,10 @@ func TestAccGameLiftGameServerGroup_MaxSize(t *testing.T) {
 }
 
 func TestAccGameLiftGameServerGroup_MinSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -512,6 +524,10 @@ func TestAccGameLiftGameServerGroup_RoleArn(t *testing.T) {
 }
 
 func TestAccGameLiftGameServerGroup_VpcSubnets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 

--- a/internal/service/gamelift/game_server_group_test.go
+++ b/internal/service/gamelift/game_server_group_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-func TestAccGameliftGameServerGroup_basic(t *testing.T) {
+func TestAccGameLiftGameServerGroup_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -27,12 +27,12 @@ func TestAccGameliftGameServerGroup_basic(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfig(rName),
+				Config: testAccGameServerGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`gameservergroup/.+`)),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "auto_scaling_group_arn", "autoscaling", regexp.MustCompile(`autoScalingGroup:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.#", "0"),
@@ -52,7 +52,7 @@ func TestAccGameliftGameServerGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_AutoScalingPolicy(t *testing.T) {
+func TestAccGameLiftGameServerGroup_AutoScalingPolicy(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -64,12 +64,12 @@ func TestAccGameliftGameServerGroup_AutoScalingPolicy(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigAutoScalingPolicy(rName),
+				Config: testAccGameServerGroupConfigAutoScalingPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.estimated_instance_warmup", "60"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.target_tracking_configuration.0.target_value", "77.7"),
 				),
@@ -84,7 +84,7 @@ func TestAccGameliftGameServerGroup_AutoScalingPolicy(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup(t *testing.T) {
+func TestAccGameLiftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -96,12 +96,12 @@ func TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup(t 
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigAutoScalingPolicyEstimatedInstanceWarmup(rName),
+				Config: testAccGameServerGroupConfigAutoScalingPolicyEstimatedInstanceWarmup(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.estimated_instance_warmup", "66"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.target_tracking_configuration.0.target_value", "77.7"),
 				),
@@ -116,7 +116,7 @@ func TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup(t 
 	})
 }
 
-func TestAccGameliftGameServerGroup_BalancingStrategy(t *testing.T) {
+func TestAccGameLiftGameServerGroup_BalancingStrategy(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -128,12 +128,12 @@ func TestAccGameliftGameServerGroup_BalancingStrategy(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigBalancingStrategy(rName, gamelift.BalancingStrategySpotOnly),
+				Config: testAccGameServerGroupConfigBalancingStrategy(rName, gamelift.BalancingStrategySpotOnly),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "balancing_strategy", gamelift.BalancingStrategySpotOnly),
 				),
 			},
@@ -147,7 +147,7 @@ func TestAccGameliftGameServerGroup_BalancingStrategy(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_GameServerGroupName(t *testing.T) {
+func TestAccGameLiftGameServerGroup_GameServerGroupName(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -159,12 +159,12 @@ func TestAccGameliftGameServerGroup_GameServerGroupName(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigGameServerGroupName(rName, rName),
+				Config: testAccGameServerGroupConfigGameServerGroupName(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "game_server_group_name", rName),
 				),
 			},
@@ -175,9 +175,9 @@ func TestAccGameliftGameServerGroup_GameServerGroupName(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigGameServerGroupName(rName, rName+"-new"),
+				Config: testAccGameServerGroupConfigGameServerGroupName(rName, rName+"-new"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "game_server_group_name", rName+"-new"),
 				),
 			},
@@ -185,7 +185,7 @@ func TestAccGameliftGameServerGroup_GameServerGroupName(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_InstanceDefinition(t *testing.T) {
+func TestAccGameLiftGameServerGroup_InstanceDefinition(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -197,12 +197,12 @@ func TestAccGameliftGameServerGroup_InstanceDefinition(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigInstanceDefinition(rName, 2),
+				Config: testAccGameServerGroupConfigInstanceDefinition(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "2"),
 				),
 			},
@@ -213,9 +213,9 @@ func TestAccGameliftGameServerGroup_InstanceDefinition(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigInstanceDefinition(rName, 3),
+				Config: testAccGameServerGroupConfigInstanceDefinition(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "3"),
 				),
 			},
@@ -223,7 +223,7 @@ func TestAccGameliftGameServerGroup_InstanceDefinition(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity(t *testing.T) {
+func TestAccGameLiftGameServerGroup_InstanceDefinition_WeightedCapacity(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -235,12 +235,12 @@ func TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity(t *testi
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName, "1"),
+				Config: testAccGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName, "1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.0.weighted_capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.1.weighted_capacity", "1"),
@@ -253,9 +253,9 @@ func TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity(t *testi
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName, "2"),
+				Config: testAccGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName, "2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.0.weighted_capacity", "2"),
 					resource.TestCheckResourceAttr(resourceName, "instance_definition.1.weighted_capacity", "2"),
@@ -265,7 +265,7 @@ func TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity(t *testi
 	})
 }
 
-func TestAccGameliftGameServerGroup_LaunchTemplate_Id(t *testing.T) {
+func TestAccGameLiftGameServerGroup_LaunchTemplate_Id(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -277,12 +277,12 @@ func TestAccGameliftGameServerGroup_LaunchTemplate_Id(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigLaunchTemplateId(rName),
+				Config: testAccGameServerGroupConfigLaunchTemplateId(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", "aws_launch_template.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", ""),
@@ -298,7 +298,7 @@ func TestAccGameliftGameServerGroup_LaunchTemplate_Id(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_LaunchTemplate_Name(t *testing.T) {
+func TestAccGameLiftGameServerGroup_LaunchTemplate_Name(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -310,12 +310,12 @@ func TestAccGameliftGameServerGroup_LaunchTemplate_Name(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigLaunchTemplateName(rName),
+				Config: testAccGameServerGroupConfigLaunchTemplateName(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", "aws_launch_template.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", ""),
@@ -331,7 +331,7 @@ func TestAccGameliftGameServerGroup_LaunchTemplate_Name(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_LaunchTemplate_Version(t *testing.T) {
+func TestAccGameLiftGameServerGroup_LaunchTemplate_Version(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -343,12 +343,12 @@ func TestAccGameliftGameServerGroup_LaunchTemplate_Version(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigLaunchTemplateVersion(rName),
+				Config: testAccGameServerGroupConfigLaunchTemplateVersion(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", "aws_launch_template.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", "1"),
@@ -364,7 +364,7 @@ func TestAccGameliftGameServerGroup_LaunchTemplate_Version(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_GameServerProtectionPolicy(t *testing.T) {
+func TestAccGameLiftGameServerGroup_GameServerProtectionPolicy(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -376,12 +376,12 @@ func TestAccGameliftGameServerGroup_GameServerProtectionPolicy(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigGameServerProtectionPolicy(rName, gamelift.GameServerProtectionPolicyFullProtection),
+				Config: testAccGameServerGroupConfigGameServerProtectionPolicy(rName, gamelift.GameServerProtectionPolicyFullProtection),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "game_server_protection_policy", gamelift.GameServerProtectionPolicyFullProtection),
 				),
 			},
@@ -395,7 +395,7 @@ func TestAccGameliftGameServerGroup_GameServerProtectionPolicy(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_MaxSize(t *testing.T) {
+func TestAccGameLiftGameServerGroup_MaxSize(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -407,12 +407,12 @@ func TestAccGameliftGameServerGroup_MaxSize(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigMaxSize(rName, "1"),
+				Config: testAccGameServerGroupConfigMaxSize(rName, "1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "max_size", "1"),
 				),
 			},
@@ -423,9 +423,9 @@ func TestAccGameliftGameServerGroup_MaxSize(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigMaxSize(rName, "2"),
+				Config: testAccGameServerGroupConfigMaxSize(rName, "2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "max_size", "2"),
 				),
 			},
@@ -433,7 +433,7 @@ func TestAccGameliftGameServerGroup_MaxSize(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_MinSize(t *testing.T) {
+func TestAccGameLiftGameServerGroup_MinSize(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -445,12 +445,12 @@ func TestAccGameliftGameServerGroup_MinSize(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigMinSize(rName, "1"),
+				Config: testAccGameServerGroupConfigMinSize(rName, "1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "min_size", "1"),
 				),
 			},
@@ -461,9 +461,9 @@ func TestAccGameliftGameServerGroup_MinSize(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigMinSize(rName, "2"),
+				Config: testAccGameServerGroupConfigMinSize(rName, "2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "min_size", "2"),
 				),
 			},
@@ -471,7 +471,7 @@ func TestAccGameliftGameServerGroup_MinSize(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_RoleArn(t *testing.T) {
+func TestAccGameLiftGameServerGroup_RoleArn(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -483,12 +483,12 @@ func TestAccGameliftGameServerGroup_RoleArn(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigRoleArn(rName, "test1"),
+				Config: testAccGameServerGroupConfigRoleArn(rName, "test1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf(`role/%s-test1`, rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test1", "arn"),
 				),
@@ -500,9 +500,9 @@ func TestAccGameliftGameServerGroup_RoleArn(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigRoleArn(rName, "test2"),
+				Config: testAccGameServerGroupConfigRoleArn(rName, "test2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf(`role/%s-test2`, rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test2", "arn"),
 				),
@@ -511,7 +511,7 @@ func TestAccGameliftGameServerGroup_RoleArn(t *testing.T) {
 	})
 }
 
-func TestAccGameliftGameServerGroup_VpcSubnets(t *testing.T) {
+func TestAccGameLiftGameServerGroup_VpcSubnets(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_gamelift_game_server_group.test"
 
@@ -523,12 +523,12 @@ func TestAccGameliftGameServerGroup_VpcSubnets(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, gamelift.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		CheckDestroy: testAccCheckGameServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGameliftGameServerGroupConfigVpcSubnets(rName, 1),
+				Config: testAccGameServerGroupConfigVpcSubnets(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 				),
 			},
 			{
@@ -538,16 +538,16 @@ func TestAccGameliftGameServerGroup_VpcSubnets(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"vpc_subnets"},
 			},
 			{
-				Config: testAccGameliftGameServerGroupConfigVpcSubnets(rName, 2),
+				Config: testAccGameServerGroupConfigVpcSubnets(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckGameServerGroupExists(resourceName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckGameliftGameServerGroupDestroy(s *terraform.State) error {
+func testAccCheckGameServerGroupDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -570,14 +570,14 @@ func testAccCheckGameliftGameServerGroupDestroy(s *terraform.State) error {
 		}
 
 		if output != nil {
-			return fmt.Errorf("Gamelift Game Server Group (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("GameLift Game Server Group (%s) still exists", rs.Primary.ID)
 		}
 	}
 
 	return nil
 }
 
-func testAccCheckGameliftGameServerGroupExists(resourceName string) resource.TestCheckFunc {
+func testAccCheckGameServerGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -597,18 +597,18 @@ func testAccCheckGameliftGameServerGroupExists(resourceName string) resource.Tes
 		output, err := conn.DescribeGameServerGroup(&input)
 
 		if err != nil {
-			return fmt.Errorf("error reading Gamelift Game Server Group (%s): %w", rs.Primary.ID, err)
+			return fmt.Errorf("error reading GameLift Game Server Group (%s): %w", rs.Primary.ID, err)
 		}
 
 		if output == nil {
-			return fmt.Errorf("Gamelift Game Server Group (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("GameLift Game Server Group (%s) not found", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccGameliftGameServerGroupIamConfig(rName string, name string) string {
+func testAccGameServerGroupIamConfig(rName string, name string) string {
 	return fmt.Sprintf(`
 data "aws_partition" %[2]q {}
 
@@ -640,7 +640,7 @@ resource "aws_iam_role_policy_attachment" %[2]q {
 `, rName, name)
 }
 
-func testAccGameliftGameServerGroupLaunchTemplateConfig(rName string) string {
+func testAccGameServerGroupLaunchTemplateConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpc" "test" {
   default = true
@@ -664,7 +664,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccGameliftGameServerGroupInstanceTypeOfferingsConfig() string {
+func testAccGameServerGroupInstanceTypeOfferingsConfig() string {
 	return `
 data "aws_ec2_instance_type_offerings" "available" {
   filter {
@@ -675,12 +675,12 @@ data "aws_ec2_instance_type_offerings" "available" {
 `
 }
 
-func testAccGameliftGameServerGroupConfig(rName string) string {
+func testAccGameServerGroupConfig(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -705,12 +705,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName))
 }
 
-func testAccGameliftGameServerGroupConfigAutoScalingPolicy(rName string) string {
+func testAccGameServerGroupConfigAutoScalingPolicy(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   auto_scaling_policy {
@@ -740,12 +740,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName))
 }
 
-func testAccGameliftGameServerGroupConfigAutoScalingPolicyEstimatedInstanceWarmup(rName string) string {
+func testAccGameServerGroupConfigAutoScalingPolicyEstimatedInstanceWarmup(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   auto_scaling_policy {
@@ -776,12 +776,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName))
 }
 
-func testAccGameliftGameServerGroupConfigBalancingStrategy(rName string, balancingStrategy string) string {
+func testAccGameServerGroupConfigBalancingStrategy(rName string, balancingStrategy string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   balancing_strategy     = %[2]q
@@ -807,12 +807,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, balancingStrategy))
 }
 
-func testAccGameliftGameServerGroupConfigGameServerGroupName(rName string, gameServerGroupName string) string {
+func testAccGameServerGroupConfigGameServerGroupName(rName string, gameServerGroupName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -837,12 +837,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, gameServerGroupName))
 }
 
-func testAccGameliftGameServerGroupConfigInstanceDefinition(rName string, count int) string {
+func testAccGameServerGroupConfigInstanceDefinition(rName string, count int) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -867,12 +867,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, count))
 }
 
-func testAccGameliftGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName string, weightedCapacity string) string {
+func testAccGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName string, weightedCapacity string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -898,12 +898,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, weightedCapacity))
 }
 
-func testAccGameliftGameServerGroupConfigLaunchTemplateId(rName string) string {
+func testAccGameServerGroupConfigLaunchTemplateId(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -928,12 +928,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName))
 }
 
-func testAccGameliftGameServerGroupConfigLaunchTemplateName(rName string) string {
+func testAccGameServerGroupConfigLaunchTemplateName(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -958,12 +958,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName))
 }
 
-func testAccGameliftGameServerGroupConfigLaunchTemplateVersion(rName string) string {
+func testAccGameServerGroupConfigLaunchTemplateVersion(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -989,12 +989,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName))
 }
 
-func testAccGameliftGameServerGroupConfigMaxSize(rName string, maxSize string) string {
+func testAccGameServerGroupConfigMaxSize(rName string, maxSize string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -1019,12 +1019,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, maxSize))
 }
 
-func testAccGameliftGameServerGroupConfigMinSize(rName string, minSize string) string {
+func testAccGameServerGroupConfigMinSize(rName string, minSize string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -1049,12 +1049,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, minSize))
 }
 
-func testAccGameliftGameServerGroupConfigGameServerProtectionPolicy(rName string, gameServerProtectionPolicy string) string {
+func testAccGameServerGroupConfigGameServerProtectionPolicy(rName string, gameServerProtectionPolicy string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name        = %[1]q
@@ -1080,12 +1080,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, gameServerProtectionPolicy))
 }
 
-func testAccGameliftGameServerGroupConfigRoleArn(rName string, roleArn string) string {
+func testAccGameServerGroupConfigRoleArn(rName string, roleArn string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, roleArn),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, roleArn),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q
@@ -1110,12 +1110,12 @@ resource "aws_gamelift_game_server_group" "test" {
 `, rName, roleArn))
 }
 
-func testAccGameliftGameServerGroupConfigVpcSubnets(rName string, count int) string {
+func testAccGameServerGroupConfigVpcSubnets(rName string, count int) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		testAccGameliftGameServerGroupIamConfig(rName, "test"),
-		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
-		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		testAccGameServerGroupIamConfig(rName, "test"),
+		testAccGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameServerGroupLaunchTemplateConfig(rName),
 		fmt.Sprintf(`
 resource "aws_gamelift_game_server_group" "test" {
   game_server_group_name = %[1]q

--- a/internal/service/gamelift/game_session_queue.go
+++ b/internal/service/gamelift/game_session_queue.go
@@ -79,15 +79,15 @@ func resourceGameSessionQueueCreate(d *schema.ResourceData, meta interface{}) er
 
 	input := gamelift.CreateGameSessionQueueInput{
 		Name:                  aws.String(d.Get("name").(string)),
-		Destinations:          expandGameliftGameSessionQueueDestinations(d.Get("destinations").([]interface{})),
-		PlayerLatencyPolicies: expandGameliftGameSessionPlayerLatencyPolicies(d.Get("player_latency_policy").([]interface{})),
+		Destinations:          expandGameSessionQueueDestinations(d.Get("destinations").([]interface{})),
+		PlayerLatencyPolicies: expandGameSessionPlayerLatencyPolicies(d.Get("player_latency_policy").([]interface{})),
 		TimeoutInSeconds:      aws.Int64(int64(d.Get("timeout_in_seconds").(int))),
 		Tags:                  Tags(tags.IgnoreAWS()),
 	}
-	log.Printf("[INFO] Creating Gamelift Session Queue: %s", input)
+	log.Printf("[INFO] Creating GameLift Session Queue: %s", input)
 	out, err := conn.CreateGameSessionQueue(&input)
 	if err != nil {
-		return fmt.Errorf("error creating Gamelift Game Session Queue: %s", err)
+		return fmt.Errorf("error creating GameLift Game Session Queue: %s", err)
 	}
 
 	d.SetId(aws.StringValue(out.GameSessionQueue.Name))
@@ -100,7 +100,7 @@ func resourceGameSessionQueueRead(d *schema.ResourceData, meta interface{}) erro
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	log.Printf("[INFO] Describing Gamelift Session Queues: %s", d.Id())
+	log.Printf("[INFO] Describing GameLift Session Queues: %s", d.Id())
 	limit := int64(1)
 	out, err := conn.DescribeGameSessionQueues(&gamelift.DescribeGameSessionQueuesInput{
 		Names: aws.StringSlice([]string{d.Id()}),
@@ -108,21 +108,21 @@ func resourceGameSessionQueueRead(d *schema.ResourceData, meta interface{}) erro
 	})
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Gamelift Session Queues (%s) not found, removing from state", d.Id())
+			log.Printf("[WARN] GameLift Session Queues (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading Gamelift Game Session Queue (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading GameLift Game Session Queue (%s): %s", d.Id(), err)
 	}
 	sessionQueues := out.GameSessionQueues
 
 	if len(sessionQueues) < 1 {
-		log.Printf("[WARN] Gamelift Session Queue (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] GameLift Session Queue (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 	if len(sessionQueues) != 1 {
-		return fmt.Errorf("expected exactly 1 Gamelift Session Queues, found %d under %q",
+		return fmt.Errorf("expected exactly 1 GameLift Session Queues, found %d under %q",
 			len(sessionQueues), d.Id())
 	}
 	sessionQueue := sessionQueues[0]
@@ -131,10 +131,10 @@ func resourceGameSessionQueueRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("arn", arn)
 	d.Set("name", sessionQueue.Name)
 	d.Set("timeout_in_seconds", sessionQueue.TimeoutInSeconds)
-	if err := d.Set("destinations", flattenGameliftGameSessionQueueDestinations(sessionQueue.Destinations)); err != nil {
+	if err := d.Set("destinations", flattenGameSessionQueueDestinations(sessionQueue.Destinations)); err != nil {
 		return fmt.Errorf("error setting destinations: %s", err)
 	}
-	if err := d.Set("player_latency_policy", flattenGameliftPlayerLatencyPolicies(sessionQueue.PlayerLatencyPolicies)); err != nil {
+	if err := d.Set("player_latency_policy", flattenPlayerLatencyPolicies(sessionQueue.PlayerLatencyPolicies)); err != nil {
 		return fmt.Errorf("error setting player_latency_policy: %s", err)
 	}
 
@@ -158,7 +158,7 @@ func resourceGameSessionQueueRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func flattenGameliftGameSessionQueueDestinations(destinations []*gamelift.GameSessionQueueDestination) []interface{} {
+func flattenGameSessionQueueDestinations(destinations []*gamelift.GameSessionQueueDestination) []interface{} {
 	l := make([]interface{}, 0)
 
 	for _, destination := range destinations {
@@ -171,7 +171,7 @@ func flattenGameliftGameSessionQueueDestinations(destinations []*gamelift.GameSe
 	return l
 }
 
-func flattenGameliftPlayerLatencyPolicies(playerLatencyPolicies []*gamelift.PlayerLatencyPolicy) []interface{} {
+func flattenPlayerLatencyPolicies(playerLatencyPolicies []*gamelift.PlayerLatencyPolicy) []interface{} {
 	l := make([]interface{}, 0)
 	for _, policy := range playerLatencyPolicies {
 		m := map[string]interface{}{
@@ -186,18 +186,18 @@ func flattenGameliftPlayerLatencyPolicies(playerLatencyPolicies []*gamelift.Play
 func resourceGameSessionQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Updating Gamelift Session Queue: %s", d.Id())
+	log.Printf("[INFO] Updating GameLift Session Queue: %s", d.Id())
 
 	input := gamelift.UpdateGameSessionQueueInput{
 		Name:                  aws.String(d.Id()),
-		Destinations:          expandGameliftGameSessionQueueDestinations(d.Get("destinations").([]interface{})),
-		PlayerLatencyPolicies: expandGameliftGameSessionPlayerLatencyPolicies(d.Get("player_latency_policy").([]interface{})),
+		Destinations:          expandGameSessionQueueDestinations(d.Get("destinations").([]interface{})),
+		PlayerLatencyPolicies: expandGameSessionPlayerLatencyPolicies(d.Get("player_latency_policy").([]interface{})),
 		TimeoutInSeconds:      aws.Int64(int64(d.Get("timeout_in_seconds").(int))),
 	}
 
 	_, err := conn.UpdateGameSessionQueue(&input)
 	if err != nil {
-		return fmt.Errorf("error updating Gamelift Game Session Queue (%s): %s", d.Id(), err)
+		return fmt.Errorf("error updating GameLift Game Session Queue (%s): %s", d.Id(), err)
 	}
 
 	arn := d.Get("arn").(string)
@@ -214,7 +214,7 @@ func resourceGameSessionQueueUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceGameSessionQueueDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
-	log.Printf("[INFO] Deleting Gamelift Session Queue: %s", d.Id())
+	log.Printf("[INFO] Deleting GameLift Session Queue: %s", d.Id())
 	_, err := conn.DeleteGameSessionQueue(&gamelift.DeleteGameSessionQueueInput{
 		Name: aws.String(d.Id()),
 	})
@@ -222,13 +222,13 @@ func resourceGameSessionQueueDelete(d *schema.ResourceData, meta interface{}) er
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Gamelift Game Session Queue (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting GameLift Game Session Queue (%s): %s", d.Id(), err)
 	}
 
 	return nil
 }
 
-func expandGameliftGameSessionQueueDestinations(destinationsMap []interface{}) []*gamelift.GameSessionQueueDestination {
+func expandGameSessionQueueDestinations(destinationsMap []interface{}) []*gamelift.GameSessionQueueDestination {
 	if len(destinationsMap) < 1 {
 		return nil
 	}
@@ -243,7 +243,7 @@ func expandGameliftGameSessionQueueDestinations(destinationsMap []interface{}) [
 	return destinations
 }
 
-func expandGameliftGameSessionPlayerLatencyPolicies(destinationsPlayerLatencyPolicyMap []interface{}) []*gamelift.PlayerLatencyPolicy {
+func expandGameSessionPlayerLatencyPolicies(destinationsPlayerLatencyPolicyMap []interface{}) []*gamelift.PlayerLatencyPolicy {
 	if len(destinationsPlayerLatencyPolicyMap) < 1 {
 		return nil
 	}

--- a/internal/service/gamelift/game_session_queue_test.go
+++ b/internal/service/gamelift/game_session_queue_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-const testAccGameliftGameSessionQueuePrefix = "tfAccQueue-"
+const testAccGameSessionQueuePrefix = "tfAccQueue-"
 
 func TestAccGameLiftGameSessionQueue_basic(t *testing.T) {
 	var conf gamelift.GameSessionQueue
 
 	resourceName := "aws_gamelift_game_session_queue.test"
-	queueName := testAccGameliftGameSessionQueuePrefix + sdkacctest.RandString(8)
+	queueName := testAccGameSessionQueuePrefix + sdkacctest.RandString(8)
 	playerLatencyPolicies := []gamelift.PlayerLatencyPolicy{
 		{
 			MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(100),
@@ -110,7 +110,7 @@ func TestAccGameLiftGameSessionQueue_tags(t *testing.T) {
 	var conf gamelift.GameSessionQueue
 
 	resourceName := "aws_gamelift_game_session_queue.test"
-	queueName := testAccGameliftGameSessionQueuePrefix + sdkacctest.RandString(8)
+	queueName := testAccGameSessionQueuePrefix + sdkacctest.RandString(8)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -160,7 +160,7 @@ func TestAccGameLiftGameSessionQueue_disappears(t *testing.T) {
 	var conf gamelift.GameSessionQueue
 
 	resourceName := "aws_gamelift_game_session_queue.test"
-	queueName := testAccGameliftGameSessionQueuePrefix + sdkacctest.RandString(8)
+	queueName := testAccGameSessionQueuePrefix + sdkacctest.RandString(8)
 	playerLatencyPolicies := []gamelift.PlayerLatencyPolicy{
 		{
 			MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(100),
@@ -204,7 +204,7 @@ func testAccCheckGameSessionQueueExists(n string, res *gamelift.GameSessionQueue
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no Gamelift Session Queue Name is set")
+			return fmt.Errorf("no GameLift Session Queue Name is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
@@ -223,7 +223,7 @@ func testAccCheckGameSessionQueueExists(n string, res *gamelift.GameSessionQueue
 			return fmt.Errorf("gmelift Session Queue %q not found", name)
 		}
 		if len(attributes) != 1 {
-			return fmt.Errorf("expected exactly 1 Gamelift Session Queue, found %d under %q",
+			return fmt.Errorf("expected exactly 1 GameLift Session Queue, found %d under %q",
 				len(attributes), name)
 		}
 		queue := attributes[0]

--- a/internal/service/gamelift/gamelift_test.go
+++ b/internal/service/gamelift/gamelift_test.go
@@ -10,20 +10,20 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-type testAccGameliftGame struct {
+type testAccGame struct {
 	Location   *gamelift.S3Location
 	LaunchPath string
 }
 
-func (gg *testAccGameliftGame) Parameters(portNumber int) string {
+func (gg *testAccGame) Parameters(portNumber int) string {
 	return fmt.Sprintf("+sv_port %d +gamelift_start_server", portNumber)
 }
 
 // Location found from CloudTrail event after finishing tutorial
 // e.g. https://us-west-2.console.aws.amazon.com/gamelift/home?region=us-west-2#/r/fleets/sample
-func testAccSampleGame(region string) (*testAccGameliftGame, error) {
+func testAccSampleGame(region string) (*testAccGame, error) {
 	version := "v1.2.0.0"
-	accId, err := testAccGameliftAccountIdByRegion(region)
+	accId, err := testAccAccountIdByRegion(region)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func testAccSampleGame(region string) (*testAccGameliftGame, error) {
 	roleArn := fmt.Sprintf("arn:%s:iam::%s:role/sample-build-upload-role-%s", acctest.Partition(), accId, region)
 	launchPath := `C:\game\Bin64.Release.Dedicated\MultiplayerProjectLauncher_Server.exe`
 
-	gg := &testAccGameliftGame{
+	gg := &testAccGame{
 		Location: &gamelift.S3Location{
 			Bucket:  aws.String(bucket),
 			Key:     aws.String(key),
@@ -45,7 +45,7 @@ func testAccSampleGame(region string) (*testAccGameliftGame, error) {
 }
 
 // Account ID found from CloudTrail event (role ARN) after finishing tutorial in given region
-func testAccGameliftAccountIdByRegion(region string) (string, error) {
+func testAccAccountIdByRegion(region string) (string, error) {
 	m := map[string]string{
 		endpoints.ApNortheast1RegionID: "120069834884",
 		endpoints.ApNortheast2RegionID: "805673136642",

--- a/internal/service/gamelift/script.go
+++ b/internal/service/gamelift/script.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-const awsMutexGameliftScript = `aws_gamelift_script`
+const awsMutexGameLiftScript = `aws_gamelift_script`
 
 func ResourceScript() *schema.Resource {
 	return &schema.Resource{
@@ -99,7 +99,7 @@ func resourceScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("storage_location"); ok && len(v.([]interface{})) > 0 {
-		input.StorageLocation = expandGameliftStorageLocation(v.([]interface{}))
+		input.StorageLocation = expandStorageLocation(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("version"); ok {
@@ -107,8 +107,8 @@ func resourceScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("zip_file"); ok {
-		conns.GlobalMutexKV.Lock(awsMutexGameliftScript)
-		defer conns.GlobalMutexKV.Unlock(awsMutexGameliftScript)
+		conns.GlobalMutexKV.Lock(awsMutexGameLiftScript)
+		defer conns.GlobalMutexKV.Unlock(awsMutexGameLiftScript)
 
 		file, err := loadFileContent(v.(string))
 		if err != nil {
@@ -117,7 +117,7 @@ func resourceScriptCreate(d *schema.ResourceData, meta interface{}) error {
 		input.ZipFile = file
 	}
 
-	log.Printf("[INFO] Creating Gamelift Script: %s", input)
+	log.Printf("[INFO] Creating GameLift Script: %s", input)
 	var out *gamelift.CreateScriptOutput
 	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
 		var err error
@@ -135,7 +135,7 @@ func resourceScriptCreate(d *schema.ResourceData, meta interface{}) error {
 		out, err = conn.CreateScript(&input)
 	}
 	if err != nil {
-		return fmt.Errorf("Error creating Gamelift script client: %w", err)
+		return fmt.Errorf("Error creating GameLift script client: %w", err)
 	}
 
 	d.SetId(aws.StringValue(out.Script.ScriptId))
@@ -148,7 +148,7 @@ func resourceScriptRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	log.Printf("[INFO] Reading Gamelift Script: %s", d.Id())
+	log.Printf("[INFO] Reading GameLift Script: %s", d.Id())
 	script, err := FindScriptByID(conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] GameLift Script (%s) not found, removing from state", d.Id())
@@ -193,7 +193,7 @@ func resourceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
 	if d.HasChangesExcept("tags", "tags_all") {
-		log.Printf("[INFO] Updating Gamelift Script: %s", d.Id())
+		log.Printf("[INFO] Updating GameLift Script: %s", d.Id())
 		input := gamelift.UpdateScriptInput{
 			ScriptId: aws.String(d.Id()),
 			Name:     aws.String(d.Get("name").(string)),
@@ -207,14 +207,14 @@ func resourceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if d.HasChange("storage_location") {
 			if v, ok := d.GetOk("storage_location"); ok {
-				input.StorageLocation = expandGameliftStorageLocation(v.([]interface{}))
+				input.StorageLocation = expandStorageLocation(v.([]interface{}))
 			}
 		}
 
 		if d.HasChange("zip_file") {
 			if v, ok := d.GetOk("zip_file"); ok {
-				conns.GlobalMutexKV.Lock(awsMutexGameliftScript)
-				defer conns.GlobalMutexKV.Unlock(awsMutexGameliftScript)
+				conns.GlobalMutexKV.Lock(awsMutexGameLiftScript)
+				defer conns.GlobalMutexKV.Unlock(awsMutexGameLiftScript)
 
 				file, err := loadFileContent(v.(string))
 				if err != nil {
@@ -226,7 +226,7 @@ func resourceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := conn.UpdateScript(&input)
 		if err != nil {
-			return fmt.Errorf("Error updating Gamelift Script: %w", err)
+			return fmt.Errorf("Error updating GameLift Script: %w", err)
 		}
 	}
 
@@ -245,7 +245,7 @@ func resourceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceScriptDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GameLiftConn
 
-	log.Printf("[INFO] Deleting Gamelift Script: %s", d.Id())
+	log.Printf("[INFO] Deleting GameLift Script: %s", d.Id())
 	_, err := conn.DeleteScript(&gamelift.DeleteScriptInput{
 		ScriptId: aws.String(d.Id()),
 	})
@@ -254,7 +254,7 @@ func resourceScriptDelete(d *schema.ResourceData, meta interface{}) error {
 		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Gamelift script: %w", err)
+		return fmt.Errorf("Error deleting GameLift script: %w", err)
 	}
 
 	return nil

--- a/internal/service/gamelift/script_test.go
+++ b/internal/service/gamelift/script_test.go
@@ -154,7 +154,7 @@ func testAccCheckScriptExists(n string, res *gamelift.Script) resource.TestCheck
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Gamelift Script ID is set")
+			return fmt.Errorf("No GameLift Script ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GameLiftConn
@@ -165,7 +165,7 @@ func testAccCheckScriptExists(n string, res *gamelift.Script) resource.TestCheck
 		}
 
 		if aws.StringValue(script.ScriptId) != rs.Primary.ID {
-			return fmt.Errorf("Gamelift Script not found")
+			return fmt.Errorf("GameLift Script not found")
 		}
 
 		*res = *script

--- a/internal/service/gamelift/sweep.go
+++ b/internal/service/gamelift/sweep.go
@@ -62,19 +62,19 @@ func sweepAliases(region string) error {
 
 	err = listAliases(&gamelift.ListAliasesInput{}, conn, func(resp *gamelift.ListAliasesOutput) error {
 		if len(resp.Aliases) == 0 {
-			log.Print("[DEBUG] No Gamelift Aliases to sweep")
+			log.Print("[DEBUG] No GameLift Aliases to sweep")
 			return nil
 		}
 
-		log.Printf("[INFO] Found %d Gamelift Aliases", len(resp.Aliases))
+		log.Printf("[INFO] Found %d GameLift Aliases", len(resp.Aliases))
 
 		for _, alias := range resp.Aliases {
-			log.Printf("[INFO] Deleting Gamelift Alias %q", *alias.AliasId)
+			log.Printf("[INFO] Deleting GameLift Alias %q", *alias.AliasId)
 			_, err := conn.DeleteAlias(&gamelift.DeleteAliasInput{
 				AliasId: alias.AliasId,
 			})
 			if err != nil {
-				return fmt.Errorf("Error deleting Gamelift Alias (%s): %s",
+				return fmt.Errorf("Error deleting GameLift Alias (%s): %s",
 					*alias.AliasId, err)
 			}
 		}
@@ -82,10 +82,10 @@ func sweepAliases(region string) error {
 	})
 	if err != nil {
 		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Gamelift Alias sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping GameLift Alias sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error listing Gamelift Aliases: %s", err)
+		return fmt.Errorf("Error listing GameLift Aliases: %s", err)
 	}
 
 	return nil
@@ -104,23 +104,23 @@ func sweepBuilds(region string) error {
 			log.Printf("[WARN] Skipping Gamelife Build sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error listing Gamelift Builds: %s", err)
+		return fmt.Errorf("Error listing GameLift Builds: %s", err)
 	}
 
 	if len(resp.Builds) == 0 {
-		log.Print("[DEBUG] No Gamelift Builds to sweep")
+		log.Print("[DEBUG] No GameLift Builds to sweep")
 		return nil
 	}
 
-	log.Printf("[INFO] Found %d Gamelift Builds", len(resp.Builds))
+	log.Printf("[INFO] Found %d GameLift Builds", len(resp.Builds))
 
 	for _, build := range resp.Builds {
-		log.Printf("[INFO] Deleting Gamelift Build %q", *build.BuildId)
+		log.Printf("[INFO] Deleting GameLift Build %q", *build.BuildId)
 		_, err := conn.DeleteBuild(&gamelift.DeleteBuildInput{
 			BuildId: build.BuildId,
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting Gamelift Build (%s): %s",
+			return fmt.Errorf("Error deleting GameLift Build (%s): %s",
 				*build.BuildId, err)
 		}
 	}
@@ -141,23 +141,23 @@ func sweepScripts(region string) error {
 			log.Printf("[WARN] Skipping Gamelife Script sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error listing Gamelift Scripts: %s", err)
+		return fmt.Errorf("Error listing GameLift Scripts: %s", err)
 	}
 
 	if len(resp.Scripts) == 0 {
-		log.Print("[DEBUG] No Gamelift Scripts to sweep")
+		log.Print("[DEBUG] No GameLift Scripts to sweep")
 		return nil
 	}
 
-	log.Printf("[INFO] Found %d Gamelift Scripts", len(resp.Scripts))
+	log.Printf("[INFO] Found %d GameLift Scripts", len(resp.Scripts))
 
 	for _, build := range resp.Scripts {
-		log.Printf("[INFO] Deleting Gamelift Script %q", *build.ScriptId)
+		log.Printf("[INFO] Deleting GameLift Script %q", *build.ScriptId)
 		_, err := conn.DeleteScript(&gamelift.DeleteScriptInput{
 			ScriptId: build.ScriptId,
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting Gamelift Script (%s): %s",
+			return fmt.Errorf("Error deleting GameLift Script (%s): %s",
 				*build.ScriptId, err)
 		}
 	}
@@ -288,23 +288,23 @@ func sweepGameSessionQueue(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing Gamelift Session Queue: %s", err)
+		return fmt.Errorf("error listing GameLift Session Queue: %s", err)
 	}
 
 	if len(out.GameSessionQueues) == 0 {
-		log.Print("[DEBUG] No Gamelift Session Queue to sweep")
+		log.Print("[DEBUG] No GameLift Session Queue to sweep")
 		return nil
 	}
 
-	log.Printf("[INFO] Found %d Gamelift Session Queue", len(out.GameSessionQueues))
+	log.Printf("[INFO] Found %d GameLift Session Queue", len(out.GameSessionQueues))
 
 	for _, queue := range out.GameSessionQueues {
-		log.Printf("[INFO] Deleting Gamelift Session Queue %q", *queue.Name)
+		log.Printf("[INFO] Deleting GameLift Session Queue %q", *queue.Name)
 		_, err := conn.DeleteGameSessionQueue(&gamelift.DeleteGameSessionQueueInput{
 			Name: aws.String(*queue.Name),
 		})
 		if err != nil {
-			return fmt.Errorf("error deleting Gamelift Session Queue (%s): %s",
+			return fmt.Errorf("error deleting GameLift Session Queue (%s): %s",
 				*queue.Name, err)
 		}
 	}

--- a/internal/service/gamelift/wait.go
+++ b/internal/service/gamelift/wait.go
@@ -71,7 +71,7 @@ func waitFleetTerminated(conn *gamelift.GameLift, id string, timeout time.Durati
 	outputRaw, err := stateConf.WaitForState()
 
 	if err != nil {
-		events, fErr := getGameliftFleetFailures(conn, id)
+		events, fErr := getFleetFailures(conn, id)
 		if fErr != nil {
 			log.Printf("[WARN] Failed to poll fleet failures: %s", fErr)
 		}
@@ -87,13 +87,13 @@ func waitFleetTerminated(conn *gamelift.GameLift, id string, timeout time.Durati
 	return nil, err
 }
 
-func getGameliftFleetFailures(conn *gamelift.GameLift, id string) ([]*gamelift.Event, error) {
+func getFleetFailures(conn *gamelift.GameLift, id string) ([]*gamelift.Event, error) {
 	var events []*gamelift.Event
-	err := _getGameliftFleetFailures(conn, id, nil, &events)
+	err := _getFleetFailures(conn, id, nil, &events)
 	return events, err
 }
 
-func _getGameliftFleetFailures(conn *gamelift.GameLift, id string, nextToken *string, events *[]*gamelift.Event) error {
+func _getFleetFailures(conn *gamelift.GameLift, id string, nextToken *string, events *[]*gamelift.Event) error {
 	eOut, err := conn.DescribeFleetEvents(&gamelift.DescribeFleetEventsInput{
 		FleetId:   aws.String(id),
 		NextToken: nextToken,
@@ -103,13 +103,13 @@ func _getGameliftFleetFailures(conn *gamelift.GameLift, id string, nextToken *st
 	}
 
 	for _, e := range eOut.Events {
-		if isGameliftEventFailure(e) {
+		if isEventFailure(e) {
 			*events = append(*events, e)
 		}
 	}
 
 	if eOut.NextToken != nil {
-		err := _getGameliftFleetFailures(conn, id, nextToken, events)
+		err := _getFleetFailures(conn, id, nextToken, events)
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ func _getGameliftFleetFailures(conn *gamelift.GameLift, id string, nextToken *st
 	return nil
 }
 
-func isGameliftEventFailure(event *gamelift.Event) bool {
+func isEventFailure(event *gamelift.Event) bool {
 	failureCodes := []string{
 		gamelift.EventCodeFleetActivationFailed,
 		gamelift.EventCodeFleetActivationFailedNoInstances,

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -72,7 +72,7 @@ EventBridge (CloudWatch Events)
 EventBridge Schemas
 File System (FSx)
 Firewall Manager (FMS)
-Gamelift
+GameLift
 Glacier
 Global Accelerator
 Glue

--- a/website/docs/r/gamelift_alias.html.markdown
+++ b/website/docs/r/gamelift_alias.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Gamelift"
+subcategory: "GameLift"
 layout: "aws"
 page_title: "AWS: aws_gamelift_alias"
 description: |-
-  Provides a Gamelift Alias resource.
+  Provides a GameLift Alias resource.
 ---
 
 # Resource: aws_gamelift_alias
 
-Provides a Gamelift Alias resource.
+Provides a GameLift Alias resource.
 
 ## Example Usage
 
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 #### `routing_strategy`
 
-* `fleet_id` - (Optional) ID of the Gamelift Fleet to point the alias to.
+* `fleet_id` - (Optional) ID of the GameLift Fleet to point the alias to.
 * `message` - (Optional) Message text to be used with the `TERMINAL` routing strategy.
 * `type` - (Required) Type of routing strategyE.g., `SIMPLE` or `TERMINAL`
 
@@ -51,7 +51,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Gamelift Aliases can be imported using the ID, e.g.,
+GameLift Aliases can be imported using the ID, e.g.,
 
 ```
 $ terraform import aws_gamelift_alias.example <alias-id>

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Gamelift"
+subcategory: "GameLift"
 layout: "aws"
 page_title: "AWS: aws_gamelift_build"
 description: |-
-  Provides a Gamelift Build resource.
+  Provides a GameLift Build resource.
 ---
 
 # Resource: aws_gamelift_build
 
-Provides an Gamelift Build resource.
+Provides an GameLift Build resource.
 
 ## Example Usage
 
@@ -48,13 +48,13 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Gamelift Build ID.
-* `arn` - Gamelift Build ARN.
+* `id` - GameLift Build ID.
+* `arn` - GameLift Build ARN.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 
-Gamelift Builds can be imported using the ID, e.g.,
+GameLift Builds can be imported using the ID, e.g.,
 
 ```
 $ terraform import aws_gamelift_build.example <build-id>

--- a/website/docs/r/gamelift_fleet.html.markdown
+++ b/website/docs/r/gamelift_fleet.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Gamelift"
+subcategory: "GameLift"
 layout: "aws"
 page_title: "AWS: aws_gamelift_fleet"
 description: |-
-  Provides a Gamelift Fleet resource.
+  Provides a GameLift Fleet resource.
 ---
 
 # Resource: aws_gamelift_fleet
 
-Provides a Gamelift Fleet resource.
+Provides a GameLift Fleet resource.
 
 ## Example Usage
 
@@ -32,7 +32,7 @@ resource "aws_gamelift_fleet" "example" {
 
 The following arguments are supported:
 
-* `build_id` - (Optional) ID of the Gamelift Build to be deployed on the fleet.
+* `build_id` - (Optional) ID of the GameLift Build to be deployed on the fleet.
 * `certificate_configuration` - (Optional) Prompts GameLift to generate a TLS/SSL certificate for the fleet. See [certificate_configuration](#certificate_configuration).
 * `description` - (Optional) Human-readable description of the fleet.
 * `ec2_inbound_permission` - (Optional) Range of IP addresses and port settings that permit inbound traffic to access server processes running on the fleet. See below.
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `new_game_session_protection_policy` - (Optional) Game session protection policy to apply to all instances in this fleetE.g., `FullProtection`. Defaults to `NoProtection`.
 * `resource_creation_limit_policy` - (Optional) Policy that limits the number of game sessions an individual player can create over a span of time for this fleet. See below.
 * `runtime_configuration` - (Optional) Instructions for launching server processes on each instance in the fleet. See below.
-* `script_id` - (Optional) ID of the Gamelift Script to be deployed on the fleet.
+* `script_id` - (Optional) ID of the GameLift Script to be deployed on the fleet.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Nested Fields
@@ -97,7 +97,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Gamelift Fleets can be imported using the ID, e.g.,
+GameLift Fleets can be imported using the ID, e.g.,
 
 ```
 $ terraform import aws_gamelift_fleet.example <fleet-id>

--- a/website/docs/r/gamelift_game_server_group.markdown
+++ b/website/docs/r/gamelift_game_server_group.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Gamelift"
+subcategory: "GameLift"
 layout: "aws"
 page_title: "AWS: aws_gamelift_game_server_group"
 description: |-
-  Provides a Gamelift Game Server Group resource.
+  Provides a GameLift Game Server Group resource.
 ---
 
 # Resource: aws_gamelift_game_server_group
 
-Provides an Gamelift Game Server Group resource.
+Provides an GameLift Game Server Group resource.
 
 ## Example Usage
 
@@ -87,7 +87,7 @@ resource "aws_gamelift_game_server_group" "example" {
 }
 ```
 
-### Example IAM Role for Gamelift Game Server Group
+### Example IAM Role for GameLift Game Server Group
 
 ```terraform
 data "aws_partition" "current" {}
@@ -183,8 +183,8 @@ You can specify the template using either the template name or ID.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The name of the Gamelift Game Server Group.
-* `arn` - The ARN of the Gamelift Game Server Group.
+* `id` - The name of the GameLift Game Server Group.
+* `arn` - The ARN of the GameLift Game Server Group.
 * `auto_scaling_group_arn` - The ARN of the created EC2 Auto Scaling group.
 
 ## Timeouts
@@ -192,12 +192,12 @@ In addition to all arguments above, the following attributes are exported:
 `aws_gamelift_game_server_group` provides the following
 [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
 
-* `create` - (Default `10 minutes`) How long to wait for the Gamelift Game Server Group to be created.
-* `delete` - (Default `30 minutes`) How long to wait for the Gamelift Game Server Group to be deleted.
+* `create` - (Default `10 minutes`) How long to wait for the GameLift Game Server Group to be created.
+* `delete` - (Default `30 minutes`) How long to wait for the GameLift Game Server Group to be deleted.
 
 ## Import
 
-Gamelift Game Server Group can be imported using the `name`, e.g.
+GameLift Game Server Group can be imported using the `name`, e.g.
 
 ```
 $ terraform import aws_gamelift_game_server_group.example example

--- a/website/docs/r/gamelift_game_session_queue.html.markdown
+++ b/website/docs/r/gamelift_game_session_queue.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Gamelift"
+subcategory: "GameLift"
 layout: "aws"
 page_title: "AWS: aws_gamelift_game_session_queue"
 description: |-
-  Provides a Gamelift Game Session Queue resource.
+  Provides a GameLift Game Session Queue resource.
 ---
 
 # Resource: aws_gamelift_game_session_queue
 
-Provides an Gamelift Game Session Queue resource.
+Provides an GameLift Game Session Queue resource.
 
 ## Example Usage
 
@@ -60,7 +60,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Gamelift Game Session Queues can be imported by their `name`, e.g.,
+GameLift Game Session Queues can be imported by their `name`, e.g.,
 
 ```
 $ terraform import aws_gamelift_game_session_queue.example example

--- a/website/docs/r/gamelift_script.html.markdown
+++ b/website/docs/r/gamelift_script.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Gamelift"
+subcategory: "GameLift"
 layout: "aws"
 page_title: "AWS: aws_gamelift_script"
 description: |-
-  Provides a Gamelift Script resource.
+  Provides a GameLift Script resource.
 ---
 
 # Resource: aws_gamelift_script
 
-Provides an Gamelift Script resource.
+Provides an GameLift Script resource.
 
 ## Example Usage
 
@@ -47,13 +47,13 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Gamelift Script ID.
-* `arn` - Gamelift Script ARN.
+* `id` - GameLift Script ID.
+* `arn` - GameLift Script ARN.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 
-Gamelift Scripts can be imported using the ID, e.g.,
+GameLift Scripts can be imported using the ID, e.g.,
 
 ```
 $ terraform import aws_gamelift_script.example <script-id>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=Test PKG=gamelift 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/gamelift/... -v -count 1 -parallel 20 -run='Test'  -timeout 180m
--- PASS: TestDiffGameLiftPortSettings (0.00s)
--- PASS: TestAccGameLiftGameSessionQueue_basic (26.69s)
--- PASS: TestAccGameLiftGameSessionQueue_tags (35.98s)
--- PASS: TestAccGameLiftGameSessionQueue_disappears (10.34s)
--- PASS: TestAccGameLiftAlias_disappears (21.09s)
--- PASS: TestAccGameLiftScript_disappears (21.12s)
--- PASS: TestAccGameLiftBuild_disappears (30.37s)
--- PASS: TestAccGameLiftAlias_basic (39.56s)
--- PASS: TestAccGameLiftScript_basic (40.58s)
--- PASS: TestAccGameLiftBuild_tags (52.82s)
--- PASS: TestAccGameLiftScript_tags (61.46s)
--- PASS: TestAccGameLiftBuild_basic (54.53s)
--- PASS: TestAccGameLiftGameServerGroup_LaunchTemplate_Id (214.58s)
--- PASS: TestAccGameLiftGameServerGroup_InstanceDefinition_WeightedCapacity (214.99s)
--- PASS: TestAccGameLiftGameServerGroup_LaunchTemplate_Version (220.10s)
--- PASS: TestAccGameLiftGameServerGroup_LaunchTemplate_Name (222.56s)
--- PASS: TestAccGameLiftGameServerGroup_RoleArn (211.80s)
--- PASS: TestAccGameLiftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup (194.42s)
--- PASS: TestAccGameLiftAlias_tags (39.59s)
--- PASS: TestAccGameLiftGameServerGroup_BalancingStrategy (275.37s)
--- PASS: TestAccGameLiftGameServerGroup_InstanceDefinition (283.42s)
--- PASS: TestAccGameLiftGameServerGroup_basic (216.73s)
--- PASS: TestAccGameLiftGameServerGroup_AutoScalingPolicy (256.32s)
--- PASS: TestAccGameLiftGameServerGroup_MinSize (329.22s)
--- PASS: TestAccGameLiftGameServerGroup_MaxSize (327.47s)
--- PASS: TestAccGameLiftGameServerGroup_GameServerGroupName (389.07s)
--- PASS: TestAccGameLiftGameServerGroup_GameServerProtectionPolicy (202.57s)
--- PASS: TestAccGameLiftGameServerGroup_VpcSubnets (505.01s)
--- PASS: TestAccGameLiftFleet_script (1342.72s)
--- PASS: TestAccGameLiftFleet_cert (2013.60s)
--- PASS: TestAccGameLiftFleet_basic (2044.50s)
--- PASS: TestAccGameLiftAlias_fleetRouting (2145.87s)
--- PASS: TestAccGameLiftFleet_tags (2260.02s)
--- PASS: TestAccGameLiftFleet_disappears (2614.01s)
--- PASS: TestAccGameLiftFleet_allFields (4150.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/gamelift	4224.979s
```
