### PR TITLE
service/ssm: updates for semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -56,7 +56,6 @@ rules:
         - internal/service/opsworks
         - internal/service/redshift
         - internal/service/s3
-        - internal/service/ssm
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/ssm/association.go
+++ b/internal/service/ssm/association.go
@@ -275,7 +275,7 @@ func resourceAssociationRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting targets error: %w", err)
 	}
 
-	if err := d.Set("output_location", flattenAssociationOutoutLocation(association.OutputLocation)); err != nil {
+	if err := d.Set("output_location", flattenAssociationOutputLocation(association.OutputLocation)); err != nil {
 		return fmt.Errorf("Error setting output_location error: %w", err)
 	}
 
@@ -401,22 +401,22 @@ func expandSSMAssociationOutputLocation(config []interface{}) *ssm.InstanceAssoc
 	}
 }
 
-func flattenAssociationOutoutLocation(location *ssm.InstanceAssociationOutputLocation) []map[string]interface{} {
-	if location == nil {
+func flattenAssociationOutputLocation(location *ssm.InstanceAssociationOutputLocation) []map[string]interface{} {
+	if location == nil || location.S3Location == nil {
 		return nil
 	}
 
 	result := make([]map[string]interface{}, 0)
 	item := make(map[string]interface{})
 
-	item["s3_bucket_name"] = *location.S3Location.OutputS3BucketName
+	item["s3_bucket_name"] = aws.StringValue(location.S3Location.OutputS3BucketName)
 
 	if location.S3Location.OutputS3KeyPrefix != nil {
-		item["s3_key_prefix"] = *location.S3Location.OutputS3KeyPrefix
+		item["s3_key_prefix"] = aws.StringValue(location.S3Location.OutputS3KeyPrefix)
 	}
 
 	if location.S3Location.OutputS3Region != nil {
-		item["s3_region"] = *location.S3Location.OutputS3Region
+		item["s3_region"] = aws.StringValue(location.S3Location.OutputS3Region)
 	}
 
 	result = append(result, item)

--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -342,16 +342,16 @@ func resourceDocumentRead(d *schema.ResourceData, meta interface{}) error {
 		param := make(map[string]interface{})
 
 		if dp.DefaultValue != nil {
-			param["default_value"] = *dp.DefaultValue
+			param["default_value"] = aws.StringValue(dp.DefaultValue)
 		}
 		if dp.Description != nil {
-			param["description"] = *dp.Description
+			param["description"] = aws.StringValue(dp.Description)
 		}
 		if dp.Name != nil {
-			param["name"] = *dp.Name
+			param["name"] = aws.StringValue(dp.Name)
 		}
 		if dp.Type != nil {
-			param["type"] = *dp.Type
+			param["type"] = aws.StringValue(dp.Type)
 		}
 		params = append(params, param)
 	}
@@ -549,16 +549,13 @@ func getDocumentPermissions(d *schema.ResourceData, meta interface{}) (map[strin
 		return nil, fmt.Errorf("Error setting permissions for SSM document: %s", err)
 	}
 
-	var account_ids = make([]string, len(resp.AccountIds))
-	for i := 0; i < len(resp.AccountIds); i++ {
-		account_ids[i] = *resp.AccountIds[i]
-	}
-
 	ids := ""
-	if len(account_ids) == 1 {
-		ids = account_ids[0]
-	} else if len(account_ids) > 1 {
-		ids = strings.Join(account_ids, ",")
+	accountIds := aws.StringValueSlice(resp.AccountIds)
+
+	if len(accountIds) == 1 {
+		ids = accountIds[0]
+	} else if len(accountIds) > 1 {
+		ids = strings.Join(accountIds, ",")
 	}
 
 	if ids == "" {
@@ -694,7 +691,7 @@ func updateDocument(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error updating SSM document: %s", err)
 	} else {
 		log.Printf("[INFO] Updating the default version to the new version %s: %s", newDefaultVersion, d.Id())
-		newDefaultVersion = *updated.DocumentDescription.DocumentVersion
+		newDefaultVersion = aws.StringValue(updated.DocumentDescription.DocumentVersion)
 	}
 
 	updateDefaultInput := &ssm.UpdateDocumentDefaultVersionInput{

--- a/internal/service/ssm/flex.go
+++ b/internal/service/ssm/flex.go
@@ -47,7 +47,7 @@ func flattenTargets(targets []*ssm.Target) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(targets))
 	for _, target := range targets {
 		t := make(map[string]interface{}, 1)
-		t["key"] = *target.Key
+		t["key"] = aws.StringValue(target.Key)
 		t["values"] = flex.FlattenStringList(target.Values)
 
 		result = append(result, t)

--- a/internal/service/ssm/resource_data_sync.go
+++ b/internal/service/ssm/resource_data_sync.go
@@ -1,6 +1,8 @@
 package ssm
 
 import (
+	"fmt"
+	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -70,9 +72,12 @@ func ResourceResourceDataSync() *schema.Resource {
 
 func resourceResourceDataSyncCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SSMConn
+
+	name := d.Get("name").(string)
+
 	input := &ssm.CreateResourceDataSyncInput{
 		S3Destination: expandSsmResourceDataSyncS3Destination(d),
-		SyncName:      aws.String(d.Get("name").(string)),
+		SyncName:      aws.String(name),
 	}
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
@@ -90,10 +95,10 @@ func resourceResourceDataSyncCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating SSM Resource Data Sync (%s): %w", name, err)
 	}
 
-	d.SetId(d.Get("name").(string))
+	d.SetId(name)
 	return resourceResourceDataSyncRead(d, meta)
 }
 
@@ -101,13 +106,17 @@ func resourceResourceDataSyncRead(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*conns.AWSClient).SSMConn
 
 	syncItem, err := FindResourceDataSyncItem(conn, d.Id())
-	if err != nil {
-		return err
-	}
-	if syncItem == nil {
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SSM Resource Data Sync (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+
+	if err != nil {
+		return fmt.Errorf("error reading SSM Resource Data Sync (%s): %w", d.Id(), err)
+	}
+
 	d.Set("name", syncItem.SyncName)
 	d.Set("s3_destination", flattenSsmResourceDataSyncS3Destination(syncItem.S3Destination))
 	return nil
@@ -117,53 +126,61 @@ func resourceResourceDataSyncDelete(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*conns.AWSClient).SSMConn
 
 	input := &ssm.DeleteResourceDataSyncInput{
-		SyncName: aws.String(d.Get("name").(string)),
+		SyncName: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteResourceDataSync(input)
+
+	if tfawserr.ErrCodeEquals(err, ssm.ErrCodeResourceDataSyncNotFoundException) {
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, ssm.ErrCodeResourceDataSyncNotFoundException) {
-			return nil
-		}
-		return err
+		return fmt.Errorf("error deleting SSM Resource Data Sync (%s): %w", d.Id(), err)
 	}
 	return nil
 }
 
 func FindResourceDataSyncItem(conn *ssm.SSM, name string) (*ssm.ResourceDataSyncItem, error) {
-	nextToken := ""
-	for {
-		input := &ssm.ListResourceDataSyncInput{}
-		if nextToken != "" {
-			input.NextToken = aws.String(nextToken)
+	var result *ssm.ResourceDataSyncItem
+	input := &ssm.ListResourceDataSyncInput{}
+
+	err := conn.ListResourceDataSyncPages(input, func(page *ssm.ListResourceDataSyncOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
-		resp, err := conn.ListResourceDataSync(input)
-		if err != nil {
-			return nil, err
-		}
-		for _, v := range resp.ResourceDataSyncItems {
-			if aws.StringValue(v.SyncName) == name {
-				return v, nil
+
+		for _, item := range page.ResourceDataSyncItems {
+			if aws.StringValue(item.SyncName) == name {
+				result = item
+				return false
 			}
 		}
-		if resp.NextToken == nil {
-			break
-		}
-		nextToken = *resp.NextToken
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
 	}
-	return nil, nil
+
+	if result == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return result, nil
 }
 
 func flattenSsmResourceDataSyncS3Destination(dest *ssm.ResourceDataSyncS3Destination) []interface{} {
 	result := make(map[string]interface{})
-	result["bucket_name"] = *dest.BucketName
-	result["region"] = *dest.Region
-	result["sync_format"] = *dest.SyncFormat
+	result["bucket_name"] = aws.StringValue(dest.BucketName)
+	result["region"] = aws.StringValue(dest.Region)
+	result["sync_format"] = aws.StringValue(dest.SyncFormat)
 	if dest.AWSKMSKeyARN != nil {
-		result["kms_key_arn"] = *dest.AWSKMSKeyARN
+		result["kms_key_arn"] = aws.StringValue(dest.AWSKMSKeyARN)
 	}
 	if dest.Prefix != nil {
-		result["prefix"] = *dest.Prefix
+		result["prefix"] = aws.StringValue(dest.Prefix)
 	}
 	return []interface{}{result}
 }

--- a/internal/service/ssm/resource_data_sync_test.go
+++ b/internal/service/ssm/resource_data_sync_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccSSMResourceDataSync_basic(t *testing.T) {
@@ -76,12 +77,19 @@ func testAccCheckResourceDataSyncDestroy(s *terraform.State) error {
 		if rs.Type != "aws_ssm_resource_data_sync" {
 			continue
 		}
-		syncItem, err := tfssm.FindResourceDataSyncItem(conn, rs.Primary.Attributes["name"])
+
+		syncItem, err := tfssm.FindResourceDataSyncItem(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
 			return err
 		}
+
 		if syncItem != nil {
-			return fmt.Errorf("Resource Data Sync (%s) found", rs.Primary.Attributes["name"])
+			return fmt.Errorf("Resource Data Sync (%s) found", rs.Primary.ID)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```

```
make testacc TESTARGS='-run=TestAccSSM' PKG=ssm ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 5  -run=TestAccSSM -timeout 180m
=== RUN   TestAccSSMActivation_basic
=== PAUSE TestAccSSMActivation_basic
=== RUN   TestAccSSMActivation_update
=== PAUSE TestAccSSMActivation_update
=== RUN   TestAccSSMActivation_expirationDate
=== PAUSE TestAccSSMActivation_expirationDate
=== RUN   TestAccSSMActivation_disappears
=== PAUSE TestAccSSMActivation_disappears
=== RUN   TestAccSSMAssociation_basic
=== PAUSE TestAccSSMAssociation_basic
=== RUN   TestAccSSMAssociation_disappears
=== PAUSE TestAccSSMAssociation_disappears
=== RUN   TestAccSSMAssociation_disappears_document
=== PAUSE TestAccSSMAssociation_disappears_document
=== RUN   TestAccSSMAssociation_applyOnlyAtCronInterval
=== PAUSE TestAccSSMAssociation_applyOnlyAtCronInterval
=== RUN   TestAccSSMAssociation_withTargets
=== PAUSE TestAccSSMAssociation_withTargets
=== RUN   TestAccSSMAssociation_withParameters
=== PAUSE TestAccSSMAssociation_withParameters
=== RUN   TestAccSSMAssociation_withAssociationName
=== PAUSE TestAccSSMAssociation_withAssociationName
=== RUN   TestAccSSMAssociation_withAssociationNameAndScheduleExpression
=== PAUSE TestAccSSMAssociation_withAssociationNameAndScheduleExpression
=== RUN   TestAccSSMAssociation_withDocumentVersion
=== PAUSE TestAccSSMAssociation_withDocumentVersion
=== RUN   TestAccSSMAssociation_withOutputLocation
=== PAUSE TestAccSSMAssociation_withOutputLocation
=== RUN   TestAccSSMAssociation_withOutputLocation_s3Region
=== PAUSE TestAccSSMAssociation_withOutputLocation_s3Region
=== RUN   TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout
=== PAUSE TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout
=== RUN   TestAccSSMAssociation_withAutomationTargetParamName
=== PAUSE TestAccSSMAssociation_withAutomationTargetParamName
=== RUN   TestAccSSMAssociation_withScheduleExpression
=== PAUSE TestAccSSMAssociation_withScheduleExpression
=== RUN   TestAccSSMAssociation_withComplianceSeverity
=== PAUSE TestAccSSMAssociation_withComplianceSeverity
=== RUN   TestAccSSMAssociation_rateControl
=== PAUSE TestAccSSMAssociation_rateControl
=== RUN   TestAccSSMDocumentDataSource_basic
=== PAUSE TestAccSSMDocumentDataSource_basic
=== RUN   TestAccSSMDocumentDataSource_awsManaged
=== PAUSE TestAccSSMDocumentDataSource_awsManaged
=== RUN   TestAccSSMDocument_basic
=== PAUSE TestAccSSMDocument_basic
=== RUN   TestAccSSMDocument_name
=== PAUSE TestAccSSMDocument_name
=== RUN   TestAccSSMDocument_Target_type
=== PAUSE TestAccSSMDocument_Target_type
=== RUN   TestAccSSMDocument_versionName
=== PAUSE TestAccSSMDocument_versionName
=== RUN   TestAccSSMDocument_update
=== PAUSE TestAccSSMDocument_update
=== RUN   TestAccSSMDocument_Permission_public
=== PAUSE TestAccSSMDocument_Permission_public
=== RUN   TestAccSSMDocument_Permission_private
=== PAUSE TestAccSSMDocument_Permission_private
=== RUN   TestAccSSMDocument_Permission_batching
=== PAUSE TestAccSSMDocument_Permission_batching
=== RUN   TestAccSSMDocument_Permission_change
=== PAUSE TestAccSSMDocument_Permission_change
=== RUN   TestAccSSMDocument_params
=== PAUSE TestAccSSMDocument_params
=== RUN   TestAccSSMDocument_automation
=== PAUSE TestAccSSMDocument_automation
=== RUN   TestAccSSMDocument_package
=== PAUSE TestAccSSMDocument_package
=== RUN   TestAccSSMDocument_SchemaVersion_1
=== PAUSE TestAccSSMDocument_SchemaVersion_1
=== RUN   TestAccSSMDocument_session
=== PAUSE TestAccSSMDocument_session
=== RUN   TestAccSSMDocument_DocumentFormat_yaml
=== PAUSE TestAccSSMDocument_DocumentFormat_yaml
=== RUN   TestAccSSMDocument_tags
=== PAUSE TestAccSSMDocument_tags
=== RUN   TestAccSSMDocument_disappears
=== PAUSE TestAccSSMDocument_disappears
=== RUN   TestAccSSMInstancesDataSource_filter
=== PAUSE TestAccSSMInstancesDataSource_filter
=== RUN   TestAccSSMMaintenanceWindowTarget_basic
=== PAUSE TestAccSSMMaintenanceWindowTarget_basic
=== RUN   TestAccSSMMaintenanceWindowTarget_noNameOrDescription
=== PAUSE TestAccSSMMaintenanceWindowTarget_noNameOrDescription
=== RUN   TestAccSSMMaintenanceWindowTarget_validation
=== PAUSE TestAccSSMMaintenanceWindowTarget_validation
=== RUN   TestAccSSMMaintenanceWindowTarget_update
=== PAUSE TestAccSSMMaintenanceWindowTarget_update
=== RUN   TestAccSSMMaintenanceWindowTarget_resourceGroup
=== PAUSE TestAccSSMMaintenanceWindowTarget_resourceGroup
=== RUN   TestAccSSMMaintenanceWindowTarget_disappears
=== PAUSE TestAccSSMMaintenanceWindowTarget_disappears
=== RUN   TestAccSSMMaintenanceWindowTarget_Disappears_window
=== PAUSE TestAccSSMMaintenanceWindowTarget_Disappears_window
=== RUN   TestAccSSMMaintenanceWindowTask_basic
=== PAUSE TestAccSSMMaintenanceWindowTask_basic
=== RUN   TestAccSSMMaintenanceWindowTask_noTarget
=== PAUSE TestAccSSMMaintenanceWindowTask_noTarget
=== RUN   TestAccSSMMaintenanceWindowTask_cutoff
=== PAUSE TestAccSSMMaintenanceWindowTask_cutoff
=== RUN   TestAccSSMMaintenanceWindowTask_noRole
=== PAUSE TestAccSSMMaintenanceWindowTask_noRole
=== RUN   TestAccSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccSSMMaintenanceWindowTask_updateForcesNewResource
=== RUN   TestAccSSMMaintenanceWindowTask_description
=== PAUSE TestAccSSMMaintenanceWindowTask_description
=== RUN   TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters
=== PAUSE TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters
=== RUN   TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters
=== PAUSE TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters
=== RUN   TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters
=== PAUSE TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters
=== RUN   TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch
=== PAUSE TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch
=== RUN   TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters
=== PAUSE TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters
=== RUN   TestAccSSMMaintenanceWindowTask_emptyNotification
=== PAUSE TestAccSSMMaintenanceWindowTask_emptyNotification
=== RUN   TestAccSSMMaintenanceWindowTask_disappears
=== PAUSE TestAccSSMMaintenanceWindowTask_disappears
=== RUN   TestAccSSMMaintenanceWindow_basic
=== PAUSE TestAccSSMMaintenanceWindow_basic
=== RUN   TestAccSSMMaintenanceWindow_description
=== PAUSE TestAccSSMMaintenanceWindow_description
=== RUN   TestAccSSMMaintenanceWindow_tags
=== PAUSE TestAccSSMMaintenanceWindow_tags
=== RUN   TestAccSSMMaintenanceWindow_disappears
=== PAUSE TestAccSSMMaintenanceWindow_disappears
=== RUN   TestAccSSMMaintenanceWindow_multipleUpdates
=== PAUSE TestAccSSMMaintenanceWindow_multipleUpdates
=== RUN   TestAccSSMMaintenanceWindow_cutoff
=== PAUSE TestAccSSMMaintenanceWindow_cutoff
=== RUN   TestAccSSMMaintenanceWindow_duration
=== PAUSE TestAccSSMMaintenanceWindow_duration
=== RUN   TestAccSSMMaintenanceWindow_enabled
=== PAUSE TestAccSSMMaintenanceWindow_enabled
=== RUN   TestAccSSMMaintenanceWindow_endDate
=== PAUSE TestAccSSMMaintenanceWindow_endDate
=== RUN   TestAccSSMMaintenanceWindow_schedule
=== PAUSE TestAccSSMMaintenanceWindow_schedule
=== RUN   TestAccSSMMaintenanceWindow_scheduleTimezone
=== PAUSE TestAccSSMMaintenanceWindow_scheduleTimezone
=== RUN   TestAccSSMMaintenanceWindow_scheduleOffset
=== PAUSE TestAccSSMMaintenanceWindow_scheduleOffset
=== RUN   TestAccSSMMaintenanceWindow_startDate
=== PAUSE TestAccSSMMaintenanceWindow_startDate
=== RUN   TestAccSSMMaintenanceWindowsDataSource_filter
=== PAUSE TestAccSSMMaintenanceWindowsDataSource_filter
=== RUN   TestAccSSMParameterDataSource_basic
=== PAUSE TestAccSSMParameterDataSource_basic
=== RUN   TestAccSSMParameterDataSource_fullPath
=== PAUSE TestAccSSMParameterDataSource_fullPath
=== RUN   TestAccSSMParameter_basic
=== PAUSE TestAccSSMParameter_basic
=== RUN   TestAccSSMParameter_tier
=== PAUSE TestAccSSMParameter_tier
=== RUN   TestAccSSMParameter_Tier_intelligentTieringToStandard
=== PAUSE TestAccSSMParameter_Tier_intelligentTieringToStandard
=== RUN   TestAccSSMParameter_Tier_intelligentTieringToAdvanced
=== PAUSE TestAccSSMParameter_Tier_intelligentTieringToAdvanced
=== RUN   TestAccSSMParameter_disappears
=== PAUSE TestAccSSMParameter_disappears
=== RUN   TestAccSSMParameter_overwrite
=== PAUSE TestAccSSMParameter_overwrite
=== RUN   TestAccSSMParameter_overwriteCascade
=== PAUSE TestAccSSMParameter_overwriteCascade
=== RUN   TestAccSSMParameter_overwriteWithTags
=== PAUSE TestAccSSMParameter_overwriteWithTags
=== RUN   TestAccSSMParameter_noOverwriteWithTags
=== PAUSE TestAccSSMParameter_noOverwriteWithTags
=== RUN   TestAccSSMParameter_updateToOverwriteWithTags
=== PAUSE TestAccSSMParameter_updateToOverwriteWithTags
=== RUN   TestAccSSMParameter_tags
=== PAUSE TestAccSSMParameter_tags
=== RUN   TestAccSSMParameter_updateType
=== PAUSE TestAccSSMParameter_updateType
=== RUN   TestAccSSMParameter_updateDescription
=== PAUSE TestAccSSMParameter_updateDescription
=== RUN   TestAccSSMParameter_changeNameForcesNew
=== PAUSE TestAccSSMParameter_changeNameForcesNew
=== RUN   TestAccSSMParameter_fullPath
=== PAUSE TestAccSSMParameter_fullPath
=== RUN   TestAccSSMParameter_secure
=== PAUSE TestAccSSMParameter_secure
=== RUN   TestAccSSMParameter_DataType_awsEC2Image
=== PAUSE TestAccSSMParameter_DataType_awsEC2Image
=== RUN   TestAccSSMParameter_secureWithKey
=== PAUSE TestAccSSMParameter_secureWithKey
=== RUN   TestAccSSMParameter_Secure_keyUpdate
=== PAUSE TestAccSSMParameter_Secure_keyUpdate
=== RUN   TestAccSSMParametersByPathDataSource_basic
=== PAUSE TestAccSSMParametersByPathDataSource_basic
=== RUN   TestAccSSMParametersByPathDataSource_withRecursion
=== PAUSE TestAccSSMParametersByPathDataSource_withRecursion
=== RUN   TestAccSSMPatchBaselineDataSource_existingBaseline
=== PAUSE TestAccSSMPatchBaselineDataSource_existingBaseline
=== RUN   TestAccSSMPatchBaselineDataSource_newBaseline
=== PAUSE TestAccSSMPatchBaselineDataSource_newBaseline
=== RUN   TestAccSSMPatchBaseline_basic
=== PAUSE TestAccSSMPatchBaseline_basic
=== RUN   TestAccSSMPatchBaseline_tags
=== PAUSE TestAccSSMPatchBaseline_tags
=== RUN   TestAccSSMPatchBaseline_disappears
=== PAUSE TestAccSSMPatchBaseline_disappears
=== RUN   TestAccSSMPatchBaseline_operatingSystem
=== PAUSE TestAccSSMPatchBaseline_operatingSystem
=== RUN   TestAccSSMPatchBaseline_approveUntilDateParam
=== PAUSE TestAccSSMPatchBaseline_approveUntilDateParam
=== RUN   TestAccSSMPatchBaseline_sources
=== PAUSE TestAccSSMPatchBaseline_sources
=== RUN   TestAccSSMPatchBaseline_approvedPatchesNonSec
=== PAUSE TestAccSSMPatchBaseline_approvedPatchesNonSec
=== RUN   TestAccSSMPatchBaseline_rejectPatchesAction
=== PAUSE TestAccSSMPatchBaseline_rejectPatchesAction
=== RUN   TestAccSSMPatchGroup_basic
=== PAUSE TestAccSSMPatchGroup_basic
=== RUN   TestAccSSMPatchGroup_disappears
=== PAUSE TestAccSSMPatchGroup_disappears
=== RUN   TestAccSSMPatchGroup_multipleBaselines
=== PAUSE TestAccSSMPatchGroup_multipleBaselines
=== RUN   TestAccSSMResourceDataSync_basic
=== PAUSE TestAccSSMResourceDataSync_basic
=== RUN   TestAccSSMResourceDataSync_update
=== PAUSE TestAccSSMResourceDataSync_update
=== CONT  TestAccSSMActivation_basic
=== CONT  TestAccSSMParameterDataSource_fullPath
=== CONT  TestAccSSMParameter_Secure_keyUpdate
=== CONT  TestAccSSMParameter_secureWithKey
=== CONT  TestAccSSMParameter_DataType_awsEC2Image
--- PASS: TestAccSSMParameterDataSource_fullPath (15.47s)
=== CONT  TestAccSSMParameter_secure
--- PASS: TestAccSSMParameter_secureWithKey (19.07s)
=== CONT  TestAccSSMParameter_fullPath
--- PASS: TestAccSSMActivation_basic (26.61s)
=== CONT  TestAccSSMParameter_changeNameForcesNew
--- PASS: TestAccSSMParameter_Secure_keyUpdate (30.78s)
=== CONT  TestAccSSMParameter_updateDescription
--- PASS: TestAccSSMParameter_secure (15.44s)
=== CONT  TestAccSSMParameter_updateType
--- PASS: TestAccSSMParameter_fullPath (15.55s)
=== CONT  TestAccSSMParameter_tags
--- PASS: TestAccSSMParameter_DataType_awsEC2Image (40.88s)
=== CONT  TestAccSSMParameter_updateToOverwriteWithTags
--- PASS: TestAccSSMParameter_changeNameForcesNew (28.24s)
=== CONT  TestAccSSMParameter_noOverwriteWithTags
--- PASS: TestAccSSMParameter_updateDescription (28.12s)
=== CONT  TestAccSSMParameter_overwriteWithTags
--- PASS: TestAccSSMParameter_updateType (28.01s)
=== CONT  TestAccSSMParameter_overwriteCascade
--- PASS: TestAccSSMParameter_updateToOverwriteWithTags (27.83s)
=== CONT  TestAccSSMParameter_overwrite
--- PASS: TestAccSSMParameter_noOverwriteWithTags (16.27s)
=== CONT  TestAccSSMParameter_disappears
--- PASS: TestAccSSMParameter_tags (39.03s)
=== CONT  TestAccSSMParameter_Tier_intelligentTieringToAdvanced
--- PASS: TestAccSSMParameter_overwriteWithTags (15.80s)
=== CONT  TestAccSSMParameter_Tier_intelligentTieringToStandard
--- PASS: TestAccSSMParameter_disappears (11.36s)
=== CONT  TestAccSSMParameter_tier
--- PASS: TestAccSSMParameter_overwrite (27.26s)
=== CONT  TestAccSSMParameter_basic
--- PASS: TestAccSSMParameter_overwriteCascade (37.13s)
=== CONT  TestAccSSMPatchBaseline_approveUntilDateParam
--- PASS: TestAccSSMParameter_basic (18.55s)
=== CONT  TestAccSSMResourceDataSync_update
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (43.78s)
=== CONT  TestAccSSMResourceDataSync_basic
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (47.05s)
=== CONT  TestAccSSMPatchGroup_multipleBaselines
--- PASS: TestAccSSMParameter_tier (44.08s)
=== CONT  TestAccSSMPatchGroup_disappears
--- PASS: TestAccSSMPatchBaseline_approveUntilDateParam (31.89s)
=== CONT  TestAccSSMPatchGroup_basic
--- PASS: TestAccSSMPatchGroup_multipleBaselines (17.05s)
=== CONT  TestAccSSMPatchBaseline_rejectPatchesAction
--- PASS: TestAccSSMPatchGroup_disappears (17.29s)
=== CONT  TestAccSSMPatchBaseline_approvedPatchesNonSec
--- PASS: TestAccSSMPatchGroup_basic (16.51s)
=== CONT  TestAccSSMPatchBaseline_sources
=== CONT  TestAccSSMResourceDataSync_basic
    testing_new.go:79: Error running post-test destroy, there may be dangling resources: empty result
--- PASS: TestAccSSMResourceDataSync_basic (26.12s)
=== CONT  TestAccSSMDocument_disappears
--- PASS: TestAccSSMPatchBaseline_rejectPatchesAction (17.11s)
=== CONT  TestAccSSMParameterDataSource_basic
--- PASS: TestAccSSMDocument_disappears (14.07s)
=== CONT  TestAccSSMMaintenanceWindowsDataSource_filter
--- PASS: TestAccSSMPatchBaseline_approvedPatchesNonSec (18.81s)
=== CONT  TestAccSSMMaintenanceWindow_startDate
=== CONT  TestAccSSMResourceDataSync_update
    testing_new.go:79: Error running post-test destroy, there may be dangling resources: empty result
--- PASS: TestAccSSMResourceDataSync_update (51.28s)
=== CONT  TestAccSSMMaintenanceWindow_scheduleOffset
--- PASS: TestAccSSMPatchBaseline_sources (29.57s)
=== CONT  TestAccSSMMaintenanceWindow_scheduleTimezone
--- PASS: TestAccSSMParameterDataSource_basic (27.89s)
=== CONT  TestAccSSMMaintenanceWindow_schedule
--- PASS: TestAccSSMMaintenanceWindowsDataSource_filter (27.41s)
=== CONT  TestAccSSMMaintenanceWindow_endDate
--- PASS: TestAccSSMMaintenanceWindow_scheduleOffset (30.65s)
=== CONT  TestAccSSMMaintenanceWindow_enabled
--- PASS: TestAccSSMMaintenanceWindow_startDate (42.36s)
=== CONT  TestAccSSMMaintenanceWindow_duration
--- PASS: TestAccSSMMaintenanceWindow_schedule (30.23s)
=== CONT  TestAccSSMMaintenanceWindow_cutoff
--- PASS: TestAccSSMMaintenanceWindow_scheduleTimezone (44.05s)
=== CONT  TestAccSSMMaintenanceWindow_multipleUpdates
--- PASS: TestAccSSMMaintenanceWindow_endDate (43.12s)
=== CONT  TestAccSSMMaintenanceWindow_disappears
--- PASS: TestAccSSMMaintenanceWindow_enabled (30.59s)
=== CONT  TestAccSSMMaintenanceWindow_tags
--- PASS: TestAccSSMMaintenanceWindow_duration (29.13s)
=== CONT  TestAccSSMMaintenanceWindow_description
--- PASS: TestAccSSMMaintenanceWindow_cutoff (29.41s)
=== CONT  TestAccSSMMaintenanceWindow_basic
--- PASS: TestAccSSMMaintenanceWindow_multipleUpdates (26.41s)
=== CONT  TestAccSSMMaintenanceWindowTask_disappears
--- PASS: TestAccSSMMaintenanceWindow_disappears (11.52s)
=== CONT  TestAccSSMMaintenanceWindowTask_emptyNotification
--- PASS: TestAccSSMMaintenanceWindow_basic (16.70s)
=== CONT  TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters
--- PASS: TestAccSSMMaintenanceWindowTask_disappears (15.82s)
=== CONT  TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch
--- PASS: TestAccSSMMaintenanceWindowTask_emptyNotification (16.00s)
=== CONT  TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters
--- PASS: TestAccSSMMaintenanceWindow_description (27.50s)
=== CONT  TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters
--- PASS: TestAccSSMMaintenanceWindow_tags (41.31s)
=== CONT  TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters (18.62s)
=== CONT  TestAccSSMMaintenanceWindowTask_description
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters (36.80s)
=== CONT  TestAccSSMMaintenanceWindowTask_updateForcesNewResource
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters (41.23s)
=== CONT  TestAccSSMMaintenanceWindowTask_noRole
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch (44.99s)
=== CONT  TestAccSSMMaintenanceWindowTask_cutoff
--- PASS: TestAccSSMMaintenanceWindowTask_description (31.99s)
=== CONT  TestAccSSMMaintenanceWindowTask_noTarget
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters (35.26s)
=== CONT  TestAccSSMMaintenanceWindowTask_basic
--- PASS: TestAccSSMMaintenanceWindowTask_noRole (16.86s)
=== CONT  TestAccSSMMaintenanceWindowTarget_Disappears_window
--- PASS: TestAccSSMMaintenanceWindowTask_noTarget (18.09s)
=== CONT  TestAccSSMMaintenanceWindowTarget_disappears
--- PASS: TestAccSSMMaintenanceWindowTask_updateForcesNewResource (31.62s)
=== CONT  TestAccSSMMaintenanceWindowTarget_resourceGroup
--- PASS: TestAccSSMMaintenanceWindowTarget_Disappears_window (11.98s)
=== CONT  TestAccSSMMaintenanceWindowTarget_update
--- PASS: TestAccSSMMaintenanceWindowTask_cutoff (31.15s)
=== CONT  TestAccSSMMaintenanceWindowTarget_validation
--- PASS: TestAccSSMMaintenanceWindowTarget_validation (1.73s)
=== CONT  TestAccSSMMaintenanceWindowTarget_noNameOrDescription
--- PASS: TestAccSSMMaintenanceWindowTask_basic (31.51s)
=== CONT  TestAccSSMMaintenanceWindowTarget_basic
--- PASS: TestAccSSMMaintenanceWindowTarget_disappears (13.86s)
=== CONT  TestAccSSMInstancesDataSource_filter
--- PASS: TestAccSSMMaintenanceWindowTarget_resourceGroup (16.22s)
=== CONT  TestAccSSMPatchBaseline_basic
--- PASS: TestAccSSMMaintenanceWindowTarget_noNameOrDescription (17.49s)
=== CONT  TestAccSSMPatchBaseline_operatingSystem
--- PASS: TestAccSSMMaintenanceWindowTarget_basic (17.85s)
=== CONT  TestAccSSMPatchBaseline_disappears
--- PASS: TestAccSSMMaintenanceWindowTarget_update (33.23s)
=== CONT  TestAccSSMPatchBaseline_tags
--- PASS: TestAccSSMPatchBaseline_disappears (12.04s)
=== CONT  TestAccSSMPatchBaselineDataSource_existingBaseline
--- PASS: TestAccSSMPatchBaseline_basic (28.48s)
=== CONT  TestAccSSMPatchBaselineDataSource_newBaseline
--- PASS: TestAccSSMPatchBaselineDataSource_existingBaseline (10.80s)
=== CONT  TestAccSSMAssociation_rateControl
--- PASS: TestAccSSMPatchBaseline_operatingSystem (28.83s)
=== CONT  TestAccSSMDocument_tags
--- PASS: TestAccSSMPatchBaselineDataSource_newBaseline (14.37s)
=== CONT  TestAccSSMDocument_DocumentFormat_yaml
--- PASS: TestAccSSMPatchBaseline_tags (38.90s)
=== CONT  TestAccSSMDocument_session
--- PASS: TestAccSSMAssociation_rateControl (29.22s)
=== CONT  TestAccSSMDocument_SchemaVersion_1
--- PASS: TestAccSSMDocument_DocumentFormat_yaml (28.87s)
=== CONT  TestAccSSMDocument_package
--- PASS: TestAccSSMDocument_session (17.64s)
=== CONT  TestAccSSMDocument_automation
--- PASS: TestAccSSMDocument_tags (40.10s)
=== CONT  TestAccSSMDocument_params
--- PASS: TestAccSSMDocument_SchemaVersion_1 (29.35s)
=== CONT  TestAccSSMDocument_Permission_change
--- PASS: TestAccSSMDocument_params (15.98s)
=== CONT  TestAccSSMDocument_Permission_batching
--- PASS: TestAccSSMDocument_Permission_batching (17.65s)
=== CONT  TestAccSSMDocument_Permission_private
--- PASS: TestAccSSMDocument_automation (40.22s)
=== CONT  TestAccSSMDocument_Permission_public
--- PASS: TestAccSSMDocument_Permission_private (17.12s)
=== CONT  TestAccSSMDocument_update
--- PASS: TestAccSSMDocument_package (59.42s)
=== CONT  TestAccSSMDocument_versionName
--- PASS: TestAccSSMDocument_Permission_public (16.75s)
=== CONT  TestAccSSMDocument_Target_type
--- PASS: TestAccSSMDocument_Permission_change (39.81s)
=== CONT  TestAccSSMDocument_name
--- PASS: TestAccSSMDocument_update (27.74s)
=== CONT  TestAccSSMDocument_basic
--- PASS: TestAccSSMDocument_versionName (27.86s)
=== CONT  TestAccSSMDocumentDataSource_awsManaged
--- PASS: TestAccSSMDocument_Target_type (27.87s)
=== CONT  TestAccSSMDocumentDataSource_basic
--- PASS: TestAccSSMDocument_name (27.70s)
=== CONT  TestAccSSMParametersByPathDataSource_withRecursion
--- PASS: TestAccSSMDocumentDataSource_awsManaged (10.57s)
=== CONT  TestAccSSMAssociation_withAssociationName
--- PASS: TestAccSSMDocument_basic (15.78s)
=== CONT  TestAccSSMAssociation_withComplianceSeverity
--- PASS: TestAccSSMParametersByPathDataSource_withRecursion (13.73s)
=== CONT  TestAccSSMAssociation_withScheduleExpression
--- PASS: TestAccSSMDocumentDataSource_basic (25.78s)
=== CONT  TestAccSSMAssociation_withAutomationTargetParamName
--- PASS: TestAccSSMAssociation_withAssociationName (28.73s)
=== CONT  TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout
--- PASS: TestAccSSMAssociation_withComplianceSeverity (27.33s)
=== CONT  TestAccSSMAssociation_withOutputLocation_s3Region
--- PASS: TestAccSSMAssociation_withScheduleExpression (27.21s)
=== CONT  TestAccSSMAssociation_withOutputLocation
--- PASS: TestAccSSMInstancesDataSource_filter (215.03s)
=== CONT  TestAccSSMAssociation_withDocumentVersion
--- PASS: TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout (20.40s)
=== CONT  TestAccSSMAssociation_withAssociationNameAndScheduleExpression
--- PASS: TestAccSSMAssociation_withDocumentVersion (16.12s)
=== CONT  TestAccSSMParametersByPathDataSource_basic
--- PASS: TestAccSSMParametersByPathDataSource_basic (14.20s)
=== CONT  TestAccSSMAssociation_disappears
--- PASS: TestAccSSMAssociation_withAutomationTargetParamName (55.63s)
=== CONT  TestAccSSMAssociation_withParameters
--- PASS: TestAccSSMAssociation_withAssociationNameAndScheduleExpression (28.46s)
=== CONT  TestAccSSMAssociation_withTargets
--- PASS: TestAccSSMAssociation_withOutputLocation_s3Region (51.51s)
=== CONT  TestAccSSMAssociation_applyOnlyAtCronInterval
--- PASS: TestAccSSMAssociation_withOutputLocation (49.86s)
=== CONT  TestAccSSMAssociation_disappears_document
--- PASS: TestAccSSMAssociation_withParameters (30.37s)
=== CONT  TestAccSSMActivation_expirationDate
--- PASS: TestAccSSMAssociation_applyOnlyAtCronInterval (28.37s)
=== CONT  TestAccSSMAssociation_basic
--- PASS: TestAccSSMAssociation_withTargets (39.41s)
=== CONT  TestAccSSMActivation_disappears
--- PASS: TestAccSSMActivation_expirationDate (33.41s)
=== CONT  TestAccSSMActivation_update
--- PASS: TestAccSSMActivation_disappears (30.35s)
--- PASS: TestAccSSMActivation_update (37.98s)
--- PASS: TestAccSSMAssociation_disappears_document (124.34s)
--- PASS: TestAccSSMAssociation_disappears (136.67s)
--- PASS: TestAccSSMAssociation_basic (109.82s)
```