### PR TITLE
ec2: Split docs into subcategories

### DIFF
--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -54,7 +54,8 @@ DocDB (DocumentDB)
 DS (Directory Service)
 DynamoDB
 DynamoDB Accelerator (DAX)
-EC2
+EBS (EC2)
+EC2 (Elastic Compute Cloud)
 EC2 Image Builder
 ECR (Elastic Container Registry)
 ECR Public
@@ -112,6 +113,7 @@ OpenSearch
 OpsWorks
 Organizations
 Outposts
+Outposts (EC2)
 Pinpoint
 Pricing Calculator
 QLDB (Quantum Ledger Database)
@@ -150,10 +152,15 @@ Storage Gateway
 SWF (Simple Workflow)
 Timestream Write
 Transfer Family
-VPC
+Transit Gateway
+VPC (Virtual Private Cloud)
+VPC IPAM (IP Address Manager)
+VPN (Client)
+VPN (Site-to-Site)
 WAF
 WAF Classic
 WAF Classic Regional
+Wavelength
 Web Services Budgets
 WorkLink
 WorkMail

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ami"
 description: |-

--- a/website/docs/d/ami_ids.html.markdown
+++ b/website/docs/d/ami_ids.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ami_ids"
 description: |-

--- a/website/docs/d/availability_zone.html.markdown
+++ b/website/docs/d/availability_zone.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_availability_zone"
 description: |-

--- a/website/docs/d/availability_zones.html.markdown
+++ b/website/docs/d/availability_zones.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_availability_zones"
 description: |-

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Site-to-Site)"
 layout: "aws"
 page_title: "AWS: aws_customer_gateway"
 description: |-

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_default_kms_key"
 description: |-

--- a/website/docs/d/ebs_encryption_by_default.html.markdown
+++ b/website/docs/d/ebs_encryption_by_default.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_encryption_by_default"
 description: |-

--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_snapshot"
 description: |-

--- a/website/docs/d/ebs_snapshot_ids.html.markdown
+++ b/website/docs/d/ebs_snapshot_ids.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_snapshot_ids"
 description: |-

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_volume"
 description: |-

--- a/website/docs/d/ebs_volumes.html.markdown
+++ b/website/docs/d/ebs_volumes.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_volumes"
 description: |-

--- a/website/docs/d/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/d/ec2_client_vpn_endpoint.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_ec2_client_vpn_endpoint"
 description: |-

--- a/website/docs/d/ec2_coip_pool.html.markdown
+++ b/website/docs/d/ec2_coip_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_coip_pool"
 description: |-

--- a/website/docs/d/ec2_coip_pools.html.markdown
+++ b/website/docs/d/ec2_coip_pools.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_coip_pools"
 description: |-

--- a/website/docs/d/ec2_host.html.markdown
+++ b/website/docs/d/ec2_host.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_host"
 description: |-

--- a/website/docs/d/ec2_instance_type.html.markdown
+++ b/website/docs/d/ec2_instance_type.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_instance_type"
 description: |-

--- a/website/docs/d/ec2_instance_type_offering.html.markdown
+++ b/website/docs/d/ec2_instance_type_offering.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_instance_type_offering"
 description: |-

--- a/website/docs/d/ec2_instance_type_offerings.html.markdown
+++ b/website/docs/d/ec2_instance_type_offerings.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_instance_type_offerings"
 description: |-

--- a/website/docs/d/ec2_instance_types.html.markdown
+++ b/website/docs/d/ec2_instance_types.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_instance_types"
 description: |-

--- a/website/docs/d/ec2_local_gateway.html.markdown
+++ b/website/docs/d/ec2_local_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway"
 description: |-

--- a/website/docs/d/ec2_local_gateway_route_table.html.markdown
+++ b/website/docs/d/ec2_local_gateway_route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_route_table"
 description: |-

--- a/website/docs/d/ec2_local_gateway_route_tables.html.markdown
+++ b/website/docs/d/ec2_local_gateway_route_tables.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_route_tables"
 description: |-

