### PR TITLE
Add retry for "conflicting operation" when creating/updating multiple `aws_cloudwatch_log_subscription_filter` resources

### DIFF
--- a/.changelog/24148.txt
+++ b/.changelog/24148.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_subscription_filter: Retry resource create and update when a conflicting operation error is returned
+```

--- a/internal/service/cloudwatchlogs/subscription_filter.go
+++ b/internal/service/cloudwatchlogs/subscription_filter.go
@@ -82,6 +82,9 @@ func resourceSubscriptionFilterCreate(d *schema.ResourceData, meta interface{}) 
 		if tfawserr.ErrMessageContains(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not execute the lambda function") {
 			return resource.RetryableError(err)
 		}
+		if tfawserr.ErrMessageContains(err, cloudwatchlogs.ErrCodeOperationAbortedException, "Please try again") {
+			return resource.RetryableError(err)
+		}
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -115,6 +118,9 @@ func resourceSubscriptionFilterUpdate(d *schema.ResourceData, meta interface{}) 
 			return resource.RetryableError(err)
 		}
 		if tfawserr.ErrMessageContains(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not execute the lambda function") {
+			return resource.RetryableError(err)
+		}
+		if tfawserr.ErrMessageContains(err, cloudwatchlogs.ErrCodeOperationAbortedException, "Please try again") {
 			return resource.RetryableError(err)
 		}
 		if err != nil {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24063

Changes proposed in this pull request:

- Add retry for error `OperationAbortedException: [.*] Please try again.` (rather than ensuring creation is serial as originally described in issue)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCloudWatchLogsSubscriptionFilter_many PKG=cloudwatchlogs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatchlogs/... -v -count 1 -parallel 20 -run='TestAccCloudWatchLogsSubscriptionFilter_many'  -timeout 180m
=== RUN   TestAccCloudWatchLogsSubscriptionFilter_many
=== PAUSE TestAccCloudWatchLogsSubscriptionFilter_many
=== CONT  TestAccCloudWatchLogsSubscriptionFilter_many
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_many (35.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs	35.949s
```
