### PR TITLE
rd/aw_ imagebuilder_infrastructure_configuration - instance metadata options

### DIFF
--- a/.changelog/24285.txt
+++ b/.changelog/24285.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_imagebuilder_infrastructure_configuration: Add `instance_metadata_options` argument
 ```
+
+```release-note:enhancement
+data-source/aws_imagebuilder_infrastructure_configuration: Add `instance_metadata_options` attribute
+```

--- a/.changelog/24285.txt
+++ b/.changelog/24285.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_infrastructure_configuration: Add `instance_metadata_options` argument
+```

--- a/internal/service/imagebuilder/infrastructure_configuration.go
+++ b/internal/service/imagebuilder/infrastructure_configuration.go
@@ -46,6 +46,25 @@ func ResourceInfrastructureConfiguration() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
+			"instance_metadata_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_put_response_hop_limit": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 64),
+						},
+						"http_tokens": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"required", "optional"}, false),
+						},
+					},
+				},
+			},
 			"instance_profile_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -138,6 +157,10 @@ func resourceInfrastructureConfigurationCreate(d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("instance_metadata_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.InstanceMetadataOptions = expandInstanceMetadataOptions(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("instance_profile_name"); ok {
@@ -245,6 +268,15 @@ func resourceInfrastructureConfigurationRead(d *schema.ResourceData, meta interf
 	d.Set("date_created", infrastructureConfiguration.DateCreated)
 	d.Set("date_updated", infrastructureConfiguration.DateUpdated)
 	d.Set("description", infrastructureConfiguration.Description)
+
+	if infrastructureConfiguration.InstanceMetadataOptions != nil {
+		d.Set("instance_metadata_options", []interface{}{
+			flattenInstanceMetadataOptions(infrastructureConfiguration.InstanceMetadataOptions),
+		})
+	} else {
+		d.Set("instance_metadata_options", nil)
+	}
+
 	d.Set("instance_profile_name", infrastructureConfiguration.InstanceProfileName)
 	d.Set("instance_types", aws.StringValueSlice(infrastructureConfiguration.InstanceTypes))
 	d.Set("key_pair", infrastructureConfiguration.KeyPair)
@@ -278,6 +310,7 @@ func resourceInfrastructureConfigurationUpdate(d *schema.ResourceData, meta inte
 
 	if d.HasChanges(
 		"description",
+		"instance_metadata_options",
 		"instance_profile_name",
 		"instance_types",
 		"key_pair",
@@ -295,6 +328,10 @@ func resourceInfrastructureConfigurationUpdate(d *schema.ResourceData, meta inte
 
 		if v, ok := d.GetOk("description"); ok {
 			input.Description = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("instance_metadata_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			input.InstanceMetadataOptions = expandInstanceMetadataOptions(v.([]interface{})[0].(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("instance_profile_name"); ok {
@@ -383,6 +420,24 @@ func resourceInfrastructureConfigurationDelete(d *schema.ResourceData, meta inte
 	return nil
 }
 
+func expandInstanceMetadataOptions(tfMap map[string]interface{}) *imagebuilder.InstanceMetadataOptions {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.InstanceMetadataOptions{}
+
+	if v, ok := tfMap["http_put_response_hop_limit"].(int); ok && v != 0 {
+		apiObject.HttpPutResponseHopLimit = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["http_tokens"].(string); ok && v != "" {
+		apiObject.HttpTokens = aws.String(v)
+	}
+
+	return apiObject
+}
+
 func expandLogging(tfMap map[string]interface{}) *imagebuilder.Logging {
 	if tfMap == nil {
 		return nil
@@ -413,6 +468,24 @@ func expandS3Logs(tfMap map[string]interface{}) *imagebuilder.S3Logs {
 	}
 
 	return apiObject
+}
+
+func flattenInstanceMetadataOptions(apiObject *imagebuilder.InstanceMetadataOptions) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.HttpPutResponseHopLimit; v != nil {
+		tfMap["http_put_response_hop_limit"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.HttpTokens; v != nil {
+		tfMap["http_tokens"] = aws.StringValue(v)
+	}
+
+	return tfMap
 }
 
 func flattenLogging(apiObject *imagebuilder.Logging) map[string]interface{} {

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source.go
@@ -33,6 +33,22 @@ func DataSourceInfrastructureConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"instance_metadata_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_put_response_hop_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"http_tokens": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"instance_profile_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -124,6 +140,13 @@ func dataSourceInfrastructureConfigurationRead(d *schema.ResourceData, meta inte
 	d.Set("date_created", infrastructureConfiguration.DateCreated)
 	d.Set("date_updated", infrastructureConfiguration.DateUpdated)
 	d.Set("description", infrastructureConfiguration.Description)
+
+	if infrastructureConfiguration.InstanceMetadataOptions != nil {
+		d.Set("instance_metadata_options", []interface{}{flattenInstanceMetadataOptions(infrastructureConfiguration.InstanceMetadataOptions)})
+	} else {
+		d.Set("instance_metadata_options", nil)
+	}
+
 	d.Set("instance_profile_name", infrastructureConfiguration.InstanceProfileName)
 	d.Set("instance_types", aws.StringValueSlice(infrastructureConfiguration.InstanceTypes))
 	d.Set("key_pair", infrastructureConfiguration.KeyPair)

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccImageBuilderInfrastructureConfigurationDataSource_arn(t *testing.T) 
 					resource.TestCheckResourceAttrPair(dataSourceName, "date_created", resourceName, "date_created"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "date_updated", resourceName, "date_updated"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instance_metadata_options.#", resourceName, "instance_metadata_options.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "instance_profile_name", resourceName, "instance_profile_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "instance_types.#", resourceName, "instance_types.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "key_pair", resourceName, "key_pair"),

--- a/internal/service/imagebuilder/infrastructure_configuration_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_test.go
@@ -34,6 +34,7 @@ func TestAccImageBuilderInfrastructureConfiguration_basic(t *testing.T) {
 					acctest.CheckResourceAttrRFC3339(resourceName, "date_created"),
 					resource.TestCheckResourceAttr(resourceName, "date_updated", ""),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.#", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_profile_name", iamInstanceProfileResourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "key_pair", ""),
@@ -107,6 +108,34 @@ func TestAccImageBuilderInfrastructureConfiguration_description(t *testing.T) {
 					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckInfrastructureConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfrastructureConfigurationInstanceMetadataOptionsConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.0.http_put_response_hop_limit", "64"),
+					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.0.http_tokens", "required"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -618,6 +647,22 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
   name                  = %[1]q
 }
 `, rName, description))
+}
+
+func testAccInfrastructureConfigurationInstanceMetadataOptionsConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccInfrastructureConfigurationBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name = %[1]q
+
+  instance_metadata_options {
+	http_put_response_hop_limit = 64
+	http_tokens = "required"
+  }
+}
+`, rName))
 }
 
 func testAccInfrastructureConfigurationInstanceProfileName1Config(rName string) string {

--- a/internal/service/imagebuilder/infrastructure_configuration_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_test.go
@@ -655,11 +655,11 @@ func testAccInfrastructureConfigurationInstanceMetadataOptionsConfig(rName strin
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
-  name = %[1]q
+  name                  = %[1]q
 
   instance_metadata_options {
-	http_put_response_hop_limit = 64
-	http_tokens = "required"
+    http_put_response_hop_limit = 64
+    http_tokens                 = "required"
   }
 }
 `, rName))

--- a/website/docs/d/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/d/imagebuilder_infrastructure_configuration.html.markdown
@@ -31,6 +31,9 @@ In addition to all arguments above, the following attributes are exported:
 * `date_created` - Date the infrastructure configuration was created.
 * `date_created` - Date the infrastructure configuration was updated.
 * `description` - Description of the infrastructure configuration.
+* `instance_metadata_options` - Nested list of instance metadata options for the HTTP requests that pipeline builds use to launch EC2 build and test instances.
+    * `http_put_response_hop_limit` - Number of hops that an instance can traverse to reach its destonation.
+    * `http_tokens` - Whether a signed token is required for instance metadata retrieval requests.
 * `instance_profile_name` - Name of the IAM Instance Profile associated with the configuration.
 * `instance_types` - Set of EC2 Instance Types associated with the configuration.
 * `key_pair` - Name of the EC2 Key Pair associated with the configuration.

--- a/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
@@ -47,6 +47,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `description` - (Optional) Description for the configuration.
+* `instance_metadata_options` - (Optional) Configuration block with instance metadata options for the HTTP requests that pipeline builds use to launch EC2 build and test instances. Detailed below.
 * `instance_types` - (Optional) Set of EC2 Instance Types.
 * `key_pair` - (Optional) Name of EC2 Key Pair.
 * `logging` - (Optional) Configuration block with logging settings. Detailed below.
@@ -56,6 +57,13 @@ The following arguments are optional:
 * `subnet_id` - (Optional) EC2 Subnet identifier. Also requires `security_group_ids` argument.
 * `tags` - (Optional) Key-value map of resource tags to assign to the configuration. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `terminate_instance_on_failure` - (Optional) Enable if the instance should be terminated when the pipeline fails. Defaults to `false`.
+
+### instance_metadata_options
+
+The following arguments are optional:
+
+* `http_put_response_hop_limit` - The number of hops that an instance can traverse to reach its destonation.
+* `http_tokens` - Whether a signed token is required for instance metadata retrieval requests. Valid values: `required`, `optional`.
 
 ### logging
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24006.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=imagebuilder TESTS="TestAccImageBuilderInfrastructureConfiguration_|TestAccImageBuilderInfrastructureConfigurationDataSource_" ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 2 -run='TestAccImageBuilderInfrastructureConfiguration_|TestAccImageBuilderInfrastructureConfigurationDataSource_'  -timeout 180m
=== RUN   TestAccImageBuilderInfrastructureConfigurationDataSource_arn
=== PAUSE TestAccImageBuilderInfrastructureConfigurationDataSource_arn
=== RUN   TestAccImageBuilderInfrastructureConfiguration_basic
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_basic
=== RUN   TestAccImageBuilderInfrastructureConfiguration_disappears
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_disappears
=== RUN   TestAccImageBuilderInfrastructureConfiguration_description
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_description
=== RUN   TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions
=== RUN   TestAccImageBuilderInfrastructureConfiguration_instanceProfileName
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_instanceProfileName
=== RUN   TestAccImageBuilderInfrastructureConfiguration_instanceTypes
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_instanceTypes
=== RUN   TestAccImageBuilderInfrastructureConfiguration_keyPair
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_keyPair
=== RUN   TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName
=== RUN   TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix
=== RUN   TestAccImageBuilderInfrastructureConfiguration_resourceTags
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_resourceTags
=== RUN   TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs
=== RUN   TestAccImageBuilderInfrastructureConfiguration_snsTopicARN
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_snsTopicARN
=== RUN   TestAccImageBuilderInfrastructureConfiguration_subnetID
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_subnetID
=== RUN   TestAccImageBuilderInfrastructureConfiguration_tags
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_tags
=== RUN   TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure
=== CONT  TestAccImageBuilderInfrastructureConfigurationDataSource_arn
=== CONT  TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName
--- PASS: TestAccImageBuilderInfrastructureConfigurationDataSource_arn (43.06s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName (90.97s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_tags
--- PASS: TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure (62.03s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_subnetID
--- PASS: TestAccImageBuilderInfrastructureConfiguration_subnetID (66.31s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_snsTopicARN
--- PASS: TestAccImageBuilderInfrastructureConfiguration_tags (85.36s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs
--- PASS: TestAccImageBuilderInfrastructureConfiguration_snsTopicARN (67.83s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_resourceTags
--- PASS: TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs (65.72s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix (73.36s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions
--- PASS: TestAccImageBuilderInfrastructureConfiguration_resourceTags (94.31s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_keyPair
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions (40.43s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_instanceTypes
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceTypes (64.98s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_instanceProfileName
--- PASS: TestAccImageBuilderInfrastructureConfiguration_keyPair (96.57s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_disappears
--- PASS: TestAccImageBuilderInfrastructureConfiguration_disappears (36.50s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_description
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceProfileName (72.53s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_basic
--- PASS: TestAccImageBuilderInfrastructureConfiguration_description (62.79s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_basic (40.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       535.338s
```
