### PR TITLE
elasticache: Add new user_group_association resource

### DIFF
--- a/.changelog/24204.txt
+++ b/.changelog/24204.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_elasticache_user_group_association
+```

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
       UV_THREADPOOL_SIZE: 128
     steps:
     - uses: actions/checkout@v3
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: YakDriver/md-check-links@v2.0.2
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
-    - run: git config --global --add safe.directory /github/workspace
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
       UV_THREADPOOL_SIZE: 128
     steps:
     - uses: actions/checkout@v3
-    - uses: YakDriver/md-check-links@v2.0.2
+    - uses: YakDriver/md-check-links@v2.0.3
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,8 +18,8 @@ jobs:
       UV_THREADPOOL_SIZE: 128
     steps:
     - uses: actions/checkout@v3
-    - run: git config --global --add safe.directory /github/workspace
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - run: git config --global --add safe.directory /github/workspace
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,6 +18,7 @@ jobs:
       UV_THREADPOOL_SIZE: 128
     steps:
     - uses: actions/checkout@v3
+    - run: git config --global --add safe.directory /github/workspace
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      - run: git config --global --add safe.directory /github/workspace
         name: markdown-link-check website/docs/**/*.markdown
         with:
           use-quiet-mode: "yes"
@@ -36,7 +35,6 @@ jobs:
           base-branch: "main"
           check-modified-files-only: "yes"
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      - run: git config --global --add safe.directory /github/workspace
         name: markdown-link-check website/docs/**/*.md
         with:
           use-quiet-mode: "yes"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,7 @@ jobs:
       UV_THREADPOOL_SIZE: 128
     steps:
       - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: YakDriver/md-check-links@v2.0.2
         name: markdown-link-check website/docs/**/*.markdown
         with:
           use-quiet-mode: "yes"
@@ -34,7 +34,7 @@ jobs:
           file-extension: ".markdown"
           base-branch: "main"
           check-modified-files-only: "yes"
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: YakDriver/md-check-links@v2.0.2
         name: markdown-link-check website/docs/**/*.md
         with:
           use-quiet-mode: "yes"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,7 @@ jobs:
       UV_THREADPOOL_SIZE: 128
     steps:
       - uses: actions/checkout@v3
-      - uses: YakDriver/md-check-links@v2.0.2
+      - uses: YakDriver/md-check-links@v2.0.3
         name: markdown-link-check website/docs/**/*.markdown
         with:
           use-quiet-mode: "yes"
@@ -34,7 +34,7 @@ jobs:
           file-extension: ".markdown"
           base-branch: "main"
           check-modified-files-only: "yes"
-      - uses: YakDriver/md-check-links@v2.0.2
+      - uses: YakDriver/md-check-links@v2.0.3
         name: markdown-link-check website/docs/**/*.md
         with:
           use-quiet-mode: "yes"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - run: git config --global --add safe.directory /github/workspace
         name: markdown-link-check website/docs/**/*.markdown
         with:
           use-quiet-mode: "yes"
@@ -35,6 +36,7 @@ jobs:
           base-branch: "main"
           check-modified-files-only: "yes"
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - run: git config --global --add safe.directory /github/workspace
         name: markdown-link-check website/docs/**/*.md
         with:
           use-quiet-mode: "yes"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1365,6 +1365,7 @@ func Provider() *schema.Provider {
 			"aws_elasticache_subnet_group":             elasticache.ResourceSubnetGroup(),
 			"aws_elasticache_user":                     elasticache.ResourceUser(),
 			"aws_elasticache_user_group":               elasticache.ResourceUserGroup(),
+			"aws_elasticache_user_group_association":   elasticache.ResourceUserGroupAssociation(),
 
 			"aws_elastic_beanstalk_application":            elasticbeanstalk.ResourceApplication(),
 			"aws_elastic_beanstalk_application_version":    elasticbeanstalk.ResourceApplicationVersion(),

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -125,7 +125,6 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return resourceUserRead(d, meta)
-
 }
 
 func resourceUserRead(d *schema.ResourceData, meta interface{}) error {

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -1,0 +1,155 @@
+package elasticache
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceUserGroupAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUserGroupAssociationCreate,
+		Read:   resourceUserGroupAssociationRead,
+		Delete: resourceUserGroupAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"user_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceUserGroupAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ElastiCacheConn
+
+	input := &elasticache.ModifyUserGroupInput{
+		UserGroupId:  aws.String(d.Get("user_group_id").(string)),
+		UserIdsToAdd: aws.StringSlice([]string{d.Get("user_id").(string)}),
+	}
+
+	id := userGroupAssociationID(d.Get("user_group_id").(string), d.Get("user_id").(string))
+
+	_, err := tfresource.RetryWhenNotFound(d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+		return conn.ModifyUserGroup(input)
+	})
+
+	if err != nil {
+		return fmt.Errorf("creating ElastiCache User Group Association (%q): %w", id, err)
+	}
+
+	d.SetId(id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:        []string{"modifying", ""},
+		Target:         []string{"active"},
+		Refresh:        resourceUserGroupStateRefreshFunc(d.Get("user_group_id").(string), conn),
+		Timeout:        d.Timeout(schema.TimeoutCreate),
+		MinTimeout:     10 * time.Second,
+		NotFoundChecks: 5,
+		Delay:          30 * time.Second, // Wait 30 secs before starting
+	}
+
+	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("creating ElastiCache User Group Association (%q): %w", d.Id(), err)
+	}
+
+	return resourceUserGroupAssociationRead(d, meta)
+}
+
+func resourceUserGroupAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ElastiCacheConn
+
+	groupID, userID, err := UserGroupAssociationParseID(d.Id())
+
+	output, err := FindUserGroupByID(conn, groupID)
+	if !d.IsNewResource() && (tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault)) {
+		d.SetId("")
+		log.Printf("[DEBUG] ElastiCache User Group Association (%s) not found", d.Id())
+		return nil
+	}
+
+	if err != nil && !tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
+		return fmt.Errorf("describing ElastiCache User Group (%s): %w", d.Id(), err)
+	}
+
+	gotUserID := ""
+	for _, v := range output.UserIds {
+		if aws.StringValue(v) == userID {
+			gotUserID = aws.StringValue(v)
+			break
+		}
+	}
+
+	d.Set("user_id", gotUserID)
+	d.Set("user_group_id", groupID)
+
+	return nil
+}
+
+func resourceUserGroupAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ElastiCacheConn
+
+	input := &elasticache.ModifyUserGroupInput{
+		UserGroupId:     aws.String(d.Get("user_group_id").(string)),
+		UserIdsToRemove: aws.StringSlice([]string{d.Get("user_id").(string)}),
+	}
+
+	_, err := conn.ModifyUserGroup(input)
+	if err != nil && !tfawserr.ErrMessageContains(err, elasticache.ErrCodeInvalidParameterValueException, "not a member") {
+		return fmt.Errorf("deleting ElastiCache User Group Association (%q): %w", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"modifying"},
+		Target:     []string{"active"},
+		Refresh:    resourceUserGroupStateRefreshFunc(d.Get("user_group_id").(string), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second, // Wait 30 secs before starting
+	}
+
+	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("waiting for ElastiCache User Group Association delete (%q): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func userGroupAssociationID(userGroupID, userID string) string {
+	parts := []string{userGroupID, userID}
+	id := strings.Join(parts, ",")
+	return id
+}
+
+func UserGroupAssociationParseID(id string) (string, string, error) {
+	parts := strings.Split(id, ",")
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ElastiCache User Group Association ID (%q), expected '<user group ID>,<user ID>'", id)
+}

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -82,6 +82,9 @@ func resourceUserGroupAssociationRead(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*conns.AWSClient).ElastiCacheConn
 
 	groupID, userID, err := UserGroupAssociationParseID(d.Id())
+	if err != nil {
+		return fmt.Errorf("reading ElastiCache User Group Association (%s): %w", d.Id(), err)
+	}
 
 	output, err := FindUserGroupByID(conn, groupID)
 	if !d.IsNewResource() && (tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault)) {

--- a/internal/service/elasticache/user_group_association_test.go
+++ b/internal/service/elasticache/user_group_association_test.go
@@ -1,0 +1,262 @@
+package elasticache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
+)
+
+func TestAccElastiCacheUserGroupAssociation_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_user_group_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserGroupAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupAssociationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_id", fmt.Sprintf("%s-2", rName)),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUserGroupAssociation_update(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_user_group_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserGroupAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupAssociationPreUpdateConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_id", fmt.Sprintf("%s-2", rName)),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+				),
+			},
+			{
+				Config: testAccUserGroupAssociationUpdateConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_id", fmt.Sprintf("%s-3", rName)),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUserGroupAssociation_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_user_group_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserGroupAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupAssociationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupAssociationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfelasticache.ResourceUserGroupAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckUserGroupAssociationDestroy(s *terraform.State) error {
+	return testAccCheckUserGroupAssociationDestroyWithProvider(s, acctest.Provider)
+}
+
+func testAccCheckUserGroupAssociationDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*conns.AWSClient).ElastiCacheConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticache_user_group_association" {
+			continue
+		}
+
+		groupID, userID, err := tfelasticache.UserGroupAssociationParseID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("parsing User Group Association ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		output, err := tfelasticache.FindUserGroupByID(conn, groupID)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
+				return nil
+			}
+		}
+
+		gotUserID := ""
+		for _, v := range output.UserIds {
+			if aws.StringValue(v) == userID {
+				gotUserID = aws.StringValue(v)
+				break
+			}
+		}
+
+		if gotUserID != "" {
+			return fmt.Errorf("ElastiCache User Group Association (%s) found, should be deleted", rs.Primary.ID)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccCheckUserGroupAssociationExists(n string) resource.TestCheckFunc {
+	return testAccCheckUserGroupAssociationExistsWithProvider(n, func() *schema.Provider { return acctest.Provider })
+}
+
+func testAccCheckUserGroupAssociationExistsWithProvider(n string, providerF func() *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ElastiCache User Group Association ID is set")
+		}
+
+		groupID, userID, err := tfelasticache.UserGroupAssociationParseID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("parsing User Group Association ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		provider := providerF()
+		conn := provider.Meta().(*conns.AWSClient).ElastiCacheConn
+		output, err := tfelasticache.FindUserGroupByID(conn, groupID)
+		if err != nil {
+			return fmt.Errorf("ElastiCache User Group Association (%s) not found: %w", rs.Primary.ID, err)
+		}
+
+		gotUserID := ""
+		for _, v := range output.UserIds {
+			if aws.StringValue(v) == userID {
+				gotUserID = aws.StringValue(v)
+				break
+			}
+		}
+
+		if gotUserID == "" {
+			return fmt.Errorf("ElastiCache User Group Association (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccUserGroupAssociationBaseConfig(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test1" {
+  user_id       = "%[1]s-1"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user" "test2" {
+  user_id       = "%[1]s-2"
+  user_name     = "username1"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[1]q
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test1.user_id]
+
+  lifecycle {
+    ignore_changes = [user_ids]
+  }
+}
+`, rName))
+}
+
+func testAccUserGroupAssociationBasicConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserGroupAssociationBaseConfig(rName),
+		`
+resource "aws_elasticache_user_group_association" "test" {
+  user_group_id = aws_elasticache_user_group.test.user_group_id
+  user_id       = aws_elasticache_user.test2.user_id
+}
+`)
+}
+
+func testAccUserGroupAssociationPreUpdateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserGroupAssociationBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test3" {
+  user_id       = "%[1]s-3"
+  user_name     = "username2"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group_association" "test" {
+  user_group_id = aws_elasticache_user_group.test.user_group_id
+  user_id       = aws_elasticache_user.test2.user_id
+}
+`, rName))
+}
+
+func testAccUserGroupAssociationUpdateConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserGroupAssociationBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test3" {
+  user_id       = "%[1]s-3"
+  user_name     = "username2"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group_association" "test" {
+  user_group_id = aws_elasticache_user_group.test.user_group_id
+  user_id       = aws_elasticache_user.test3.user_id
+}
+`, rName))
+}

