### PR TITLE
elasticache: ISO tagging, check for additional error

### DIFF
--- a/.changelog/24275.txt
+++ b/.changelog/24275.txt
@@ -1,0 +1,27 @@
+```release-note:bug
+data-source/aws_elasticache_cluster: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:bug
+resource/aws_elasticache_cluster: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:bug
+resource/aws_elasticache_parameter_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:bug
+resource/aws_elasticache_replication_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:bug
+resource/aws_elasticache_subnet_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:bug
+resource/aws_elasticache_user_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:bug
+resource/aws_elasticache_user: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/24275.txt
+++ b/.changelog/24275.txt
@@ -1,27 +1,27 @@
 ```release-note:bug
-data-source/aws_elasticache_cluster: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+data-source/aws_elasticache_cluster: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```
 
 ```release-note:bug
-resource/aws_elasticache_cluster: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+resource/aws_elasticache_cluster: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```
 
 ```release-note:bug
-resource/aws_elasticache_parameter_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+resource/aws_elasticache_parameter_group: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```
 
 ```release-note:bug
-resource/aws_elasticache_replication_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+resource/aws_elasticache_replication_group: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```
 
 ```release-note:bug
-resource/aws_elasticache_subnet_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+resource/aws_elasticache_subnet_group: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```
 
 ```release-note:bug
-resource/aws_elasticache_user_group: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+resource/aws_elasticache_user_group: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```
 
 ```release-note:bug
