### PR TITLE
r/ssm_association: use the `Overview.Status` field in the custom wait function instead of the root-level `Status`

### DIFF
--- a/.changelog/24300.txt
+++ b/.changelog/24300.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_association: Prevent panic when `wait_for_success_timeout_seconds` is configured
+```

--- a/internal/service/ssm/status.go
+++ b/internal/service/ssm/status.go
@@ -23,7 +23,13 @@ func statusAssociation(conn *ssm.SSM, id string) resource.StateRefreshFunc {
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status.Name), nil
+		// Use the Overview.Status field instead of the root-level Status as DescribeAssociation
+		// does not appear to return the root-level Status in the API response at this time.
+		if output.Overview == nil {
+			return nil, "", nil
+		}
+
+		return output, aws.StringValue(output.Overview.Status), nil
 	}
 }
 

--- a/internal/service/ssm/wait.go
+++ b/internal/service/ssm/wait.go
@@ -25,9 +25,9 @@ func waitAssociationSuccess(conn *ssm.SSM, id string, timeout time.Duration) (*s
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*ssm.AssociationDescription); ok {
-		if statusName := aws.StringValue(output.Status.Name); statusName == ssm.AssociationStatusNameFailed {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Status.Message)))
+	if output, ok := outputRaw.(*ssm.AssociationDescription); ok && output.Overview != nil {
+		if status := aws.StringValue(output.Overview.Status); status == ssm.AssociationStatusNameFailed {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Overview.DetailedStatus)))
 		}
 		return output, err
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23326

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout (38.61s)
--- PASS: TestAccSSMAssociation_withDocumentVersion (31.01s)
--- PASS: TestAccSSMAssociation_withAssociationNameAndScheduleExpression (40.88s)
--- PASS: TestAccSSMAssociation_withAssociationName (43.10s)
--- PASS: TestAccSSMAssociation_rateControl (49.74s)
--- PASS: TestAccSSMAssociation_withScheduleExpression (50.53s)
--- PASS: TestAccSSMAssociation_withComplianceSeverity (55.12s)
--- PASS: TestAccSSMAssociation_withParameters (61.99s)
--- PASS: TestAccSSMAssociation_withTargets (65.87s)
--- PASS: TestAccSSMAssociation_withAutomationTargetParamName (70.32s)
--- PASS: TestAccSSMAssociation_withOutputLocation (72.60s)
--- PASS: TestAccSSMAssociation_applyOnlyAtCronInterval (75.66s)
--- PASS: TestAccSSMAssociation_withOutputLocation_s3Region (86.53s)
--- PASS: TestAccSSMAssociation_disappears_document (119.48s)
--- PASS: TestAccSSMAssociation_disappears (122.18s)
--- PASS: TestAccSSMAssociation_basic (139.80s)
```
