### PR TITLE
fix: aws_acm_certificate_validation uses create timestamp as id for validation not certificate arn

### DIFF
--- a/.changelog/24453.txt
+++ b/.changelog/24453.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_acm_certificate_validation: Restore resource ID as certificate issuance timestamp
+```

--- a/.changelog/24453.txt
+++ b/.changelog/24453.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_acm_certificate_validation: Restore resource ID as certificate issuance timestamp, fixing error on existing resource Read
+resource/aws_acm_certificate_validation: Restore certificate issuance timestamp as the resource `id` value, fixing error on existing resource Read
 ```

--- a/.changelog/24453.txt
+++ b/.changelog/24453.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_acm_certificate_validation: Restore resource ID as certificate issuance timestamp
+resource/aws_acm_certificate_validation: Restore resource ID as certificate issuance timestamp, fixing error on existing resource Read
 ```

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -99,7 +99,7 @@ func resourceCertificateValidationRead(d *schema.ResourceData, meta interface{})
 	conn := meta.(*conns.AWSClient).ACMConn
 
 	arn := d.Get("certificate_arn").(string)
-	certificate, err := FindCertificateByARN(conn, arn)
+	certificate, err := FindCertificateValidationByARN(conn, arn)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] ACM Certificate %s not found, removing from state", arn)
@@ -111,22 +111,7 @@ func resourceCertificateValidationRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("reading ACM Certificate (%s): %w", arn, err)
 	}
 
-	if certificate == nil {
-		return fmt.Errorf("error describing ACM Certificate (%s): empty response", arn)
-	}
-
-	if status := aws.StringValue(certificate.Status); status != acm.CertificateStatusIssued {
-		if d.IsNewResource() {
-			return fmt.Errorf("ACM Certificate (%s) status not issued: %s", arn, status)
-		}
-
-		log.Printf("[WARN] ACM Certificate (%s) status not issued (%s), removing from state", arn, status)
-		d.SetId("")
-		return nil
-	}
-
 	d.Set("certificate_arn", certificate.CertificateArn)
-	d.SetId(aws.TimeValue(certificate.IssuedAt).String())
 
 	return nil
 }

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -90,7 +90,7 @@ func resourceCertificateValidationCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("waiting for ACM Certificate (%s) to be issued: %w", arn, err)
 	}
 
-	d.SetId(arn)
+	d.SetId(aws.TimeValue(certificate.IssuedAt).String())
 
 	return resourceCertificateValidationRead(d, meta)
 }
@@ -98,19 +98,21 @@ func resourceCertificateValidationCreate(d *schema.ResourceData, meta interface{
 func resourceCertificateValidationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ACMConn
 
-	certificate, err := FindCertificateValidationByARN(conn, d.Id())
+	arn := d.Get("certificate_arn").(string)
+	certificate, err := FindCertificateByARN(conn, arn)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] ACM Certificate %s not found, removing from state", d.Id())
+		log.Printf("[WARN] ACM Certificate %s not found, removing from state", arn)
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("reading ACM Certificate (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading ACM Certificate (%s): %w", arn, err)
 	}
 
 	d.Set("certificate_arn", certificate.CertificateArn)
+	d.SetId(aws.TimeValue(certificate.IssuedAt).String())
 
 	return nil
 }

--- a/internal/service/acm/certificate_validation_test.go
+++ b/internal/service/acm/certificate_validation_test.go
@@ -233,7 +233,7 @@ func testAccCheckAcmCertificateValidationExists(n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ACMConn
 
-		_, err := tfacm.FindCertificateValidationByARN(conn, rs.Primary.ID)
+		_, err := tfacm.FindCertificateValidationByARN(conn, rs.Primary.Attributes["certificate_arn"])
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Resolves #24452.

Advice required from @mattburgess and @ewbankkit as it is relates to fixing breaking changes at #20073.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
<details>
<summary>test output (isn't quite right?)</summary>
```
$ make testacc TESTS=TestAccACM PKG=acm

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACM'  -timeout 180m
=== RUN   TestAccACMCertificateDataSource_singleIssued
    certificate_data_source_test.go:19: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set
--- SKIP: TestAccACMCertificateDataSource_singleIssued (0.00s)
=== RUN   TestAccACMCertificateDataSource_multipleIssued
    certificate_data_source_test.go:94: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set
--- SKIP: TestAccACMCertificateDataSource_multipleIssued (0.00s)
=== RUN   TestAccACMCertificateDataSource_noMatchReturnsError
    certificate_data_source_test.go:158: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set
