### PR TITLE
r/vpc_ipam_scope: prevent panic and add pagination when describing existing scopes by ID

### DIFF
--- a/.changelog/24188.txt
+++ b/.changelog/24188.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_vpc_ipam_scope: Prevent panic when describing IPAM Scopes by ID
+```
+
+```release-note:enhancement
+resource/aws_vpc_ipam_scope: Add pagination when describing IPAM Scopes
+```

--- a/internal/service/ec2/vpc_ipam_scope.go
+++ b/internal/service/ec2/vpc_ipam_scope.go
@@ -120,15 +120,6 @@ func ResourceVPCIpamScopeRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading IPAM Scope (%s): %w", d.Id(), err)
 	}
 
-	if scope == nil {
-		if d.IsNewResource() {
-			return fmt.Errorf("error reading IPAM Scope (%s): not found after creation", d.Id())
-		}
-		log.Printf("[WARN] IPAM Scope (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
 	ipamId := strings.Split(aws.StringValue(scope.IpamArn), "/")[1]
 
 	d.Set("arn", scope.IpamScopeArn)
@@ -290,7 +281,7 @@ func statusIpamScopeStatus(conn *ec2.EC2, ipamScopeId string) resource.StateRefr
 
 		output, err := findIpamScopeById(conn, ipamScopeId)
 
-		if tfawserr.ErrCodeEquals(err, InvalidIpamScopeIdNotFound) {
+		if tfresource.NotFound(err) {
 			return output, InvalidIpamScopeIdNotFound, nil
 		}
 


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24168

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccVPCIpamScope_' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCIpamScope_ -timeout 180m
=== RUN   TestAccVPCIpamScope_basic
=== PAUSE TestAccVPCIpamScope_basic
=== RUN   TestAccVPCIpamScope_tags
=== PAUSE TestAccVPCIpamScope_tags
=== CONT  TestAccVPCIpamScope_basic
=== CONT  TestAccVPCIpamScope_tags
--- PASS: TestAccVPCIpamScope_basic (53.71s)
--- PASS: TestAccVPCIpamScope_tags (64.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	67.913s
```
