### PR TITLE
[WIP] Switch service labels to be dynamically generated

### DIFF
--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -1,234 +1,50 @@
-#
-# For future consideration, this list could be automatically generated
-# via the AWS SDK service list.
-#
-
-variable "service_labels" {
-  default = [
-    "accessanalyzer",
-    "account",
-    "acm",
-    "acmpca",
-    "alexaforbusiness",
-    "amp",
-    "amplify",
-    "apigateway",
-    "apigatewaymanagementapi",
-    "apigatewayv2",
-    "appconfig",
-    "appflow",
-    "appintegrations",
-    "applicationautoscaling",
-    "applicationdiscoveryservice",
-    "applicationinsights",
-    "appmesh",
-    "apprunner",
-    "appstream",
-    "appsync",
-    "athena",
-    "auditmanager",
-    "autoscaling",
-    "autoscalingplans",
-    "backup",
-    "batch",
-    "braket",
-    "budgets",
-    "chime",
-    "cloud9",
-    "cloudcontrolapi",
-    "clouddirectory",
-    "cloudformation",
-    "cloudfront",
-    "cloudhsm",
-    "cloudhsmv2",
-    "cloudsearch",
-    "cloudtrail",
-    "cloudwatch",
-    "cloudwatchevidently",
-    "cloudwatchlogs",
-    "cloudwatchrum",
-    "codeartifact",
-    "codebuild",
-    "codecommit",
-    "codedeploy",
-    "codeguruprofiler",
-    "codegurureviewer",
-    "codepipeline",
-    "codestar",
-    "codestarconnections",
-    "codestarnotifications",
-    "cognito",
-    "cognitoidentityprovider",
-    "comprehend",
-    "comprehendmedical",
-    "computeoptimizer",
-    "configservice",
-    "connect",
-    "costandusagereportservice",
-    "costexplorer",
-    "databasemigrationservice",
-    "dataexchange",
-    "datapipeline",
-    "datasync",
-    "dax",
-    "detective",
-    "devicefarm",
-    "directconnect",
-    "directoryservice",
-    "dlm",
-    "docdb",
-    "dynamodb",
-    "ec2-classic",
-    "ec2",
-    "ecr",
-    "ecrpublic",
-    "ecs",
-    "efs",
-    "eks",
-    "elastictranscoder",
-    "elasticache",
-    "elasticbeanstalk",
-    "elasticinference",
-    "elasticsearch",
-    "elb",
-    "elbv2",
-    "emr",
-    "emrcontainers",
-    "events",
-    "firehose",
-    "fms",
-    "forecastservice",
-    "frauddetector",
-    "fsx",
-    "gamelift",
-    "glacier",
-    "globalaccelerator",
-    "glue",
-    "grafana",
-    "greengrass",
-    "groundstation",
-    "guardduty",
-    "honeycode",
-    "iam",
-    "identitystore",
-    "imagebuilder",
-    "inspector",
-    "iot",
-    "iotanalytics",
-    "iotevents",
-    "iotsecuretunneling",
-    "iotsitewise",
-    "iotthingsgraph",
-    "ivs",
-    "kafka",
-    "kafkaconnect",
-    "kendra",
-    "keyspaces",
-    "kinesis",
-    "kinesisanalytics",
-    "kinesisanalyticsv2",
-    "kinesisvideo",
-    "kms",
-    "lakeformation",
-    "lambda",
-    "lexmodels",
-    "licensemanager",
-    "lightsail",
-    "location",
-    "machinelearning",
-    "macie",
-    "macie2",
-    "managedblockchain",
-    "marketplacecatalog",
-    "mediaconnect",
-    "mediaconvert",
-    "medialive",
-    "mediapackage",
-    "mediapackagevod",
-    "mediastore",
-    "mediatailor",
-    "memorydb",
-    "meteringmarketplace",
-    "mobile",
-    "mq",
-    "mwaa",
-    "neptune",
-    "networkfirewall",
-    "networkmanager",
-    "opensearch",
-    "opsworks",
-    "opsworkscm",
-    "organizations",
-    "outposts",
-    "personalize",
-    "pi",
-    "pinpoint",
-    "pinpointemail",
-    "pinpointsmsvoice",
-    "polly",
-    "pricing",
-    "qldb",
-    "quicksight",
-    "ram",
-    "rds",
-    "redshift",
-    "resourcegroups",
-    "resourcegroupstaggingapi",
-    "robomaker",
-    "route53",
-    "route53domains",
-    "route53recoverycontrolconfig",
-    "route53recoveryreadiness",
-    "route53resolver",
-    "s3",
-    "s3control",
-    "s3outposts",
-    "sagemaker",
-    "savingsplans",
-    "schemas",
-    "secretsmanager",
-    "securityhub",
-    "serverlessrepo",
-    "servicecatalog",
-    "servicediscovery",
-    "servicequotas",
-    "ses",
-    "sesv2",
-    "sfn",
-    "shield",
-    "signer",
-    "simpledb",
-    "sms",
-    "snowball",
-    "sns",
-    "sqs",
-    "ssm",
-    "ssoadmin",
-    "storagegateway",
-    "sts",
-    "support",
-    "swf",
-    "synthetics",
-    "textract",
-    "timestreamwrite",
-    "transcribeservice",
-    "timestreamwrite",
-    "transfer",
-    "translate",
-    "waf",
-    "wafv2",
-    "workdocs",
-    "worklink",
-    "workmail",
-    "workspaces",
-    "xray",
-  ]
-  description = "Set of AWS Go SDK service labels"
-  type        = set(string)
+data "github_branch" "main" {
+  branch     = "main"
+  repository = "terraform-provider-aws"
 }
 
+data "github_tree" "main" {
+  recursive  = true
+  repository = data.github_branch.main.repository
+  tree_sha   = data.github_branch.main.sha
+}
+
+locals {
+
+  # A breakdown on this becuase while I realize it's a pretty ugly one-liner,
+  # I wasn't able to come up with a prettier way to do it, outside of just
+  # breaking the `compact()` and `toset()` functions out into separate locals.
+  #
+  # The `for` bit in here takes the list of tree entries from the data source
+  # uses `regexall` to check to see if the path for the entry is a directory
+  # under the `internal/service/` directory. `regexall()` returns a list of
+  # every match, so by testing whether the length is greater than 0, we can
+  # determine if the filepath matches our regex.
+  #
+  # If the path matches the regex, we then trim the `internal/service/` prefix
+  # before adding the path to our resulting list. If the path does not match,
+  # we pass `null` instead.
+  #
+  # As a note, it would probably be more efficient to *not* trim 'service/`,
+  # however, we would need to do some state surgery to move over to that, since
+  # we were previously supplying a static list of service names rather than
+  # using these data sources.
+  #
+  # Passing `null` means that we can wrap the whole list to `compact()` to
+  # remove all of the `null` values and leave only the list of tag values.
+  # Further, passing this list to `toset()` means that we have something that
+  # can be used by `for_each` in the label resource below.
+
+  services = toset(compact([
+    for entry in data.github_tree.main.entries :
+    length(regexall("^internal\\/service\\/[[:alnum:]]+$", entry.path)) > 0 ? trimprefix(entry.path, "internal/service/") : null
+  ]))
+
+}
+
+
 resource "github_issue_label" "service" {
-  for_each = var.service_labels
+  for_each = var.services
 
   repository  = "terraform-provider-aws"
   name        = "service/${each.value}"

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -44,7 +44,7 @@ locals {
 
 
 resource "github_issue_label" "service" {
-  for_each = var.services
+  for_each = local.services
 
   repository  = "terraform-provider-aws"
   name        = "service/${each.value}"


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing: N/a, relates to repository labels Terraform configuration

### Information

Previously, we used a static list of service names that had to be updated manually any time a new service was added. This PR switches the configuration to use the [`github_tree`](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/tree) data source to get the `tree` of the repository, then filters down to only the directories under `internal/service/` to get the list of services.

At this time, there's a `trimprefix()` that trims off `internal/service/` from the paths -- this could be switched to leave the `service/`, since that's included in the label name, but given that we already have a Terraform state that has these indexed as _only_ the service names, I've opted to keep that formatting for now. If we feel it would be better, I'm happy to modify the configuration / state file to leave `service/`.