### PR TITLE
Fix DMS documentation on kinesis_settings block.

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -108,7 +108,7 @@ The following arguments are optional:
 * `include_partition_value` - (Optional) Shows the partition value within the Kinesis message output, unless the partition type is schema-table-type. Default is `false`.
 * `include_table_alter_operations` - (Optional) Includes any data definition language (DDL) operations that change the table in the control data. Default is `false`.
 * `include_transaction_details` - (Optional) Provides detailed transaction information from the source database. Default is `false`.
-* `message_format` - (Optional) Output format for the records created. Default is `json`. Valid values are `json` and `json_unformatted` (a single line with no tab).
+* `message_format` - (Optional) Output format for the records created. Default is `json`. Valid values are `json` and `json-unformatted` (a single line with no tab).
 * `partition_include_schema_table` - (Optional) Prefixes schema and table names to partition values, when the partition type is primary-key-type. Default is `false`.
 * `service_access_role_arn` - (Optional) ARN of the IAM Role with permissions to write to the Kinesis data stream.
 * `stream_arn` - (Optional) ARN of the Kinesis data stream.


### PR DESCRIPTION
See the error when `json_unformatted` is used:
```
Error: expected kinesis_settings.0.message_format to be one of [json json-unformatted], got json_unformatted
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
