### PR TITLE
r/ecs_service: add wait condition after create/update and handle errors when using `wait_for_steady_state`

### DIFF
--- a/.changelog/24223.txt
+++ b/.changelog/24223.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecs_service: Retry when using the `wait_for_steady_state` parameter and `ResourceNotReady` errors are returned from the AWS API
+```
+
+```release-note:bug
+resource/aws_ecs_service: Wait for service to reach an active state after create and update operations
+```

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1222,6 +1222,10 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	})
 
 	client.ECSConn.Handlers.Retry.PushBack(func(r *request.Request) {
+		// By design the "WaitUntilServicesStable" method will poll every 15 seconds until a successful state
+		// has been reached. This will exit with a return code of 255 (ResourceNotReady) after 40 failed checks.
+		// Thus, here we retry the operation a set number of times as
+		// described in https://github.com/hashicorp/terraform-provider-aws/pull/23747.
 		if r.Operation.Name == "WaitUntilServicesStable" {
 			if tfawserr.ErrCodeEquals(r.Error, "ResourceNotReady") {
 				// We only want to retry briefly as the default max retry count would

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -550,14 +550,15 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] ECS service created: %s", aws.StringValue(output.Service.ServiceArn))
 	d.SetId(aws.StringValue(output.Service.ServiceArn))
 
-	if d.Get("wait_for_steady_state").(bool) {
-		cluster := ""
-		if v, ok := d.GetOk("cluster"); ok {
-			cluster = v.(string)
-		}
+	cluster := d.Get("cluster").(string)
 
+	if d.Get("wait_for_steady_state").(bool) {
 		if err := waitServiceStable(conn, d.Id(), cluster); err != nil {
-			return fmt.Errorf("error waiting for ECS service (%s) to become ready: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for ECS service (%s) to reach steady state after creation: %w", d.Id(), err)
+		}
+	} else {
+		if _, err := waitServiceDescribeReady(conn, d.Id(), cluster); err != nil {
+			return fmt.Errorf("error waiting for ECS service (%s) to become active after creation: %w", d.Id(), err)
 		}
 	}
 
@@ -608,6 +609,7 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
+		log.Printf("[DEBUG] Waiting for ECS Service (%s) to become active", d.Id())
 		output, err = waitServiceDescribeReady(conn, d.Id(), d.Get("cluster").(string))
 	}
 
@@ -618,7 +620,7 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading ECS service: %w", err)
+		return fmt.Errorf("error reading ECS service (%s): %w", d.Id(), err)
 	}
 
 	if len(output.Services) < 1 {
@@ -633,7 +635,7 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 	service := output.Services[0]
 
 	// Status==INACTIVE means deleted service
-	if aws.StringValue(service.Status) == "INACTIVE" {
+	if aws.StringValue(service.Status) == serviceStatusInactive {
 		log.Printf("[WARN] Removing ECS service %q because it's INACTIVE", aws.StringValue(service.ServiceArn))
 		d.SetId("")
 		return nil
@@ -1110,14 +1112,14 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error updating ECS Service (%s): %w", d.Id(), err)
 		}
 
+		cluster := d.Get("cluster").(string)
 		if d.Get("wait_for_steady_state").(bool) {
-			cluster := ""
-			if v, ok := d.GetOk("cluster"); ok {
-				cluster = v.(string)
-			}
-
 			if err := waitServiceStable(conn, d.Id(), cluster); err != nil {
-				return fmt.Errorf("error waiting for ECS service (%s) to become ready: %w", d.Id(), err)
+				return fmt.Errorf("error waiting for ECS service (%s) to reach steady state after update: %w", d.Id(), err)
+			}
+		} else {
+			if _, err := waitServiceDescribeReady(conn, d.Id(), cluster); err != nil {
+				return fmt.Errorf("error waiting for ECS service (%s) to become active after update: %w", d.Id(), err)
 			}
 		}
 	}

--- a/internal/service/ecs/wait.go
+++ b/internal/service/ecs/wait.go
@@ -63,7 +63,6 @@ func waitCapacityProviderUpdated(conn *ecs.ECS, arn string) (*ecs.CapacityProvid
 }
 
 func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
-	var err error
 	input := &ecs.DescribeServicesInput{
 		Services: aws.StringSlice([]string{id}),
 	}
@@ -72,12 +71,10 @@ func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
 		input.Cluster = aws.String(cluster)
 	}
 
-	for i := 0; i < 3; i++ {
-		if err := conn.WaitUntilServicesStable(input); err == nil {
-			return nil
-		}
+	if err := conn.WaitUntilServicesStable(input); err != nil {
+		return err
 	}
-	return err
+	return nil
 }
 
 func waitServiceInactive(conn *ecs.ECS, id, cluster string) error {

--- a/internal/service/ecs/wait.go
+++ b/internal/service/ecs/wait.go
@@ -63,6 +63,7 @@ func waitCapacityProviderUpdated(conn *ecs.ECS, arn string) (*ecs.CapacityProvid
 }
 
 func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
+	var err error
 	input := &ecs.DescribeServicesInput{
 		Services: aws.StringSlice([]string{id}),
 	}
@@ -71,10 +72,12 @@ func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
 		input.Cluster = aws.String(cluster)
 	}
 
-	if err := conn.WaitUntilServicesStable(input); err != nil {
-		return err
+	for i := 0; i < 3; i++ {
+		if err := conn.WaitUntilServicesStable(input); err == nil {
+			return nil
+		}
 	}
-	return nil
+	return err
 }
 
 func waitServiceInactive(conn *ecs.ECS, id, cluster string) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/pull/23747 (this PR is a continuation)
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20452

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TESTARGS='-run=TestAccECSService_' PKG=ecs ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 5  -run=TestAccECSService_ -timeout 180m
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_basicImport
=== PAUSE TestAccECSService_basicImport
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_CapacityProviderStrategy_multiple
=== PAUSE TestAccECSService_CapacityProviderStrategy_multiple
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_renamedCluster
=== PAUSE TestAccECSService_renamedCluster
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSService_multipleTargetGroups
=== CONT  TestAccECSService_iamRole
=== CONT  TestAccECSService_executeCommand
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
--- PASS: TestAccECSService_iamRole (60.92s)
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
--- PASS: TestAccECSService_basic (68.02s)
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
--- PASS: TestAccECSService_executeCommand (100.17s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (197.50s)
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (133.08s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (185.09s)
=== CONT  TestAccECSService_PlacementStrategy_missing
--- PASS: TestAccECSService_PlacementStrategy_missing (0.72s)
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_LaunchTypeFargate_basic (148.98s)
=== CONT  TestAccECSService_LaunchTypeEC2_network
--- PASS: TestAccECSService_multipleTargetGroups (282.07s)
=== CONT  TestAccECSService_Tags_propagate
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (87.52s)
=== CONT  TestAccECSService_Tags_managed
--- PASS: TestAccECSService_PlacementConstraints_basic (98.68s)
=== CONT  TestAccECSService_Tags_basic
--- PASS: TestAccECSService_LaunchTypeEC2_network (58.79s)
=== CONT  TestAccECSService_forceNewDeployment
--- PASS: TestAccECSService_Tags_propagate (63.69s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
--- PASS: TestAccECSService_PlacementStrategy_basic (103.55s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_Tags_managed (71.21s)
=== CONT  TestAccECSService_renamedCluster
--- PASS: TestAccECSService_forceNewDeployment (69.93s)
=== CONT  TestAccECSService_familyAndRevision
--- PASS: TestAccECSService_Tags_basic (98.31s)
=== CONT  TestAccECSService_CapacityProviderStrategy_multiple
--- PASS: TestAccECSService_renamedCluster (81.08s)
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_familyAndRevision (80.96s)
=== CONT  TestAccECSService_ServiceRegistries_container
--- PASS: TestAccECSService_replicaSchedulingStrategy (87.96s)
=== CONT  TestAccECSService_ServiceRegistries_changes
--- PASS: TestAccECSService_ServiceRegistries_container (170.22s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (39.46s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (337.18s)
=== CONT  TestAccECSService_ServiceRegistries_basic
--- PASS: TestAccECSService_CapacityProviderStrategy_update (350.46s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (39.38s)
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
--- PASS: TestAccECSService_ServiceRegistries_changes (244.99s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (86.23s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_ServiceRegistries_basic (153.75s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (160.16s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (85.06s)
=== CONT  TestAccECSService_basicImport
--- PASS: TestAccECSService_disappears (85.36s)
=== CONT  TestAccECSService_loadBalancerChanges
--- PASS: TestAccECSService_basicImport (74.53s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_DeploymentControllerType_external (42.28s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_alb (288.71s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (238.46s)
=== CONT  TestAccECSService_deploymentCircuitBreaker
--- PASS: TestAccECSService_DeploymentValues_basic (85.10s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_deploymentCircuitBreaker (86.65s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSService_loadBalancerChanges (270.41s)
--- PASS: TestAccECSService_clusterName (86.22s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (302.74s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (111.83s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (395.79s)
PASS
PASS	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	1457.819s
```
