### PR TITLE
r/servicediscovery_service: updates for semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -59,7 +59,6 @@ rules:
         - internal/service/redshift
         - internal/service/route53
         - internal/service/s3
-        - internal/service/servicediscovery
         - internal/service/ssm
     patterns:
       - pattern: '$LHS = *$RHS'

--- a/internal/service/servicediscovery/service.go
+++ b/internal/service/servicediscovery/service.go
@@ -365,17 +365,17 @@ func flattenServiceDiscoveryDnsConfig(config *servicediscovery.DnsConfig) []map[
 	result := map[string]interface{}{}
 
 	if config.NamespaceId != nil {
-		result["namespace_id"] = *config.NamespaceId
+		result["namespace_id"] = aws.StringValue(config.NamespaceId)
 	}
 	if config.RoutingPolicy != nil {
-		result["routing_policy"] = *config.RoutingPolicy
+		result["routing_policy"] = aws.StringValue(config.RoutingPolicy)
 	}
 	if config.DnsRecords != nil {
 		drs := make([]map[string]interface{}, 0)
 		for _, v := range config.DnsRecords {
 			dr := map[string]interface{}{}
-			dr["ttl"] = *v.TTL
-			dr["type"] = *v.Type
+			dr["ttl"] = aws.Int64Value(v.TTL)
+			dr["type"] = aws.StringValue(v.Type)
 			drs = append(drs, dr)
 		}
 		result["dns_records"] = drs
@@ -432,13 +432,13 @@ func flattenServiceDiscoveryHealthCheckConfig(config *servicediscovery.HealthChe
 	result := map[string]interface{}{}
 
 	if config.FailureThreshold != nil {
-		result["failure_threshold"] = *config.FailureThreshold
+		result["failure_threshold"] = aws.Int64Value(config.FailureThreshold)
 	}
 	if config.ResourcePath != nil {
-		result["resource_path"] = *config.ResourcePath
+		result["resource_path"] = aws.StringValue(config.ResourcePath)
 	}
 	if config.Type != nil {
-		result["type"] = *config.Type
+		result["type"] = aws.StringValue(config.Type)
 	}
 
 	if len(result) < 1 {
@@ -468,7 +468,7 @@ func flattenServiceDiscoveryHealthCheckCustomConfig(config *servicediscovery.Hea
 	result := map[string]interface{}{}
 
 	if config.FailureThreshold != nil {
-		result["failure_threshold"] = *config.FailureThreshold
+		result["failure_threshold"] = aws.Int64Value(config.FailureThreshold)
 	}
 
 	if len(result) < 1 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
```
$make testacc TESTARGS='-run=TestAccServiceDiscoveryService' PKG=servicediscovery
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicediscovery/... -v -count 1 -parallel 20  -run=TestAccServiceDiscoveryService -timeout 180m
=== RUN   TestAccServiceDiscoveryService_private
=== PAUSE TestAccServiceDiscoveryService_private
=== RUN   TestAccServiceDiscoveryService_public
=== PAUSE TestAccServiceDiscoveryService_public
=== RUN   TestAccServiceDiscoveryService_http
=== PAUSE TestAccServiceDiscoveryService_http
=== RUN   TestAccServiceDiscoveryService_disappears
=== PAUSE TestAccServiceDiscoveryService_disappears
=== RUN   TestAccServiceDiscoveryService_tags
=== PAUSE TestAccServiceDiscoveryService_tags
=== CONT  TestAccServiceDiscoveryService_private
=== CONT  TestAccServiceDiscoveryService_tags
=== CONT  TestAccServiceDiscoveryService_http
=== CONT  TestAccServiceDiscoveryService_public
=== CONT  TestAccServiceDiscoveryService_disappears
--- PASS: TestAccServiceDiscoveryService_disappears (103.20s)
--- PASS: TestAccServiceDiscoveryService_http (105.81s)
--- PASS: TestAccServiceDiscoveryService_private (121.90s)
--- PASS: TestAccServiceDiscoveryService_tags (128.75s)
--- PASS: TestAccServiceDiscoveryService_public (128.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	132.254s
```

