### PR TITLE
r/aws_ec2_availability_zone_group: Prevent crash on unknown group name

### DIFF
--- a/.changelog/24422.txt
+++ b/.changelog/24422.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_availability_zone_group: Don't crash if `group_name` is not found
+```

--- a/internal/service/ec2/ec2_availability_zone_data_source_test.go
+++ b/internal/service/ec2/ec2_availability_zone_data_source_test.go
@@ -190,7 +190,7 @@ func testAccPreCheckLocalZoneAvailable(t *testing.T) {
 		}),
 	}
 
-	output, err := conn.DescribeAvailabilityZones(input)
+	output, err := tfec2.FindAvailabilityZones(conn, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
@@ -200,7 +200,7 @@ func testAccPreCheckLocalZoneAvailable(t *testing.T) {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 
-	if output == nil || len(output.AvailabilityZones) == 0 {
+	if len(output) == 0 {
 		t.Skip("skipping since no Local Zones are available")
 	}
 }

--- a/internal/service/ec2/ec2_availability_zone_group.go
+++ b/internal/service/ec2/ec2_availability_zone_group.go
@@ -2,12 +2,9 @@ package ec2
 
 import (
 	"fmt"
-	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -19,12 +16,9 @@ func ResourceAvailabilityZoneGroup() *schema.Resource {
 		Read:   resourceAvailabilityZoneGroupRead,
 		Update: resourceAvailabilityZoneGroupUpdate,
 		Delete: schema.Noop,
-		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-				d.Set("group_name", d.Id())
 
-				return []*schema.ResourceData{d}, nil
-			},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -48,30 +42,20 @@ func ResourceAvailabilityZoneGroup() *schema.Resource {
 func resourceAvailabilityZoneGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	configurationOptInStatus := d.Get("opt_in_status").(string)
+	groupName := d.Get("group_name").(string)
+	availabilityZone, err := FindAvailabilityZoneByGroupName(conn, groupName)
 
-	d.SetId(d.Get("group_name").(string))
-
-	if err := resourceAvailabilityZoneGroupRead(d, meta); err != nil {
-		return err
+	if err != nil {
+		return fmt.Errorf("reading EC2 Availability Zone Group (%s): %w", groupName, err)
 	}
 
-	apiOptInStatus := d.Get("opt_in_status").(string)
-
-	if apiOptInStatus != configurationOptInStatus {
-		input := &ec2.ModifyAvailabilityZoneGroupInput{
-			GroupName:   aws.String(d.Id()),
-			OptInStatus: aws.String(configurationOptInStatus),
-		}
-
-		if _, err := conn.ModifyAvailabilityZoneGroup(input); err != nil {
-			return fmt.Errorf("error modifying EC2 Availability Zone Group (%s): %w", d.Id(), err)
-		}
-
-		if err := waitForEc2AvailabilityZoneGroupOptInStatus(conn, d.Id(), configurationOptInStatus); err != nil {
-			return fmt.Errorf("error waiting for EC2 Availability Zone Group (%s) opt-in status update: %w", d.Id(), err)
+	if v := d.Get("opt_in_status").(string); v != aws.StringValue(availabilityZone.OptInStatus) {
+		if err := modifyAvailabilityZoneOptInStatus(conn, groupName, v); err != nil {
+			return err
 		}
 	}
+
+	d.SetId(groupName)
 
 	return resourceAvailabilityZoneGroupRead(d, meta)
 }
@@ -79,10 +63,10 @@ func resourceAvailabilityZoneGroupCreate(d *schema.ResourceData, meta interface{
 func resourceAvailabilityZoneGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	availabilityZone, err := ec2DescribeAvailabilityZoneGroup(conn, d.Id())
+	availabilityZone, err := FindAvailabilityZoneByGroupName(conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error describing EC2 Availability Zone Group (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading EC2 Availability Zone Group (%s): %w", d.Id(), err)
 	}
 
 	if aws.StringValue(availabilityZone.OptInStatus) == ec2.AvailabilityZoneOptInStatusOptInNotRequired {
@@ -97,93 +81,32 @@ func resourceAvailabilityZoneGroupRead(d *schema.ResourceData, meta interface{})
 
 func resourceAvailabilityZoneGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
-	optInStatus := d.Get("opt_in_status").(string)
 
-	input := &ec2.ModifyAvailabilityZoneGroupInput{
-		GroupName:   aws.String(d.Id()),
-		OptInStatus: aws.String(optInStatus),
-	}
-
-	if _, err := conn.ModifyAvailabilityZoneGroup(input); err != nil {
-		return fmt.Errorf("error modifying EC2 Availability Zone Group (%s): %w", d.Id(), err)
-	}
-
-	if err := waitForEc2AvailabilityZoneGroupOptInStatus(conn, d.Id(), optInStatus); err != nil {
-		return fmt.Errorf("error waiting for EC2 Availability Zone Group (%s) opt-in status update: %w", d.Id(), err)
+	if err := modifyAvailabilityZoneOptInStatus(conn, d.Id(), d.Get("opt_in_status").(string)); err != nil {
+		return err
 	}
 
 	return resourceAvailabilityZoneGroupRead(d, meta)
 }
 
-func ec2DescribeAvailabilityZoneGroup(conn *ec2.EC2, groupName string) (*ec2.AvailabilityZone, error) {
-	input := &ec2.DescribeAvailabilityZonesInput{
-		AllAvailabilityZones: aws.Bool(true),
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("group-name"),
-				Values: aws.StringSlice([]string{groupName}),
-			},
-		},
+func modifyAvailabilityZoneOptInStatus(conn *ec2.EC2, groupName, optInStatus string) error {
+	input := &ec2.ModifyAvailabilityZoneGroupInput{
+		GroupName:   aws.String(groupName),
+		OptInStatus: aws.String(optInStatus),
 	}
 
-	output, err := conn.DescribeAvailabilityZones(input)
-
-	if err != nil {
-		return nil, err
+	if _, err := conn.ModifyAvailabilityZoneGroup(input); err != nil {
+		return fmt.Errorf("modifying EC2 Availability Zone Group (%s): %w", groupName, err)
 	}
 
-	if output == nil || len(output.AvailabilityZones) == 0 {
-		return nil, nil
-	}
-
-	for _, availabilityZone := range output.AvailabilityZones {
-		if availabilityZone == nil {
-			continue
-		}
-
-		if aws.StringValue(availabilityZone.GroupName) == groupName {
-			return availabilityZone, nil
-		}
-	}
-
-	return nil, nil
-}
-
-func ec2AvailabilityZoneGroupOptInStatusRefreshFunc(conn *ec2.EC2, groupName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		availabilityZone, err := ec2DescribeAvailabilityZoneGroup(conn, groupName)
-
-		if err != nil {
-			return nil, "", fmt.Errorf("error describing EC2 Availability Zone Group (%s): %w", groupName, err)
-		}
-
-		if availabilityZone == nil {
-			return nil, "", fmt.Errorf("error describing EC2 Availability Zone Group (%s): not found", groupName)
-		}
-
-		return availabilityZone, aws.StringValue(availabilityZone.OptInStatus), nil
-	}
-}
-
-func waitForEc2AvailabilityZoneGroupOptInStatus(conn *ec2.EC2, groupName string, optInStatus string) error {
-	pending := ec2.AvailabilityZoneOptInStatusNotOptedIn
-
+	waiter := WaitAvailabilityZoneOptedIn
 	if optInStatus == ec2.AvailabilityZoneOptInStatusNotOptedIn {
-		pending = ec2.AvailabilityZoneOptInStatusOptedIn
+		waiter = WaitAvailabilityZoneNotOptedIn
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{pending},
-		Target:                    []string{optInStatus},
-		Refresh:                   ec2AvailabilityZoneGroupOptInStatusRefreshFunc(conn, groupName),
-		Timeout:                   10 * time.Minute,
-		Delay:                     10 * time.Second,
-		MinTimeout:                2 * time.Second,
-		ContinuousTargetOccurence: 3,
+	if _, err := waiter(conn, groupName); err != nil {
+		return fmt.Errorf("waiting for EC2 Availability Zone Group (%s) opt-in status update: %w", groupName, err)
 	}
 
-	log.Printf("[DEBUG] Waiting for EC2 Availability Zone Group (%s) opt-in status update", groupName)
-	_, err := stateConf.WaitForState()
-
-	return err
+	return nil
 }

--- a/internal/service/ec2/ec2_availability_zone_group.go
+++ b/internal/service/ec2/ec2_availability_zone_group.go
@@ -43,7 +43,7 @@ func resourceAvailabilityZoneGroupCreate(d *schema.ResourceData, meta interface{
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	groupName := d.Get("group_name").(string)
-	availabilityZone, err := FindAvailabilityZoneByGroupName(conn, groupName)
+	availabilityZone, err := FindAvailabilityZoneGroupByName(conn, groupName)
 
 	if err != nil {
 		return fmt.Errorf("reading EC2 Availability Zone Group (%s): %w", groupName, err)
@@ -63,7 +63,7 @@ func resourceAvailabilityZoneGroupCreate(d *schema.ResourceData, meta interface{
 func resourceAvailabilityZoneGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	availabilityZone, err := FindAvailabilityZoneByGroupName(conn, d.Id())
+	availabilityZone, err := FindAvailabilityZoneGroupByName(conn, d.Id())
 
 	if err != nil {
 		return fmt.Errorf("reading EC2 Availability Zone Group (%s): %w", d.Id(), err)
@@ -99,9 +99,9 @@ func modifyAvailabilityZoneOptInStatus(conn *ec2.EC2, groupName, optInStatus str
 		return fmt.Errorf("modifying EC2 Availability Zone Group (%s): %w", groupName, err)
 	}
 
-	waiter := WaitAvailabilityZoneOptedIn
+	waiter := WaitAvailabilityZoneGroupOptedIn
 	if optInStatus == ec2.AvailabilityZoneOptInStatusNotOptedIn {
-		waiter = WaitAvailabilityZoneNotOptedIn
+		waiter = WaitAvailabilityZoneGroupNotOptedIn
 	}
 
 	if _, err := waiter(conn, groupName); err != nil {

--- a/internal/service/ec2/ec2_availability_zone_group_test.go
+++ b/internal/service/ec2/ec2_availability_zone_group_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 func TestAccEC2AvailabilityZoneGroup_optInStatus(t *testing.T) {
@@ -17,16 +16,16 @@ func TestAccEC2AvailabilityZoneGroup_optInStatus(t *testing.T) {
 	// Filter to one Availability Zone Group per Region as Local Zones become available
 	// e.g. ensure there are not two us-west-2-XXX when adding to this list
 	// (Not including in config to avoid lintignoring entire config.)
-	localZone := "us-west-2-lax-1" // lintignore:AWSAT003 // currently the only generally available local zone
+	localZone := "us-west-2-lax-1" // lintignore:AWSAT003
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAvailabilityZoneGroup(t) },
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckRegion(t, endpoints.UsWest2RegionID) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEc2AvailabilityZoneGroupConfigOptInStatus(localZone, ec2.AvailabilityZoneOptInStatusOptedIn),
+				Config: testAccEc2AvailabilityZoneGroupOptInStatusConfig(localZone, ec2.AvailabilityZoneOptInStatusOptedIn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptedIn),
 				),
@@ -55,38 +54,7 @@ func TestAccEC2AvailabilityZoneGroup_optInStatus(t *testing.T) {
 	})
 }
 
-func testAccPreCheckAvailabilityZoneGroup(t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
-
-	input := &ec2.DescribeAvailabilityZonesInput{
-		AllAvailabilityZones: aws.Bool(true),
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("opt-in-status"),
-				Values: aws.StringSlice([]string{
-					ec2.AvailabilityZoneOptInStatusNotOptedIn,
-					ec2.AvailabilityZoneOptInStatusOptedIn,
-				}),
-			},
-		},
-	}
-
-	output, err := conn.DescribeAvailabilityZones(input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-
-	if output == nil || len(output.AvailabilityZones) == 0 || output.AvailabilityZones[0] == nil {
-		t.Skipf("skipping acceptance testing: no opt-in EC2 Availability Zone Groups found")
-	}
-}
-
-func testAccEc2AvailabilityZoneGroupConfigOptInStatus(localZone, optInStatus string) string {
+func testAccEc2AvailabilityZoneGroupOptInStatusConfig(name, optInStatus string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "test" {
   all_availability_zones = true
@@ -104,5 +72,5 @@ resource "aws_ec2_availability_zone_group" "test" {
   group_name    = tolist(data.aws_availability_zones.test.group_names)[0]
   opt_in_status = %[2]q
 }
-`, localZone, optInStatus)
+`, name, optInStatus)
 }

--- a/internal/service/ec2/ec2_spot_instance_request_test.go
+++ b/internal/service/ec2/ec2_spot_instance_request_test.go
@@ -19,6 +19,7 @@ import (
 func TestAccEC2SpotInstanceRequest_basic(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
 	resourceName := "aws_spot_instance_request.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -27,7 +28,7 @@ func TestAccEC2SpotInstanceRequest_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig(),
+				Config: testAccSpotInstanceRequestConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributes(&sir),
@@ -50,6 +51,7 @@ func TestAccEC2SpotInstanceRequest_basic(t *testing.T) {
 func TestAccEC2SpotInstanceRequest_disappears(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
 	resourceName := "aws_spot_instance_request.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -58,7 +60,7 @@ func TestAccEC2SpotInstanceRequest_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig(),
+				Config: testAccSpotInstanceRequestConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSpotInstanceRequest(), resourceName),
@@ -658,17 +660,24 @@ func testAccCheckSpotInstanceRequestRecreated(before, after *ec2.SpotInstanceReq
 	}
 }
 
-func testAccSpotInstanceRequestConfig() string {
+func testAccSpotInstanceRequestConfig(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"), `
+		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
   ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
   spot_price           = "0.05"
   wait_for_fulfillment = true
 }
