### PR TITLE
docs: globalaccelerator_accelerator document refactor

### DIFF
--- a/website/docs/r/globalaccelerator_accelerator.html.markdown
+++ b/website/docs/r/globalaccelerator_accelerator.html.markdown
@@ -71,7 +71,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Global Accelerator accelerators can be imported using the `id`, e.g.,
+Global Accelerator accelerators can be imported using the `arn`, e.g.,
 
 ```
 $ terraform import aws_globalaccelerator_accelerator.example arn:aws:globalaccelerator::111111111111:accelerator/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

I fixed website document of `globalaccelerator_accelerator` Import section.
We can import `globalaccelerator_accelerator` using `arn` but document say `id`。