### PR TITLE
fix: add Elemental MediaTailor to list of allowed subcategories

### DIFF
--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -73,6 +73,7 @@ ELB Classic
 Elemental MediaConvert
 Elemental MediaPackage
 Elemental MediaStore
+Elemental MediaTailor
 EMR
 EMR Containers
 EventBridge


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Add Elemental MediaTailor to the list of allowed subcategories for documentation navigation. This is the only missing step of the [guidelines for adding a new service](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#new-service) to the provider.
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #24214

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