--- a/website/docs/d/ec2_local_gateway_virtual_interface.html.markdown
+++ b/website/docs/d/ec2_local_gateway_virtual_interface.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_virtual_interface"
 description: |-

--- a/website/docs/d/ec2_local_gateway_virtual_interface_group.html.markdown
+++ b/website/docs/d/ec2_local_gateway_virtual_interface_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_virtual_interface_group"
 description: |-

--- a/website/docs/d/ec2_local_gateway_virtual_interface_groups.html.markdown
+++ b/website/docs/d/ec2_local_gateway_virtual_interface_groups.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_virtual_interface_groups"
 description: |-

--- a/website/docs/d/ec2_local_gateways.html.markdown
+++ b/website/docs/d/ec2_local_gateways.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateways"
 description: |-

--- a/website/docs/d/ec2_managed_prefix_list.html.markdown
+++ b/website/docs/d/ec2_managed_prefix_list.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_managed_prefix_list"
 description: |-

--- a/website/docs/d/ec2_serial_console_access.html.markdown
+++ b/website/docs/d/ec2_serial_console_access.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_serial_console_access"
 description: |-

--- a/website/docs/d/ec2_spot_price.html.markdown
+++ b/website/docs/d/ec2_spot_price.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_spot_price"
 description: |-

--- a/website/docs/d/ec2_transit_gateway.html.markdown
+++ b/website/docs/d/ec2_transit_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_connect.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_connect.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_connect"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_connect_peer.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_connect_peer.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_connect_peer"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_dx_gateway_attachment"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_multicast_domain.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_multicast_domain.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_multicast_domain"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_peering_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_peering_attachment"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_route_table.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_route_table"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_route_tables"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_vpc_attachment"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_vpc_attachments"
 description: |-

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_vpn_attachment"
 description: |-

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_eip"
 description: |-

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_eips"
 description: |-

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_instance"
 description: |-

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_instances"
 description: |-

--- a/website/docs/d/internet_gateway.html.markdown
+++ b/website/docs/d/internet_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_internet_gateway"
 description: |-

--- a/website/docs/d/key_pair.html.markdown
+++ b/website/docs/d/key_pair.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_key_pair"
 description: |-

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_launch_template"
 description: |-

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_nat_gateway"
 description: |-

--- a/website/docs/d/network_acls.html.markdown
+++ b/website/docs/d/network_acls.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_acls"
 description: |-

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_interface"
 description: |-

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_interfaces"
 description: |-

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_prefix_list"
 description: |-

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_route"
 description: |-

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_route_table"
 description: |-

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_route_tables"
 description: |-

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_security_group"
 description: |-

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_security_groups"
 description: |-

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_subnet"
 description: |-

--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_subnet_ids"
 description: |-

--- a/website/docs/d/subnets.html.markdown
+++ b/website/docs/d/subnets.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_subnets"
 description: |-

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc"
 description: |-

--- a/website/docs/d/vpc_dhcp_options.html.markdown
+++ b/website/docs/d/vpc_dhcp_options.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_dhcp_options"
 description: |-

--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint"
 description: |-

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_service"
 description: |-

--- a/website/docs/d/vpc_ipam_pool.html.markdown
+++ b/website/docs/d/vpc_ipam_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_pool"
 description: |-

--- a/website/docs/d/vpc_ipam_preview_next_cidr.html.markdown
+++ b/website/docs/d/vpc_ipam_preview_next_cidr.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_preview_next_cidr"
 description: |-

--- a/website/docs/d/vpc_peering_connection.html.markdown
+++ b/website/docs/d/vpc_peering_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection"
 description: |-

--- a/website/docs/d/vpc_peering_connections.html.markdown
+++ b/website/docs/d/vpc_peering_connections.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_peering_connections"
 description: |-

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpcs"
 description: |-

