### PR TITLE
23510/s3 bucket versioning

### DIFF
--- a/.changelog/23510.txt
+++ b/.changelog/23510.txt
@@ -1,4 +1,6 @@
 ```release-note:bug
 resource/aws_s3_bucket_versioning: Let resource be removed from tfstate if bucket deleted outside Terraform
+```
+```release-note:bug
 resource/aws_s3_bucket_policy: Let resource be removed from tfstate if bucket deleted outside Terraform
 ```

--- a/.changelog/23510.txt
+++ b/.changelog/23510.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_versioning: Let resource be removed from tfstate if bucket deleted outside Terraform
+```

--- a/.changelog/23510.txt
+++ b/.changelog/23510.txt
@@ -1,3 +1,4 @@
 ```release-note:bug
 resource/aws_s3_bucket_versioning: Let resource be removed from tfstate if bucket deleted outside Terraform
+resource/aws_s3_bucket_policy: Let resource be removed from tfstate if bucket deleted outside Terraform
 ```

--- a/.changelog/23510.txt
+++ b/.changelog/23510.txt
@@ -1,6 +1,7 @@
 ```release-note:bug
 resource/aws_s3_bucket_versioning: Let resource be removed from tfstate if bucket deleted outside Terraform
 ```
+
 ```release-note:bug
 resource/aws_s3_bucket_policy: Let resource be removed from tfstate if bucket deleted outside Terraform
 ```

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -93,6 +93,12 @@ func resourceBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		Bucket: aws.String(d.Id()),
 	})
 
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] S3 Bucket Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	v := ""
 	if err == nil && pol.Policy != nil {
 		v = aws.StringValue(pol.Policy)

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -93,7 +93,7 @@ func resourceBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		Bucket: aws.String(d.Id()),
 	})
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeNoSuchBucketPolicy, s3.ErrCodeNoSuchBucket) {
 		log.Printf("[WARN] S3 Bucket Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 )
 
 func TestAccS3BucketPolicy_basic(t *testing.T) {
@@ -54,6 +55,91 @@ func TestAccS3BucketPolicy_basic(t *testing.T) {
 				ResourceName:      "aws_s3_bucket_policy.bucket",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketPolicy_disappears(t *testing.T) {
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	partition := acctest.Partition()
+	bucketResourceName := "aws_s3_bucket.bucket"
+	resourceName := "aws_s3_bucket_policy.bucket"
+
+	expectedPolicyText := fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:*",
+      "Resource": [
+        "arn:%s:s3:::%s/*",
+        "arn:%s:s3:::%s"
+      ]
+    }
+  ]
+}`, partition, name, partition, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					testAccCheckBucketHasPolicy(bucketResourceName, expectedPolicyText),
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucketPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketPolicy_disappears_bucket(t *testing.T) {
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	partition := acctest.Partition()
+	bucketResourceName := "aws_s3_bucket.bucket"
+
+	expectedPolicyText := fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:*",
+      "Resource": [
+        "arn:%s:s3:::%s/*",
+        "arn:%s:s3:::%s"
+      ]
+    }
+  ]
+}`, partition, name, partition, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(bucketResourceName),
+					testAccCheckBucketHasPolicy(bucketResourceName, expectedPolicyText),
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucket(), bucketResourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -141,10 +141,7 @@ func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, m
 
 	var output *s3.GetBucketVersioningOutput
 
-	if output, err = waitForBucketVersioningStatus(ctx, conn, bucket, expectedBucketOwner); err != nil {
-		return diag.Errorf("error waiting for S3 Bucket Versioning status for bucket (%s): %s", d.Id(), err)
-	}
-
+	output, err = waitForBucketVersioningStatus(ctx, conn, bucket, expectedBucketOwner)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Versioning (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -66,6 +66,29 @@ func TestAccS3BucketVersioning_disappears(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketVersioning_disappears_bucket(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketVersioningDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningBasicConfig(rName, s3.BucketVersioningStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucket(), bucketResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketVersioning_update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_versioning.test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23510

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccS3BucketVersioning_ PKG=s3 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3 -run='TestAccS3BucketVersioning_'  -timeout 180m
=== RUN   TestAccS3BucketVersioning_basic
=== PAUSE TestAccS3BucketVersioning_basic
=== RUN   TestAccS3BucketVersioning_disappears
=== PAUSE TestAccS3BucketVersioning_disappears
=== RUN   TestAccS3BucketVersioning_update
=== PAUSE TestAccS3BucketVersioning_update
=== RUN   TestAccS3BucketVersioning_MFADelete
=== PAUSE TestAccS3BucketVersioning_MFADelete
=== RUN   TestAccS3BucketVersioning_migrate_versioningDisabledNoChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningDisabledNoChange
=== RUN   TestAccS3BucketVersioning_migrate_versioningDisabledWithChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningDisabledWithChange
=== RUN   TestAccS3BucketVersioning_migrate_versioningEnabledNoChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningEnabledNoChange
=== RUN   TestAccS3BucketVersioning_migrate_versioningEnabledWithChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningEnabledWithChange
=== RUN   TestAccS3BucketVersioning_migrate_mfaDeleteNoChange
=== PAUSE TestAccS3BucketVersioning_migrate_mfaDeleteNoChange
=== RUN   TestAccS3BucketVersioning_Status_disabled
=== PAUSE TestAccS3BucketVersioning_Status_disabled
=== RUN   TestAccS3BucketVersioning_Status_disabledToEnabled
=== PAUSE TestAccS3BucketVersioning_Status_disabledToEnabled
=== RUN   TestAccS3BucketVersioning_Status_disabledToSuspended
=== PAUSE TestAccS3BucketVersioning_Status_disabledToSuspended
=== RUN   TestAccS3BucketVersioning_Status_enabledToDisabled
=== PAUSE TestAccS3BucketVersioning_Status_enabledToDisabled
=== RUN   TestAccS3BucketVersioning_Status_suspendedToDisabled
=== PAUSE TestAccS3BucketVersioning_Status_suspendedToDisabled
=== CONT  TestAccS3BucketVersioning_basic
=== CONT  TestAccS3BucketVersioning_migrate_versioningEnabledWithChange
=== CONT  TestAccS3BucketVersioning_Status_disabledToSuspended
--- PASS: TestAccS3BucketVersioning_basic (31.91s)
=== CONT  TestAccS3BucketVersioning_Status_suspendedToDisabled
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledWithChange (46.11s)
=== CONT  TestAccS3BucketVersioning_Status_enabledToDisabled
--- PASS: TestAccS3BucketVersioning_Status_disabledToSuspended (55.46s)
=== CONT  TestAccS3BucketVersioning_Status_disabled
--- PASS: TestAccS3BucketVersioning_Status_suspendedToDisabled (32.62s)
=== CONT  TestAccS3BucketVersioning_Status_disabledToEnabled
--- PASS: TestAccS3BucketVersioning_Status_enabledToDisabled (30.78s)
=== CONT  TestAccS3BucketVersioning_migrate_versioningDisabledNoChange
--- PASS: TestAccS3BucketVersioning_Status_disabled (29.18s)
=== CONT  TestAccS3BucketVersioning_migrate_versioningEnabledNoChange
--- PASS: TestAccS3BucketVersioning_Status_disabledToEnabled (53.38s)
=== CONT  TestAccS3BucketVersioning_migrate_versioningDisabledWithChange
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledNoChange (43.12s)
=== CONT  TestAccS3BucketVersioning_update
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledNoChange (44.97s)
=== CONT  TestAccS3BucketVersioning_MFADelete
--- PASS: TestAccS3BucketVersioning_MFADelete (30.92s)
=== CONT  TestAccS3BucketVersioning_migrate_mfaDeleteNoChange
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledWithChange (43.00s)
=== CONT  TestAccS3BucketVersioning_disappears
--- PASS: TestAccS3BucketVersioning_disappears (27.05s)
--- PASS: TestAccS3BucketVersioning_update (76.01s)
--- PASS: TestAccS3BucketVersioning_migrate_mfaDeleteNoChange (45.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	208.132s
$ make testacc TESTS=TestAccS3BucketPolicy_ PKG=s3 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3 -run='TestAccS3BucketPolicy_'  -timeout 180m
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPolicy_policyUpdate
=== PAUSE TestAccS3BucketPolicy_policyUpdate
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== RUN   TestAccS3BucketPolicy_migrate_noChange
=== PAUSE TestAccS3BucketPolicy_migrate_noChange
=== RUN   TestAccS3BucketPolicy_migrate_withChange
=== PAUSE TestAccS3BucketPolicy_migrate_withChange
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== CONT  TestAccS3BucketPolicy_migrate_withChange
--- PASS: TestAccS3BucketPolicy_basic (28.29s)
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
--- PASS: TestAccS3BucketPolicy_migrate_withChange (60.34s)
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (72.70s)
=== CONT  TestAccS3BucketPolicy_policyUpdate
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (136.23s)
=== CONT  TestAccS3BucketPolicy_migrate_noChange
--- PASS: TestAccS3BucketPolicy_policyUpdate (45.56s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (93.30s)
--- PASS: TestAccS3BucketPolicy_migrate_noChange (40.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	178.866s
...
```

Note: I'm not sure how the `_disappears` tests were passing before, since the essence of this change is to allow removal of the resource from the tfstate file if the underlying bucket has been deleted outside of Terraform (seems to me this is the essence of "disappearing" secondary/dependent resources but I might be misunderstanding).