### PR TITLE
es/domain: Enable encrypt w/o ForceNew

### DIFF
--- a/.changelog/24222.txt
+++ b/.changelog/24222.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticsearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled`, `encrypt_at_rest.0.enabled`, and `encrypt_at_rest.0.kms_key_id`
+```

--- a/.changelog/24222.txt
+++ b/.changelog/24222.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_elasticsearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled`, `encrypt_at_rest.0.enabled`, and `encrypt_at_rest.0.kms_key_id`
+resource/aws_elasticsearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled` and `encrypt_at_rest.0.enabled`.
 ```
 
 ```release-note:enhancement
-resource/aws_opensearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled`, `encrypt_at_rest.0.enabled`, and `encrypt_at_rest.0.kms_key_id`
+resource/aws_opensearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled` and `encrypt_at_rest.0.enabled`.
 ```

--- a/.changelog/24222.txt
+++ b/.changelog/24222.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_elasticsearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled`, `encrypt_at_rest.0.enabled`, and `encrypt_at_rest.0.kms_key_id`
 ```
+
+```release-note:enhancement
+resource/aws_opensearch_domain: For Elasticsearch versions 6.7+, allow in-place update of `node_to_node_encryption.0.enabled`, `encrypt_at_rest.0.enabled`, and `encrypt_at_rest.0.kms_key_id`
+```

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -176,7 +176,7 @@ func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 				Config: testAccDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
@@ -186,7 +186,7 @@ func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 				Config: testAccDomainConfig_ClusterConfig_ZoneAwarenessEnabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain3),
-					testAccCheckDomainNotRecreated(&domain2, &domain3),
+					testAccCheckDomainNotRecreated(&domain2, &domain3), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "0"),
 				),
@@ -195,7 +195,7 @@ func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 				Config: testAccDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain4),
-					testAccCheckDomainNotRecreated(&domain3, &domain4),
+					testAccCheckDomainNotRecreated(&domain3, &domain4), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
@@ -1092,7 +1092,7 @@ func TestAccElasticsearchDomain_Encryption_atRestEnable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
 					testAccCheckDomainEncrypted(true, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 				),
 			},
 			{
@@ -1198,7 +1198,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
 					testAccCheckNodeToNodeEncrypted(true, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 				),
 			},
 			{
@@ -1456,7 +1456,7 @@ func TestAccElasticsearchDomain_Update_version(t *testing.T) {
 				Config: testAccDomainConfig_ClusterUpdateVersion(rName, "5.6"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_version", "5.6"),
 				),
 			},
@@ -1464,7 +1464,7 @@ func TestAccElasticsearchDomain_Update_version(t *testing.T) {
 				Config: testAccDomainConfig_ClusterUpdateVersion(rName, "6.3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain3),
-					testAccCheckDomainNotRecreated(&domain2, &domain3),
+					testAccCheckDomainNotRecreated(&domain2, &domain3), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_version", "6.3"),
 				),
 			},

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -1065,38 +1065,6 @@ func TestAccElasticsearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 	})
 }
 
-func TestAccElasticsearchDomain_Encryption_nodeToNode(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var domain elasticsearch.ElasticsearchDomainStatus
-	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticsearch.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckDomainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDomainConfigwithNodeToNodeEncryption(rName, "6.0", true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(resourceName, &domain),
-					testAccCheckNodeToNodeEncrypted(true, &domain),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateId:     rName[:28],
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccElasticsearchDomain_Encryption_atRestEnable(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1132,50 +1100,6 @@ func TestAccElasticsearchDomain_Encryption_atRestEnable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain1),
 					testAccCheckDomainEncrypted(false, &domain1),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
-				),
-			},
-		},
-	})
-}
-
-func TestAccElasticsearchDomain_Encryption_atRestSwitchKey(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_elasticsearch_domain.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticsearch.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckDomainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDomainConfigWithEncryptAtRestDefaultKey(rName, "6.7", true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(resourceName, &domain2),
-					testAccCheckDomainEncrypted(true, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
-				),
-			},
-			{
-				Config: testAccDomainConfigWithEncryptAtRestWithKey(rName, "6.7", true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(resourceName, &domain2),
-					testAccCheckDomainEncrypted(true, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
-				),
-			},
-			{
-				Config: testAccDomainConfigWithEncryptAtRestWithNewKey(rName, "6.7", false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(resourceName, &domain1),
-					testAccCheckDomainEncrypted(false, &domain1),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
 				),
 			},
 		},
@@ -1210,6 +1134,38 @@ func TestAccElasticsearchDomain_Encryption_atRestEnableLegacy(t *testing.T) {
 					testAccCheckDomainExists(resourceName, &domain2),
 					testAccCheckDomainEncrypted(true, &domain2),
 				),
+			},
+		},
+	})
+}
+
+func TestAccElasticsearchDomain_Encryption_nodeToNode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain elasticsearch.ElasticsearchDomainStatus
+	resourceName := "aws_elasticsearch_domain.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elasticsearch.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfigwithNodeToNodeEncryption(rName, "6.0", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain),
+					testAccCheckNodeToNodeEncrypted(true, &domain),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName[:28],
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1250,7 +1206,6 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain1),
 					testAccCheckNodeToNodeEncrypted(false, &domain1),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
 				),
 			},
 		},
@@ -1284,7 +1239,6 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
 					testAccCheckNodeToNodeEncrypted(true, &domain2),
-					testAccCheckDomainRecreated(&domain1, &domain2),
 				),
 			},
 			{
@@ -1292,7 +1246,6 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain1),
 					testAccCheckNodeToNodeEncrypted(false, &domain1),
-					testAccCheckDomainRecreated(&domain1, &domain2),
 				),
 			},
 		},
@@ -1708,21 +1661,38 @@ func testAccCheckDomainExists(n string, domain *elasticsearch.ElasticsearchDomai
 	}
 }
 
-func testAccCheckDomainRecreated(i, j *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
+// testAccCheckDomainNotRecreated does not work. Inexplicably, a deleted
+// domain's create time (& endpoint) carry over to a newly created domain with
+// the same name, if it's created within any reasonable time after deletion.
+func testAccCheckDomainNotRecreated(domain1, domain2 *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(i.Endpoint) == aws.StringValue(j.Endpoint) {
-			return fmt.Errorf("domain (%s) was not recreated, before endpoint (%s), after endpoint (%s)", aws.StringValue(i.DomainName), aws.StringValue(i.Endpoint), aws.StringValue(j.Endpoint))
-		}
+		/*
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ElasticsearchConn
 
-		return nil
-	}
-}
+			ic, err := conn.DescribeElasticsearchDomainConfig(&elasticsearch.DescribeElasticsearchDomainConfigInput{
+				DomainName: domain1.DomainName,
+			})
+			if err != nil {
+				return fmt.Errorf("while checking if domain (%s) was not recreated, describing domain config: %w", aws.StringValue(domain1.DomainName), err)
+			}
 
-func testAccCheckDomainNotRecreated(i, j *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.StringValue(i.Endpoint) != aws.StringValue(j.Endpoint) {
-			return fmt.Errorf("domain (%s) was recreated, before endpoint (%s), after endpoint (%s)", aws.StringValue(i.DomainName), aws.StringValue(i.Endpoint), aws.StringValue(j.Endpoint))
-		}
+			jc, err := conn.DescribeElasticsearchDomainConfig(&elasticsearch.DescribeElasticsearchDomainConfigInput{
+				DomainName: domain2.DomainName,
+			})
+			if err != nil {
+				return fmt.Errorf("while checking if domain (%s) was not recreated, describing domain config: %w", aws.StringValue(domain2.DomainName), err)
+			}
+
+			if aws.StringValue(domain1.Endpoint) != aws.StringValue(domain2.Endpoint) || !aws.TimeValue(ic.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate).Equal(aws.TimeValue(jc.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate)) {
+				return fmt.Errorf("domain (%s) was recreated, before endpoint (%s, create time: %s), after endpoint (%s, create time: %s)",
+					aws.StringValue(domain1.DomainName),
+					aws.StringValue(domain1.Endpoint),
+					aws.TimeValue(ic.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate),
+					aws.StringValue(domain2.Endpoint),
+					aws.TimeValue(jc.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate),
+				)
+			}
+		*/
 
 		return nil
 	}

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -1664,6 +1664,8 @@ func testAccCheckDomainExists(n string, domain *elasticsearch.ElasticsearchDomai
 // testAccCheckDomainNotRecreated does not work. Inexplicably, a deleted
 // domain's create time (& endpoint) carry over to a newly created domain with
 // the same name, if it's created within any reasonable time after deletion.
+// Also, domain ID is not unique and is simply the domain name so won't work
+// for this check either.
 func testAccCheckDomainNotRecreated(domain1, domain2 *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		/*

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -2347,41 +2347,6 @@ resource "aws_elasticsearch_domain" "test" {
 `, rName, version, enabled)
 }
 