-`)
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
+`, rName))
 }
 
 func testAccSpotInstanceRequestConfigTags1(rName, tagKey1, tagValue1 string) string {
@@ -685,6 +694,12 @@ resource "aws_spot_instance_request" "test" {
   tags = {
     %[2]q = %[3]q
   }
+}
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
 }
 `, rName, tagKey1, tagValue1))
 }
@@ -705,6 +720,12 @@ resource "aws_spot_instance_request" "test" {
     %[4]q = %[5]q
   }
 }
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
@@ -724,6 +745,12 @@ resource "aws_spot_instance_request" "test" {
     Name = %[1]q
   }
 }
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
 `, rName, validUntil))
 }
 
@@ -740,6 +767,12 @@ resource "aws_spot_instance_request" "test" {
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
 }
 `, rName))
 }
@@ -768,6 +801,12 @@ resource "aws_key_pair" "test" {
     Name = %[1]q
   }
 }
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
 `, rName, publicKey))
 }
 
@@ -787,6 +826,12 @@ resource "aws_spot_instance_request" "test" {
     Name = %[1]q
   }
 }
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
 `, rName))
 }
 
@@ -805,6 +850,12 @@ resource "aws_spot_instance_request" "test" {
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
 }
 `, rName))
 }
@@ -843,6 +894,12 @@ resource "aws_spot_instance_request" "test" {
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
 }
 `, rName))
 }
@@ -895,6 +952,12 @@ resource "aws_security_group" "test" {
     Name = %[1]q
   }
 }
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
 `, rName))
 }
 
