### PR TITLE
docs: update cloudtrail docs for aws_s3_bucket

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -34,7 +34,10 @@ resource "aws_cloudtrail" "foobar" {
 resource "aws_s3_bucket" "foo" {
   bucket        = "tf-test-trail"
   force_destroy = true
+}
 
+resource "aws_s3_bucket_policy" "foo" {
+  bucket = aws_s3_bucket.foo.id
   policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -46,7 +49,7 @@ resource "aws_s3_bucket" "foo" {
               "Service": "cloudtrail.amazonaws.com"
             },
             "Action": "s3:GetBucketAcl",
-            "Resource": "arn:aws:s3:::tf-test-trail"
+            "Resource": "${aws_s3_bucket.foo.arn}"
         },
         {
             "Sid": "AWSCloudTrailWrite",
@@ -55,7 +58,7 @@ resource "aws_s3_bucket" "foo" {
               "Service": "cloudtrail.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::tf-test-trail/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+            "Resource": "${aws_s3_bucket.foo.arn}/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
             "Condition": {
                 "StringEquals": {
                     "s3:x-amz-acl": "bucket-owner-full-control"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

This is just update of documentation as `aws_s3_bucket` policy statement was deprecated and now should be in resource `aws_s3_bucket_policy`


Before updating example:
```
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.foo,
│   on main.tf line 14, in resource "aws_s3_bucket" "foo":
│   14:   policy = <<POLICY
│   15: {
│   16:     "Version": "2012-10-17",
│   17:     "Statement": [
│   18:         {
│   19:             "Sid": "AWSCloudTrailAclCheck",
│   20:             "Effect": "Allow",
│   21:             "Principal": {
│   22:               "Service": "cloudtrail.amazonaws.com"
│   23:             },
│   24:             "Action": "s3:GetBucketAcl",
│   25:             "Resource": "arn:aws:s3:::tf-test-trail"
│   26:         },
│   27:         {
│   28:             "Sid": "AWSCloudTrailWrite",
│   29:             "Effect": "Allow",
│   30:             "Principal": {
│   31:               "Service": "cloudtrail.amazonaws.com"
│   32:             },
│   33:             "Action": "s3:PutObject",
│   34:             "Resource": "arn:aws:s3:::tf-test-trail/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
│   35:             "Condition": {
│   36:                 "StringEquals": {
│   37:                     "s3:x-amz-acl": "bucket-owner-full-control"
│   38:                 }
│   39:             }
│   40:         }
│   41:     ]
│   42: }
│   43: POLICY
│ 
│ Use the aws_s3_bucket_policy resource instead
│ 
│ (and one more similar warning elsewhere)
╵
```

After update there is no warning during plan.


