### PR TITLE
Added new Datasource to list cloudfront origin access identities #24023

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -454,6 +454,7 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_distribution":                   cloudfront.DataSourceDistribution(),
 			"aws_cloudfront_function":                       cloudfront.DataSourceFunction(),
 			"aws_cloudfront_log_delivery_canonical_user_id": cloudfront.DataSourceLogDeliveryCanonicalUserID(),
+			"aws_cloudfront_origin_access_identities":       cloudfront.DataSourceOriginAccessIdentities(),
 			"aws_cloudfront_origin_access_identity":         cloudfront.DataSourceOriginAccessIdentity(),
 			"aws_cloudfront_origin_request_policy":          cloudfront.DataSourceOriginRequestPolicy(),
 			"aws_cloudfront_realtime_log_config":            cloudfront.DataSourceRealtimeLogConfig(),

--- a/internal/service/cloudfront/origin_access_identities_data_source.go
+++ b/internal/service/cloudfront/origin_access_identities_data_source.go
@@ -1,0 +1,143 @@
+package cloudfront
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+)
+
+func DataSourceOriginAccessIdentities() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOriginAccessIdentitiesRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"s3_canonical_user_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceOriginAccessIdentitiesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).CloudFrontConn
+
+	comments := extractComments(d)
+
+	input := &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{}
+
+	var results []*cloudfront.OriginAccessIdentitySummary
+
+	err := conn.ListCloudFrontOriginAccessIdentitiesPages(input, func(page *cloudfront.ListCloudFrontOriginAccessIdentitiesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+		for _, originAccessIdentity := range page.CloudFrontOriginAccessIdentityList.Items {
+
+			if originAccessIdentity == nil {
+				continue
+			}
+			if len(comments) > 0 {
+
+				if ok := SliceContainsString(comments, *originAccessIdentity.Comment); !ok {
+					continue
+				}
+
+			}
+
+			results = append(results, originAccessIdentity)
+		}
+		return !lastPage
+
+	})
+	if err != nil {
+		return fmt.Errorf("error reading Cloudfront OriginAccessIdentities: %w", err)
+	}
+
+	var arns, ids, s3UserIds []string
+
+	for _, r := range results {
+		iamArn := arn.ARN{
+			Partition: meta.(*conns.AWSClient).Partition,
+			Service:   "iam",
+			AccountID: "cloudfront",
+			Resource:  fmt.Sprintf("user/CloudFront Origin Access Identity %s", *r.Id),
+		}.String()
+		arns = append(arns, iamArn)
+		ids = append(ids, aws.StringValue(r.Id))
+		s3UserIds = append(s3UserIds, *r.S3CanonicalUserId)
+	}
+
+	accountId := meta.(*conns.AWSClient).AccountID
+	d.SetId(fmt.Sprintf("originaccessidentities-%s", accountId))
+
+	if err := d.Set("arns", arns); err != nil {
+		return fmt.Errorf("error setting arns: %w", err)
+	}
+
+	if err := d.Set("ids", ids); err != nil {
+		return fmt.Errorf("error setting ids: %w", err)
+	}
+
+	if err := d.Set("s3_canonical_user_ids", s3UserIds); err != nil {
+		return fmt.Errorf("error setting s3_canonical_user_ids: %w", err)
+	}
+
+	return nil
+}
+
+func extractComments(d *schema.ResourceData) []*string {
+	if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		tfMap := v.([]interface{})[0].(map[string]interface{})
+		if u, ok := tfMap["name"].(string); ok && u == "comment" {
+			if w, ok := tfMap["values"].(*schema.Set); ok && w.Len() > 0 {
+				return flex.ExpandStringSet(w)
+			}
+		}
+	}
+	return nil
+}
+
+func SliceContainsString(slice []*string, s string) bool {
+	for _, value := range slice {
+		if strings.EqualFold(*value, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/cloudfront/origin_access_identities_data_source_test.go
+++ b/internal/service/cloudfront/origin_access_identities_data_source_test.go
@@ -1,0 +1,95 @@
+package cloudfront_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccCloudFrontOriginAccessIdentitiesDataSource_With_Filter(t *testing.T) {
+	dataSourceName := "data.aws_cloudfront_origin_access_identities.test"
+	resource2Name := "aws_cloudfront_origin_access_identity.test.1"
+	rCount := strconv.Itoa(sdkacctest.RandIntRange(2, 5))
+	fCount := "1"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloudfront.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOriginAccessIdentitiesBasicDataSourceConfigFilter(rCount, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", fCount),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", fCount),
+					resource.TestCheckResourceAttr(dataSourceName, "s3_canonical_user_ids.#", fCount),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arns.0", resource2Name, "iam_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", resource2Name, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "s3_canonical_user_ids.0", resource2Name, "s3_canonical_user_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontOriginAccessIdentitiesDataSource_No_Filter(t *testing.T) {
+	dataSourceName := "data.aws_cloudfront_origin_access_identities.test"
+	resource1Name := "aws_cloudfront_origin_access_identity.test.0"
+	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloudfront.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOriginAccessIdentitiesBasicDataSourceConfigNoFilter(rCount, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", rCount),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", rCount),
+					resource.TestCheckResourceAttr(dataSourceName, "s3_canonical_user_ids.#", rCount),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arns.0", resource1Name, "iam_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", resource1Name, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "s3_canonical_user_ids.0", resource1Name, "s3_canonical_user_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOriginAccessIdentitiesBasicDataSourceConfigFilter(rCount, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_origin_access_identity" "test" {
+  count = %[1]s
+  comment  = "%[2]s-${count.index}-comment"
+}
+
+data "aws_cloudfront_origin_access_identities" "test" {
+	filter{
+		name = "comment"
+		values = [aws_cloudfront_origin_access_identity.test.1.comment]
+
+	}
+}
+`, rCount, rName)
+}
+
+func testAccOriginAccessIdentitiesBasicDataSourceConfigNoFilter(rCount, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_origin_access_identity" "test" {
+  count = %[1]s
+  comment  = "%[2]s-${count.index}-comment"
+}
+
+data "aws_cloudfront_origin_access_identities" "test" {
+
+}
+`, rCount, rName)
+}

--- a/website/docs/d/cloudfront_origin_access_identities.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_identities.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_origin_access_identities"
+description: |-
+  Use this data source to retrieve information about a set of Amazon CloudFront origin access identities.
+---
+
+# Data Source: aws_cloudfront_origin_access_identities
+
+Use this data source to get ARNs, ids, S3 canonical user IDs of Amazon CloudFront origin access identities.
+
+## Example Usage
+
+### All origin access identities in the account
+
+```terraform
+data "aws_cloudfront_origin_access_identities" "example" {
+
+}
+```
+
+### Origin access identities filtered by comment/name
+
+Origin access identities whose comments are `example-comment1`, `example-comment2`
+
+```terraform
+data "aws_cloudfront_origin_access_identities" "example" {
+  	filter {
+		name = "comment"
+		values = ["example-comment1","example-comment2"]
+	}
+}
+```
+
+## Argument Reference
+
+* `filter` (Optional) - Object that determines whether to filter based on certain parameter and return only a set of CloudFront origin access identities. See [Filter Config](#filter-config) for more information.
+
+### Filter Config
+
+* `name` (Required) - Name of the parameter to filter. Valid value is `comment`.
+* `values` (Required) - A list of existing origin access identities comments.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+
+* `arns` - Set of ARNs of the matched origin access identities.
+* `ids` - Set of ids of the matched origin access identities.
+* `s3_canonical_user_ids` - Set of S3 canonical user IDs of the matched origin access identities.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #24023

Sample output of the datasource:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/42437992/164990331-7259660a-1d6a-42e6-902d-e6543b82e681.png">

iam new, please let me know, if changes are required

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
