### PR TITLE
Fix example KMS key policies granting full public access to keys.

### DIFF
--- a/website/docs/r/codebuild_report_group.html.markdown
+++ b/website/docs/r/codebuild_report_group.html.markdown
@@ -13,6 +13,8 @@ Provides a CodeBuild Report Groups Resource.
 ## Example Usage
 
 ```terraform
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "example" {
   description             = "my test kms key"
   deletion_window_in_days = 7
@@ -26,7 +28,7 @@ resource "aws_kms_key" "example" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -106,6 +106,8 @@ resource "aws_dlm_lifecycle_policy" "example" {
 
 ```terraform
 # ...other configuration...
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "dlm_cross_region_copy_cmk" {
   provider = aws.alternate
 
@@ -120,7 +122,7 @@ resource "aws_kms_key" "dlm_cross_region_copy_cmk" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -23,6 +23,8 @@ resource "aws_xray_encryption_config" "example" {
 ## Example Usage with KMS Key
 
 ```terraform
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "example" {
   description             = "Some Key"
   deletion_window_in_days = 7
@@ -36,7 +38,7 @@ resource "aws_kms_key" "example" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

---
Several resources have documentation with examples that create KMS keys with a policy granting `kms:*` to `"AWS": "*"`, which grants full access to all AWS accounts. Not exactly a best practice for key management! Based on the `Sid`, the intention appears to be to enable IAM-based management of the key, which is done by granting access to the account's root principal, not `*` ([docs](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-overview.html)).

I initially noticed this in `route53_hosted_zone_dnssec`, but discovered after some searching that it had been copy-and-pasted several times. I've included fixes for those as well.

I also found that  `backup_vault_policy`, `glue_resource_policy`, and `ses_identity_policy` have non-KMS policies with `"AWS": "*"` grants that seem suspicious, as well. (The SES one, for example, appears to allow anyone on the internet to send mail with your verified domain.) I'll file a separate issue for those; I didn't include a fix here since I'm less familiar with those policy types.