### PR TITLE
fix: add validation to passwords field of elasticache replication group

### DIFF
--- a/.changelog/24274.txt
+++ b/.changelog/24274.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_user: Add plan-time validation of password argumnet length
+```

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -53,10 +53,13 @@ func ResourceUser() *schema.Resource {
 				Default:  false,
 			},
 			"passwords": {
-				Type:      schema.TypeSet,
-				Optional:  true,
-				MaxItems:  2,
-				Elem:      &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 2,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(16, 128),
+				},
 				Sensitive: true,
 			},
 			"tags":     tftags.TagsSchema(),


### PR DESCRIPTION
This PR adds in the validation logic using existing validation with the SDK to validate that a user password for an elasticache cluster is within a specific range.  Without this, a module may fail after initial validation which is especially problematic for long running Terraform scripts.

Signed-off-by: Dustin Scott <sdustin@vmware.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24273 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccElastiCacheUser_* PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser_*'  -timeout 180m
=== RUN   TestAccElastiCacheUserDataSource_basic
=== PAUSE TestAccElastiCacheUserDataSource_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_update
=== PAUSE TestAccElastiCacheUserGroup_update
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUserGroup_disappears
=== PAUSE TestAccElastiCacheUserGroup_disappears
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== CONT  TestAccElastiCacheUserDataSource_basic
=== CONT  TestAccElastiCacheUser_basic
=== CONT  TestAccElastiCacheUser_disappears
=== CONT  TestAccElastiCacheUser_update
=== CONT  TestAccElastiCacheUserGroup_update
=== CONT  TestAccElastiCacheUserGroup_tags
=== CONT  TestAccElastiCacheUser_tags
=== CONT  TestAccElastiCacheUserGroup_basic
=== CONT  TestAccElastiCacheUserGroup_disappears
=== CONT  TestAccElastiCacheUserGroupAssociation_update
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
--- PASS: TestAccElastiCacheUser_basic (81.37s)
--- PASS: TestAccElastiCacheUserDataSource_basic (82.32s)
--- PASS: TestAccElastiCacheUser_disappears (104.62s)
--- PASS: TestAccElastiCacheUser_tags (144.28s)
--- PASS: TestAccElastiCacheUser_update (145.23s)
--- PASS: TestAccElastiCacheUserGroup_disappears (208.57s)
--- PASS: TestAccElastiCacheUserGroup_basic (210.24s)
--- PASS: TestAccElastiCacheUserGroup_tags (269.85s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (334.15s)
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (334.54s)
--- PASS: TestAccElastiCacheUserGroup_update (335.89s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (459.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        461.141s
```
