### PR TITLE
Include OpenSearch service sweepers

### DIFF
--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -86,6 +86,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/neptune"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/opensearch"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/opsworks"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/qldb"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24336.

```console
% make sweep SWEEPARGS=-sweep-run=aws_opensearch_domain SWEEP=us-west-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_opensearch_domain -timeout 60m
2022/04/21 08:36:28 [DEBUG] Running Sweepers for region (us-west-2):
2022/04/21 08:36:28 [DEBUG] Running Sweeper (aws_opensearch_domain) in region (us-west-2)
2022/04/21 08:36:28 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/04/21 08:36:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/04/21 08:36:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/04/21 08:36:30 [INFO] Skipping OpenSearch Domain (tf-acc-test-3728881455934422) with deleted status
2022/04/21 08:36:30 [INFO] Skipping OpenSearch Domain (tf-test-841758105109071952) with deleted status
2022/04/21 08:36:30 [DEBUG] Waiting for state to become: [success]
2022/04/21 08:36:30 [DEBUG] Deleting OpenSearch domain: "tf-acc-test-5660670197803725"
2022/04/21 08:36:30 [DEBUG] Waiting for OpenSearch domain "tf-acc-test-5660670197803725" to be deleted
2022/04/21 08:36:30 [DEBUG] Waiting for state to become: [success]
2022/04/21 08:36:30 [TRACE] Waiting 500ms before next try
2022/04/21 08:36:31 [TRACE] Waiting 1s before next try
2022/04/21 08:36:32 [TRACE] Waiting 2s before next try
2022/04/21 08:36:34 [TRACE] Waiting 4s before next try
2022/04/21 08:36:38 [TRACE] Waiting 8s before next try
2022/04/21 08:36:47 [TRACE] Waiting 10s before next try
2022/04/21 08:36:57 [TRACE] Waiting 10s before next try
2022/04/21 08:37:07 [TRACE] Waiting 10s before next try
2022/04/21 08:37:18 [TRACE] Waiting 10s before next try
2022/04/21 08:37:28 [TRACE] Waiting 10s before next try
2022/04/21 08:37:39 [TRACE] Waiting 10s before next try
2022/04/21 08:37:49 [TRACE] Waiting 10s before next try
2022/04/21 08:38:00 [TRACE] Waiting 10s before next try
2022/04/21 08:38:10 [TRACE] Waiting 10s before next try
2022/04/21 08:38:21 [TRACE] Waiting 10s before next try
2022/04/21 08:38:32 [TRACE] Waiting 10s before next try
2022/04/21 08:38:42 [TRACE] Waiting 10s before next try
2022/04/21 08:38:53 [TRACE] Waiting 10s before next try
2022/04/21 08:39:03 [TRACE] Waiting 10s before next try
2022/04/21 08:39:14 [TRACE] Waiting 10s before next try
2022/04/21 08:39:24 [TRACE] Waiting 10s before next try
2022/04/21 08:39:35 [TRACE] Waiting 10s before next try
2022/04/21 08:39:45 [TRACE] Waiting 10s before next try
2022/04/21 08:39:55 [TRACE] Waiting 10s before next try
2022/04/21 08:40:06 [TRACE] Waiting 10s before next try
2022/04/21 08:40:16 [TRACE] Waiting 10s before next try
2022/04/21 08:40:27 [TRACE] Waiting 10s before next try
2022/04/21 08:40:37 [TRACE] Waiting 10s before next try
2022/04/21 08:40:47 [TRACE] Waiting 10s before next try
2022/04/21 08:40:58 [TRACE] Waiting 10s before next try
2022/04/21 08:41:08 [TRACE] Waiting 10s before next try
2022/04/21 08:41:19 [TRACE] Waiting 10s before next try
2022/04/21 08:41:29 [TRACE] Waiting 10s before next try
2022/04/21 08:41:40 [TRACE] Waiting 10s before next try
2022/04/21 08:41:50 [TRACE] Waiting 10s before next try
2022/04/21 08:42:01 [TRACE] Waiting 10s before next try
2022/04/21 08:42:11 [TRACE] Waiting 10s before next try
2022/04/21 08:42:21 [TRACE] Waiting 10s before next try
2022/04/21 08:42:32 [TRACE] Waiting 10s before next try
2022/04/21 08:42:42 [TRACE] Waiting 10s before next try
2022/04/21 08:42:53 [TRACE] Waiting 10s before next try
2022/04/21 08:43:03 [TRACE] Waiting 10s before next try
2022/04/21 08:43:13 [TRACE] Waiting 10s before next try
2022/04/21 08:43:24 [TRACE] Waiting 10s before next try
2022/04/21 08:43:35 [TRACE] Waiting 10s before next try
2022/04/21 08:43:45 [TRACE] Waiting 10s before next try
2022/04/21 08:43:55 [TRACE] Waiting 10s before next try
2022/04/21 08:44:06 [TRACE] Waiting 10s before next try
2022/04/21 08:44:16 [TRACE] Waiting 10s before next try
2022/04/21 08:44:27 [DEBUG] Completed Sweeper (aws_opensearch_domain) in region (us-west-2) in 7m59.623379301s
2022/04/21 08:44:27 Completed Sweepers for region (us-west-2) in 7m59.6235881s
2022/04/21 08:44:27 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_opensearch_domain
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	486.708s
```