--- a/website/docs/d/vpn_gateway.html.markdown
+++ b/website/docs/d/vpn_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Site-to-Site)"
 layout: "aws"
 page_title: "AWS: aws_vpn_gateway"
 description: |-

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ami"
 description: |-

--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ami_copy"
 description: |-

--- a/website/docs/r/ami_from_instance.html.markdown
+++ b/website/docs/r/ami_from_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ami_from_instance"
 description: |-

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ami_launch_permission"
 description: |-

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Site-to-Site)"
 layout: "aws"
 page_title: "AWS: aws_customer_gateway"
 description: |-

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_default_network_acl"
 description: |-

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_default_route_table"
 description: |-

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_default_security_group"
 description: |-

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_default_subnet"
 description: |-

--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_default_vpc"
 description: |-

--- a/website/docs/r/default_vpc_dhcp_options.html.markdown
+++ b/website/docs/r/default_vpc_dhcp_options.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_default_vpc_dhcp_options"
 description: |-

--- a/website/docs/r/ebs_default_kms_key.html.markdown
+++ b/website/docs/r/ebs_default_kms_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_default_kms_key"
 description: |-

--- a/website/docs/r/ebs_encryption_by_default.html.markdown
+++ b/website/docs/r/ebs_encryption_by_default.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_encryption_by_default"
 description: |-

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_snapshot"
 description: |-

--- a/website/docs/r/ebs_snapshot_copy.html.markdown
+++ b/website/docs/r/ebs_snapshot_copy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_snapshot_copy"
 description: |-

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_snapshot_import"
 description: |-

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ebs_volume"
 description: |-

--- a/website/docs/r/ec2_availability_zone_group.html.markdown
+++ b/website/docs/r/ec2_availability_zone_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_availability_zone_group"
 description: |-

--- a/website/docs/r/ec2_capacity_reservation.html.markdown
+++ b/website/docs/r/ec2_capacity_reservation.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_capacity_reservation"
 description: |-

--- a/website/docs/r/ec2_carrier_gateway.html.markdown
+++ b/website/docs/r/ec2_carrier_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Wavelength"
 layout: "aws"
 page_title: "AWS: aws_ec2_carrier_gateway"
 description: |-

--- a/website/docs/r/ec2_client_vpn_authorization_rule.html.markdown
+++ b/website/docs/r/ec2_client_vpn_authorization_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_ec2_client_vpn_authorization_rule"
 description: |-

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_ec2_client_vpn_endpoint"
 description: |-

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_ec2_client_vpn_network_association"
 description: |-

--- a/website/docs/r/ec2_client_vpn_route.html.markdown
+++ b/website/docs/r/ec2_client_vpn_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_ec2_client_vpn_route"
 description: |-

--- a/website/docs/r/ec2_fleet.html.markdown
+++ b/website/docs/r/ec2_fleet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_fleet"
 description: |-

--- a/website/docs/r/ec2_host.html.markdown
+++ b/website/docs/r/ec2_host.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_host"
 description: |-

--- a/website/docs/r/ec2_local_gateway_route.html.markdown
+++ b/website/docs/r/ec2_local_gateway_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_route"
 description: |-

--- a/website/docs/r/ec2_local_gateway_route_table_vpc_association.html.markdown
+++ b/website/docs/r/ec2_local_gateway_route_table_vpc_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Outposts (EC2)"
 layout: "aws"
 page_title: "AWS: aws_ec2_local_gateway_route_table_vpc_association"
 description: |-

--- a/website/docs/r/ec2_managed_prefix_list.html.markdown
+++ b/website/docs/r/ec2_managed_prefix_list.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_managed_prefix_list"
 description: |-

--- a/website/docs/r/ec2_managed_prefix_list_entry.html.markdown
+++ b/website/docs/r/ec2_managed_prefix_list_entry.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_managed_prefix_list_entry"
 description: |-

--- a/website/docs/r/ec2_network_insights_path.html.markdown
+++ b/website/docs/r/ec2_network_insights_path.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_network_insights_path"
 description: |-