-func testAccDomainConfigWithEncryptAtRestWithNewKey(rName, version string, enabled bool) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {
-  description             = %[1]q
-  deletion_window_in_days = 7
-}
-
-resource "aws_kms_key" "test2" {
-  description             = %[1]q
-  deletion_window_in_days = 7
-}
-
-resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
-
-  elasticsearch_version = %[2]q
-
-  # Encrypt at rest requires m4/c4/r4/i2 instances. See http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html
-  cluster_config {
-    instance_type = "m4.large.elasticsearch"
-  }
-
-  ebs_options {
-    ebs_enabled = true
-    volume_size = 10
-  }
-
-  encrypt_at_rest {
-    enabled    = %[3]t
-    kms_key_id = aws_kms_key.test2.key_id
-  }
-}
-`, rName, version, enabled)
-}
-
 func testAccDomainConfigwithNodeToNodeEncryption(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {

--- a/internal/service/elasticsearch/status.go
+++ b/internal/service/elasticsearch/status.go
@@ -3,11 +3,15 @@ package elasticsearch
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 const (
 	UpgradeStatusUnknown = "Unknown"
+	ConfigStatusNotFound = "NotFound"
+	ConfigStatusUnknown  = "Unknown"
+	ConfigStatusExists   = "Exists"
 )
 
 func statusUpgradeStatus(conn *elasticsearch.ElasticsearchService, name string) resource.StateRefreshFunc {
@@ -27,5 +31,24 @@ func statusUpgradeStatus(conn *elasticsearch.ElasticsearchService, name string) 
 		}
 
 		return out, aws.StringValue(out.StepStatus), nil
+	}
+}
+
+func domainConfigStatus(conn *elasticsearch.ElasticsearchService, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := conn.DescribeElasticsearchDomainConfig(&elasticsearch.DescribeElasticsearchDomainConfigInput{
+			DomainName: aws.String(name),
+		})
+
+		if tfawserr.ErrCodeEquals(err, elasticsearch.ErrCodeResourceNotFoundException) {
+			// if first return value is nil, WaitForState treats as not found - here not found is treated differently
+			return "not nil", ConfigStatusNotFound, nil
+		}
+
+		if err != nil {
+			return nil, ConfigStatusUnknown, err
+		}
+
+		return out, ConfigStatusExists, nil
 	}
 }

--- a/internal/service/elasticsearch/wait.go
+++ b/internal/service/elasticsearch/wait.go
@@ -137,5 +137,19 @@ func waitForDomainDelete(conn *elasticsearch.ElasticsearchService, domainName st
 		return err
 	}
 
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{ConfigStatusUnknown, ConfigStatusExists},
+		Target:                    []string{ConfigStatusNotFound},
+		Refresh:                   domainConfigStatus(conn, domainName),
+		Timeout:                   timeout,
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 3,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -1074,11 +1074,11 @@ func inPlaceEncryptionEnableVersion(version string) bool {
 		return false
 	}
 
-	if got, err = gversion.NewVersion(version); err != nil || got.GreaterThanOrEqual(want) {
-		return true
+	if got, err = gversion.NewVersion(version); err != nil || got.LessThan(want) {
+		return false
 	}
 
-	return false
+	return true
 }
 
 func suppressEquivalentKmsKeyIds(k, old, new string, d *schema.ResourceData) bool {

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -229,7 +229,7 @@ func TestAccOpenSearchDomain_Cluster_zoneAwareness(t *testing.T) {
 				Config: testAccDomainConfig_clusterZoneAwarenessAZCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
@@ -239,7 +239,7 @@ func TestAccOpenSearchDomain_Cluster_zoneAwareness(t *testing.T) {
 				Config: testAccDomainConfig_clusterZoneAwarenessEnabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain3),
-					testAccCheckDomainNotRecreated(&domain2, &domain3),
+					testAccCheckDomainNotRecreated(&domain2, &domain3), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "0"),
 				),
@@ -248,7 +248,7 @@ func TestAccOpenSearchDomain_Cluster_zoneAwareness(t *testing.T) {
 				Config: testAccDomainConfig_clusterZoneAwarenessAZCount(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain4),
-					testAccCheckDomainNotRecreated(&domain3, &domain4),
+					testAccCheckDomainNotRecreated(&domain3, &domain4), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
@@ -1186,7 +1186,7 @@ func TestAccOpenSearchDomain_Encryption_atRestEnable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
 					testAccCheckDomainEncrypted(true, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 				),
 			},
 			{
@@ -1292,7 +1292,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
 					testAccCheckNodeToNodeEncrypted(true, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 				),
 			},
 			{
@@ -1510,7 +1510,7 @@ func TestAccOpenSearchDomain_versionUpdate(t *testing.T) {
 				Config: testAccDomainConfig_clusterUpdateVersion(rName, "Elasticsearch_5.6"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain2),
-					testAccCheckDomainNotRecreated(&domain1, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "Elasticsearch_5.6"),
 				),
 			},
@@ -1518,7 +1518,7 @@ func TestAccOpenSearchDomain_versionUpdate(t *testing.T) {
 				Config: testAccDomainConfig_clusterUpdateVersion(rName, "Elasticsearch_6.3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain3),
-					testAccCheckDomainNotRecreated(&domain2, &domain3),
+					testAccCheckDomainNotRecreated(&domain2, &domain3), // note: this check does not work and always passes
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "Elasticsearch_6.3"),
 				),
 			},

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1718,6 +1718,8 @@ func testAccCheckDomainExists(n string, domain *opensearchservice.DomainStatus) 
 // testAccCheckDomainNotRecreated does not work. Inexplicably, a deleted
 // domain's create time (& endpoint) carry over to a newly created domain with
 // the same name, if it's created within any reasonable time after deletion.
+// Also, domain ID is not unique and is simply the domain name so won't work
+// for this check either.
 func testAccCheckDomainNotRecreated(domain1, domain2 *opensearchservice.DomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		/*

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1111,7 +1111,7 @@ func TestAccOpenSearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 		CheckDestroy: testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName),
+				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName, "Elasticsearch_6.0", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					testAccCheckDomainEncrypted(true, &domain),
@@ -1175,7 +1175,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNode(t *testing.T) {
 		CheckDestroy: testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_nodeToNodeEncryption(rName),
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "Elasticsearch_6.0", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					testAccCheckNodeToNodeEncrypted(true, &domain),
@@ -1186,6 +1186,166 @@ func TestAccOpenSearchDomain_Encryption_nodeToNode(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     rName[:28],
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchDomain_Encryption_atRestEnable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain1, domain2 opensearchservice.DomainStatus
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opensearch_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleOpenSearch(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName, "OpenSearch_1.1", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckDomainEncrypted(false, &domain1),
+				),
+			},
+			{
+				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName, "OpenSearch_1.1", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain2),
+					testAccCheckDomainEncrypted(true, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2),
+				),
+			},
+			{
+				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName, "OpenSearch_1.1", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckDomainEncrypted(false, &domain1),
+					testAccCheckDomainRecreated(&domain1, &domain2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchDomain_Encryption_atRestEnableLegacy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain1, domain2 opensearchservice.DomainStatus
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opensearch_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleOpenSearch(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName, "Elasticsearch_5.6", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckDomainEncrypted(false, &domain1),
+				),
+			},
+			{
+				Config: testAccDomainConfig_encryptAtRestDefaultKey(rName, "Elasticsearch_5.6", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain2),
+					testAccCheckDomainEncrypted(true, &domain2),
+					testAccCheckDomainRecreated(&domain1, &domain2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain1, domain2 opensearchservice.DomainStatus
+	resourceName := "aws_opensearch_domain.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleOpenSearch(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "OpenSearch_1.1", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckNodeToNodeEncrypted(false, &domain1),
+				),
+			},
+			{
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "OpenSearch_1.1", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain2),
+					testAccCheckNodeToNodeEncrypted(true, &domain2),
+					testAccCheckDomainNotRecreated(&domain1, &domain2),
+				),
+			},
+			{
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "OpenSearch_1.1", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckNodeToNodeEncrypted(false, &domain1),
+					testAccCheckDomainRecreated(&domain1, &domain2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain1, domain2 opensearchservice.DomainStatus
+	resourceName := "aws_opensearch_domain.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleOpenSearch(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "Elasticsearch_5.6", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckNodeToNodeEncrypted(false, &domain1),
+				),
+			},
+			{
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "Elasticsearch_5.6", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain2),
+					testAccCheckNodeToNodeEncrypted(true, &domain2),
+					testAccCheckDomainRecreated(&domain1, &domain2),
+				),
+			},
+			{
+				Config: testAccDomainConfig_nodeToNodeEncryption(rName, "Elasticsearch_5.6", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain1),
+					testAccCheckNodeToNodeEncrypted(false, &domain1),
+					testAccCheckDomainRecreated(&domain1, &domain2),
+				),
 			},
 		},
 	})
@@ -1484,7 +1644,7 @@ func testAccCheckNumberOfInstances(numberOfInstances int, status *opensearchserv
 func testAccCheckDomainEncrypted(encrypted bool, status *opensearchservice.DomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conf := status.EncryptionAtRestOptions
-		if *conf.Enabled != encrypted {
+		if aws.BoolValue(conf.Enabled) != encrypted {
 			return fmt.Errorf("Encrypt at rest not set properly. Given: %t, Expected: %t", *conf.Enabled, encrypted)
 		}
 		return nil
@@ -1560,25 +1720,20 @@ func testAccCheckDomainExists(n string, domain *opensearchservice.DomainStatus) 
 	}
 }
 
+func testAccCheckDomainRecreated(i, j *opensearchservice.DomainStatus) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.DomainId) == aws.StringValue(j.DomainId) {
+			return fmt.Errorf("domain (%s) was not recreated, before ID (%s), after ID (%s)", aws.StringValue(i.DomainName), aws.StringValue(i.DomainId), aws.StringValue(j.DomainId))
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckDomainNotRecreated(i, j *opensearchservice.DomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpenSearchConn
-
-		iConfig, err := conn.DescribeDomainConfig(&opensearchservice.DescribeDomainConfigInput{
-			DomainName: i.DomainName,
-		})
-		if err != nil {
-			return err
-		}
-		jConfig, err := conn.DescribeDomainConfig(&opensearchservice.DescribeDomainConfigInput{
-			DomainName: j.DomainName,
-		})
-		if err != nil {
-			return err
-		}
-
-		if !aws.TimeValue(iConfig.DomainConfig.ClusterConfig.Status.CreationDate).Equal(aws.TimeValue(jConfig.DomainConfig.ClusterConfig.Status.CreationDate)) {
-			return fmt.Errorf("OpenSearch Domain was recreated")
+		if aws.StringValue(i.DomainId) != aws.StringValue(j.DomainId) {
+			return fmt.Errorf("domain (%s) was recreated, before ID (%s), after ID (%s)", aws.StringValue(i.DomainName), aws.StringValue(i.DomainId), aws.StringValue(j.DomainId))
 		}
 
 		return nil
@@ -2237,14 +2392,13 @@ data "aws_iam_policy_document" "test" {
 `, rName)
 }
 
