### PR TITLE
d/aws_ssm_patch_baseline - new attributes

### DIFF
--- a/.changelog/24401.txt
+++ b/.changelog/24401.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ssm_patch_baseline: Add the following attributes: `approved_patches`, `approved_patches_compliance_level`, `approval_rule`, `global_filter`, `rejected_patches`, `rejected_patches_action`, `source`
+```

--- a/internal/service/ssm/patch_baseline_data_source.go
+++ b/internal/service/ssm/patch_baseline_data_source.go
@@ -15,26 +15,10 @@ func DataSourcePatchBaseline() *schema.Resource {
 	return &schema.Resource{
 		Read: dataPatchBaselineRead,
 		Schema: map[string]*schema.Schema{
-			"owner": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 255),
-			},
 			"default_baseline": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"operating_system": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(ssm.OperatingSystem_Values(), false),
-			},
-			// Computed values
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -42,6 +26,21 @@ func DataSourcePatchBaseline() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"name_prefix": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 255),
+			},
+			"operating_system": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ssm.OperatingSystem_Values(), false),
+			},
+			"owner": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 		},
 	}

--- a/internal/service/ssm/patch_baseline_data_source.go
+++ b/internal/service/ssm/patch_baseline_data_source.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
 func DataSourcePatchBaseline() *schema.Resource {
@@ -144,7 +143,6 @@ func DataSourcePatchBaseline() *schema.Resource {
 					},
 				},
 			},
-			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
 }

--- a/internal/service/ssm/patch_baseline_data_source_test.go
+++ b/internal/service/ssm/patch_baseline_data_source_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccSSMPatchBaselineDataSource_existingBaseline(t *testing.T) {
-	resourceName := "data.aws_ssm_patch_baseline.test_existing"
+	dataSourceName := "data.aws_ssm_patch_baseline.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -21,8 +21,17 @@ func TestAccSSMPatchBaselineDataSource_existingBaseline(t *testing.T) {
 			{
 				Config: testAccCheckPatchBaselineDataSourceConfig_existingBaseline(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "AWS-CentOSDefaultPatchBaseline"),
-					resource.TestCheckResourceAttr(resourceName, "description", "Default Patch Baseline for CentOS Provided by AWS."),
+					resource.TestCheckResourceAttr(dataSourceName, "approved_patches.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "approved_patches_compliance_level", "UNSPECIFIED"),
+					resource.TestCheckResourceAttr(dataSourceName, "approved_patches_enable_non_security", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "approval_rule.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_baseline", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "Default Patch Baseline for CentOS Provided by AWS."),
+					resource.TestCheckResourceAttr(dataSourceName, "global_filter.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "AWS-CentOSDefaultPatchBaseline"),
+					resource.TestCheckResourceAttr(dataSourceName, "rejected_patches.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "rejected_patches_action", "ALLOW_AS_DEPENDENCY"),
+					resource.TestCheckResourceAttr(dataSourceName, "source.#", "0"),
 				),
 			},
 		},
@@ -30,7 +39,8 @@ func TestAccSSMPatchBaselineDataSource_existingBaseline(t *testing.T) {
 }
 
 func TestAccSSMPatchBaselineDataSource_newBaseline(t *testing.T) {
-	resourceName := "data.aws_ssm_patch_baseline.test_new"
+	dataSourceName := "data.aws_ssm_patch_baseline.test"
+	resourceName := "aws_ssm_patch_baseline.test"
 	rName := sdkacctest.RandomWithPrefix("tf-bl-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,9 +52,17 @@ func TestAccSSMPatchBaselineDataSource_newBaseline(t *testing.T) {
 			{
 				Config: testAccCheckPatchBaselineDataSourceConfig_newBaseline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_ssm_patch_baseline.test_new", "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "description", "aws_ssm_patch_baseline.test_new", "description"),
-					resource.TestCheckResourceAttrPair(resourceName, "operating_system", "aws_ssm_patch_baseline.test_new", "operating_system"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "approved_patches", resourceName, "approved_patches"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "approved_patches_compliance_level", resourceName, "approved_patches_compliance_level"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "approved_patches_enable_non_security", resourceName, "approved_patches_enable_non_security"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "approval_rule", resourceName, "approval_rule"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_filter.#", resourceName, "global_filter.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "operating_system", resourceName, "operating_system"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "rejected_patches", resourceName, "rejected_patches"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "rejected_patches_action", resourceName, "rejected_patches_action"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "source", resourceName, "source"),
 				),
 			},
 		},
@@ -54,7 +72,7 @@ func TestAccSSMPatchBaselineDataSource_newBaseline(t *testing.T) {
 // Test against one of the default baselines created by AWS
 func testAccCheckPatchBaselineDataSourceConfig_existingBaseline() string {
 	return `
