### PR TITLE
r/s3_bucket_website_configuration: backport "add `routing_rules` parameter to assist in configuring rules with empty string values"

### DIFF
--- a/.changelog/24199.txt
+++ b/.changelog/24199.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_website_configuration: Add `routing_rules` parameter to be used in-place of `routing_rule` to support configurations with empty String values
+```

--- a/.changelog/24199.txt
+++ b/.changelog/24199.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_s3_bucket_website_configuration: Add `routing_rules` parameter to be used in-place of `routing_rule` to support configurations with empty String values
+resource/aws_s3_bucket_website_configuration: Add `routing_rules` parameter to be used instead of `routing_rule` to support configurations with empty String values
 ```

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -72,6 +74,7 @@ func ResourceBucketWebsiteConfiguration() *schema.Resource {
 					"error_document",
 					"index_document",
 					"routing_rule",
+					"routing_rules",
 				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -88,8 +91,10 @@ func ResourceBucketWebsiteConfiguration() *schema.Resource {
 				},
 			},
 			"routing_rule": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"routing_rules"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"condition": {
@@ -142,6 +147,17 @@ func ResourceBucketWebsiteConfiguration() *schema.Resource {
 					},
 				},
 			},
+			"routing_rules": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"routing_rule"},
+				ValidateFunc:  validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
 			"website_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -176,6 +192,14 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 
 	if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		websiteConfig.RoutingRules = expandS3BucketWebsiteConfigurationRoutingRules(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("routing_rules"); ok {
+		var unmarshalledRules []*s3.RoutingRule
+		if err := json.Unmarshal([]byte(v.(string)), &unmarshalledRules); err != nil {
+			return diag.FromErr(fmt.Errorf("error creating S3 Bucket (%s) website configuration: %w", bucket, err))
+		}
+		websiteConfig.RoutingRules = unmarshalledRules
 	}
 
 	input := &s3.PutBucketWebsiteInput{
@@ -252,6 +276,16 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("error setting routing_rule: %w", err))
 	}
 
+	if output.RoutingRules != nil {
+		rr, err := normalizeRoutingRules(output.RoutingRules)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error while marshaling routing rules: %w", err))
+		}
+		d.Set("routing_rules", rr)
+	} else {
+		d.Set("routing_rules", nil)
+	}
+
 	// Add website_endpoint and website_domain as attributes
 	websiteEndpoint, err := resourceBucketWebsiteConfigurationWebsiteEndpoint(ctx, meta.(*conns.AWSClient), bucket, expectedBucketOwner)
 	if err != nil {
@@ -288,8 +322,29 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 		websiteConfig.RedirectAllRequestsTo = expandS3BucketWebsiteConfigurationRedirectAllRequestsTo(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.RoutingRules = expandS3BucketWebsiteConfigurationRoutingRules(v.([]interface{}))
+	if d.HasChanges("routing_rule", "routing_rules") {
+		if d.HasChange("routing_rule") {
+			websiteConfig.RoutingRules = expandS3BucketWebsiteConfigurationRoutingRules(d.Get("routing_rule").([]interface{}))
+		} else {
+			var unmarshalledRules []*s3.RoutingRule
+			if err := json.Unmarshal([]byte(d.Get("routing_rules").(string)), &unmarshalledRules); err != nil {
+				return diag.FromErr(fmt.Errorf("error updating S3 Bucket (%s) website configuration: %w", bucket, err))
+			}
+			websiteConfig.RoutingRules = unmarshalledRules
+		}
+	} else {
+		// Still send the current RoutingRules configuration
+		if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			websiteConfig.RoutingRules = expandS3BucketWebsiteConfigurationRoutingRules(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("routing_rules"); ok {
+			var unmarshalledRules []*s3.RoutingRule
+			if err := json.Unmarshal([]byte(v.(string)), &unmarshalledRules); err != nil {
+				return diag.FromErr(fmt.Errorf("error updating S3 Bucket (%s) website configuration: %w", bucket, err))
+			}
+			websiteConfig.RoutingRules = unmarshalledRules
+		}
 	}
 
 	input := &s3.PutBucketWebsiteInput{

--- a/internal/service/s3/bucket_website_configuration_test.go
+++ b/internal/service/s3/bucket_website_configuration_test.go
@@ -131,7 +131,7 @@ func TestAccS3BucketWebsiteConfiguration_Redirect(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *testing.T) {
+func TestAccS3BucketWebsiteConfiguration_RoutingRule_ConditionAndRedirect(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_website_configuration.test"
 
@@ -142,7 +142,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_OptionalRedirection(rName),
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRule_OptionalRedirection(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketWebsiteConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
@@ -152,6 +152,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 						"redirect.#":                         "1",
 						"redirect.0.replace_key_prefix_with": "documents/",
 					}),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
 				),
 			},
 			{
@@ -160,7 +161,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectErrors(rName),
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRule_RedirectErrors(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketWebsiteConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
@@ -170,6 +171,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 						"redirect.#":                         "1",
 						"redirect.0.replace_key_prefix_with": "report-404",
 					}),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
 				),
 			},
 			{
@@ -178,7 +180,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectToPage(rName),
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRule_RedirectToPage(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketWebsiteConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
@@ -188,6 +190,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 						"redirect.#":                    "1",
 						"redirect.0.replace_key_with":   "errorpage.html",
 					}),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
 				),
 			},
 			{
@@ -199,7 +202,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *te
 	})
 }
 
