### PR TITLE
Fix a subtle bug with beanstalkCnamePrefixRegexp

### DIFF
--- a/.changelog/24278.txt
+++ b/.changelog/24278.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elastic_beanstalk_environment: Correctly set `cname_prefix` attribute
+```

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -571,7 +571,7 @@ func resourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if env.CNAME != nil {
-		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+)(.\w{2}-\w{4,9}-\d)?.(elasticbeanstalk.com|eb.amazonaws.com.cn)$`)
+		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+)(.\w{2}-\w{4,9}-\d)?\.(elasticbeanstalk\.com|eb\.amazonaws\.com\.cn)$`)
 		var cnamePrefix string
 		cnamePrefixMatch := beanstalkCnamePrefixRegexp.FindStringSubmatch(*env.CNAME)
 


### PR DESCRIPTION
Hey, there seems to be a subtle bug with the beanstalkCnamePrefixRegexp where it may match domains that are likely unexpected to be matched e.g. ebamazonaws.com.cn instead of eb.amazonaws.com.cn.

I've found this by accident, so please confirm if this commit/PR is correct before merging it.
