### PR TITLE
Fix list in aws_cloudformation_stack_set docs

### DIFF
--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -105,12 +105,12 @@ The following arguments are supported:
 
 The `operation_preferences` configuration block supports the following arguments:
 
-*`failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
-*`failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
-*`max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time.
-*`max_concurrent_percentage` - (Optional) The maximum percentage of accounts in which to perform this operation at one time.
-*`region_concurrency_type` - (Optional) The concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time.
-*`region_order` - (Optional) The order of the Regions in where you want to perform the stack operation.
+* `failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
+* `failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
+* `max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time.
+* `max_concurrent_percentage` - (Optional) The maximum percentage of accounts in which to perform this operation at one time.
+* `region_concurrency_type` - (Optional) The concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time.
+* `region_order` - (Optional) The order of the Regions in where you want to perform the stack operation.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing: n/a, docs

### Information

The list modified didn't have spaces between the `*` and the list item, so the markdown rendered poorly. This PR aims to fix that formatting.

<img width="673" alt="Screenshot of malformed documentation, where multiple list items were concatenated on to one line" src="https://user-images.githubusercontent.com/44710313/162841249-7a12ae11-e49a-47cd-9db2-87ecf5659efd.png">