@@ -924,6 +987,12 @@ resource "aws_key_pair" "test" {
     Name = %[1]q
   }
 }
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
+}
 `, rName, publicKey))
 }
 
@@ -942,6 +1011,12 @@ resource "aws_spot_instance_request" "test" {
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_ec2_tag" "test" {
+  resource_id = aws_spot_instance_request.test.spot_instance_id
+  key         = "Name"
+  value       = %[1]q
 }
 `, rName, interruptionBehavior))
 }

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -45,9 +45,11 @@ func FindAvailabilityZone(conn *ec2.EC2, input *ec2.DescribeAvailabilityZonesInp
 	return output[0], nil
 }
 
-func FindAvailabilityZoneByName(conn *ec2.EC2, name string) (*ec2.AvailabilityZone, error) {
+func FindAvailabilityZoneByGroupName(conn *ec2.EC2, name string) (*ec2.AvailabilityZone, error) {
 	input := &ec2.DescribeAvailabilityZonesInput{
-		ZoneNames: aws.StringSlice([]string{name}),
+		Filters: BuildAttributeFilterList(map[string]string{
+			"group-name": name,
+		}),
 	}
 
 	output, err := FindAvailabilityZone(conn, input)
@@ -57,7 +59,7 @@ func FindAvailabilityZoneByName(conn *ec2.EC2, name string) (*ec2.AvailabilityZo
 	}
 
 	// Eventual consistency check.
-	if aws.StringValue(output.ZoneName) != name {
+	if aws.StringValue(output.GroupName) != name {
 		return nil, &resource.NotFoundError{
 			LastRequest: input,
 		}

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -13,6 +13,59 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+func FindAvailabilityZones(conn *ec2.EC2, input *ec2.DescribeAvailabilityZonesInput) ([]*ec2.AvailabilityZone, error) {
+	output, err := conn.DescribeAvailabilityZones(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.AvailabilityZones, nil
+}
+
+func FindAvailabilityZone(conn *ec2.EC2, input *ec2.DescribeAvailabilityZonesInput) (*ec2.AvailabilityZone, error) {
+	output, err := FindAvailabilityZones(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 || output[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output[0], nil
+}
+
+func FindAvailabilityZoneByName(conn *ec2.EC2, name string) (*ec2.AvailabilityZone, error) {
+	input := &ec2.DescribeAvailabilityZonesInput{
+		ZoneNames: aws.StringSlice([]string{name}),
+	}
+
+	output, err := FindAvailabilityZone(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Eventual consistency check.
+	if aws.StringValue(output.ZoneName) != name {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
 func FindCapacityReservation(conn *ec2.EC2, input *ec2.DescribeCapacityReservationsInput) (*ec2.CapacityReservation, error) {
 	output, err := FindCapacityReservations(conn, input)
 

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -47,6 +47,7 @@ func FindAvailabilityZone(conn *ec2.EC2, input *ec2.DescribeAvailabilityZonesInp
 
 func FindAvailabilityZoneGroupByName(conn *ec2.EC2, name string) (*ec2.AvailabilityZone, error) {
 	input := &ec2.DescribeAvailabilityZonesInput{
+		AllAvailabilityZones: aws.Bool(true),
 		Filters: BuildAttributeFilterList(map[string]string{
 			"group-name": name,
 		}),

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func StatusAvailabilityZoneOptInStatus(conn *ec2.EC2, groupName string) resource.StateRefreshFunc {
+func StatusAvailabilityZoneGroupOptInStatus(conn *ec2.EC2, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindAvailabilityZoneByGroupName(conn, groupName)
+		output, err := FindAvailabilityZoneGroupByName(conn, name)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -13,6 +13,22 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func StatusAvailabilityZoneOptInStatus(conn *ec2.EC2, groupName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindAvailabilityZoneByGroupName(conn, groupName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.OptInStatus), nil
+	}
+}
+
 func StatusCapacityReservationState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindCapacityReservationByID(conn, id)

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -30,6 +30,44 @@ const (
 )
 
 const (
+	AvailabilityZoneOptInStatusTimeout = 10 * time.Minute
+)
+
+func WaitAvailabilityZoneOptedIn(conn *ec2.EC2, groupName string) (*ec2.AvailabilityZone, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.AvailabilityZoneOptInStatusNotOptedIn},
+		Target:  []string{ec2.AvailabilityZoneOptInStatusOptedIn},
+		Refresh: StatusAvailabilityZoneOptInStatus(conn, groupName),
+		Timeout: AvailabilityZoneOptInStatusTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.AvailabilityZone); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func WaitAvailabilityZoneNotOptedIn(conn *ec2.EC2, groupName string) (*ec2.AvailabilityZone, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.AvailabilityZoneOptInStatusOptedIn},
+		Target:  []string{ec2.AvailabilityZoneOptInStatusNotOptedIn},
+		Refresh: StatusAvailabilityZoneOptInStatus(conn, groupName),
+		Timeout: AvailabilityZoneOptInStatusTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.AvailabilityZone); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+const (
 	CapacityReservationActiveTimeout  = 2 * time.Minute
 	CapacityReservationDeletedTimeout = 2 * time.Minute
 )

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -30,15 +30,15 @@ const (
 )
 
 const (
-	AvailabilityZoneOptInStatusTimeout = 10 * time.Minute
+	AvailabilityZoneGroupOptInStatusTimeout = 10 * time.Minute
 )
 
-func WaitAvailabilityZoneOptedIn(conn *ec2.EC2, groupName string) (*ec2.AvailabilityZone, error) {
+func WaitAvailabilityZoneGroupOptedIn(conn *ec2.EC2, name string) (*ec2.AvailabilityZone, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.AvailabilityZoneOptInStatusNotOptedIn},
 		Target:  []string{ec2.AvailabilityZoneOptInStatusOptedIn},
-		Refresh: StatusAvailabilityZoneOptInStatus(conn, groupName),
-		Timeout: AvailabilityZoneOptInStatusTimeout,
+		Refresh: StatusAvailabilityZoneGroupOptInStatus(conn, name),
+		Timeout: AvailabilityZoneGroupOptInStatusTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -50,12 +50,12 @@ func WaitAvailabilityZoneOptedIn(conn *ec2.EC2, groupName string) (*ec2.Availabi
 	return nil, err
 }
 
-func WaitAvailabilityZoneNotOptedIn(conn *ec2.EC2, groupName string) (*ec2.AvailabilityZone, error) {
+func WaitAvailabilityZoneGroupNotOptedIn(conn *ec2.EC2, name string) (*ec2.AvailabilityZone, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.AvailabilityZoneOptInStatusOptedIn},
 		Target:  []string{ec2.AvailabilityZoneOptInStatusNotOptedIn},
-		Refresh: StatusAvailabilityZoneOptInStatus(conn, groupName),
-		Timeout: AvailabilityZoneOptInStatusTimeout,
+		Refresh: StatusAvailabilityZoneGroupOptInStatus(conn, name),
+		Timeout: AvailabilityZoneGroupOptInStatusTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/internal/service/ec2/wavelength_carrier_gateway_test.go
+++ b/internal/service/ec2/wavelength_carrier_gateway_test.go
@@ -182,7 +182,7 @@ func testAccPreCheckWavelengthZoneAvailable(t *testing.T) {
 		}),
 	}
 
-	output, err := conn.DescribeAvailabilityZones(input)
+	output, err := tfec2.FindAvailabilityZones(conn, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
@@ -192,7 +192,7 @@ func testAccPreCheckWavelengthZoneAvailable(t *testing.T) {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 
-	if output == nil || len(output.AvailabilityZones) == 0 {
+	if len(output) == 0 {
 		t.Skip("skipping since no Wavelength Zones are available")
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24391.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEC2AvailabilityZoneGroup_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2AvailabilityZoneGroup_'  -timeout 180m
=== RUN   TestAccEC2AvailabilityZoneGroup_optInStatus
=== PAUSE TestAccEC2AvailabilityZoneGroup_optInStatus
=== CONT  TestAccEC2AvailabilityZoneGroup_optInStatus
--- PASS: TestAccEC2AvailabilityZoneGroup_optInStatus (27.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	35.482s
% make testacc TESTS=TestAccEC2AvailabilityZoneDataSource_ PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2 -run='TestAccEC2AvailabilityZoneDataSource_'  -timeout 180m
=== RUN   TestAccEC2AvailabilityZoneDataSource_allAvailabilityZones
=== PAUSE TestAccEC2AvailabilityZoneDataSource_allAvailabilityZones
=== RUN   TestAccEC2AvailabilityZoneDataSource_filter
=== PAUSE TestAccEC2AvailabilityZoneDataSource_filter
=== RUN   TestAccEC2AvailabilityZoneDataSource_localZone
=== PAUSE TestAccEC2AvailabilityZoneDataSource_localZone
=== RUN   TestAccEC2AvailabilityZoneDataSource_name
=== PAUSE TestAccEC2AvailabilityZoneDataSource_name
=== RUN   TestAccEC2AvailabilityZoneDataSource_wavelengthZone
=== PAUSE TestAccEC2AvailabilityZoneDataSource_wavelengthZone
=== RUN   TestAccEC2AvailabilityZoneDataSource_zoneID
=== PAUSE TestAccEC2AvailabilityZoneDataSource_zoneID
=== CONT  TestAccEC2AvailabilityZoneDataSource_allAvailabilityZones
=== CONT  TestAccEC2AvailabilityZoneDataSource_name
--- PASS: TestAccEC2AvailabilityZoneDataSource_allAvailabilityZones (13.86s)
=== CONT  TestAccEC2AvailabilityZoneDataSource_zoneID
--- PASS: TestAccEC2AvailabilityZoneDataSource_name (14.48s)
=== CONT  TestAccEC2AvailabilityZoneDataSource_localZone
--- PASS: TestAccEC2AvailabilityZoneDataSource_zoneID (10.75s)
=== CONT  TestAccEC2AvailabilityZoneDataSource_wavelengthZone
--- PASS: TestAccEC2AvailabilityZoneDataSource_localZone (10.46s)
=== CONT  TestAccEC2AvailabilityZoneDataSource_filter
--- PASS: TestAccEC2AvailabilityZoneDataSource_wavelengthZone (10.51s)
--- PASS: TestAccEC2AvailabilityZoneDataSource_filter (10.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	39.496s
% make testacc TESTS=TestAccEC2SpotInstanceRequest_ PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3 -run='TestAccEC2SpotInstanceRequest_'  -timeout 180m
=== RUN   TestAccEC2SpotInstanceRequest_basic
=== PAUSE TestAccEC2SpotInstanceRequest_basic
=== RUN   TestAccEC2SpotInstanceRequest_disappears
=== PAUSE TestAccEC2SpotInstanceRequest_disappears
=== RUN   TestAccEC2SpotInstanceRequest_tags
=== PAUSE TestAccEC2SpotInstanceRequest_tags
=== RUN   TestAccEC2SpotInstanceRequest_keyName
=== PAUSE TestAccEC2SpotInstanceRequest_keyName
=== RUN   TestAccEC2SpotInstanceRequest_withLaunchGroup
=== PAUSE TestAccEC2SpotInstanceRequest_withLaunchGroup
=== RUN   TestAccEC2SpotInstanceRequest_withBlockDuration
=== PAUSE TestAccEC2SpotInstanceRequest_withBlockDuration
=== RUN   TestAccEC2SpotInstanceRequest_vpc
=== PAUSE TestAccEC2SpotInstanceRequest_vpc
=== RUN   TestAccEC2SpotInstanceRequest_validUntil
=== PAUSE TestAccEC2SpotInstanceRequest_validUntil
=== RUN   TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== PAUSE TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== RUN   TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
=== PAUSE TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
=== RUN   TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
=== PAUSE TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
=== RUN   TestAccEC2SpotInstanceRequest_getPasswordData
=== PAUSE TestAccEC2SpotInstanceRequest_getPasswordData
=== RUN   TestAccEC2SpotInstanceRequest_interruptStop
=== PAUSE TestAccEC2SpotInstanceRequest_interruptStop
=== RUN   TestAccEC2SpotInstanceRequest_interruptHibernate
=== PAUSE TestAccEC2SpotInstanceRequest_interruptHibernate
=== RUN   TestAccEC2SpotInstanceRequest_interruptUpdate
=== PAUSE TestAccEC2SpotInstanceRequest_interruptUpdate
=== CONT  TestAccEC2SpotInstanceRequest_basic
=== CONT  TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== CONT  TestAccEC2SpotInstanceRequest_withLaunchGroup
--- PASS: TestAccEC2SpotInstanceRequest_withLaunchGroup (75.62s)
=== CONT  TestAccEC2SpotInstanceRequest_validUntil
--- PASS: TestAccEC2SpotInstanceRequest_basic (93.76s)
=== CONT  TestAccEC2SpotInstanceRequest_vpc
--- PASS: TestAccEC2SpotInstanceRequest_withoutSpotPrice (94.60s)
=== CONT  TestAccEC2SpotInstanceRequest_withBlockDuration
--- PASS: TestAccEC2SpotInstanceRequest_validUntil (108.45s)
=== CONT  TestAccEC2SpotInstanceRequest_tags
--- PASS: TestAccEC2SpotInstanceRequest_vpc (109.36s)
=== CONT  TestAccEC2SpotInstanceRequest_keyName
--- PASS: TestAccEC2SpotInstanceRequest_withBlockDuration (116.61s)
=== CONT  TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
--- PASS: TestAccEC2SpotInstanceRequest_keyName (117.73s)
=== CONT  TestAccEC2SpotInstanceRequest_getPasswordData
--- PASS: TestAccEC2SpotInstanceRequest_networkInterfaceAttributes (128.62s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptUpdate
--- PASS: TestAccEC2SpotInstanceRequest_tags (205.03s)
=== CONT  TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
--- PASS: TestAccEC2SpotInstanceRequest_getPasswordData (165.21s)
=== CONT  TestAccEC2SpotInstanceRequest_disappears
--- PASS: TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress (131.59s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptHibernate
--- PASS: TestAccEC2SpotInstanceRequest_interruptUpdate (204.42s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptStop
--- PASS: TestAccEC2SpotInstanceRequest_interruptHibernate (124.37s)
--- PASS: TestAccEC2SpotInstanceRequest_interruptStop (102.61s)
--- PASS: TestAccEC2SpotInstanceRequest_disappears (345.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	835.807s
```
