### PR TITLE
document how to protect sensitive variables in secretsmanager_secret_version docs

### DIFF
--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -45,7 +45,7 @@ resource "aws_secretsmanager_secret_version" "example" {
 }
 ```
 
-In Terraform 0.14 and later, use `sensitive = true` to protect the values of that `variable` from being printed in logs and console output (see ["Protect Sensitive Input Variables"](https://learn.hashicorp.com/tutorials/terraform/sensitive-variables)).
+-> **Note:** In Terraform 0.14 and later, use `sensitive = true` to protect the values of the variable from being printed in logs and console output (see [Protect Sensitive Input Variables](https://learn.hashicorp.com/tutorials/terraform/sensitive-variables)).
 
 Reading key-value pairs from JSON back into a native Terraform map can be accomplished in Terraform 0.12 and later with the [`jsondecode()` function](https://www.terraform.io/docs/configuration/functions/jsondecode.html):
 

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -45,6 +45,8 @@ resource "aws_secretsmanager_secret_version" "example" {
 }
 ```
 
+In Terraform 0.14 and later, use `sensitive = true` to protect the values of that `variable` from being printed in logs and console output (see ["Protect Sensitive Input Variables"](https://learn.hashicorp.com/tutorials/terraform/sensitive-variables)).
+
 Reading key-value pairs from JSON back into a native Terraform map can be accomplished in Terraform 0.12 and later with the [`jsondecode()` function](https://www.terraform.io/docs/configuration/functions/jsondecode.html):
 
 ```terraform


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The documentation for creating an `aws_secretsmanager_secret_version` recommends using a `variable` to store a map of key-value pairs.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version#key-value-pairs

```hcl
variable "example" {
  default = {
    key1 = "value1"
    key2 = "value2"
  }

  type = map(string)
}

resource "aws_secretsmanager_secret_version" "example" {
  secret_id     = aws_secretsmanager_secret.example.id
  secret_string = jsonencode(var.example)
}
```

Starting in Terraform 0.14, it's possible to add `sensitive = true` to Terraform `variable`s, to prevent their values from being printed in logs and console output.

https://learn.hashicorp.com/tutorials/terraform/sensitive-variables

This PR proposes adding a small note about that to the `secret_version` documentation, to encourage users of this provider to be more protective of their secrets.

Thanks very much for this provider, and for your time and consideration.