### PR TITLE
r/athena_database - add `properties` + import support

### DIFF
--- a/.changelog/24172.txt
+++ b/.changelog/24172.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_athena_database: Add import support.
+```
+
+```release-note:enhancement
+resource/aws_athena_database: Add `properties` argument.
+```
+
+```release-note:bug
+resource/aws_athena_database: Add drift detection for `comment`.
+```

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -106,11 +106,11 @@ func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	var queryString bytes.Buffer
 
-	createStmt := fmt.Sprintf("create database `%[1]s`", name)
+	createStmt := fmt.Sprintf("create database `%s`", name)
 	queryString.WriteString(createStmt)
 
 	if v, ok := d.GetOk("comment"); ok && v.(string) != "" {
-		commentStmt := fmt.Sprintf(" comment '%[1]s';", name, strings.Replace(v.(string), "'", "\\'", -1))
+		commentStmt := fmt.Sprintf(" comment '%s'", strings.Replace(v.(string), "'", "\\'", -1))
 		queryString.WriteString(commentStmt)
 	}
 
@@ -121,7 +121,7 @@ func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 			props = append(props, prop)
 		}
 
-		propStmt := fmt.Sprintf(" WITH DBPROPERTIES(%[1]s)", strings.Join(props, ","))
+		propStmt := fmt.Sprintf(" WITH DBPROPERTIES(%s)", strings.Join(props, ","))
 		queryString.WriteString(propStmt)
 	}
 

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -60,3 +60,17 @@ Athena Databases can be imported using their name, e.g.,
 ```
 $ terraform import aws_athena_database.example example
 ```
+
+Certain resource arguments, like `encryption_configuration` and `bucket`, do not have an API method for reading the information after creation. If the argument is set in the Terraform configuration on an imported resource, Terraform will always show a difference. To workaround this behavior, either omit the argument from the Terraform configuration or use [`ignore_changes`](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) to hide the difference, e.g.,
+
+```terraform
+resource "aws_athena_database" "example" {
+  name   = "database_name"
+  bucket = aws_s3_bucket.example.bucket
+
+  # There is no API for reading bucket
+  lifecycle {
+    ignore_changes = [bucket]
+  }
+}
+```

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `encryption_configuration` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. See [Encryption Configuration](#encryption-configuration) below.
 * `expected_bucket_owner` - (Optional) The AWS account ID that you expect to be the owner of the Amazon S3 bucket.
 * `force_destroy` - (Optional, Default: false) A boolean that indicates all tables should be deleted from the database so that the database can be destroyed without error. The tables are *not* recoverable.
+* `properties` - (Optional) A key-value map of custom metadata properties for the database definition.
 
 ### ACL Configuration
 
@@ -51,3 +52,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The database name
+
+## Import
+
+Athena Databases can be imported using their name, e.g.,
+
+```
+$ terraform import aws_athena_database.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24022

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAthenaDatabase_ PKG=athena

--- PASS: TestAccAthenaDatabase_nameCantHaveUppercase (4.89s)
--- PASS: TestAccAthenaDatabase_disppears (49.70s)
--- PASS: TestAccAthenaDatabase_properties (55.26s)
--- PASS: TestAccAthenaDatabase_forceDestroyAlwaysSucceeds (55.45s)
--- PASS: TestAccAthenaDatabase_basic (57.23s)
--- PASS: TestAccAthenaDatabase_acl (57.44s)
--- PASS: TestAccAthenaDatabase_nameStartsWithUnderscore (57.46s)
--- PASS: TestAccAthenaDatabase_unescaped_description (57.54s)
--- PASS: TestAccAthenaDatabase_description (57.55s)
--- PASS: TestAccAthenaDatabase_encryption (60.38s)
--- PASS: TestAccAthenaDatabase_destroyFailsIfTablesExist (64.35s)
```
