### PR TITLE
fix: [CloudWatch Dashboard] import sample code

### DIFF
--- a/website/docs/r/cloudwatch_dashboard.html.markdown
+++ b/website/docs/r/cloudwatch_dashboard.html.markdown
@@ -74,5 +74,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudWatch dashboards can be imported using the `dashboard_name`, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_dashboard.sample <dashboard_name>
+$ terraform import aws_cloudwatch_dashboard.sample dashboard_name
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Closes #24355

Output from acceptance testing: N/a, docs

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### why
The dashboard_name is not displayed and the sample code for import is incomplete,
and we would like to resolve this.

### do
- Remove <> surrounding dashboard_name


### info
Attached are the results of a local preview of the markdown file.

|before|after|
|---|---|
|![スクリーンショット 2022-04-23 15 35 28](https://user-images.githubusercontent.com/12161701/164883395-64136bbb-3115-43d2-b945-d53bd76b1c0d.png)|![スクリーンショット 2022-04-23 15 35 41](https://user-images.githubusercontent.com/12161701/164883393-538157a5-c9d9-493b-a1c7-68c949b2ef72.png)|