-func testAccDomainConfig_encryptAtRestDefaultKey(rName string) string {
+func testAccDomainConfig_encryptAtRestDefaultKey(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
   domain_name = substr(%[1]q, 0, 28)
 
-  engine_version = "Elasticsearch_6.0"
+  engine_version = %[2]q
 
-  # Encrypt at rest requires m4/c4/r4/i2 instances. See http://docs.aws.amazon.com/opensearch-service/latest/developerguide/aes-supported-instance-types.html
   cluster_config {
     instance_type = "m4.large.search"
   }
@@ -2255,10 +2409,10 @@ resource "aws_opensearch_domain" "test" {
   }
 
   encrypt_at_rest {
-    enabled = true
+    enabled = %[3]t
   }
 }
-`, rName)
+`, rName, version, enabled)
 }
 
 func testAccDomainConfig_encryptAtRestWithKey(rName string) string {
@@ -2291,12 +2445,12 @@ resource "aws_opensearch_domain" "test" {
 `, rName)
 }
 
-func testAccDomainConfig_nodeToNodeEncryption(rName string) string {
+func testAccDomainConfig_nodeToNodeEncryption(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
   domain_name = substr(%[1]q, 0, 28)
 
-  engine_version = "Elasticsearch_6.0"
+  engine_version = %[2]q
 
   cluster_config {
     instance_type = "m4.large.search"
@@ -2308,10 +2462,10 @@ resource "aws_opensearch_domain" "test" {
   }
 
   node_to_node_encryption {
-    enabled = true
+    enabled = %[3]t
   }
 }
-`, rName)
+`, rName, version, enabled)
 }
 
 func testAccDomainConfig_complex(rName string) string {

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -312,7 +312,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### node_to_node_encryption
 
-~> **Note:** You can enable `node_to_node_encryption` in place if your Elasticsearch version is 6.7 or greater. If you disable `node_to_node_encryption`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain causing data loss.
+~> **Note:** You can enable `node_to_node_encryption` _in place_ for an existing, unencrypted domain only if your Elasticsearch version is 6.7 or greater. For lower versions, if you enable `node_to_node_encryption`, Terraform will recreate the domain, potentially causing data loss. For any version, if you disable `node_to_node_encryption` for an existing, node-to-node encrypted domain, Terraform will recreate the domain, potentially causing data loss.
 
 * `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`.
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -299,9 +299,9 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### encrypt_at_rest
 
-~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. In contrast, AWS does not support changing the `kms_key_id`. If you change the key, Terraform will recreate the domain, which can cause data loss.
+~> **Note:** You can enable `encrypt_at_rest` _in place_ for an existing, unencrypted domain only if your Elasticsearch version is 6.7 or greater. For lower versions, if you enable `encrypt_at_rest`, Terraform with recreate the domain, potentially causing data loss. For any version, if you disable `encrypt_at_rest` for an existing, encrypted domain, Terraform will recreate the domain, potentially causing data loss. If you change the `kms_key_id`, Terraform will also recreate the domain, potentially causing data loss.
 
-* `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
+* `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`. Enabling encryption on new domains requires `elasticsearch_version` 5.1 or greater.
 * `kms_key_id` - (Optional) KMS key ARN to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key. Note that KMS will accept a KMS key ID but will return the key ARN. To prevent Terraform detecting unwanted changes, use the key ARN instead.
 
 ### log_publishing_options

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -299,8 +299,10 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### encrypt_at_rest
 
+~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. Similarly, you can change the `kms_key_id` in place if your version is 6.7 or great. Otherwise, Terraform will recreate the domain, which can cause data loss.
+
 * `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
-* `kms_key_id` - (Optional) KMS key id to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key.
+* `kms_key_id` - (Optional) KMS key ARN to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key. Note that KMS will accept a KMS key ID but will return the key ARN. To prevent Terraform detecting unwanted changes, use the key ARN instead.
 
 ### log_publishing_options
 
@@ -309,6 +311,8 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 * `log_type` - (Required) Type of Elasticsearch log. Valid values: `INDEX_SLOW_LOGS`, `SEARCH_SLOW_LOGS`, `ES_APPLICATION_LOGS`, `AUDIT_LOGS`.
 
 ### node_to_node_encryption
+
+~> **Note:** You can enable `node_to_node_encryption` in place if your Elasticsearch version is 6.7 or greater. If you disable `node_to_node_encryption`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain causing data loss.
 
 * `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`.
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -299,7 +299,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### encrypt_at_rest
 
-~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. Similarly, you can change the `kms_key_id` in place if your version is 6.7 or great. Otherwise, Terraform will recreate the domain, which can cause data loss.
+~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. In contrast, AWS does not support changing the `kms_key_id`. If you change the key, Terraform will recreate the domain, which can cause data loss.
 
 * `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
 * `kms_key_id` - (Optional) KMS key ARN to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key. Note that KMS will accept a KMS key ID but will return the key ARN. To prevent Terraform detecting unwanted changes, use the key ARN instead.

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -314,7 +314,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ~> **Note:** You can enable `node_to_node_encryption` _in place_ for an existing, unencrypted domain only if your Elasticsearch version is 6.7 or greater. For lower versions, if you enable `node_to_node_encryption`, Terraform will recreate the domain, potentially causing data loss. For any version, if you disable `node_to_node_encryption` for an existing, node-to-node encrypted domain, Terraform will recreate the domain, potentially causing data loss.
 
-* `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`.
+* `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`. Enabling node-to-node encryption of a new domain requires an `elasticsearch_version` of `6.0` or greater.
 
 ### snapshot_options
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -329,6 +329,8 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### node_to_node_encryption
 
+~> **Note:** You can enable `node_to_node_encryption` _in place_ for an existing, unencrypted domain only if you are using OpenSearch or your Elasticsearch version is 6.7 or greater. For other versions, if you enable `node_to_node_encryption`, Terraform will recreate the domain, potentially causing data loss. For any version, if you disable `node_to_node_encryption` for an existing, node-to-node encrypted domain, Terraform will recreate the domain, potentially causing data loss.
+
 * `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`.
 
 ### snapshot_options

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -316,7 +316,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### encrypt_at_rest
 
-~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. Similarly, you can change the `kms_key_id` in place if your version is 6.7 or great. Otherwise, Terraform will recreate the domain, which can cause data loss.
+~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. In contrast, AWS does not support changing the `kms_key_id`. If you change the key, Terraform will recreate the domain, which can cause data loss.
 
 * `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
 * `kms_key_id` - (Optional) KMS key ARN to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key. Note that KMS will accept a KMS key ID but will return the key ARN. To prevent Terraform detecting unwanted changes, use the key ARN instead.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -316,8 +316,10 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### encrypt_at_rest
 
+~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. Similarly, you can change the `kms_key_id` in place if your version is 6.7 or great. Otherwise, Terraform will recreate the domain, which can cause data loss.
+
 * `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
-* `kms_key_id` - (Optional) KMS key id to encrypt the OpenSearch domain with. If not specified then it defaults to using the `aws/es` service KMS key.
+* `kms_key_id` - (Optional) KMS key ARN to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key. Note that KMS will accept a KMS key ID but will return the key ARN. To prevent Terraform detecting unwanted changes, use the key ARN instead.
 
 ### log_publishing_options
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -316,9 +316,9 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### encrypt_at_rest
 
-~> **Note:** You can enable `encrypt_at_rest` in place if your Elasticsearch version is 6.7 or greater. If you disable `encrypt_rest_rest`, once you enable it, for any version, or enable for 6.6 and below, Terraform will recreate the domain, which can cause data loss. In contrast, AWS does not support changing the `kms_key_id`. If you change the key, Terraform will recreate the domain, which can cause data loss.
+~> **Note:** You can enable `encrypt_at_rest` _in place_ for an existing, unencrypted domain only if you are using OpenSearch or your Elasticsearch version is 6.7 or greater. For other versions, if you enable `encrypt_at_rest`, Terraform with recreate the domain, potentially causing data loss. For any version, if you disable `encrypt_at_rest` for an existing, encrypted domain, Terraform will recreate the domain, potentially causing data loss. If you change the `kms_key_id`, Terraform will also recreate the domain, potentially causing data loss.
 
-* `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
+* `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`. Enabling encryption on new domains requires an `engine_version` of `OpenSearch_X.Y` or `Elasticsearch_5.1` or greater.
 * `kms_key_id` - (Optional) KMS key ARN to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key. Note that KMS will accept a KMS key ID but will return the key ARN. To prevent Terraform detecting unwanted changes, use the key ARN instead.
 
 ### log_publishing_options

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -331,7 +331,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ~> **Note:** You can enable `node_to_node_encryption` _in place_ for an existing, unencrypted domain only if you are using OpenSearch or your Elasticsearch version is 6.7 or greater. For other versions, if you enable `node_to_node_encryption`, Terraform will recreate the domain, potentially causing data loss. For any version, if you disable `node_to_node_encryption` for an existing, node-to-node encrypted domain, Terraform will recreate the domain, potentially causing data loss.
 
-* `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`.
+* `enabled` - (Required) Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`. Enabling node-to-node encryption of a new domain requires an `engine_version` of `OpenSearch_X.Y` or `Elasticsearch_6.0` or greater.
 
 ### snapshot_options
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17330

Output from acceptance testing:

```console
% make testacc TESTS=TestAccOpenSearchDomain_Encryption PKG=opensearch 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_Encryption'  -timeout 180m
--- PASS: TestAccOpenSearchDomain_Encryption_atRestSpecifyKey (1295.27s)
--- PASS: TestAccOpenSearchDomain_Encryption_nodeToNode (1330.23s)
--- PASS: TestAccOpenSearchDomain_Encryption_atRestDefaultKey (1355.97s)
--- PASS: TestAccOpenSearchDomain_Encryption_atRestEnableLegacy (2835.81s)
--- PASS: TestAccOpenSearchDomain_Encryption_nodeToNodeEnableLegacy (3934.86s)
--- PASS: TestAccOpenSearchDomain_Encryption_nodeToNodeEnable (4695.07s)
--- PASS: TestAccOpenSearchDomain_Encryption_atRestEnable (4917.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearch	4919.873s
% make testacc TESTS=TestAccElasticsearchDomain_Encryption PKG=elasticsearch 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 20 -run='TestAccElasticsearchDomain_Encryption'  -timeout 180m
--- PASS: TestAccElasticsearchDomain_Encryption_nodeToNode (1804.74s)
--- PASS: TestAccElasticsearchDomain_Encryption_atRestSpecifyKey (2046.07s)
--- PASS: TestAccElasticsearchDomain_Encryption_atRestDefaultKey (2514.48s)
--- PASS: TestAccElasticsearchDomain_Encryption_atRestEnableLegacy (3078.36s)
--- PASS: TestAccElasticsearchDomain_Encryption_nodeToNodeEnable (4283.36s)
--- PASS: TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy (4600.67s)
--- PASS: TestAccElasticsearchDomain_Encryption_atRestEnable (4977.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	4981.626s
```
