### PR TITLE
F/aws opensearch domain Support for cold_storage

### DIFF
--- a/.changelog/24284.txt
+++ b/.changelog/24284.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Add `cold_storage_options` argument to the `cluster_config` configuration block
+```

--- a/.changelog/24284.txt
+++ b/.changelog/24284.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_opensearch_domain: Add `cold_storage_options` argument to the `cluster_config` configuration block
 ```
+
+```release-note:enhancement
+data-source/aws_opensearch_domain: Add `cold_storage_options` attribute to the `cluster_config` configuration block
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -912,7 +912,7 @@ func resourceDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 					input.ClusterConfig = expandClusterConfig(m)
 
 					// Work around "ValidationException: Your domain's Elasticsearch version does not support cold storage options. Upgrade to Elasticsearch 7.9 or later.".
-					if engineType, version, err := ParseEngineVersion(d.Get("engine_version").(string)); err != nil {
+					if engineType, version, err := ParseEngineVersion(d.Get("engine_version").(string)); err == nil {
 						switch engineType {
 						case opensearchservice.EngineTypeElasticsearch:
 							if want, err := gversion.NewVersion("7.9"); err == nil {

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -167,6 +167,18 @@ func DataSourceDomain() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"cold_storage_options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"dedicated_master_count": {
 							Type:     schema.TypeInt,
 							Computed: true,

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1783,7 +1783,7 @@ func testAccDomainConfig_clusterWithColdStorageOptions(rName string, warmEnabled
 	if warmEnabled {
 		warmConfig = `
 	warm_count = "2"
-	warm_type = "ultrawarm1.medium.elasticsearch"
+	warm_type = "ultrawarm1.medium.search"
 `
 	}
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -22,6 +22,59 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func TestParseEngineVersion(t *testing.T) {
+	testCases := []struct {
+		TestName           string
+		InputEngineVersion string
+		ExpectError        bool
+		ExpectedEngineType string
+		ExpectedSemver     string
+	}{
+		{
+			TestName:    "empty engine version",
+			ExpectError: true,
+		},
+		{
+			TestName:           "no separator",
+			InputEngineVersion: "OpenSearch2.0",
+			ExpectError:        true,
+		},
+		{
+			TestName:           "too many separators",
+			InputEngineVersion: "Open_Search_2.0",
+			ExpectError:        true,
+		},
+		{
+			TestName:           "valid",
+			InputEngineVersion: "Elasticsearch_7.2",
+			ExpectedEngineType: "Elasticsearch",
+			ExpectedSemver:     "7.2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			engineType, semver, err := tfopensearch.ParseEngineVersion(testCase.InputEngineVersion)
+
+			if err == nil && testCase.ExpectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if err != nil && !testCase.ExpectError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if engineType != testCase.ExpectedEngineType {
+				t.Errorf("engine type got %s, expected %s", engineType, testCase.ExpectedEngineType)
+			}
+
+			if semver != testCase.ExpectedSemver {
+				t.Errorf("semver got %s, expected %s", semver, testCase.ExpectedSemver)
+			}
+		})
+	}
+}
+
 func TestAccOpenSearchDomain_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24195.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/19713.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccOpenSearchDomain_Cluster_coldStorage PKG=opensearch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_Cluster_coldStorage'  -timeout 180m
=== RUN   TestAccOpenSearchDomain_Cluster_coldStorage
=== PAUSE TestAccOpenSearchDomain_Cluster_coldStorage
=== CONT  TestAccOpenSearchDomain_Cluster_coldStorage
--- PASS: TestAccOpenSearchDomain_Cluster_coldStorage (3013.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearch	3019.363s

...
```
