### PR TITLE
Issue-20146 Add username parameter to RDS proxy auth

### DIFF
--- a/.changelog/24264.txt
+++ b/.changelog/24264.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_db_proxy: The `username` attribute is now available in the auth config.
+resource/aws_db_proxy: Add `auth.username` argument
 ```

--- a/.changelog/24264.txt
+++ b/.changelog/24264.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_db_proxy: The `username` attribute is now available in the auth config.
+```

--- a/internal/service/rds/find.go
+++ b/internal/service/rds/find.go
@@ -166,7 +166,16 @@ func FindDBProxyByName(conn *rds.RDS, name string) (*rds.DBProxy, error) {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return output.DBProxies[0], nil
+	dbProxy := output.DBProxies[0]
+
+	// Eventual consistency check.
+	if aws.StringValue(dbProxy.DBProxyName) != name {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	return dbProxy, nil
 }
 
 func FindEventSubscriptionByID(conn *rds.RDS, id string) (*rds.EventSubscription, error) {

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -38,49 +38,6 @@ func ResourceProxy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validIdentifier,
-			},
-			"debug_logging": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"engine_family": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(rds.EngineFamily_Values(), false),
-			},
-			"idle_client_timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"require_tls": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"role_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"vpc_security_group_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"vpc_subnet_ids": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
 			"auth": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -112,12 +69,55 @@ func ResourceProxy() *schema.Resource {
 					},
 				},
 			},
+			"debug_logging": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"engine_family": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(rds.EngineFamily_Values(), false),
+			},
+			"idle_client_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validIdentifier,
+			},
+			"require_tls": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
+			"vpc_security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"vpc_subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -178,86 +178,6 @@ func resourceProxyCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceProxyRead(d, meta)
 }
 
-func resourceProxyRefreshFunc(conn *rds.RDS, proxyName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeDBProxies(&rds.DescribeDBProxiesInput{
-			DBProxyName: aws.String(proxyName),
-		})
-
-		if err != nil {
-			if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) {
-				return 42, "", nil
-			}
-			return 42, "", err
-		}
-
-		dbProxy := resp.DBProxies[0]
-		return dbProxy, *dbProxy.Status, nil
-	}
-}
-
-func expandDbProxyAuth(l []interface{}) []*rds.UserAuthConfig {
-	if len(l) == 0 {
-		return nil
-	}
-
-	userAuthConfigs := make([]*rds.UserAuthConfig, 0, len(l))
-
-	for _, mRaw := range l {
-		m, ok := mRaw.(map[string]interface{})
-
-		if !ok {
-			continue
-		}
-
-		userAuthConfig := &rds.UserAuthConfig{}
-
-		if v, ok := m["auth_scheme"].(string); ok && v != "" {
-			userAuthConfig.AuthScheme = aws.String(v)
-		}
-
-		if v, ok := m["description"].(string); ok && v != "" {
-			userAuthConfig.Description = aws.String(v)
-		}
-
-		if v, ok := m["iam_auth"].(string); ok && v != "" {
-			userAuthConfig.IAMAuth = aws.String(v)
-		}
-
-		if v, ok := m["secret_arn"].(string); ok && v != "" {
-			userAuthConfig.SecretArn = aws.String(v)
-		}
-
-		if v, ok := m["username"].(string); ok && v != "" {
-			userAuthConfig.UserName = aws.String(v)
-		}
-
-		userAuthConfigs = append(userAuthConfigs, userAuthConfig)
-	}
-
-	return userAuthConfigs
-}
-
-func flattenDbProxyAuth(userAuthConfig *rds.UserAuthConfigInfo) map[string]interface{} {
-	m := make(map[string]interface{})
-
-	m["auth_scheme"] = aws.StringValue(userAuthConfig.AuthScheme)
-	m["description"] = aws.StringValue(userAuthConfig.Description)
-	m["iam_auth"] = aws.StringValue(userAuthConfig.IAMAuth)
-	m["secret_arn"] = aws.StringValue(userAuthConfig.SecretArn)
-	m["username"] = aws.StringValue(userAuthConfig.UserName)
-
-	return m
-}
-
-func flattenDbProxyAuths(userAuthConfigs []*rds.UserAuthConfigInfo) []interface{} {
-	s := []interface{}{}
-	for _, v := range userAuthConfigs {
-		s = append(s, flattenDbProxyAuth(v))
-	}
-	return s
-}
-
 func resourceProxyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).RDSConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
