### PR TITLE
organizations/account: Add GovCloud ability

### DIFF
--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -17,6 +17,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceAccount() *schema.Resource {
@@ -39,6 +40,11 @@ func ResourceAccount() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"create_govcloud": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"email": {
 				ForceNew: true,
 				Type:     schema.TypeString,
@@ -47,6 +53,10 @@ func ResourceAccount() *schema.Resource {
 					validation.StringLenBetween(6, 64),
 					validation.StringMatch(regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`), "must be a valid email address"),
 				),
+			},
+			"govcloud_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"iam_user_access_to_billing": {
 				ForceNew:     true,
@@ -97,41 +107,36 @@ func resourceAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	// Create the account
-	name := d.Get("name").(string)
-	input := &organizations.CreateAccountInput{
-		AccountName: aws.String(name),
-		Email:       aws.String(d.Get("email").(string)),
-	}
+	var iamUserAccessToBilling *string
 
 	if v, ok := d.GetOk("iam_user_access_to_billing"); ok {
-		input.IamUserAccessToBilling = aws.String(v.(string))
+		iamUserAccessToBilling = aws.String(v.(string))
 	}
+
+	var roleName *string
 
 	if v, ok := d.GetOk("role_name"); ok {
-		input.RoleName = aws.String(v.(string))
+		roleName = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating AWS Organizations Account: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(4*time.Minute,
-		func() (interface{}, error) {
-			return conn.CreateAccount(input)
-		},
-		organizations.ErrCodeFinalizingOrganizationException,
+	s, err := createAccount(
+		conn,
+		d.Get("name").(string),
+		d.Get("email").(string),
+		iamUserAccessToBilling,
+		roleName,
+		Tags(tags.IgnoreAWS()),
+		d.Get("create_govcloud").(bool),
 	)
 
 	if err != nil {
-		return fmt.Errorf("error creating AWS Organizations Account (%s): %w", name, err)
+		return fmt.Errorf("error creating AWS Organizations Account (%s): %w", d.Get("name").(string), err)
 	}
 
-	output, err := waitAccountCreated(conn, aws.StringValue(outputRaw.(*organizations.CreateAccountOutput).CreateAccountStatus.Id))
+	output, err := waitAccountCreated(conn, aws.StringValue(s.Id))
 
 	if err != nil {
-		return fmt.Errorf("error waiting for AWS Organizations Account (%s) create: %w", name, err)
+		return fmt.Errorf("error waiting for AWS Organizations Account (%s) create: %w", d.Get("name").(string), err)
 	}
 
 	d.SetId(aws.StringValue(output.AccountId))
@@ -190,6 +195,14 @@ func resourceAccountRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", account.Name)
 	d.Set("parent_id", parentAccountID)
 	d.Set("status", account.Status)
+
+	s, err := findCreateAccountStatusByID(conn, d.Id())
+
+	if err != nil {
+		return names.Error(names.Organizations, "finding", "Create Account Status", d.Id(), err)
+	}
+
+	d.Set("govcloud_id", s.GovCloudAccountId)
 
 	tags, err := ListTags(conn, d.Id())
 
@@ -272,6 +285,72 @@ func resourceAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func createAccount(conn *organizations.Organizations, name, email string, iamUserAccessToBilling, roleName *string, tags []*organizations.Tag, govCloud bool) (*organizations.CreateAccountStatus, error) {
+	if govCloud {
+		input := &organizations.CreateGovCloudAccountInput{
+			AccountName: aws.String(name),
+			Email:       aws.String(email),
+		}
+
+		if iamUserAccessToBilling != nil {
+			input.IamUserAccessToBilling = iamUserAccessToBilling
+		}
+
+		if roleName != nil {
+			input.RoleName = roleName
+		}
+
+		if len(tags) > 0 {
+			input.Tags = tags
+		}
+
+		log.Printf("[DEBUG] Creating AWS Organizations Account with GovCloud Account: %s", input)
+		outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(4*time.Minute,
+			func() (interface{}, error) {
+				return conn.CreateGovCloudAccount(input)
+			},
+			organizations.ErrCodeFinalizingOrganizationException,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return outputRaw.(*organizations.CreateGovCloudAccountOutput).CreateAccountStatus, nil
+	}
+
+	input := &organizations.CreateAccountInput{
+		AccountName: aws.String(name),
+		Email:       aws.String(email),
+	}
+
+	if iamUserAccessToBilling != nil {
+		input.IamUserAccessToBilling = iamUserAccessToBilling
+	}
+
+	if roleName != nil {
+		input.RoleName = roleName
+	}
+
+	if len(tags) > 0 {
+		input.Tags = tags
+	}
+
+	log.Printf("[DEBUG] Creating AWS Organizations Account: %s", input)
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(4*time.Minute,
+		func() (interface{}, error) {
+			return conn.CreateAccount(input)
+		},
+		organizations.ErrCodeFinalizingOrganizationException,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return outputRaw.(*organizations.CreateAccountOutput).CreateAccountStatus, nil
 }
 
 func findParentAccountID(conn *organizations.Organizations, id string) (string, error) {

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -25,14 +25,18 @@ resource "aws_organizations_account" "account" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `name` - (Required) A friendly name for the member account.
-* `email` - (Required) The email address of the owner to assign to the new member account. This email address must not already be associated with another AWS account.
+* `email` - (Required) Email address of the owner to assign to the new member account. This email address must not already be associated with another AWS account.
+* `name` - (Required) Friendly name for the member account.
+
+The following arguments are optional:
+
+* `close_on_deletion` - (Optional) If true, a deletion event will close the account. Otherwise, it will only remove from the organization. This is not supported for GovCloud accounts.
+* `create_govcloud` - (Optional) Whether to also create a GovCloud account. The GovCloud account is tied to the main (commercial) account this resource creates. If `true`, the GovCloud account ID is available in the `govcloud_id` attribute. The only way to manage the GovCloud account with Terraform is to subsequently import the account using this resource.
 * `iam_user_access_to_billing` - (Optional) If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information.
 * `parent_id` - (Optional) Parent Organizational Unit ID or Root ID for the account. Defaults to the Organization default Root ID. A configuration must be present for this argument to perform drift detection.
 * `role_name` - (Optional) The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator. The role has administrator permissions in the new member account. The Organizations API provides no method for reading this information after account creation, so Terraform cannot perform drift detection on its value and will always show a difference for a configured value after import unless [`ignore_changes`](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) is used.
-* `close_on_deletion` - (Optional) If true, a deletion event will close the account. Otherwise, it will only remove from the organization.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
@@ -40,6 +44,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN for this account.
+* `govcloud_id` - ID for a GovCloud account created with the account.
 * `id` - The AWS account id
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
