### PR TITLE
Fix DAX semgrep `prefer-aws-go-sdk-pointer-conversion-conditional` errors

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -74,7 +74,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/**/*_test.go
-        - internal/service/dax
         - internal/service/docdb
         - internal/service/ec2
         - internal/service/ecs

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -73,7 +73,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/**/*_test.go
         - internal/service/docdb
         - internal/service/ec2
         - internal/service/ecs

--- a/internal/service/dax/parameter_group.go
+++ b/internal/service/dax/parameter_group.go
@@ -114,7 +114,7 @@ func resourceParameterGroupRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", pg.ParameterGroupName)
 	desc := pg.Description
 	// default description is " "
-	if desc != nil && *desc == " " {
+	if desc != nil && aws.StringValue(desc) == " " {
 		*desc = ""
 	}
 	d.Set("description", desc)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #12992.

Fixes:

```
Findings:

  internal/service/dax/cluster.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        350┆ if *c.NotificationConfiguration.TopicStatus == "active" {
          ⋮┆----------------------------------------
        518┆ *b[i].NodeId < *b[j].NodeId
          ⋮┆----------------------------------------
        583┆ if *cluster.ClusterName == clusterID {
          ⋮┆----------------------------------------
        617┆ if int64(len(c.Nodes)) != *c.TotalNodes {
          ⋮┆----------------------------------------
        626┆ if n.NodeStatus != nil && *n.NodeStatus != "available" {


  internal/service/dax/parameter_group.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        117┆ if desc != nil && *desc == " " {
```

```console
% make testacc TESTARGS='-run=TestAccDAXCluster_\|TestAccDAXParameterGroup_' PKG=dax ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dax/... -v -count 1 -parallel 2  -run=TestAccDAXCluster_\|TestAccDAXParameterGroup_ -timeout 180m
=== RUN   TestAccDAXCluster_basic
=== PAUSE TestAccDAXCluster_basic
=== RUN   TestAccDAXCluster_resize
=== PAUSE TestAccDAXCluster_resize
=== RUN   TestAccDAXCluster_Encryption_disabled
=== PAUSE TestAccDAXCluster_Encryption_disabled
=== RUN   TestAccDAXCluster_Encryption_enabled
=== PAUSE TestAccDAXCluster_Encryption_enabled
=== RUN   TestAccDAXCluster_EndpointEncryption_disabled
=== PAUSE TestAccDAXCluster_EndpointEncryption_disabled
=== RUN   TestAccDAXCluster_EndpointEncryption_enabled
=== PAUSE TestAccDAXCluster_EndpointEncryption_enabled
=== RUN   TestAccDAXParameterGroup_basic
=== PAUSE TestAccDAXParameterGroup_basic
=== CONT  TestAccDAXCluster_basic
=== CONT  TestAccDAXCluster_EndpointEncryption_disabled
--- PASS: TestAccDAXCluster_basic (704.94s)
=== CONT  TestAccDAXCluster_Encryption_disabled
--- PASS: TestAccDAXCluster_EndpointEncryption_disabled (768.91s)
=== CONT  TestAccDAXCluster_Encryption_enabled
--- PASS: TestAccDAXCluster_Encryption_enabled (723.79s)
=== CONT  TestAccDAXParameterGroup_basic
--- PASS: TestAccDAXParameterGroup_basic (28.76s)
=== CONT  TestAccDAXCluster_resize
--- PASS: TestAccDAXCluster_Encryption_disabled (2118.33s)
=== CONT  TestAccDAXCluster_EndpointEncryption_enabled
--- PASS: TestAccDAXCluster_resize (1385.58s)
--- PASS: TestAccDAXCluster_EndpointEncryption_enabled (833.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	3662.887s
```