-func TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules(t *testing.T) {
+func TestAccS3BucketWebsiteConfiguration_RoutingRule_MultipleRules(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_website_configuration.test"
 
@@ -210,7 +213,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules(t *testing.T
 		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_MultipleRules(rName),
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRule_MultipleRules(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketWebsiteConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "2"),
@@ -226,6 +229,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules(t *testing.T
 						"redirect.#":                    "1",
 						"redirect.0.replace_key_with":   "errorpage.html",
 					}),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
 				),
 			},
 			{
@@ -243,7 +247,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules(t *testing.T
 	})
 }
 
-func TestAccS3BucketWebsiteConfiguration_RoutingRules_RedirectOnly(t *testing.T) {
+func TestAccS3BucketWebsiteConfiguration_RoutingRule_RedirectOnly(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_website_configuration.test"
 
@@ -254,7 +258,7 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_RedirectOnly(t *testing.T)
 		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectOnly(rName),
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRule_RedirectOnly(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketWebsiteConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
@@ -263,12 +267,127 @@ func TestAccS3BucketWebsiteConfiguration_RoutingRules_RedirectOnly(t *testing.T)
 						"redirect.0.protocol":         s3.ProtocolHttps,
 						"redirect.0.replace_key_with": "errorpage.html",
 					}),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_ConditionAndRedirect(rName, "documents/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirectWithEmptyString(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_ConditionAndRedirect(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRules_updateConditionAndRedirect(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_ConditionAndRedirect(rName, "documents/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
+				),
+			},
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_ConditionAndRedirect(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketWebsiteConfiguration_RoutingRuleToRoutingRules(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_website_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketWebsiteConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRule_OptionalRedirection(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
+				),
+			},
+			{
+				Config: testAccBucketWebsiteConfigurationConfig_RoutingRules_ConditionAndRedirect(rName, "documents/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketWebsiteConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "routing_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_rules"),
+				),
 			},
 		},
 	})
@@ -336,7 +455,7 @@ func TestAccS3BucketWebsiteConfiguration_migrate_websiteWithIndexDocumentWithCha
 	})
 }
 
-func TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRulesNoChange(t *testing.T) {
+func TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRuleNoChange(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	bucketResourceName := "aws_s3_bucket.bucket"
 	resourceName := "aws_s3_bucket_website_configuration.test"
@@ -366,7 +485,7 @@ func TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRulesNoChange
 	})
 }
 
