### PR TITLE
Add aws_nat_gateways data source

### DIFF
--- a/.changelog/24190.txt
+++ b/.changelog/24190.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_nat_gateways
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -558,6 +558,7 @@ func Provider() *schema.Provider {
 			"aws_key_pair":                                   ec2.DataSourceKeyPair(),
 			"aws_launch_template":                            ec2.DataSourceLaunchTemplate(),
 			"aws_nat_gateway":                                ec2.DataSourceNATGateway(),
+			"aws_nat_gateways":                               ec2.DataSourceNATGateways(),
 			"aws_network_acls":                               ec2.DataSourceNetworkACLs(),
 			"aws_network_interface":                          ec2.DataSourceNetworkInterface(),
 			"aws_network_interfaces":                         ec2.DataSourceNetworkInterfaces(),

--- a/internal/service/ec2/nat_gateways_data_source.go
+++ b/internal/service/ec2/nat_gateways_data_source.go
@@ -1,0 +1,76 @@
+package ec2
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceNATGateways() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNATGatewaysRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": DataSourceFiltersSchema(),
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceNATGatewaysRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	input := &ec2.DescribeNatGatewaysInput{}
+
+	if v, ok := d.GetOk("vpc_id"); ok {
+		input.Filter = append(input.Filter, BuildAttributeFilterList(
+			map[string]string{
+				"vpc-id": v.(string),
+			},
+		)...)
+	}
+
+	if tags, ok := d.GetOk("tags"); ok {
+		input.Filter = append(input.Filter, BuildTagFilterList(
+			Tags(tftags.New(tags.(map[string]interface{}))),
+		)...)
+	}
+
+	input.Filter = append(input.Filter, BuildFiltersDataSource(
+		d.Get("filter").(*schema.Set),
+	)...)
+	if len(input.Filter) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		input.Filter = nil
+	}
+
+	ngws, err := FindNATGateways(conn, input)
+
+	if err != nil {
+		return fmt.Errorf("error reading EC2 NAT Gateways: %w", err)
+	}
+
+	var natGatewayIds []string
+
+	for _, v := range ngws {
+		natGatewayIds = append(natGatewayIds, aws.StringValue(v.NatGatewayId))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("ids", natGatewayIds)
+
+	return nil
+}

