### PR TITLE
fixing error for creating additonal Lambda URLs on the same function

### DIFF
--- a/.changelog/24220.txt
+++ b/.changelog/24220.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function_url: Ignore `ResourceConflictException` errors caused by existing `FunctionURLAllowPublicAccess` permission statements
+```

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -153,7 +153,11 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 		_, err := conn.AddPermissionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error adding Lambda Function URL (%s) permission %s", d.Id(), err)
+			if tfawserr.ErrMessageContains(err, lambda.ErrCodeResourceConflictException, "The statement id (FunctionURLAllowPublicAccess) provided already exists") {
+				log.Printf("[DEBUG] function permission statement 'FunctionURLAllowPublicAccess' already exists.")
+			} else {
+				return diag.Errorf("error adding Lambda Function URL (%s) permission %s", d.Id(), err)
+			}
 		}
 	}
 

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -149,6 +149,10 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 			StatementId:         aws.String("FunctionURLAllowPublicAccess"),
 		}
 
+		if qualifier != "" {
+			input.Qualifier = aws.String(qualifier)
+		}
+
 		log.Printf("[DEBUG] Adding Lambda Permission: %s", input)
 		_, err := conn.AddPermissionWithContext(ctx, input)
 

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -184,7 +184,7 @@ func TestAccLambdaFunctionURL_TwoURLs(t *testing.T) {
 					resource.TestCheckResourceAttrSet(LatestURLName, "url_id"),
 
 					testAccCheckFunctionURLExists(LiveURLName, &conf),
-					resource.TestCheckResourceAttr(LiveURLName, "authorization_type", lambda.FunctionUrlAuthTypeAwsIam),
+					resource.TestCheckResourceAttr(LiveURLName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
 					resource.TestCheckResourceAttr(LiveURLName, "cors.#", "0"),
 					resource.TestCheckResourceAttrSet(LiveURLName, "function_arn"),
 					resource.TestCheckResourceAttr(LiveURLName, "function_name", funcName),
@@ -470,13 +470,13 @@ resource "aws_lambda_alias" "live" {
   name             = %[2]q
   description      = "a sample description"
   function_name    = aws_lambda_function.test.function_name
-  function_version = "1"
+  function_version = aws_lambda_function.test.version
 }
 
 resource "aws_lambda_function_url" "live" {
   function_name      = aws_lambda_function.test.function_name
   qualifier          = aws_lambda_alias.live.name
-  authorization_type = "AWS_IAM"
+  authorization_type = "NONE"
 
 }
 `, funcName, aliasName))

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -17,9 +17,7 @@ import (
 )
 
 func testAccFunctionURLPreCheck(t *testing.T) {
-	if got, want := acctest.Partition(), endpoints.AwsPartitionID; got != want {
-		t.Skipf("Lambda Function URLs are not supported in %s partition", got)
-	}
+	acctest.PreCheckPartition(endpoints.AwsPartitionID, t)
 }
 
 func TestAccLambdaFunctionURL_basic(t *testing.T) {

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -157,8 +157,8 @@ func TestAccLambdaFunctionURL_Alias(t *testing.T) {
 
 func TestAccLambdaFunctionURL_TwoURLs(t *testing.T) {
 	var conf lambda.GetFunctionUrlConfigOutput
-	LatestURLName := "aws_lambda_function_url.latest"
-	LiveURLName := "aws_lambda_function_url.live"
+	latestResourceName := "aws_lambda_function_url.latest"
+	liveResourceName := "aws_lambda_function_url.live"
 	rString := sdkacctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_basic_%s", rString)
 	aliasName := "live"
@@ -174,32 +174,32 @@ func TestAccLambdaFunctionURL_TwoURLs(t *testing.T) {
 			{
 				Config: testAccFunctionURLTwoURLsConfig(funcName, aliasName, policyName, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFunctionURLExists(LatestURLName, &conf),
-					resource.TestCheckResourceAttr(LatestURLName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
-					resource.TestCheckResourceAttr(LatestURLName, "cors.#", "0"),
-					resource.TestCheckResourceAttrSet(LatestURLName, "function_arn"),
-					resource.TestCheckResourceAttr(LatestURLName, "function_name", funcName),
-					resource.TestCheckResourceAttrSet(LatestURLName, "function_url"),
-					resource.TestCheckResourceAttr(LatestURLName, "qualifier", ""),
-					resource.TestCheckResourceAttrSet(LatestURLName, "url_id"),
+					testAccCheckFunctionURLExists(latestResourceName, &conf),
+					resource.TestCheckResourceAttr(latestResourceName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
+					resource.TestCheckResourceAttr(latestResourceName, "cors.#", "0"),
+					resource.TestCheckResourceAttrSet(latestResourceName, "function_arn"),
+					resource.TestCheckResourceAttr(latestResourceName, "function_name", funcName),
+					resource.TestCheckResourceAttrSet(latestResourceName, "function_url"),
+					resource.TestCheckResourceAttr(latestResourceName, "qualifier", ""),
+					resource.TestCheckResourceAttrSet(latestResourceName, "url_id"),
 
-					testAccCheckFunctionURLExists(LiveURLName, &conf),
-					resource.TestCheckResourceAttr(LiveURLName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
-					resource.TestCheckResourceAttr(LiveURLName, "cors.#", "0"),
-					resource.TestCheckResourceAttrSet(LiveURLName, "function_arn"),
-					resource.TestCheckResourceAttr(LiveURLName, "function_name", funcName),
-					resource.TestCheckResourceAttrSet(LiveURLName, "function_url"),
-					resource.TestCheckResourceAttr(LiveURLName, "qualifier", "live"),
-					resource.TestCheckResourceAttrSet(LiveURLName, "url_id"),
+					testAccCheckFunctionURLExists(liveResourceName, &conf),
+					resource.TestCheckResourceAttr(liveResourceName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
+					resource.TestCheckResourceAttr(liveResourceName, "cors.#", "0"),
+					resource.TestCheckResourceAttrSet(liveResourceName, "function_arn"),
+					resource.TestCheckResourceAttr(liveResourceName, "function_name", funcName),
+					resource.TestCheckResourceAttrSet(liveResourceName, "function_url"),
+					resource.TestCheckResourceAttr(liveResourceName, "qualifier", "live"),
+					resource.TestCheckResourceAttrSet(liveResourceName, "url_id"),
 				),
 			},
 			{
-				ResourceName:      LatestURLName,
+				ResourceName:      latestResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      LiveURLName,
+				ResourceName:      liveResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -477,7 +477,6 @@ resource "aws_lambda_function_url" "live" {
   function_name      = aws_lambda_function.test.function_name
   qualifier          = aws_lambda_alias.live.name
   authorization_type = "NONE"
-
 }
 `, funcName, aliasName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24152

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccLambdaFunctionURL_TwoURLs" PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20  -run=TestAccLambdaFunctionURL_TwoURLs -timeout 180m
=== RUN   TestAccLambdaFunctionURL_TwoURLs
=== PAUSE TestAccLambdaFunctionURL_TwoURLs
=== CONT  TestAccLambdaFunctionURL_TwoURLs
--- PASS: TestAccLambdaFunctionURL_TwoURLs (32.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     32.678s

...
```