@@ -416,4 +336,84 @@ func resourceProxyDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceProxyRefreshFunc(conn *rds.RDS, proxyName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeDBProxies(&rds.DescribeDBProxiesInput{
+			DBProxyName: aws.String(proxyName),
+		})
+
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) {
+				return 42, "", nil
+			}
+			return 42, "", err
+		}
+
+		dbProxy := resp.DBProxies[0]
+		return dbProxy, *dbProxy.Status, nil
+	}
+}
+
+func expandDbProxyAuth(l []interface{}) []*rds.UserAuthConfig {
+	if len(l) == 0 {
+		return nil
+	}
+
+	userAuthConfigs := make([]*rds.UserAuthConfig, 0, len(l))
+
+	for _, mRaw := range l {
+		m, ok := mRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		userAuthConfig := &rds.UserAuthConfig{}
+
+		if v, ok := m["auth_scheme"].(string); ok && v != "" {
+			userAuthConfig.AuthScheme = aws.String(v)
+		}
+
+		if v, ok := m["description"].(string); ok && v != "" {
+			userAuthConfig.Description = aws.String(v)
+		}
+
+		if v, ok := m["iam_auth"].(string); ok && v != "" {
+			userAuthConfig.IAMAuth = aws.String(v)
+		}
+
+		if v, ok := m["secret_arn"].(string); ok && v != "" {
+			userAuthConfig.SecretArn = aws.String(v)
+		}
+
+		if v, ok := m["username"].(string); ok && v != "" {
+			userAuthConfig.UserName = aws.String(v)
+		}
+
+		userAuthConfigs = append(userAuthConfigs, userAuthConfig)
+	}
+
+	return userAuthConfigs
+}
+
+func flattenDbProxyAuth(userAuthConfig *rds.UserAuthConfigInfo) map[string]interface{} {
+	m := make(map[string]interface{})
+
+	m["auth_scheme"] = aws.StringValue(userAuthConfig.AuthScheme)
+	m["description"] = aws.StringValue(userAuthConfig.Description)
+	m["iam_auth"] = aws.StringValue(userAuthConfig.IAMAuth)
+	m["secret_arn"] = aws.StringValue(userAuthConfig.SecretArn)
+	m["username"] = aws.StringValue(userAuthConfig.UserName)
+
+	return m
+}
+
+func flattenDbProxyAuths(userAuthConfigs []*rds.UserAuthConfigInfo) []interface{} {
+	s := []interface{}{}
+	for _, v := range userAuthConfigs {
+		s = append(s, flattenDbProxyAuth(v))
+	}
+	return s
 }

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -105,6 +105,10 @@ func ResourceProxy() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: verify.ValidARN,
 						},
+						"username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -224,6 +228,10 @@ func expandDbProxyAuth(l []interface{}) []*rds.UserAuthConfig {
 			userAuthConfig.SecretArn = aws.String(v)
 		}
 
+		if v, ok := m["username"].(string); ok && v != "" {
+			userAuthConfig.UserName = aws.String(v)
+		}
+
 		userAuthConfigs = append(userAuthConfigs, userAuthConfig)
 	}
 
@@ -237,6 +245,7 @@ func flattenDbProxyAuth(userAuthConfig *rds.UserAuthConfigInfo) map[string]inter
 	m["description"] = aws.StringValue(userAuthConfig.Description)
 	m["iam_auth"] = aws.StringValue(userAuthConfig.IAMAuth)
 	m["secret_arn"] = aws.StringValue(userAuthConfig.SecretArn)
+	m["username"] = aws.StringValue(userAuthConfig.UserName)
 
 	return m
 }

--- a/internal/service/rds/proxy_data_source.go
+++ b/internal/service/rds/proxy_data_source.go
@@ -37,6 +37,10 @@ func DataSourceProxy() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/rds/proxy_test.go
+++ b/internal/service/rds/proxy_test.go
@@ -412,6 +412,32 @@ func TestAccRDSProxy_authSecretARN(t *testing.T) {
 	})
 }
 
+func TestAccRDSProxy_authUsername(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbProxy rds.DBProxy
+	resourceName := "aws_db_proxy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccDBProxyPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, rds.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckProxyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProxyNameConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProxyExists(resourceName, &dbProxy),
+					resource.TestCheckResourceAttr(resourceName, "auth.0.username", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSProxy_tags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/rds/proxy_test.go
+++ b/internal/service/rds/proxy_test.go
@@ -566,8 +566,6 @@ func testAccCheckProxyExists(n string, v *rds.DBProxy) resource.TestCheckFunc {
 		*v = *output
 
 		return nil
-
-		return nil
 	}
 }
 

--- a/internal/service/rds/status.go
+++ b/internal/service/rds/status.go
@@ -121,3 +121,19 @@ func statusDBInstanceHasAutomatedBackup(conn *rds.RDS, dbInstanceID, dbInstanceA
 		return output, strconv.FormatBool(false), nil
 	}
 }