--- a/website/docs/r/elasticache_user_group_association.html.markdown
+++ b/website/docs/r/elasticache_user_group_association.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_user_group_association"
+description: |-
+  Associate an ElastiCache user and user group.
+---
+
+# Resource: aws_elasticache_user_group_association
+
+Associate an existing ElastiCache user and an existing user group.
+
+~> **NOTE:** Terraform will detect changes in the `aws_elasticache_user_group` since `aws_elasticache_user_group_association` changes the user IDs associated with the user group. You can ignore these changes with the `lifecycle` `ignore_changes` meta argument as shown in the example.
+
+## Example Usage
+
+```terraform
+resource "aws_elasticache_user" "default" {
+  user_id       = "defaultUserID"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "example" {
+  engine        = "REDIS"
+  user_group_id = "userGroupId"
+  user_ids      = [aws_elasticache_user.default.user_id]
+
+  lifecycle {
+    ignore_changes = [user_ids]
+  }
+}
+
+resource "aws_elasticache_user" "example" {
+  user_id       = "exampleUserID"
+  user_name     = "exampleuser"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group_association" "example" {
+  user_group_id = aws_elasticache_user_group.example.user_group_id
+  user_id       = aws_elasticache_user.example.user_id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `user_group_id` - (Required) ID of the user group.
+* `user_id` - (Required) ID of the user to associated with the user group.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+ElastiCache user group associations can be imported using the `user_group_id` and `user_id`, e.g.,
+
+```
+$ terraform import aws_elasticache_user_group_association.example userGoupId1,userId
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22870

Output from acceptance testing:


```console
% make testacc TESTS=TestAccElastiCacheUserGroupAssociation_ PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroupAssociation_'  -timeout 180m
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (317.57s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (319.27s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (440.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	441.786s
```
