### PR TITLE
Clarify import procedure for `aws_cloudformation_stack_set_instance`

### DIFF
--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -127,7 +127,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-CloudFormation StackSet Instances targeting an account ID can be imported using the StackSet name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.
+CloudFormation StackSet Instances that target an AWS Account ID can be imported using the StackSet name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.
 
 ```
 $ terraform import aws_cloudformation_stack_set_instance.example example,123456789012,us-east-1

--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -127,8 +127,14 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-CloudFormation StackSet Instances can be imported using the StackSet name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.,
+CloudFormation StackSet Instances targeting an account ID can be imported using the StackSet name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.
 
 ```
 $ terraform import aws_cloudformation_stack_set_instance.example example,123456789012,us-east-1
+```
+
+CloudFormation StackSet Instances that target AWS Organizational Units can be imported using the StackSet name, a slash (`/`) separated list of organizational unit IDs, and target AWS region separated by commas (`,`) e.g.
+
+```
+$ terraform import aws_cloudformation_stack_set_instance.example example,ou-sdas-123123123/ou-sdas-789789789,us-east-1
 ```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #22956

Output from acceptance testing: N/a, docs

### Information

Previously, the documentation was unclear how to import `aws_cloudformation_stack_set_instance` resources when a set of OUs was passed to `deployment_targets.organizational_unit_ids`. This PR aims to clarify the steps needed to do so.

### Reference

- [note from the `read` function of the resource that let me to the correct format](https://github.com/hashicorp/terraform-provider-aws/blob/8bde0a26b57ccd1fd0c6c29dffaf9967269235a8/internal/service/cloudformation/stack_set_instance.go#L269-L271)