### PR TITLE
source large enum validations from AWS Go SDK

### DIFF
--- a/.changelog/24286.txt
+++ b/.changelog/24286.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_waf_byte_match_set: Additional supported values for `byte_match_tuples.field_to_match.type` argument
+```
+
+```release-note:enhancement
+resource/aws_wafregional_web_acl: Additional supported values for `logging_configuration.redacted_fields.field_to_match.type` argument
+```
+
+```release-note:enhancement
+resource/aws_workspaces_workspace: Additional supported values for `workspace_properties.compute_type_name` argument
+```

--- a/internal/service/waf/byte_match_set.go
+++ b/internal/service/waf/byte_match_set.go
@@ -44,8 +44,8 @@ func ResourceByteMatchSet() *schema.Resource {
 										Optional: true,
 									},
 									"type": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
 										ValidateFunc: validation.StringInSlice(waf.MatchFieldType_Values(), false),
 									},
 								},

--- a/internal/service/waf/byte_match_set.go
+++ b/internal/service/waf/byte_match_set.go
@@ -46,15 +46,7 @@ func ResourceByteMatchSet() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											waf.MatchFieldTypeUri,
-											waf.MatchFieldTypeQueryString,
-											waf.MatchFieldTypeHeader,
-											waf.MatchFieldTypeMethod,
-											waf.MatchFieldTypeBody,
-											waf.MatchFieldTypeSingleQueryArg,
-											waf.MatchFieldTypeAllQueryArgs,
-										}, false),
+										ValidateFunc: validation.StringInSlice(waf.MatchFieldType_Values(), false),
 									},
 								},
 							},

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -55,7 +55,7 @@ func ResourceRule() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validPredicatesType(),
+							ValidateFunc: validation.StringInSlice(wafregional.PredicateType_Values(), false),
 						},
 					},
 				},

--- a/internal/service/wafregional/validate.go
+++ b/internal/service/wafregional/validate.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-
-	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func validMetricName(v interface{}, k string) (ws []string, errors []error) {

--- a/internal/service/wafregional/validate.go
+++ b/internal/service/wafregional/validate.go
@@ -20,18 +20,6 @@ func validMetricName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validPredicatesType() schema.SchemaValidateFunc {
-	return validation.StringInSlice([]string{
-		waf.PredicateTypeByteMatch,
-		waf.PredicateTypeGeoMatch,
-		waf.PredicateTypeIpmatch,
-		waf.PredicateTypeRegexMatch,
-		waf.PredicateTypeSizeConstraint,
-		waf.PredicateTypeSqlInjectionMatch,
-		waf.PredicateTypeXssMatch,
-	}, false)
-}
-
 func sliceContainsMap(l []interface{}, m map[string]interface{}) (int, bool) {
 	for i, t := range l {
 		if reflect.DeepEqual(m, t.(map[string]interface{})) {

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -84,15 +84,7 @@ func ResourceWebACL() *schema.Resource {
 												"type": {
 													Type:     schema.TypeString,
 													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														waf.MatchFieldTypeAllQueryArgs,
-														waf.MatchFieldTypeBody,
-														waf.MatchFieldTypeHeader,
-														waf.MatchFieldTypeMethod,
-														waf.MatchFieldTypeQueryString,
-														waf.MatchFieldTypeSingleQueryArg,
-														waf.MatchFieldTypeUri,
-													}, false),
+													ValidateFunc: validation.StringInSlice(wafregional.MatchFieldType_Values(), false),
 												},
 											},
 										},

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -82,8 +82,8 @@ func ResourceWebACL() *schema.Resource {
 													Optional: true,
 												},
 												"type": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
 													ValidateFunc: validation.StringInSlice(wafregional.MatchFieldType_Values(), false),
 												},
 											},

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -79,15 +79,7 @@ func ResourceWorkspace() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  workspaces.ComputeValue,
-							ValidateFunc: validation.StringInSlice([]string{
-								workspaces.ComputeValue,
-								workspaces.ComputeStandard,
-								workspaces.ComputePerformance,
-								workspaces.ComputePower,
-								workspaces.ComputePowerpro,
-								workspaces.ComputeGraphics,
-								workspaces.ComputeGraphicspro,
-							}, false),
+							ValidateFunc: validation.StringInSlice(workspaces.Compute_Values(), false),
 						},
 						"root_volume_size_gib": {
 							Type:     schema.TypeInt,

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -76,9 +76,9 @@ func ResourceWorkspace() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"compute_type_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  workspaces.ComputeValue,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      workspaces.ComputeValue,
 							ValidateFunc: validation.StringInSlice(workspaces.Compute_Values(), false),
 						},
 						"root_volume_size_gib": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/14601.
picks up a couple new workspace compute types: `GRAPHICS_G4DN` and `GRAPHICSPRO_G4DN`