### PR TITLE
github/workflows: add id to step that outputs highest version tag and use diff action to fetch workflow artifact

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -1,23 +1,46 @@
 name: Post Publish
 on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        type: string
+        description: 'Semver release tag e.g. v1.1.0'
+        required: true
   workflow_run:
     workflows: [Release]
     types:
       - completed
 jobs:
-  on-success:
+  on-success-or-workflow-dispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    outputs:
+      release-tag: ${{ steps.release-tag.outputs.tag }}
     steps:
-      - uses: actions/download-artifact@v3
+      - if: github.event_name == 'workflow_run'
+        name: Download Artifact from Release workflow
+        uses: dawidd6/action-download-artifact@v2
         with:
-          name: release_tag
-          path: release_tag.data
+          workflow: release.yml
+          name: release-tag
       - name: Output Release Tag
         id: release-tag
         run: |
-          value=`cat release_tag.data`
-          echo ::set-output name=tag_name::$value
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo ::set-output name=tag::${{ github.event.inputs.release-tag }}
+          else
+            value=`cat release-tag.data`
+            echo ::set-output name=tag::$value
+          fi
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'
+  organize:
+    needs: [ on-success-or-workflow-dispatch ]
+    runs-on: ubuntu-latest
+    steps:
       - name: Tidy Asana
         uses: breathingdust/github-asana-tidy@v1
         with:
@@ -26,16 +49,11 @@ jobs:
           asana_workspace_gid: '90955849329269'
           asana_project_gid: '632425409545160'
           asana_github_url_field_gid: '1134594824474912'
-          github_release_name: ${{ steps.release-tag.outputs.tag_name }}
+          github_release_name: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive Released Cards
         uses: breathingdust/github-project-archive@v1
         with:
           github_done_column_id: 11513756
-          github_release_name: ${{ steps.release-tag.outputs.tag_name }}
+          github_release_name: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
           github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo 'The triggering workflow failed'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,12 @@ jobs:
       tag: ${{ steps.highest-version-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v2
-        id: highest-version-tag
         with:
           # Allow tag to be fetched when ref is a commit
           fetch-depth: 0
-      - run: |
+      - name: Output highest version tag
+        id: highest-version-tag
+        run: |
           HIGHEST=$(git tag | sort -V | tail -1)
           echo ::set-output name=tag::$HIGHEST
   changelog-newversion:
@@ -108,8 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Save Release Tag
-        run: echo ${{ github.ref_name }} > release_tag.data
+        run: echo ${{ github.ref_name }} > release-tag.data
       - uses: actions/upload-artifact@v2
         with:
-          name: release_tag
-          path: release_tag.data
+          name: release-tag
+          path: release-tag.data
+          retention-days: 1


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24258 


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ actionlint .github/workflows/release.yml .github/workflows/post_publish.yml
```