--- SKIP: TestAccACMCertificateDataSource_noMatchReturnsError (0.00s)
=== RUN   TestAccACMCertificateDataSource_keyTypes
=== PAUSE TestAccACMCertificateDataSource_keyTypes
=== RUN   TestAccACMCertificate_emailValidation
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_emailValidation (0.00s)
=== RUN   TestAccACMCertificate_dnsValidation
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_dnsValidation (0.00s)
=== RUN   TestAccACMCertificate_root
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_root (0.00s)
=== RUN   TestAccACMCertificate_validationOptions
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_validationOptions (0.00s)
=== RUN   TestAccACMCertificate_privateCert
=== PAUSE TestAccACMCertificate_privateCert
=== RUN   TestAccACMCertificate_Root_trailingPeriod
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_Root_trailingPeriod (0.00s)
=== RUN   TestAccACMCertificate_rootAndWildcardSan
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_rootAndWildcardSan (0.00s)
=== RUN   TestAccACMCertificate_SubjectAlternativeNames_emptyString
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_SubjectAlternativeNames_emptyString (0.00s)
=== RUN   TestAccACMCertificate_San_single
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_single (0.00s)
=== RUN   TestAccACMCertificate_San_multiple
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_multiple (0.00s)
=== RUN   TestAccACMCertificate_San_trailingPeriod
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_trailingPeriod (0.00s)
=== RUN   TestAccACMCertificate_San_matches_domain
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_matches_domain (0.00s)
=== RUN   TestAccACMCertificate_wildcard
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_wildcard (0.00s)
=== RUN   TestAccACMCertificate_wildcardAndRootSan
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_wildcardAndRootSan (0.00s)
=== RUN   TestAccACMCertificate_disableCTLogging
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_disableCTLogging (0.00s)
=== RUN   TestAccACMCertificate_Imported_domainName
=== PAUSE TestAccACMCertificate_Imported_domainName
=== RUN   TestAccACMCertificate_Imported_ipAddress
=== PAUSE TestAccACMCertificate_Imported_ipAddress
=== RUN   TestAccACMCertificate_PrivateKey_tags
=== PAUSE TestAccACMCertificate_PrivateKey_tags
=== RUN   TestAccACMCertificateValidation_basic
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_basic (0.00s)
=== RUN   TestAccACMCertificateValidation_timeout
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_timeout (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNS
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNS (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNSEmail
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNSEmail (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNSRoot
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNSRoot (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNSRootAndWildcard
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNSRootAndWildcard (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNSSan
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNSSan (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNSWildcard
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNSWildcard (0.00s)
=== RUN   TestAccACMCertificateValidation_validationRecordFQDNSWildcardAndRoot
    acctest.go:1330: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificateValidation_validationRecordFQDNSWildcardAndRoot (0.00s)
=== CONT  TestAccACMCertificateDataSource_keyTypes
=== CONT  TestAccACMCertificate_Imported_ipAddress
=== CONT  TestAccACMCertificate_PrivateKey_tags
=== CONT  TestAccACMCertificate_Imported_domainName
=== CONT  TestAccACMCertificate_privateCert
=== CONT  TestAccACMCertificateDataSource_keyTypes
    acctest.go:196: at least one environment variable of [AWS_PROFILE AWS_ACCESS_KEY_ID AWS_CONTAINER_CREDENTIALS_FULL_URI] must be set. Usage: credentials for running acceptance testing
--- FAIL: TestAccACMCertificateDataSource_keyTypes (1.57s)
=== CONT  TestAccACMCertificate_privateCert
    certificate_test.go:180: Step 1/2 error: Error running pre-apply refresh: exit status 1

        Error: Invalid provider configuration

        Provider "registry.terraform.io/hashicorp/aws" requires explicit
        configuration. Add a provider block to the root module and configure the
        provider's required arguments as described in the provider documentation.


        Error: error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.

        Please see https://registry.terraform.io/providers/hashicorp/aws
        for more information about providing credentials.

        Error: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, request send failed, Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: i/o timeout


          with provider["registry.terraform.io/hashicorp/aws"],
          on <empty> line 0:
          (source code not available)

=== CONT  TestAccACMCertificate_PrivateKey_tags
    certificate_test.go:697: Step 1/5 error: Error running pre-apply refresh: exit status 1

        Error: Invalid provider configuration

        Provider "registry.terraform.io/hashicorp/aws" requires explicit
        configuration. Add a provider block to the root module and configure the
        provider's required arguments as described in the provider documentation.


        Error: error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.

        Please see https://registry.terraform.io/providers/hashicorp/aws
        for more information about providing credentials.

        Error: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, request send failed, Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: i/o timeout


          with provider["registry.terraform.io/hashicorp/aws"],
          on <empty> line 0:
          (source code not available)

=== CONT  TestAccACMCertificate_Imported_domainName
    certificate_test.go:616: Step 1/4 error: Error running pre-apply refresh: exit status 1

        Error: Invalid provider configuration

        Provider "registry.terraform.io/hashicorp/aws" requires explicit
        configuration. Add a provider block to the root module and configure the
        provider's required arguments as described in the provider documentation.


        Error: error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.

        Please see https://registry.terraform.io/providers/hashicorp/aws
        for more information about providing credentials.

        Error: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, request send failed, Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: i/o timeout


          with provider["registry.terraform.io/hashicorp/aws"],
          on <empty> line 0:
          (source code not available)

=== CONT  TestAccACMCertificate_Imported_ipAddress
    certificate_test.go:662: Step 1/2 error: Error running pre-apply refresh: exit status 1

        Error: Invalid provider configuration

        Provider "registry.terraform.io/hashicorp/aws" requires explicit
        configuration. Add a provider block to the root module and configure the
        provider's required arguments as described in the provider documentation.


        Error: error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.

        Please see https://registry.terraform.io/providers/hashicorp/aws
        for more information about providing credentials.

        Error: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, request send failed, Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: i/o timeout


          with provider["registry.terraform.io/hashicorp/aws"],
          on <empty> line 0:
          (source code not available)

--- FAIL: TestAccACMCertificate_PrivateKey_tags (3.61s)
--- FAIL: TestAccACMCertificate_privateCert (3.35s)
--- FAIL: TestAccACMCertificate_Imported_domainName (4.38s)
--- FAIL: TestAccACMCertificate_Imported_ipAddress (3.51s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/acm	9.633s
FAIL
```
</details>