--- a/website/docs/r/ec2_serial_console_access.html.markdown
+++ b/website/docs/r/ec2_serial_console_access.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_serial_console_access"
 description: |-

--- a/website/docs/r/ec2_subnet_cidr_reservation.html.markdown
+++ b/website/docs/r/ec2_subnet_cidr_reservation.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_subnet_cidr_reservation"
 description: |-

--- a/website/docs/r/ec2_tag.html.markdown
+++ b/website/docs/r/ec2_tag.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_tag"
 description: |-

--- a/website/docs/r/ec2_traffic_mirror_filter.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_filter.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_traffic_mirror_filter"
 description: |-

--- a/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_traffic_mirror_filter_rule"
 description: |-

--- a/website/docs/r/ec2_traffic_mirror_session.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_session.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_traffic_mirror_session"
 description: |-

--- a/website/docs/r/ec2_traffic_mirror_target.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_target.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_ec2_traffic_mirror_target"
 description: |-

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_connect.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_connect.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_connect"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_connect_peer.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_connect_peer.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_connect_peer"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_multicast_domain.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_multicast_domain.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_multicast_domain"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_multicast_domain_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_multicast_domain_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_multicast_domain_association"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_multicast_group_member.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_multicast_group_member.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_multicast_group_member"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_multicast_group_source.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_multicast_group_source.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_multicast_group_source"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_peering_attachment"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_peering_attachment_accepter.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_peering_attachment_accepter.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_peering_attachment_accepter"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_prefix_list_reference.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_prefix_list_reference.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_prefix_list_reference"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_route.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_route"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_route_table.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_route_table"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_route_table_association_table_association"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_route_table_propagation.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_propagation.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_route_table_propagation_table_propagation"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_vpc_attachment"
 description: |-

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment_accepter.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment_accepter.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "Transit Gateway"
 layout: "aws"
 page_title: "AWS: aws_ec2_transit_gateway_vpc_attachment_accepter"
 description: |-

--- a/website/docs/r/egress_only_internet_gateway.html.markdown
+++ b/website/docs/r/egress_only_internet_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_egress_only_internet_gateway"
 description: |-

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_eip"
 description: |-

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_eip_association"
 description: |-

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_flow_log"
 description: |-

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_instance"
 description: |-

--- a/website/docs/r/internet_gateway.html.markdown
+++ b/website/docs/r/internet_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_internet_gateway"
 description: |-

--- a/website/docs/r/internet_gateway_attachment.html.markdown
+++ b/website/docs/r/internet_gateway_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_internet_gateway_attachment"
 description: |-

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_key_pair"
 description: |-

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_launch_template"
 description: |-

--- a/website/docs/r/main_route_table_association.html.markdown
+++ b/website/docs/r/main_route_table_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_main_route_table_association"
 description: |-

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_nat_gateway"
 description: |-

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_acl"
 description: |-

--- a/website/docs/r/network_acl_association.html.markdown
+++ b/website/docs/r/network_acl_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_acl_association"
 description: |-

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_acl_rule"
 description: |-

--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_interface"
 description: |-

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_interface_attachment"
 description: |-

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_network_interface_sg_attachment"
 description: |-

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_placement_group"
 description: |-

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_route"
 description: |-

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_route_table"
 description: |-

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_route_table_association"
 description: |-

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_security_group"
 description: |-

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_security_group_rule"
 description: |-

--- a/website/docs/r/snapshot_create_volume_permission.html.markdown
+++ b/website/docs/r/snapshot_create_volume_permission.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_snapshot_create_volume_permission"
 description: |-

--- a/website/docs/r/spot_datafeed_subscription.html.markdown
+++ b/website/docs/r/spot_datafeed_subscription.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_spot_datafeed_subscription"
 description: |-

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_spot_fleet_request"
 description: |-

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "AWS: aws_spot_instance_request"
 description: |-

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_subnet"
 description: |-

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EC2"
+subcategory: "EBS (EC2)"
 layout: "aws"
 page_title: "AWS: aws_volume_attachment"
 description: |-

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc"
 description: |-

