### PR TITLE
Fix slip on `emr_cluster` documentation

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -380,7 +380,7 @@ resource "aws_security_group" "allow_access" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = aws_vpc.main.cidr_block
+    cidr_blocks = [aws_vpc.main.cidr_block]
   }
 
   egress {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -312,8 +312,8 @@ resource "aws_emr_cluster" "cluster" {
 
   ec2_attributes {
     subnet_id                         = aws_subnet.main.id
-    emr_managed_master_security_group = aws_security_group.allow_all.id
-    emr_managed_slave_security_group  = aws_security_group.allow_all.id
+    emr_managed_master_security_group = aws_security_group.allow_access.id
+    emr_managed_slave_security_group  = aws_security_group.allow_access.id
     instance_profile                  = aws_iam_instance_profile.emr_profile.arn
   }
 


### PR DESCRIPTION
The security group is named `allow_access`, not `allow_all`
https://github.com/hashicorp/terraform-provider-aws/blob/85cb3b05cbfe40a88fe1478a6130dd687a63fbb4/website/docs/r/emr_cluster.html.markdown?plain=1#L374

Also, `cidr_blocks` should be `list(string)`

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

