### PR TITLE
ds/efs_file_system: return error when filtering by tags returns results != 1

### DIFF
--- a/.changelog/24298.txt
+++ b/.changelog/24298.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_efs_file_system: Prevent panic when searching by tag returns 0 or multiple results
+```

--- a/internal/service/efs/file_system_data_source.go
+++ b/internal/service/efs/file_system_data_source.go
@@ -116,7 +116,7 @@ func dataSourceFileSystemRead(d *schema.ResourceData, meta interface{}) error {
 		return errors.New("error reading EFS FileSystem: empty output")
 	}
 
-	var results []*efs.FileSystemDescription
+	results := describeResp.FileSystems
 
 	if len(tagsToMatch) > 0 {
 
@@ -134,12 +134,10 @@ func dataSourceFileSystemRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		results = fileSystems
-	} else {
-		results = describeResp.FileSystems
 	}
 
-	if len(results) > 1 {
-		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(results))
+	if count := len(results); count != 1 {
+		return fmt.Errorf("Search returned %d results, please revise so only one is returned", count)
 	}
 
 	fs := results[0]

--- a/internal/service/efs/file_system_data_source_test.go
+++ b/internal/service/efs/file_system_data_source_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/efs"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -122,8 +123,7 @@ func TestAccEFSFileSystemDataSource_availabilityZone(t *testing.T) {
 	})
 }
 
-func TestAccEFSFileSystemDataSource_nonExistent(t *testing.T) {
-
+func TestAccEFSFileSystemDataSource_nonExistent_fileSystemID(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, efs.EndpointsID),
@@ -132,6 +132,30 @@ func TestAccEFSFileSystemDataSource_nonExistent(t *testing.T) {
 			{
 				Config:      testAccFileSystemIDDataSourceConfig_NonExistent,
 				ExpectError: regexp.MustCompile(`error reading EFS FileSystem`),
+			},
+		},
+	})
+}
+
+func TestAccEFSFileSystemDataSource_nonExistent_tags(t *testing.T) {
+	var desc efs.FileSystemDescription
+	resourceName := "aws_efs_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, efs.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFileSystemConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsFileSystem(resourceName, &desc),
+				),
+			},
+			{
+				Config:      testAccFileSystemTagsDataSourceConfig_NonExistent(rName),
+				ExpectError: regexp.MustCompile(`Search returned 0 results`),
 			},
 		},
 	})
@@ -176,6 +200,18 @@ data "aws_efs_file_system" "test" {
   file_system_id = "fs-nonexistent"
 }
 `
+
+func testAccFileSystemTagsDataSourceConfig_NonExistent(rName string) string {
+	return acctest.ConfigCompose(
+		testAccFileSystemConfig(rName),
+		`
+data "aws_efs_file_system" "test" {
+  tags = {
+    Name = "Does_Not_Exist"
+  }
+}
+`)
+}
 
 const testAccFileSystemNameDataSourceConfig = `
 resource "aws_efs_file_system" "test" {}


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24031
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23309
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21642

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccEFSFileSystemDataSource_nonExistent_fileSystemID (18.35s)
--- PASS: TestAccEFSFileSystemDataSource_nonExistent_tags (55.12s)
--- PASS: TestAccEFSFileSystemDataSource_id (55.58s)
--- PASS: TestAccEFSFileSystemDataSource_availabilityZone (59.63s)
--- PASS: TestAccEFSFileSystemDataSource_tags (62.36s)
--- PASS: TestAccEFSFileSystemDataSource_name (67.06s)
```