--- a/website/docs/r/vpc_dhcp_options.html.markdown
+++ b/website/docs/r/vpc_dhcp_options.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_dhcp_options"
 description: |-

--- a/website/docs/r/vpc_dhcp_options_association.html.markdown
+++ b/website/docs/r/vpc_dhcp_options_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_dhcp_options_association"
 description: |-

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint"
 description: |-

--- a/website/docs/r/vpc_endpoint_connection_accepter.html.markdown
+++ b/website/docs/r/vpc_endpoint_connection_accepter.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_connection_accepter"
 description: |-

--- a/website/docs/r/vpc_endpoint_connection_notification.html.markdown
+++ b/website/docs/r/vpc_endpoint_connection_notification.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_connection_notification"
 description: |-

--- a/website/docs/r/vpc_endpoint_policy.html.markdown
+++ b/website/docs/r/vpc_endpoint_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_policy"
 description: |-

--- a/website/docs/r/vpc_endpoint_route_table_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_route_table_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_route_table_association"
 description: |-

--- a/website/docs/r/vpc_endpoint_security_group_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_security_group_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_security_group_association"
 description: |-

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_service"
 description: |-

--- a/website/docs/r/vpc_endpoint_service_allowed_principal.html.markdown
+++ b/website/docs/r/vpc_endpoint_service_allowed_principal.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_service_allowed_principal"
 description: |-

--- a/website/docs/r/vpc_endpoint_subnet_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_subnet_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint_subnet_association"
 description: |-

--- a/website/docs/r/vpc_ipam.html.markdown
+++ b/website/docs/r/vpc_ipam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam"
 description: |-

--- a/website/docs/r/vpc_ipam_organization_admin_account.html.markdown
+++ b/website/docs/r/vpc_ipam_organization_admin_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_organization_admin_account"
 description: |-

--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_pool"
 description: |-

--- a/website/docs/r/vpc_ipam_pool_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_pool_cidr"
 description: |-

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_pool_cidr_allocation"
 description: |-

--- a/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_preview_next_cidr"
 description: |-

--- a/website/docs/r/vpc_ipam_scope.html.markdown
+++ b/website/docs/r/vpc_ipam_scope.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC IPAM (IP Address Manager)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipam_scope"
 description: |-

--- a/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
+++ b/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipv4_cidr_block_association"
 description: |-

--- a/website/docs/r/vpc_ipv6_cidr_block_association.html.markdown
+++ b/website/docs/r/vpc_ipv6_cidr_block_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_ipv6_cidr_block_association"
 description: |-

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection"
 description: |-

--- a/website/docs/r/vpc_peering_connection_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_connection_accepter.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection_accepter"
 description: |-

--- a/website/docs/r/vpc_peering_connection_options.html.markdown
+++ b/website/docs/r/vpc_peering_connection_options.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection_options"
 description: |-

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_vpn_connection"
 description: |-

--- a/website/docs/r/vpn_connection_route.html.markdown
+++ b/website/docs/r/vpn_connection_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Client)"
 layout: "aws"
 page_title: "AWS: aws_vpn_connection_route"
 description: |-

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Site-to-Site)"
 layout: "aws"
 page_title: "AWS: aws_vpn_gateway"
 description: |-

--- a/website/docs/r/vpn_gateway_attachment.html.markdown
+++ b/website/docs/r/vpn_gateway_attachment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Site-to-Site)"
 layout: "aws"
 page_title: "AWS: aws_vpn_gateway_attachment"
 description: |-

--- a/website/docs/r/vpn_gateway_route_propagation.html.markdown
+++ b/website/docs/r/vpn_gateway_route_propagation.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VPC"
+subcategory: "VPN (Site-to-Site)"
 layout: "aws"
 page_title: "AWS: aws_vpn_gateway_route_propagation"
 description: |-


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