--- a/internal/service/ec2/nat_gateways_data_source.go
+++ b/internal/service/ec2/nat_gateways_data_source.go
@@ -52,25 +52,25 @@ func dataSourceNATGatewaysRead(d *schema.ResourceData, meta interface{}) error {
 	input.Filter = append(input.Filter, BuildFiltersDataSource(
 		d.Get("filter").(*schema.Set),
 	)...)
+
 	if len(input.Filter) == 0 {
-		// Don't send an empty filters list; the EC2 API won't accept it.
 		input.Filter = nil
 	}
 
-	ngws, err := FindNATGateways(conn, input)
+	output, err := FindNATGateways(conn, input)
 
 	if err != nil {
 		return fmt.Errorf("error reading EC2 NAT Gateways: %w", err)
 	}
 
-	var natGatewayIds []string
+	var natGatewayIDs []string
 
-	for _, v := range ngws {
-		natGatewayIds = append(natGatewayIds, aws.StringValue(v.NatGatewayId))
+	for _, v := range output {
+		natGatewayIDs = append(natGatewayIDs, aws.StringValue(v.NatGatewayId))
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
-	d.Set("ids", natGatewayIds)
+	d.Set("ids", natGatewayIDs)
 
 	return nil
 }

--- a/internal/service/ec2/nat_gateways_data_source_test.go
+++ b/internal/service/ec2/nat_gateways_data_source_test.go
@@ -14,9 +14,9 @@ func TestAccEC2NATGatewaysDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
-		Providers:    acctest.Providers,
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNATGatewaysDataSourceConfig(rName),

--- a/internal/service/ec2/nat_gateways_data_source_test.go
+++ b/internal/service/ec2/nat_gateways_data_source_test.go
@@ -17,7 +17,6 @@ func TestAccEC2NATGatewaysDataSource_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNATGatewaysDataSourceConfig(rName),
@@ -43,11 +42,11 @@ resource "aws_vpc" "test1" {
 }
 
 resource "aws_vpc" "test2" {
-	cidr_block = "172.5.0.0/16"
+  cidr_block = "172.5.0.0/16"
 
-	tags = {
-		Name = %[1]q
-	}
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "test1" {
@@ -97,11 +96,11 @@ resource "aws_eip" "test2" {
 }
 
 resource "aws_eip" "test3" {
-	vpc = true
+  vpc = true
 
-	tags = {
-		Name = %[1]q
-	}
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_internet_gateway" "test1" {
@@ -159,7 +158,7 @@ resource "aws_nat_gateway" "test3" {
 data "aws_nat_gateways" "by_vpc_id" {
   vpc_id = aws_vpc.test2.id
 
-	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+  depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
 }
 
 data "aws_nat_gateways" "by_tags" {
@@ -168,30 +167,30 @@ data "aws_nat_gateways" "by_tags" {
     values = ["available"]
   }
 
-	tags = {
-		OtherTag = "some-value"
-	}
+  tags = {
+    OtherTag = "some-value"
+  }
 
-	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+  depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
 }
 
 data "aws_nat_gateways" "by_filter" {
   filter {
-		name   = "vpc-id"
-		values = [aws_vpc.test1.id, aws_vpc.test2.id]
+    name   = "vpc-id"
+    values = [aws_vpc.test1.id, aws_vpc.test2.id]
   }
 
-	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+  depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
 }
 
 data "aws_nat_gateways" "empty" {
-	vpc_id = aws_vpc.test2.id
+  vpc_id = aws_vpc.test2.id
 
-	tags = {
-		OtherTag = "some-value"
-	}
+  tags = {
+    OtherTag = "some-value"
+  }
 
-	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+  depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
 }
 `, rName))
 }

--- a/internal/service/ec2/nat_gateways_data_source_test.go
+++ b/internal/service/ec2/nat_gateways_data_source_test.go
@@ -163,6 +163,11 @@ data "aws_nat_gateways" "by_vpc_id" {
 }
 
 data "aws_nat_gateways" "by_tags" {
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+
 	tags = {
 		OtherTag = "some-value"
 	}

--- a/internal/service/ec2/nat_gateways_data_source_test.go
+++ b/internal/service/ec2/nat_gateways_data_source_test.go
@@ -1,0 +1,192 @@
+package ec2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccEC2NATGatewaysDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNATGatewaysDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_nat_gateways.by_vpc_id", "ids.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_nat_gateways.by_tags", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_nat_gateways.by_filter", "ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_nat_gateways.empty", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNATGatewaysDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "172.5.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "test2" {
+	cidr_block = "172.5.0.0/16"
+
+	tags = {
+		Name = %[1]q
+	}
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "172.5.123.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test2.id
+  cidr_block        = "172.5.123.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test3" {
+  vpc_id            = aws_vpc.test2.id
+  cidr_block        = "172.5.124.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test1" {
+  vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test2" {
+  vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test3" {
+	vpc = true
+
+	tags = {
+		Name = %[1]q
+	}
+}
+
+resource "aws_internet_gateway" "test1" {
+  vpc_id = aws_vpc.test1.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test2" {
+  vpc_id = aws_vpc.test2.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test1" {
+  subnet_id     = aws_subnet.test1.id
+  allocation_id = aws_eip.test1.id
+
+  tags = {
+    Name     = %[1]q
+    OtherTag = "some-value"
+  }
+
+  depends_on = [aws_internet_gateway.test1]
+}
+
+resource "aws_nat_gateway" "test2" {
+  subnet_id     = aws_subnet.test2.id
+  allocation_id = aws_eip.test2.id
+
+  tags = {
+    Name     = %[1]q
+    OtherTag = "some-other-value"
+  }
+
+  depends_on = [aws_internet_gateway.test2]
+}
+
+resource "aws_nat_gateway" "test3" {
+  subnet_id     = aws_subnet.test3.id
+  allocation_id = aws_eip.test3.id
+
+  tags = {
+    Name     = %[1]q
+    OtherTag = "some-other-value"
+  }
+
+  depends_on = [aws_internet_gateway.test2]
+}
+
+data "aws_nat_gateways" "by_vpc_id" {
+  vpc_id = aws_vpc.test2.id
+
+	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+}
+
+data "aws_nat_gateways" "by_tags" {
+	tags = {
+		OtherTag = "some-value"
+	}
+
+	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+}
+
+data "aws_nat_gateways" "by_filter" {
+  filter {
+		name   = "vpc-id"
+		values = [aws_vpc.test1.id, aws_vpc.test2.id]
+  }
+
+	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+}
+
+data "aws_nat_gateways" "empty" {
+	vpc_id = aws_vpc.test2.id
+
+	tags = {
+		OtherTag = "some-value"
+	}
+
+	depends_on = [aws_nat_gateway.test1, aws_nat_gateway.test2, aws_nat_gateway.test3]
+}
+`, rName))
+}

--- a/website/docs/d/nat_gateways.html.markdown
+++ b/website/docs/d/nat_gateways.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "VPC (Virtual Private Cloud)"
+layout: "aws"
+page_title: "AWS: aws_nat_gateways"
+description: |-
+    Get information on Amazon NAT Gateways.
+---
+
+# Data Source: aws_nat_gateways
+
+This resource can be useful for getting back a list of NAT gateway ids to be referenced elsewhere.
+
+## Example Usage
+
+The following returns all NAT gateways in a specified VPC that are marked as available
+
+```terraform
+data "aws_nat_gateways" "ngws" {
+  vpc_id = var.vpc_id
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+data "aws_nat_gateway" "ngw" {
+  count = length(data.aws_nat_gateways.ngws.ids)
+  id    = tolist(data.aws_nat_gateways.ngws.ids)[count.index]
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Custom filter block as described below.
+* `vpc_id` - (Optional) The VPC ID that you want to filter from.
+* `tags` - (Optional) A map of tags, each pair of which must exactly match
+  a pair on the desired NAT Gateways.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNatGateways.html).
+* `values` - (Required) Set of values that are accepted for the given field.
+  A Nat Gateway will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+* `id` - AWS Region.
+* `ids` - A list of all the NAT gateway ids found.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7575

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2NatGatewaysDataSource_basic PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2NATGatewaysDataSource_basic'  -timeout 180m
=== RUN   TestAccEC2NATGatewaysDataSource_basic
=== PAUSE TestAccEC2NATGatewaysDataSource_basic
=== CONT  TestAccEC2NATGatewaysDataSource_basic
--- PASS: TestAccEC2NATGatewaysDataSource_basic (260.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        262.364s
```

I decided to build this in the same way that `aws_route_tables` and `aws_subnets` are done, where they only return the ids to be used in other data sources/resources, instead of how #7575 suggested where everything is returned plurally, but I'm happy to revisit that method if it's preferred
