### PR TITLE
Remove trailing 'i' from prioritization guide

### DIFF
--- a/docs/contributing/prioritization.md
+++ b/docs/contributing/prioritization.md
@@ -53,4 +53,4 @@ We always include capacity for technical debt work in every iteration, but engin
 
 ### Adverse User Experience or Security Vulnerabilities
 
-Issues with the provider that provide a poor user experience (bugs, crashes), or involve a threat to security are always prioritized for inclusion. The severity of these will determine how soon they are included for release.i
+Issues with the provider that provide a poor user experience (bugs, crashes), or involve a threat to security are always prioritized for inclusion. The severity of these will determine how soon they are included for release.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing: N/a, docs

### Information

There was a trailing `i` at the end of the prioritization guide. This PR fixes that.