-data "aws_ssm_patch_baseline" "test_existing" {
+data "aws_ssm_patch_baseline" "test" {
   owner            = "AWS"
   name_prefix      = "AWS-"
   operating_system = "CENTOS"
@@ -65,7 +83,7 @@ data "aws_ssm_patch_baseline" "test_existing" {
 // Create a new baseline and pull it back
 func testAccCheckPatchBaselineDataSourceConfig_newBaseline(name string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_patch_baseline" "test_new" {
+resource "aws_ssm_patch_baseline" "test" {
   name             = "%s"
   operating_system = "AMAZON_LINUX_2"
   description      = "Test"
@@ -79,9 +97,9 @@ resource "aws_ssm_patch_baseline" "test_new" {
   }
 }
 
-data "aws_ssm_patch_baseline" "test_new" {
+data "aws_ssm_patch_baseline" "test" {
   owner            = "Self"
-  name_prefix      = aws_ssm_patch_baseline.test_new.name
+  name_prefix      = aws_ssm_patch_baseline.test.name
   operating_system = "AMAZON_LINUX_2"
 }
 `, name)

--- a/website/docs/d/ssm_patch_baseline.html.markdown
+++ b/website/docs/d/ssm_patch_baseline.html.markdown
@@ -38,17 +38,34 @@ data "aws_ssm_patch_baseline" "default_custom" {
 The following arguments are supported:
 
 * `owner` - (Required) The owner of the baseline. Valid values: `All`, `AWS`, `Self` (the current account).
-
 * `name_prefix` - (Optional) Filter results by the baseline name prefix.
-
 * `default_baseline` - (Optional) Filters the results against the baselines default_baseline field.
-
 * `operating_system` - (Optional) The specified OS for the baseline.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `approved_patches` - A list of explicitly approved patches for the baseline.
+* `approved_patches_compliance_level` - The compliance level for approved patches.
+* `approved_patches_enable_non_security` - Indicates whether the list of approved patches includes non-security updates that should be applied to the instances.
+* `approval_rule` - A list of rules used to include patches in the baseline.
+    * `approve_after_days` - The number of days after the release date of each patch matched by the rule the patch is marked as approved in the patch baseline.
+    * `approve_until_date` - The cutoff date for auto approval of released patches. Any patches released on or before this date are installed automatically. Date is formatted as `YYYY-MM-DD`. Conflicts with `approve_after_days`
+    * `compliance_level` - The compliance level for patches approved by this rule.
+    * `enable_non_security` - Boolean enabling the application of non-security updates.
+    * `patch_filter` - The patch filter group that defines the criteria for the rule.
+        * `key` - The key for the filter.
+        * `values` - The value for the filter.
+* `global_filter` - A set of global filters used to exclude patches from the baseline.
+    * `key` - The key for the filter.
+    * `values` - The value for the filter.
 * `id` - The id of the baseline.
 * `name` - The name of the baseline.
 * `description` - The description of the baseline.
+* `rejected_patches` - A list of rejected patches.
+* `rejected_patches_action` - The action specified to take on patches included in the `rejected_patches` list.
+* `source` - Information about the patches to use to update the managed nodes, including target operating systems and source repositories.
+    * `configuration` - The value of the yum repo configuration.
+    * `name` - The name specified to identify the patch source.
+    * `products` - The specific operating system versions a patch repository applies to.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24062.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ssm TESTS="TestAccSSMPatchBaselineDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMPatchBaselineDataSource_'  -timeout 180m
=== RUN   TestAccSSMPatchBaselineDataSource_existingBaseline
=== PAUSE TestAccSSMPatchBaselineDataSource_existingBaseline
=== RUN   TestAccSSMPatchBaselineDataSource_newBaseline
=== PAUSE TestAccSSMPatchBaselineDataSource_newBaseline
=== CONT  TestAccSSMPatchBaselineDataSource_existingBaseline
=== CONT  TestAccSSMPatchBaselineDataSource_newBaseline
--- PASS: TestAccSSMPatchBaselineDataSource_existingBaseline (20.56s)
--- PASS: TestAccSSMPatchBaselineDataSource_newBaseline (25.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        27.614s
```
