### PR TITLE
Add provider infrastructure for Amazon CloudWatch Evidently

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -100,6 +100,8 @@ service/cloudtrail:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudtrail'
 service/cloudwatch:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_(?!(event_|log_|query_))'
+service/cloudwatchevidently:
+  - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatchevidently_'
 service/cloudwatchlogs:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudwatch_(log_|query_)'
 service/cloudwatchrum:

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -155,6 +155,9 @@ service/cloudwatch:
   - 'internal/service/cloudwatch/**/*'
   - 'website/**/cloudwatch_dashboard*'
   - 'website/**/cloudwatch_metric_alarm*'
+service/cloudwatchevidently:
+  - 'internal/service/cloudwatchevidently/**/*'
+  - 'website/**/cloudwatchevidently_*'
 service/cloudwatchlogs:
   - 'internal/service/cloudwatchlogs/**/*'
   - 'website/**/cloudwatch_log_*'

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -44,6 +44,7 @@ variable "service_labels" {
     "cloudsearch",
     "cloudtrail",
     "cloudwatch",
+    "cloudwatchevidently",
     "cloudwatchlogs",
     "cloudwatchrum",
     "codeartifact",

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -52,6 +52,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudsearchdomain"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchrum"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
@@ -369,6 +370,7 @@ type AWSClient struct {
 	CloudSearchDomainConn             *cloudsearchdomain.CloudSearchDomain
 	CloudTrailConn                    *cloudtrail.CloudTrail
 	CloudWatchConn                    *cloudwatch.CloudWatch
+	CloudWatchEvidentlyConn           *cloudwatchevidently.CloudWatchEvidently
 	CloudWatchLogsConn                *cloudwatchlogs.CloudWatchLogs
 	CloudWatchRUMConn                 *cloudwatchrum.CloudWatchRUM
 	CodeArtifactConn                  *codeartifact.CodeArtifact
@@ -771,6 +773,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		CloudSearchDomainConn:             cloudsearchdomain.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudSearchDomain])})),
 		CloudTrailConn:                    cloudtrail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudTrail])})),
 		CloudWatchConn:                    cloudwatch.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatch])})),
+		CloudWatchEvidentlyConn:           cloudwatchevidently.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatchEvidently])})),
 		CloudWatchLogsConn:                cloudwatchlogs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatchLogs])})),
 		CloudWatchRUMConn:                 cloudwatchrum.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudWatchRUM])})),
 		CodeArtifactConn:                  codeartifact.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CodeArtifact])})),

