### PR TITLE
Add example `aws_cognito_user_pool_client` with Cognito IdP

### DIFF
--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -110,6 +110,24 @@ resource "aws_cognito_user_pool_client" "test" {
 }
 ```
 
+### Create a user pool client with Cognito as the identity provider
+
+```terraform
+resource "aws_cognito_user_pool" "pool" {
+  name = "pool"
+}
+
+resource "aws_cognito_user_pool_client" "userpool_client" {
+  name                                 = "client"
+  user_pool_id                         = aws_cognito_user_pool.pool.id
+  callback_urls                        = ["https://example.com"]
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code", "implicit"]
+  allowed_oauth_scopes                 = ["email", "openid"]
+  supported_identity_providers         = ["COGNITO"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #23374

Output from acceptance testing: n/a, docs

### Information

As requested in #23374, this PR adds an example to the `aws_cognito_user_pool_client` resource to demonstrate using `COGNITO` as the IdP.

**_Note: I would appreciate a fairly thorough look over this, as I'm not able to test thoroughly, and am basing the configuration entirely off of reading Cognito documentation._**

### References

- [CreateUserPoolClient API Reference](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html)
- [Cognito: Configuration a user pool app client](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-idp-settings.html)
- [Cognito: Configure app client settings](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-settings.html)
- [AWS Blog: Understanding Amazon Cognito user pool OAuth 2.0 grants](https://aws.amazon.com/blogs/mobile/understanding-amazon-cognito-user-pool-oauth-2-0-grants/)