### PR TITLE
r/aws_kms_alias: fix plan time validation's reserved prefix to `alias/aws/`

### DIFF
--- a/.changelog/24469.txt
+++ b/.changelog/24469.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_alias: Fix reserved prefix used in `name` and `name_prefix` plan time validation
+```

--- a/internal/service/kms/validate.go
+++ b/internal/service/kms/validate.go
@@ -22,7 +22,7 @@ func validGrantName(v interface{}, k string) (ws []string, es []error) {
 func validNameForDataSource(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9/_-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^(alias/)[a-zA-Z0-9/_-]+$`).MatchString(value) {
 		es = append(es, fmt.Errorf(
 			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9/_-]", k))
 	}
@@ -32,11 +32,11 @@ func validNameForDataSource(v interface{}, k string) (ws []string, es []error) {
 func validNameForResource(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if regexp.MustCompile(`^(alias\/aws)`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q cannot begin with reserved AWS CMK prefix 'alias/aws'", k))
+	if regexp.MustCompile(`^(alias/aws/)`).MatchString(value) {
+		es = append(es, fmt.Errorf("%q cannot begin with reserved AWS CMK prefix 'alias/aws/'", k))
 	}
 
-	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9/_-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^(alias/)[a-zA-Z0-9/_-]+$`).MatchString(value) {
 		es = append(es, fmt.Errorf(
 			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9/_-]", k))
 	}

--- a/internal/service/kms/validate_test.go
+++ b/internal/service/kms/validate_test.go
@@ -45,6 +45,10 @@ func TestValidNameForDataSource(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    "alias/aws-service-test",
+			ErrCount: 0,
+		},
+		{
 			Value:    "alias/hashicorp",
 			ErrCount: 0,
 		},
@@ -77,6 +81,10 @@ func TestValidNameForResource(t *testing.T) {
 	}{
 		{
 			Value:    "alias/hashicorp",
+			ErrCount: 0,
+		},
+		{
+			Value:    "alias/aws-service-test",
 			ErrCount: 0,
 		},
 		{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/13000#issuecomment-1113033590

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestValidNameForDataSource (0.00s)
--- PASS: TestValidNameForResource (0.00s)
```
```
$ make testacc TESTARGS='-run=TestAccKMSAlias' PKG=kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSAlias -timeout 180m
=== RUN   TestAccKMSAliasDataSource_awsService
=== PAUSE TestAccKMSAliasDataSource_awsService
=== RUN   TestAccKMSAliasDataSource_cmk
=== PAUSE TestAccKMSAliasDataSource_cmk
=== RUN   TestAccKMSAlias_basic
=== PAUSE TestAccKMSAlias_basic
=== RUN   TestAccKMSAlias_disappears
=== PAUSE TestAccKMSAlias_disappears
=== RUN   TestAccKMSAlias_Name_generated
=== PAUSE TestAccKMSAlias_Name_generated
=== RUN   TestAccKMSAlias_namePrefix
=== PAUSE TestAccKMSAlias_namePrefix
=== RUN   TestAccKMSAlias_updateKeyID
=== PAUSE TestAccKMSAlias_updateKeyID
=== RUN   TestAccKMSAlias_multipleAliasesForSameKey
=== PAUSE TestAccKMSAlias_multipleAliasesForSameKey
=== RUN   TestAccKMSAlias_arnDiffSuppress
=== PAUSE TestAccKMSAlias_arnDiffSuppress
=== CONT  TestAccKMSAliasDataSource_awsService
=== CONT  TestAccKMSAlias_namePrefix
=== CONT  TestAccKMSAlias_arnDiffSuppress
=== CONT  TestAccKMSAlias_multipleAliasesForSameKey
=== CONT  TestAccKMSAlias_updateKeyID
=== CONT  TestAccKMSAlias_disappears
=== CONT  TestAccKMSAlias_basic
=== CONT  TestAccKMSAlias_Name_generated
=== CONT  TestAccKMSAliasDataSource_cmk
--- PASS: TestAccKMSAliasDataSource_awsService (15.40s)
--- PASS: TestAccKMSAlias_disappears (19.44s)
--- PASS: TestAccKMSAliasDataSource_cmk (19.83s)
--- PASS: TestAccKMSAlias_namePrefix (21.85s)
--- PASS: TestAccKMSAlias_Name_generated (22.00s)
--- PASS: TestAccKMSAlias_basic (22.12s)
--- PASS: TestAccKMSAlias_multipleAliasesForSameKey (22.17s)
--- PASS: TestAccKMSAlias_arnDiffSuppress (29.73s)
--- PASS: TestAccKMSAlias_updateKeyID (33.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	36.920s
```