-func TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRulesWithChange(t *testing.T) {
+func TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRuleWithChange(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	bucketResourceName := "aws_s3_bucket.bucket"
 	resourceName := "aws_s3_bucket_website_configuration.test"
@@ -566,7 +685,7 @@ resource "aws_s3_bucket_website_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketWebsiteConfigurationConfig_RoutingRules_OptionalRedirection(rName string) string {
+func testAccBucketWebsiteConfigurationConfig_RoutingRule_OptionalRedirection(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -608,7 +727,7 @@ resource "aws_s3_bucket_website_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectErrors(rName string) string {
+func testAccBucketWebsiteConfigurationConfig_RoutingRule_RedirectErrors(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		fmt.Sprintf(`
@@ -652,7 +771,7 @@ resource "aws_s3_bucket_website_configuration" "test" {
 `, rName))
 }
 
-func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectToPage(rName string) string {
+func testAccBucketWebsiteConfigurationConfig_RoutingRule_RedirectToPage(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -694,7 +813,7 @@ resource "aws_s3_bucket_website_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectOnly(rName string) string {
+func testAccBucketWebsiteConfigurationConfig_RoutingRule_RedirectOnly(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -733,7 +852,7 @@ resource "aws_s3_bucket_website_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketWebsiteConfigurationConfig_RoutingRules_MultipleRules(rName string) string {
+func testAccBucketWebsiteConfigurationConfig_RoutingRule_MultipleRules(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -781,6 +900,51 @@ resource "aws_s3_bucket_website_configuration" "test" {
   }
 }
 `, rName)
+}
+
+func testAccBucketWebsiteConfigurationConfig_RoutingRules_ConditionAndRedirect(bucketName, replaceKeyPrefixWith string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rules = <<EOF
+[
+  {
+    "Condition": {
+      "KeyPrefixEquals": "docs/"
+    },
+    "Redirect": {
+      "ReplaceKeyPrefixWith": %[2]q
+    }
+  }
+]
+EOF
+}
+`, bucketName, replaceKeyPrefixWith)
 }
 
 func testAccBucketWebsiteConfigurationConfig_Migrate_WebsiteWithIndexDocumentNoChange(rName string) string {

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -12,6 +12,8 @@ Provides an S3 bucket website configuration resource. For more information, see 
 
 ## Example Usage
 
+### With `routing_rule` configured
+
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "myexamplebucket"
@@ -45,6 +47,43 @@ resource "aws_s3_bucket_website_configuration" "example" {
 }
 ```
 
+### With `routing_rules` configured
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "myexamplebucket"
+
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "example" {
+  bucket = aws_s3_bucket.example.bucket
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+
+  routing_rules = <<EOF
+[{
+    "Condition": {
+        "KeyPrefixEquals": "docs/"
+    },
+    "Redirect": {
+        "ReplaceKeyPrefixWith": ""
+    }
+}]
+EOF
+}
+```
+
 ## Usage Notes
 
 ~> **NOTE:** To avoid conflicts always add the following lifecycle object to the `aws_s3_bucket` resource of the source bucket.
@@ -68,7 +107,9 @@ The following arguments are supported:
 * `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
 * `index_document` - (Optional, Required if `redirect_all_requests_to` is not specified) The name of the index document for the website [detailed below](#index_document).
 * `redirect_all_requests_to` - (Optional, Required if `index_document` is not specified) The redirect behavior for every request to this bucket's website endpoint [detailed below](#redirect_all_requests_to). Conflicts with `error_document`, `index_document`, and `routing_rule`.
-* `routing_rule` - (Optional, Conflicts with `redirect_all_requests_to`) List of rules that define when a redirect is applied and the redirect behavior [detailed below](#routing_rule).
+* `routing_rule` - (Optional, Conflicts with `redirect_all_requests_to` and `routing_rules`) List of rules that define when a redirect is applied and the redirect behavior [detailed below](#routing_rule).
+* `routing_rules` - (Optional, Conflicts with `routing_rule` and `redirect_all_requests_to`) A json array containing [routing rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html)
+  describing redirect behavior and when redirects are applied. Use this parameter when your routing rules contain empty String values (`""`) as seen in the [example above](#with-routing_rules-configured).
 
 ### error_document
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/24048
Relates https://github.com/hashicorp/terraform-provider-aws/pull/24198

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccS3BucketWebsiteConfiguration_RoutingRule' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketWebsiteConfiguration_RoutingRule -timeout 180m
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRule_ConditionAndRedirect
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRule_ConditionAndRedirect
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRule_MultipleRules
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRule_MultipleRules
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRule_RedirectOnly
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRule_RedirectOnly
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirectWithEmptyString
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirectWithEmptyString
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRules_updateConditionAndRedirect
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRules_updateConditionAndRedirect
=== RUN   TestAccS3BucketWebsiteConfiguration_RoutingRuleToRoutingRules
=== PAUSE TestAccS3BucketWebsiteConfiguration_RoutingRuleToRoutingRules
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRule_ConditionAndRedirect
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirectWithEmptyString
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRuleToRoutingRules
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRules_updateConditionAndRedirect
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRule_RedirectOnly
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRule_RedirectOnly (30.01s)
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRule_MultipleRules
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirectWithEmptyString (30.18s)
=== CONT  TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRuleToRoutingRules (49.61s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_updateConditionAndRedirect (51.47s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect (28.88s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRule_MultipleRules (50.54s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRule_ConditionAndRedirect (96.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	99.156s
```
