### PR TITLE
feat: Add support for configuring the `aws_cloudwatch_log_subscription_filter` resource region

### DIFF
--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -3,7 +3,7 @@ subcategory: "CloudWatch"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_log_subscription_filter"
 description: |-
-  Provides a CloudWatch Logs subscription filter.
+Provides a CloudWatch Logs subscription filter.
 ---
 
 # Resource: aws_cloudwatch_log_subscription_filter
@@ -20,6 +20,7 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
   filter_pattern  = "logtype test"
   destination_arn = aws_kinesis_stream.test_logstream.arn
   distribution    = "Random"
+  region          = "us-east-1"
 }
 ```
 
@@ -33,6 +34,7 @@ The following arguments are supported:
 * `log_group_name` - (Required) The name of the log group to associate the subscription filter with
 * `role_arn` - (Optional) The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. If you use Lambda as a destination, you should skip this argument and use `aws_lambda_permission` resource for granting access from CloudWatch logs to the destination Lambda function.
 * `distribution` - (Optional) The method used to distribute log data to the destination. By default log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream. Valid values are "Random" and "ByLogStream".
+* `region` - (Optional) The region in which the cloudwatch log group to subscribe to lives.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Any and all feedback is welcome! 😄 

Currently, the [aws_cloudwatch_log_subscription_filter](https://registry.terraform.io/providers/aaronfeng/aws/latest/docs/resources/cloudwatch_log_subscription_filter) does not provide a mechanism to define which region you wish to configure the log subscription in. The region is picked up from the AWS provider configuration.
We have a specific use case where we need to be able to dynamically change which region the log subscription is created in based on user input, which currently cannot be achieved using provider aliases.

This PR adds a region variable to `aws_cloudwatch_log_subscription_filter`, and uses this region to configure the cloud watch logs client used to provision the resource(s).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24194

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