-resource/aws_elasticache_user: Gracefully handle additional error type in non-standard AWS partitions (i.e., ISO)
+resource/aws_elasticache_user: Gracefully handle additional tagging error type in non-standard AWS partitions (i.e., ISO)
 ```

--- a/internal/service/elasticache/cluster_data_source_test.go
+++ b/internal/service/elasticache/cluster_data_source_test.go
@@ -41,6 +41,10 @@ func TestAccElastiCacheClusterDataSource_Data_basic(t *testing.T) {
 }
 
 func TestAccElastiCacheClusterDataSource_Engine_Redis_LogDeliveryConfigurations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_elasticache_cluster.test"
 

--- a/internal/service/elasticache/cluster_data_source_test.go
+++ b/internal/service/elasticache/cluster_data_source_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccElastiCacheClusterDataSource_Data_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 	dataSourceName := "data.aws_elasticache_cluster.test"

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -384,6 +384,10 @@ func TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZo
 }
 
 func TestAccElastiCacheCluster_vpc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var csg elasticache.CacheSubnetGroup
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -777,6 +781,10 @@ func TestAccElastiCacheCluster_Memcached_finalSnapshot(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_Redis_finalSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -799,6 +807,10 @@ func TestAccElastiCacheCluster_Redis_finalSnapshot(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -836,6 +848,10 @@ func TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -31,6 +31,10 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 }
 
 func TestAccElastiCacheCluster_Engine_memcached(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -65,6 +69,10 @@ func TestAccElastiCacheCluster_Engine_memcached(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -99,6 +107,10 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_Engine_redis_v5(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -151,6 +163,10 @@ func TestAccElastiCacheCluster_Engine_None(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_PortRedis_default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -171,6 +187,10 @@ func TestAccElastiCacheCluster_PortRedis_default(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_ParameterGroupName_default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -204,6 +224,10 @@ func TestAccElastiCacheCluster_ParameterGroupName_default(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_port(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	port := 11212
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -265,6 +289,10 @@ func TestAccElastiCacheCluster_SecurityGroup_ec2Classic(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_snapshotsWithUpdates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -295,6 +323,10 @@ func TestAccElastiCacheCluster_snapshotsWithUpdates(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_NumCacheNodes_decrease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -324,6 +356,10 @@ func TestAccElastiCacheCluster_NumCacheNodes_decrease(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_NumCacheNodes_increase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -353,6 +389,10 @@ func TestAccElastiCacheCluster_NumCacheNodes_increase(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -411,6 +451,10 @@ func TestAccElastiCacheCluster_vpc(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_multiAZInVPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var csg elasticache.CacheSubnetGroup
 	var ec elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -434,6 +478,10 @@ func TestAccElastiCacheCluster_multiAZInVPC(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_AZMode_memcached(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -468,6 +516,10 @@ func TestAccElastiCacheCluster_AZMode_memcached(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_AZMode_redis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -498,6 +550,10 @@ func TestAccElastiCacheCluster_AZMode_redis(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_EngineVersion_memcached(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var pre, mid, post elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -539,6 +595,10 @@ func TestAccElastiCacheCluster_EngineVersion_memcached(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var v1, v2, v3, v4, v5 elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -598,6 +658,10 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_NodeTypeResize_memcached(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var pre, post elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -628,6 +692,10 @@ func TestAccElastiCacheCluster_NodeTypeResize_memcached(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_NodeTypeResize_redis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var pre, post elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -675,6 +743,10 @@ func TestAccElastiCacheCluster_NumCacheNodes_redis(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	var replicationGroup elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -700,6 +772,10 @@ func TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone(t *testing.T)
 }
 
 func TestAccElastiCacheCluster_ReplicationGroupID_singleReplica(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	var replicationGroup elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -728,6 +804,10 @@ func TestAccElastiCacheCluster_ReplicationGroupID_singleReplica(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster1, cluster2 elasticache.CacheCluster
 	var replicationGroup elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -975,6 +1055,10 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 }
 
 func TestAccElastiCacheCluster_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
@@ -1028,6 +1112,10 @@ func TestAccElastiCacheCluster_tags(t *testing.T) {
 }
 
 func TestAccElastiCacheCluster_tagWithOtherModification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var cluster elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestAccElastiCacheGlobalReplicationGroup_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var globalReplicationGroup elasticache.GlobalReplicationGroup
 	var primaryReplicationGroup elasticache.ReplicationGroup
 
@@ -63,6 +67,10 @@ func TestAccElastiCacheGlobalReplicationGroup_basic(t *testing.T) {
 }
 
 func TestAccElastiCacheGlobalReplicationGroup_description(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var globalReplicationGroup elasticache.GlobalReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -100,6 +108,10 @@ func TestAccElastiCacheGlobalReplicationGroup_description(t *testing.T) {
 }
 
 func TestAccElastiCacheGlobalReplicationGroup_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var globalReplicationGroup elasticache.GlobalReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -124,6 +136,10 @@ func TestAccElastiCacheGlobalReplicationGroup_disappears(t *testing.T) {
 }
 
 func TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var providers []*schema.Provider
 	var globalReplcationGroup elasticache.GlobalReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -149,6 +165,10 @@ func TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries(t *testing.T) 
 }
 
 func TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var providers []*schema.Provider
 	var globalReplcationGroup elasticache.GlobalReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -180,6 +200,10 @@ func TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion(t
 }
 
 func TestAccElastiCacheGlobalReplicationGroup_clusterMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var globalReplicationGroup elasticache.GlobalReplicationGroup
 	var primaryReplicationGroup elasticache.ReplicationGroup
 

--- a/internal/service/elasticache/replication_group_data_source_test.go
+++ b/internal/service/elasticache/replication_group_data_source_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestAccElastiCacheReplicationGroupDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	dataSourceName := "data.aws_elasticache_replication_group.test"
@@ -46,6 +50,10 @@ func TestAccElastiCacheReplicationGroupDataSource_basic(t *testing.T) {
 }
 
 func TestAccElastiCacheReplicationGroupDataSource_clusterMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	dataSourceName := "data.aws_elasticache_replication_group.test"
@@ -75,6 +83,10 @@ func TestAccElastiCacheReplicationGroupDataSource_clusterMode(t *testing.T) {
 }
 
 func TestAccElastiCacheReplicationGroupDataSource_multiAZ(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	dataSourceName := "data.aws_elasticache_replication_group.test"
@@ -111,6 +123,10 @@ func TestAccElastiCacheReplicationGroupDataSource_nonExistent(t *testing.T) {
 }
 
 func TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_elasticache_replication_group.test"
 

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -1981,6 +1981,10 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic(t *testin
 }
 
 func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var providers []*schema.Provider
 	var rg elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2097,6 +2101,10 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 }
 
 func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var rg elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -2187,6 +2195,10 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 }
 
 func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var rg elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2343,6 +2343,10 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValid
 }
 
 func TestAccElastiCacheReplicationGroup_dataTiering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var rg elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"

--- a/internal/service/elasticache/user_group_association_test.go
+++ b/internal/service/elasticache/user_group_association_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func TestAccElastiCacheUserGroupAssociation_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_user_group_association.test"
 
@@ -44,6 +48,10 @@ func TestAccElastiCacheUserGroupAssociation_basic(t *testing.T) {
 }
 
 func TestAccElastiCacheUserGroupAssociation_update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_user_group_association.test"
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -41,6 +41,7 @@ const (
 	ErrCodeInternalServiceError        = "InternalServiceError"
 	ErrCodeInvalidAction               = "InvalidAction"
 	ErrCodeInvalidParameterException   = "InvalidParameterException"
+	ErrCodeInvalidParameterValue       = "InvalidParameterValue"
 	ErrCodeInvalidRequest              = "InvalidRequest"
 	ErrCodeOperationDisabledException  = "OperationDisabledException"
 	ErrCodeOperationNotPermitted       = "OperationNotPermitted"
@@ -73,6 +74,10 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrCodeContains(err, ErrCodeInvalidParameterException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeInvalidParameterValue) {
 		return true
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18593
Relates #22532
Relates #23980
Closes #24276

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAcc PKG=elasticache TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAcc' -short -timeout 180m
--- PASS: TestAccElastiCacheParameterGroup_basic (25.09s)
--- PASS: TestAccElastiCacheSubnetGroup_basic (30.41s)
--- PASS: TestAccElastiCacheSubnetGroup_update (46.49s)
--- PASS: TestAccElastiCacheSubnetGroup_tags (59.17s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (4.68s)
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (0.75s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (1.80s)
--- PASS: TestAccElastiCacheUserDataSource_basic (67.54s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_nonExistent (2.25s)
--- PASS: TestAccElastiCacheUser_basic (70.33s)
--- PASS: TestAccElastiCacheUser_tags (71.26s)
--- PASS: TestAccElastiCacheUser_disappears (74.71s)
--- PASS: TestAccElastiCacheParameterGroup_tags (39.61s)
--- PASS: TestAccElastiCacheUser_update (127.60s)
--- PASS: TestAccElastiCacheParameterGroup_description (16.06s)
--- PASS: TestAccElastiCacheParameterGroup_uppercaseName (17.78s)
--- PASS: TestAccElastiCacheParameterGroup_updateReservedMemoryParameter (29.77s)
--- PASS: TestAccElastiCacheParameterGroup_switchReservedMemoryParameter (31.29s)
--- PASS: TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_remainingParameters (27.40s)
--- PASS: TestAccElastiCacheUserGroup_disappears (191.64s)
--- PASS: TestAccElastiCacheUserGroup_basic (193.30s)
--- PASS: TestAccElastiCacheUserGroup_tags (196.85s)
--- PASS: TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_allParameters (29.15s)
--- PASS: TestAccElastiCacheParameterGroup_removeAllParameters (25.67s)
--- PASS: TestAccElastiCacheParameterGroup_addParameter (28.35s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (311.25s)
--- PASS: TestAccElastiCacheUserGroup_update (318.22s)
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (318.33s)
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (1.87s)
--- PASS: TestAccElastiCacheClusterDataSource_Data_basic (438.27s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (440.43s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (722.95s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (732.46s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (740.85s)
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (524.63s)
--- PASS: TestAccElastiCacheCluster_vpc (479.11s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (902.61s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (910.92s)
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (709.70s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1033.23s)
--- PASS: TestAccElastiCacheCluster_AZMode_redis (473.30s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (1.90s)
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (435.27s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1289.63s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_disappears (1161.50s)
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (573.78s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1480.76s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1065.98s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode (1320.52s)
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (509.18s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (663.99s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (1622.87s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (648.11s)
--- PASS: TestAccElastiCacheCluster_Engine_None (0.72s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_basic (908.94s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1462.40s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (827.89s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (462.18s)
--- PASS: TestAccElastiCacheCluster_port (460.76s)
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (562.64s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1683.79s)
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (472.06s)
--- PASS: TestAccElastiCacheCluster_Engine_memcached (461.52s)
--- PASS: TestAccElastiCacheCluster_tags (474.21s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (461.52s)
--- PASS: TestAccElastiCacheCluster_PortRedis_default (502.14s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_description (1064.89s)
--- PASS: TestAccElastiCacheClusterDataSource_Engine_Redis_LogDeliveryConfigurations (691.19s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1193.09s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1163.95s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (927.23s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3060.58s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion (3513.79s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries (3652.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	3866.850s
```