+
+func statusDBProxy(conn *rds.RDS, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindDBProxyByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -270,3 +270,20 @@ func waitDBProxyDeleted(conn *rds.RDS, name string, timeout time.Duration) (*rds
 
 	return nil, err
 }
+
+func waitDBProxyUpdated(conn *rds.RDS, name string, timeout time.Duration) (*rds.DBProxy, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{rds.DBProxyStatusModifying},
+		Target:  []string{rds.DBProxyStatusAvailable},
+		Refresh: statusDBProxy(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*rds.DBProxy); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -253,3 +253,20 @@ func waitDBProxyCreated(conn *rds.RDS, name string, timeout time.Duration) (*rds
 
 	return nil, err
 }
+
+func waitDBProxyDeleted(conn *rds.RDS, name string, timeout time.Duration) (*rds.DBProxy, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{rds.DBProxyStatusDeleting},
+		Target:  []string{},
+		Refresh: statusDBProxy(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*rds.DBProxy); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -236,3 +236,20 @@ func waitDBInstanceAutomatedBackupDeleted(conn *rds.RDS, dbInstanceID, dbInstanc
 
 	return nil, err
 }
+
+func waitDBProxyCreated(conn *rds.RDS, name string, timeout time.Duration) (*rds.DBProxy, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{rds.DBProxyStatusCreating},
+		Target:  []string{rds.DBProxyStatusAvailable},
+		Refresh: statusDBProxy(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*rds.DBProxy); ok {
+		return output, err
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR adds the username parameter into the auth config for the RDS proxy, to match the API provided by AWS for the proxy. I have not included an acceptance test for setting the username field, as the behaviour of the API with this parameter does not support it: the API returns an error for requests setting both `username` and `auth_scheme`. Setting `username` without `auth_scheme` is successful but leads to a diff in the subsequent plan, as `auth_scheme` is added automatically to the resource.

It seemed sensible to make the terraform provider fully support the parameters available in the API, even though the username parameter doesn't do much.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20146 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
I did these in a few batches to avoid VPC quota issues.
```
$ make testacc TESTS=TestAccRDSProxy_n PKG=rds                         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 7 -run='TestAccRDSProxy_n'  -timeout 180m
=== RUN   TestAccRDSProxy_name
=== PAUSE TestAccRDSProxy_name
=== CONT  TestAccRDSProxy_name
--- PASS: TestAccRDSProxy_name (609.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        609.741s

$ make testacc TESTS=TestAccRDSProxy_[db] PKG=rds 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 7 -run='TestAccRDSProxy_[db]'  -timeout 180m
=== RUN   TestAccRDSProxy_basic
=== PAUSE TestAccRDSProxy_basic
=== RUN   TestAccRDSProxy_debugLogging
=== PAUSE TestAccRDSProxy_debugLogging
=== RUN   TestAccRDSProxy_disappears
=== PAUSE TestAccRDSProxy_disappears
=== CONT  TestAccRDSProxy_basic
=== CONT  TestAccRDSProxy_disappears
=== CONT  TestAccRDSProxy_debugLogging
--- PASS: TestAccRDSProxy_basic (523.43s)
--- PASS: TestAccRDSProxy_debugLogging (611.90s)
--- PASS: TestAccRDSProxy_disappears (652.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        652.368s

$ make testacc TESTS=TestAccRDSProxy_a PKG=rds  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 7 -run='TestAccRDSProxy_a'  -timeout 180m
=== RUN   TestAccRDSProxy_authDescription
=== PAUSE TestAccRDSProxy_authDescription
=== RUN   TestAccRDSProxy_authIAMAuth
=== PAUSE TestAccRDSProxy_authIAMAuth
=== RUN   TestAccRDSProxy_authSecretARN
=== PAUSE TestAccRDSProxy_authSecretARN
=== RUN   TestAccRDSProxy_authUsername
=== PAUSE TestAccRDSProxy_authUsername
=== CONT  TestAccRDSProxy_authDescription
=== CONT  TestAccRDSProxy_authSecretARN
=== CONT  TestAccRDSProxy_authIAMAuth
=== CONT  TestAccRDSProxy_authUsername
--- PASS: TestAccRDSProxy_authIAMAuth (529.97s)
--- PASS: TestAccRDSProxy_authDescription (540.66s)
--- PASS: TestAccRDSProxy_authUsername (592.87s)
--- PASS: TestAccRDSProxy_authSecretARN (621.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        621.895s

$ make testacc TESTS=TestAccRDSProxy_[rivt] PKG=rds                               ⎈ (kmi-ap1-uat-alpha/accounts-services)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 7 -run='TestAccRDSProxy_[rivt]'  -timeout 180m
=== RUN   TestAccRDSProxy_idleClientTimeout
=== PAUSE TestAccRDSProxy_idleClientTimeout
=== RUN   TestAccRDSProxy_requireTLS
=== PAUSE TestAccRDSProxy_requireTLS
=== RUN   TestAccRDSProxy_roleARN
=== PAUSE TestAccRDSProxy_roleARN
=== RUN   TestAccRDSProxy_vpcSecurityGroupIDs
=== PAUSE TestAccRDSProxy_vpcSecurityGroupIDs
=== RUN   TestAccRDSProxy_tags
=== PAUSE TestAccRDSProxy_tags
=== CONT  TestAccRDSProxy_idleClientTimeout
=== CONT  TestAccRDSProxy_vpcSecurityGroupIDs
=== CONT  TestAccRDSProxy_roleARN
=== CONT  TestAccRDSProxy_tags
=== CONT  TestAccRDSProxy_requireTLS
--- PASS: TestAccRDSProxy_tags (603.20s)
--- PASS: TestAccRDSProxy_roleARN (658.33s)
--- PASS: TestAccRDSProxy_vpcSecurityGroupIDs (668.33s)
--- PASS: TestAccRDSProxy_idleClientTimeout (685.29s)
--- PASS: TestAccRDSProxy_requireTLS (775.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        775.481s
```
