### PR TITLE
r/shield_protection_group: use `protection_group_arn` parameter when updating tags

### DIFF
--- a/.changelog/24296.txt
+++ b/.changelog/24296.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_shield_protection_group: When updating resource tags, use the `protection_group_arn` parameter instead of `arn`.
+```

--- a/internal/service/shield/protection_group.go
+++ b/internal/service/shield/protection_group.go
@@ -163,30 +163,32 @@ func resourceProtectionGroupRead(d *schema.ResourceData, meta interface{}) error
 func resourceProtectionGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ShieldConn
 
-	input := &shield.UpdateProtectionGroupInput{
-		Aggregation:       aws.String(d.Get("aggregation").(string)),
-		Pattern:           aws.String(d.Get("pattern").(string)),
-		ProtectionGroupId: aws.String(d.Id()),
-	}
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &shield.UpdateProtectionGroupInput{
+			Aggregation:       aws.String(d.Get("aggregation").(string)),
+			Pattern:           aws.String(d.Get("pattern").(string)),
+			ProtectionGroupId: aws.String(d.Id()),
+		}
 
-	if v, ok := d.GetOk("members"); ok {
-		input.Members = flex.ExpandStringList(v.([]interface{}))
-	}
+		if v, ok := d.GetOk("members"); ok {
+			input.Members = flex.ExpandStringList(v.([]interface{}))
+		}
 
-	if v, ok := d.GetOk("resource_type"); ok {
-		input.ResourceType = aws.String(v.(string))
-	}
+		if v, ok := d.GetOk("resource_type"); ok {
+			input.ResourceType = aws.String(v.(string))
+		}
 
-	log.Printf("[DEBUG] Updating Shield Protection Group: %s", input)
-	_, err := conn.UpdateProtectionGroup(input)
+		log.Printf("[DEBUG] Updating Shield Protection Group: %s", input)
+		_, err := conn.UpdateProtectionGroup(input)
 
-	if err != nil {
-		return fmt.Errorf("error updating Shield Protection Group (%s): %w", d.Id(), err)
+		if err != nil {
+			return fmt.Errorf("error updating Shield Protection Group (%s): %w", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTags(conn, d.Get("protection_group_arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24245

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccShieldProtectionGroup_disappears (50.71s)
--- PASS: TestAccShieldProtectionGroup_basic (72.69s)
--- PASS: TestAccShieldProtectionGroup_members (77.52s)
--- PASS: TestAccShieldProtectionGroup_aggregation (111.73s)
--- PASS: TestAccShieldProtectionGroup_protectionGroupID (113.33s)
--- PASS: TestAccShieldProtectionGroup_resourceType (115.03s)
--- PASS: TestAccShieldProtectionGroup_tags (126.84s)
```