--- a/internal/generate/listpages/main.go
+++ b/internal/generate/listpages/main.go
@@ -399,6 +399,7 @@ func init() {
 	awsServiceNames["cloudsearchdomain"] = "CloudSearchDomain"
 	awsServiceNames["cloudtrail"] = "CloudTrail"
 	awsServiceNames["cloudwatch"] = "CloudWatch"
+	awsServiceNames["cloudwatchevidently"] = "CloudWatchEvidently"
 	awsServiceNames["cloudwatchlogs"] = "CloudWatchLogs"
 	awsServiceNames["codeartifact"] = "CodeArtifact"
 	awsServiceNames["codebuild"] = "CodeBuild"

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -901,6 +901,7 @@ func init() {
 	awsServiceNames["cloudsearchdomain"] = "CloudSearchDomain"
 	awsServiceNames["cloudtrail"] = "CloudTrail"
 	awsServiceNames["cloudwatch"] = "CloudWatch"
+	awsServiceNames["cloudwatchevidently"] = "CloudWatchEvidently"
 	awsServiceNames["cloudwatchlogs"] = "CloudWatchLogs"
 	awsServiceNames["codeartifact"] = "CodeArtifact"
 	awsServiceNames["codebuild"] = "CodeBuild"

--- a/names/names.go
+++ b/names/names.go
@@ -45,6 +45,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudsearchdomain"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchrum"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
@@ -322,6 +323,7 @@ const (
 	CloudSearchDomain             = "cloudsearchdomain"
 	CloudTrail                    = "cloudtrail"
 	CloudWatch                    = "cloudwatch"
+	CloudWatchEvidently           = "cloudwatchevidently"
 	CloudWatchLogs                = "cloudwatchlogs"
 	CloudWatchRUM                 = "cloudwatchrum"
 	CodeArtifact                  = "codeartifact"
@@ -623,6 +625,7 @@ func init() {
 	serviceData[CloudSearchDomain] = &ServiceDatum{AWSClientName: "CloudSearchDomain", AWSServiceName: cloudsearchdomain.ServiceName, AWSEndpointsID: cloudsearchdomain.EndpointsID, AWSServiceID: cloudsearchdomain.ServiceID, ProviderNameUpper: "CloudSearchDomain", HCLKeys: []string{"cloudsearchdomain"}}
 	serviceData[CloudTrail] = &ServiceDatum{AWSClientName: "CloudTrail", AWSServiceName: cloudtrail.ServiceName, AWSEndpointsID: cloudtrail.EndpointsID, AWSServiceID: cloudtrail.ServiceID, ProviderNameUpper: "CloudTrail", HCLKeys: []string{"cloudtrail"}}
 	serviceData[CloudWatch] = &ServiceDatum{AWSClientName: "CloudWatch", AWSServiceName: cloudwatch.ServiceName, AWSEndpointsID: cloudwatch.EndpointsID, AWSServiceID: cloudwatch.ServiceID, ProviderNameUpper: "CloudWatch", HCLKeys: []string{"cloudwatch"}}
+	serviceData[CloudWatchEvidently] = &ServiceDatum{AWSClientName: "CloudWatchEvidently", AWSServiceName: cloudwatchevidently.ServiceName, AWSEndpointsID: cloudwatchevidently.EndpointsID, AWSServiceID: cloudwatchevidently.ServiceID, ProviderNameUpper: "CloudWatchEvidently", HCLKeys: []string{"cloudwatchevidently"}}
 	serviceData[CloudWatchLogs] = &ServiceDatum{AWSClientName: "CloudWatchLogs", AWSServiceName: cloudwatchlogs.ServiceName, AWSEndpointsID: cloudwatchlogs.EndpointsID, AWSServiceID: cloudwatchlogs.ServiceID, ProviderNameUpper: "CloudWatchLogs", HCLKeys: []string{"cloudwatchlogs"}}
 	serviceData[CloudWatchRUM] = &ServiceDatum{AWSClientName: "CloudWatchRUM", AWSServiceName: cloudwatchrum.ServiceName, AWSEndpointsID: cloudwatchrum.EndpointsID, AWSServiceID: cloudwatchrum.ServiceID, ProviderNameUpper: "CloudWatchRUM", HCLKeys: []string{"cloudwatchrum"}}
 	serviceData[CodeArtifact] = &ServiceDatum{AWSClientName: "CodeArtifact", AWSServiceName: codeartifact.ServiceName, AWSEndpointsID: codeartifact.EndpointsID, AWSServiceID: codeartifact.ServiceID, ProviderNameUpper: "CodeArtifact", HCLKeys: []string{"codeartifact"}}

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -67,6 +67,7 @@ func TestServicesForDirectories(t *testing.T) {
 		"braket",
 		"clouddirectory",
 		"cloudsearchdomain",
+		"cloudwatchevidently",
 		"cloudwatchrum",
 		"codeguruprofiler",
 		"codegurureviewer",

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -29,6 +29,7 @@ CloudHSM
 CloudSearch
 CloudTrail
 CloudWatch
+CloudWatch Evidently
 CloudWatch RUM
 CloudWatch Synthetics
 CodeArtifact

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -109,6 +109,7 @@ provider "aws" {
   <li><code>cloudsearchdomain</code></li>
   <li><code>cloudtrail</code></li>
   <li><code>cloudwatch</code></li>
+  <li><code>cloudwatchevidently</code></li>
   <li><code>cloudwatchlogs</code></li>
   <li><code>cloudwatchrum</code></li>
   <li><code>codeartifact</code></li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22624

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./...  -timeout=5m
?       github.com/hashicorp/terraform-provider-aws     [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/acctest    (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/attrmap    [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/conns      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/create     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable      (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/experimental/sync  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/flex       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acmpca     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amplify    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appmesh    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/budgets    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloud9     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2 (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codecommit (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codedeploy (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cur        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dax        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/detective  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dlm        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/docdb      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ds (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elb        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/firehose   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fms        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glacier    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/grafana    (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/service/greengrass [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/identitystore      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics       [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/service/iotevents  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesis    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2 (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie2     (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect       [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert       (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/service/medialive  [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediastore (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mwaa       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opsworks   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/organizations      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pricing    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/qldb       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ram        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53domains     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3control  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/schemas    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/securityhub        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sfn        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/shield     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/signer     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/simpledb   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sqs        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/swf        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/synthetics (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite    (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/transfer   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/waf        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafregional        (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/worklink   (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/workspaces (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/xray       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/tags       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/tfresource (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys       (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/vault/sdk/helper/jsonutil  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/verify     (cached)
ok      github.com/hashicorp/terraform-provider-aws/names       0.013s
?       github.com/hashicorp/terraform-provider-aws/version     [no test files]
...
```
