### PR TITLE
Clarify permissions needed for `aws_canonical_user_id` data source

### DIFF
--- a/website/docs/d/canonical_user_id.html.markdown
+++ b/website/docs/d/canonical_user_id.html.markdown
@@ -12,6 +12,8 @@ description: |-
 The Canonical User ID data source allows access to the [canonical user ID](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)
 for the effective account in which Terraform is working.  
 
+~> **NOTE:** To use this data source, you must have the `s3:ListAllMyBuckets` permission.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #24007

Output from acceptance testing: N/a, docs

### Research

- data source uses [s3.ListBuckets](https://github.com/hashicorp/terraform-provider-aws/blob/55e9157c3ba093b834b30400e4dd045d8b26d518/internal/service/s3/canonical_user_id_data_source.go#L32)
- [documentation for `s3.ListBuckets`](https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.ListBuckets) says:

> To use this operation, you must have the s3:ListAllMyBuckets permission.