### PR TITLE
provider: Fix endpoints test panic

### DIFF
--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -852,6 +852,10 @@ func testAccCheckEndpoints(providers *[]*schema.Provider) resource.TestCheckFunc
 					return fmt.Errorf("unable to match conns.AWSClient struct field name for endpoint name: %s", serviceKey)
 				}
 
+				if !reflect.Indirect(providerClientField).FieldByName("Config").IsValid() {
+					continue // currently unknown how to do this check for v2 clients
+				}
+
 				actualEndpoint := reflect.Indirect(reflect.Indirect(providerClientField).FieldByName("Config").FieldByName("Endpoint")).String()
 				expectedEndpoint := fmt.Sprintf("http://%s", serviceKey)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23954

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% TF_ACC=1 go test ./internal/acctest... -v -count 1 -parallel 20 -run='TestAccProvider' -short -timeout 180m
--- PASS: TestAccProvider_Region_stsRegion (20.73s)
--- PASS: TestAccProvider_Region_awsSC2S (20.74s)
--- PASS: TestAccProvider_Region_awsGovCloudUs (20.95s)
--- PASS: TestAccProvider_Region_awsChina (21.88s)
--- PASS: TestAccProvider_Region_awsCommercial (21.94s)
--- PASS: TestAccProvider_Region_awsC2S (22.23s)
--- PASS: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (26.05s)
--- PASS: TestAccProvider_IgnoreTagsKeys_none (26.08s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_one (26.48s)
--- PASS: TestAccProvider_DefaultTagsTags_multiple (26.52s)
--- PASS: TestAccProvider_DefaultTags_emptyBlock (26.86s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_multiple (26.87s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_none (26.88s)
--- PASS: TestAccProvider_IgnoreTagsKeys_multiple (27.07s)
--- PASS: TestAccProvider_IgnoreTagsKeys_one (27.27s)
--- PASS: TestAccProvider_endpoints (27.65s)
--- PASS: TestAccProvider_unusualEndpoints (27.66s)
--- PASS: TestAccProvider_IgnoreTags_emptyBlock (27.66s)
--- PASS: TestAccProvider_AssumeRole_empty (29.05s)
--- PASS: TestAccProvider_DefaultTagsTags_one (10.92s)
--- PASS: TestAccProvider_DefaultTagsTags_none (10.89s)
--- PASS: TestAccProvider_fipsEndpoint (36.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	38.184s
```
