### PR TITLE
r/s3_bucket_server_side_encryption_configuration: retry on SSE not found errors

### DIFF
--- a/.changelog/24266.txt
+++ b/.changelog/24266.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_server_side_encryption_configuration: Retry on `ServerSideEncryptionConfigurationNotFoundError` errors due to eventual consistency
+```


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24232

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccS3BucketServer' PKG=s3 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 5  -run=TestAccS3BucketServer -timeout 180m
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_basic
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_basic
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_disappears
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_disappears
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyArn
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyArn
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_basic
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyArn
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_basic (26.39s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS (26.42s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_disappears
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyArn (26.58s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID (26.58s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm (43.38s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256 (21.30s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange (33.14s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled (37.83s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange (31.58s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled (36.05s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_disappears (77.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	107.389s
```
