### PR TITLE
Fix function_name argument example

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -16,7 +16,7 @@ Gives an external source (like an EventBridge Rule, SNS, or S3) permission to ac
 resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.test_lambda.function_name
+  function_name = aws_lambda_function.test_lambda.arn
   principal     = "events.amazonaws.com"
   source_arn    = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
   qualifier     = aws_lambda_alias.test_alias.name
@@ -64,7 +64,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 resource "aws_lambda_permission" "with_sns" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.func.function_name
+  function_name = aws_lambda_function.func.arn
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.default.arn
 }
@@ -133,7 +133,7 @@ resource "aws_lambda_permission" "lambda_permission" {
 ```terraform
 resource "aws_lambda_permission" "logging" {
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.logging.function_name
+  function_name = aws_lambda_function.logging.arn
   principal     = "logs.eu-west-1.amazonaws.com"
   source_arn    = "${aws_cloudwatch_log_group.default.arn}:*"
 }


### PR DESCRIPTION
ARN is required in order to associate aws_lambda_permission with correct Lambda function

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
