### PR TITLE
stack_set.operation_preferences.failure_tolerance_count can be zero

### DIFF
--- a/.changelog/24250.txt
+++ b/.changelog/24250.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack_set: Prevent `Validation` errors when `operation_preferences.failure_tolerance_count` is zero
+```

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -329,6 +329,30 @@ func TestAccCloudFormationStackSet_operationPreferences(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
 				),
 			},
+			{
+				Config: testAccStackSetOperationPreferencesConfig(rName, 0, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
+				),
+			},
+			{
+				Config: testAccStackSetOperationPreferencesUpdatedConfig(rName, 0, 95),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "95"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", ""),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -345,9 +345,9 @@ func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *clo
 		apiObject.FailureToleranceCount = nil
 	}
 
-	if mcc, mcp := aws.Int64Value(apiObject.MaxConcurrentCount), aws.Int64Value(apiObject.MaxConcurrentPercentage); mcc > 0 && mcp == 0 {
+	if mcc, mcp := aws.Int64Value(apiObject.MaxConcurrentCount), aws.Int64Value(apiObject.MaxConcurrentPercentage); mcp == 0 {
 		apiObject.MaxConcurrentPercentage = nil
-	} else if mcp > 0 && mcc == 0 {
+	} else if mcc == 0 {
 		apiObject.MaxConcurrentCount = nil
 	}
 

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -339,9 +339,9 @@ func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *clo
 		apiObject.RegionOrder = flex.ExpandStringSet(v)
 	}
 
-	if ftc, ftp := aws.Int64Value(apiObject.FailureToleranceCount), aws.Int64Value(apiObject.FailureTolerancePercentage); ftc > 0 && ftp == 0 {
+	if ftc, ftp := aws.Int64Value(apiObject.FailureToleranceCount), aws.Int64Value(apiObject.FailureTolerancePercentage); ftp == 0 {
 		apiObject.FailureTolerancePercentage = nil
-	} else if ftp > 0 && ftc == 0 {
+	} else if ftc == 0 {
 		apiObject.FailureToleranceCount = nil
 	}
 


### PR DESCRIPTION
Currently, an aws_cloudformation_stack_set with:
```
  operation_preferences {
    failure_tolerance_count = 0
    max_concurrent_percentage = 100
  }
```
fails with `Validation Error: Exactly one of FailureTolerancePercentage and FailureToleranceCount must be specified since both parameters are present`. This is because currently the `FailureToleranceCount` and `FailureTolerancePercentage` attributes are both set (possibly to a default value of 0) and then one is removed if it is zero and the other is non-zero. Therefore with the `operation_preferences` block above both remain, leading to the `Validation Error` being raised. This PR removes the requirement that the other be non-zero and so allows the above `operation_preferences` block to work.

Note that although this does not apply to max_concurrent_percentage / max_concurrent_count since at least one of these must be at least one, I propose making the same change there just to keep the logic the same.