### PR TITLE
Do not validate items that conflict

### DIFF
--- a/.changelog/24202.txt
+++ b/.changelog/24202.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack_set: Prevent validation of conflicting parameters in `operation_preferences`.
+```

--- a/.changelog/24202.txt
+++ b/.changelog/24202.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cloudformation_stack_set: Prevent validation of conflicting parameters in `operation_preferences`.
+resource/aws_cloudformation_stack_set: Prevent `InvalidParameter` errors when updating `operation_preferences`
 ```

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -272,7 +272,7 @@ func TestAccCloudFormationStackSet_operationPreferences(t *testing.T) {
 		CheckDestroy: testAccCheckStackSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackSetOperationPreferencesConfig(rName),
+				Config: testAccStackSetOperationPreferencesConfig(rName, 1, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet),
 					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
@@ -292,6 +292,42 @@ func TestAccCloudFormationStackSet_operationPreferences(t *testing.T) {
 					"template_url",
 					"operation_preferences",
 				},
+			},
+			{
+				Config: testAccStackSetOperationPreferencesConfig(rName, 3, 12),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "12"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
+				),
+			},
+			{
+				Config: testAccStackSetOperationPreferencesUpdatedConfig(rName, 15, 75),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "15"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "75"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
+				),
+			},
+			{
+				Config: testAccStackSetOperationPreferencesConfig(rName, 2, 8),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "8"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
+				),
 			},
 		},
 	})
@@ -1497,7 +1533,7 @@ TEMPLATE
 `, rName, testAccStackSetTemplateBodyVPC(rName))
 }
 
-func testAccStackSetOperationPreferencesConfig(rName string) string {
+func testAccStackSetOperationPreferencesConfig(rName string, failureToleranceCount, maxConcurrentCount int) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
@@ -1527,13 +1563,54 @@ resource "aws_cloudformation_stack_set" "test" {
   name                    = %[1]q
 
   operation_preferences {
-    failure_tolerance_count = 1
-    max_concurrent_count    = 10
+    failure_tolerance_count = %[2]d
+    max_concurrent_count    = %[3]d
   }
 
   template_body = <<TEMPLATE
-%[2]s
+%[4]s
 TEMPLATE
 }
-`, rName, testAccStackSetTemplateBodyVPC(rName))
+`, rName, failureToleranceCount, maxConcurrentCount, testAccStackSetTemplateBodyVPC(rName))
+}
+
+func testAccStackSetOperationPreferencesUpdatedConfig(rName string, failureTolerancePercentage, maxConcurrentPercentage int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "cloudformation.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+
+  name = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = aws_iam_role.test.arn
+  name                    = %[1]q
+
+  operation_preferences {
+    failure_tolerance_percentage = %[2]d
+    max_concurrent_percentage    = %[3]d
+  }
+
+  template_body = <<TEMPLATE
+%[4]s
+TEMPLATE
+}
+`, rName, failureTolerancePercentage, maxConcurrentPercentage, testAccStackSetTemplateBodyVPC(rName))
 }

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -339,6 +339,18 @@ func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *clo
 		apiObject.RegionOrder = flex.ExpandStringSet(v)
 	}
 
+	if ftc, ftp := aws.Int64Value(apiObject.FailureToleranceCount), aws.Int64Value(apiObject.FailureTolerancePercentage); ftc > 0 && ftp == 0 {
+		apiObject.FailureTolerancePercentage = nil
+	} else if ftp > 0 && ftc == 0 {
+		apiObject.FailureToleranceCount = nil
+	}
+
+	if mcc, mcp := aws.Int64Value(apiObject.MaxConcurrentCount), aws.Int64Value(apiObject.MaxConcurrentPercentage); mcc > 0 && mcp == 0 {
+		apiObject.MaxConcurrentPercentage = nil
+	} else if mcp > 0 && mcc == 0 {
+		apiObject.MaxConcurrentCount = nil
+	}
+
 	return apiObject
 }
 

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -322,14 +322,12 @@ func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *clo
 
 	if v, ok := tfMap["failure_tolerance_count"].(int); ok {
 		apiObject.FailureToleranceCount = aws.Int64(int64(v))
-	}
-	if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
+	} else if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
 		apiObject.FailureTolerancePercentage = aws.Int64(int64(v))
 	}
 	if v, ok := tfMap["max_concurrent_count"].(int); ok {
 		apiObject.MaxConcurrentCount = aws.Int64(int64(v))
-	}
-	if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
+	} else if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
 		apiObject.MaxConcurrentPercentage = aws.Int64(int64(v))
 	}
 	if v, ok := tfMap["region_concurrency_type"].(string); ok && v != "" {

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -322,12 +322,14 @@ func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *clo
 
 	if v, ok := tfMap["failure_tolerance_count"].(int); ok {
 		apiObject.FailureToleranceCount = aws.Int64(int64(v))
-	} else if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
+	}
+	if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
 		apiObject.FailureTolerancePercentage = aws.Int64(int64(v))
 	}
 	if v, ok := tfMap["max_concurrent_count"].(int); ok {
 		apiObject.MaxConcurrentCount = aws.Int64(int64(v))
-	} else if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
+	}
+	if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
 		apiObject.MaxConcurrentPercentage = aws.Int64(int64(v))
 	}
 	if v, ok := tfMap["region_concurrency_type"].(string); ok && v != "" {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

The `failure_tolerance_count` and `failure_tolerance_percentage` conflict with each other, so one should be validated only if the other has failed. The same applies for `max_concurrent_count` and `max_concurrent_percentage`.

Closes #24161