### PR TITLE
Update validation pattern for aws_ses_receipt_filter.name 

### DIFF
--- a/.changelog/24383.txt
+++ b/.changelog/24383.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ses/receipt_filter: Update validation pattern for aws_ses_receipt_filter.name
+resource/aws_ses_receipt_filter: Allow period character (`.`) in `name` argument
 ```

--- a/.changelog/24383.txt
+++ b/.changelog/24383.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ses/receipt_filter: Update validation pattern for aws_ses_receipt_filter.name
+```

--- a/internal/service/ses/receipt_filter.go
+++ b/internal/service/ses/receipt_filter.go
@@ -33,7 +33,7 @@ func ResourceReceiptFilter() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 64),
-					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z._-]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
+					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z._-]+$`), "must contain only alphanumeric, period, underscore, and hyphen characters"),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z]`), "must begin with a alphanumeric character"),
 					validation.StringMatch(regexp.MustCompile(`[0-9a-zA-Z]$`), "must end with a alphanumeric character"),
 				),

--- a/internal/service/ses/receipt_filter.go
+++ b/internal/service/ses/receipt_filter.go
@@ -33,7 +33,7 @@ func ResourceReceiptFilter() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 64),
-					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
+					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-.]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z]`), "must begin with a alphanumeric character"),
 					validation.StringMatch(regexp.MustCompile(`[0-9a-zA-Z]$`), "must end with a alphanumeric character"),
 				),

--- a/internal/service/ses/receipt_filter.go
+++ b/internal/service/ses/receipt_filter.go
@@ -33,7 +33,7 @@ func ResourceReceiptFilter() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 64),
-					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-.]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
+					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z._-]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z]`), "must begin with a alphanumeric character"),
 					validation.StringMatch(regexp.MustCompile(`[0-9a-zA-Z]$`), "must end with a alphanumeric character"),
 				),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24378.
Add dot in validation regex for name in `aws_ses_receipt_filter` resource

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

