### PR TITLE
r/appstream_user_stack_association: prevent panic during resource read

### DIFF
--- a/.changelog/24303.txt
+++ b/.changelog/24303.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_user_stack_association: Prevent panic during resource read
+```

--- a/internal/service/appstream/user_stack_association.go
+++ b/internal/service/appstream/user_stack_association.go
@@ -109,7 +109,14 @@ func resourceUserStackAssociationRead(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	if len(resp.UserStackAssociations) == 0 && !d.IsNewResource() {
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error reading AppStream User Stack Association (%s): %w", d.Id(), err))
+	}
+
+	if resp == nil || len(resp.UserStackAssociations) == 0 || resp.UserStackAssociations[0] == nil {
+		if d.IsNewResource() {
+			return diag.Errorf("error reading AppStream User Stack Association (%s): empty output after creation", d.Id())
+		}
 		log.Printf("[WARN] AppStream User Stack Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22468

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAppStreamUserStackAssociation_disappears (24.42s)
--- PASS: TestAccAppStreamUserStackAssociation_basic (28.31s)
--- PASS: TestAccAppStreamUserStackAssociation_complete (45.05s)
```
