### PR TITLE
github/workflows/post_publish: parallelize jobs that run when release workflow succeeds or on manual trigger

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -32,12 +32,7 @@ jobs:
             value=`cat release-tag.data`
             echo ::set-output name=tag::$value
           fi
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo 'The triggering workflow failed'
-  organize:
+  tidy-asana:
     needs: [ on-success-or-workflow-dispatch ]
     runs-on: ubuntu-latest
     steps:
@@ -51,9 +46,18 @@ jobs:
           asana_github_url_field_gid: '1134594824474912'
           github_release_name: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Archive Released Cards
+  archive-release-cards:
+    needs: [ on-success-or-workflow-dispatch ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Archive Release Cards
         uses: breathingdust/github-project-archive@v1
         with:
           github_done_column_id: 11513756
           github_release_name: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
           github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Description:

* noticed these jobs could run in parallel as they're not dependent on each other

Output from acceptance testing:

```
N/A or @actionlint if available
```
