### PR TITLE
service/s3: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -55,7 +55,6 @@ rules:
         - internal/service/iam
         - internal/service/opsworks
         - internal/service/redshift
-        - internal/service/s3
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -358,16 +358,15 @@ func FlattenAnalyticsFilter(analyticsFilter *s3.AnalyticsFilter) []map[string]in
 	}
 
 	result := make(map[string]interface{})
-	if analyticsFilter.And != nil {
-		and := *analyticsFilter.And
+	if and := analyticsFilter.And; and != nil {
 		if and.Prefix != nil {
-			result["prefix"] = *and.Prefix
+			result["prefix"] = aws.StringValue(and.Prefix)
 		}
 		if and.Tags != nil {
 			result["tags"] = KeyValueTags(and.Tags).IgnoreAWS().Map()
 		}
 	} else if analyticsFilter.Prefix != nil {
-		result["prefix"] = *analyticsFilter.Prefix
+		result["prefix"] = aws.StringValue(analyticsFilter.Prefix)
 	} else if analyticsFilter.Tag != nil {
 		tags := []*s3.Tag{
 			analyticsFilter.Tag,

--- a/internal/service/s3/bucket_metric.go
+++ b/internal/service/s3/bucket_metric.go
@@ -221,16 +221,15 @@ func ExpandMetricsFilter(m map[string]interface{}) *s3.MetricsFilter {
 func FlattenMetricsFilter(metricsFilter *s3.MetricsFilter) map[string]interface{} {
 	m := make(map[string]interface{})
 
-	if metricsFilter.And != nil {
-		and := *metricsFilter.And
+	if and := metricsFilter.And; and != nil {
 		if and.Prefix != nil {
-			m["prefix"] = *and.Prefix
+			m["prefix"] = aws.StringValue(and.Prefix)
 		}
 		if and.Tags != nil {
 			m["tags"] = KeyValueTags(and.Tags).IgnoreAWS().Map()
 		}
 	} else if metricsFilter.Prefix != nil {
-		m["prefix"] = *metricsFilter.Prefix
+		m["prefix"] = aws.StringValue(metricsFilter.Prefix)
 	} else if metricsFilter.Tag != nil {
 		tags := []*s3.Tag{
 			metricsFilter.Tag,

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -284,7 +284,7 @@ func TestAccS3BucketMetric_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketMetricsExistsConfig(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
-					resource.TestCheckNoResourceAttr(resourceName, "filter"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", metricName),
 				),
 			},

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -425,10 +425,10 @@ func flattenNotificationConfigurationFilter(filter *s3.NotificationConfiguration
 
 	for _, f := range filter.Key.FilterRules {
 		if strings.ToLower(*f.Name) == s3.FilterRuleNamePrefix {
-			filterRules["filter_prefix"] = *f.Value
+			filterRules["filter_prefix"] = aws.StringValue(f.Value)
 		}
 		if strings.ToLower(*f.Name) == s3.FilterRuleNameSuffix {
-			filterRules["filter_suffix"] = *f.Value
+			filterRules["filter_suffix"] = aws.StringValue(f.Value)
 		}
 	}
 	return filterRules
@@ -444,9 +444,9 @@ func flattenTopicConfigurations(configs []*s3.TopicConfiguration) []map[string]i
 			conf = map[string]interface{}{}
 		}
 
-		conf["id"] = *notification.Id
+		conf["id"] = aws.StringValue(notification.Id)
 		conf["events"] = flex.FlattenStringSet(notification.Events)
-		conf["topic_arn"] = *notification.TopicArn
+		conf["topic_arn"] = aws.StringValue(notification.TopicArn)
 		topicNotifications = append(topicNotifications, conf)
 	}
 
@@ -463,9 +463,9 @@ func flattenQueueConfigurations(configs []*s3.QueueConfiguration) []map[string]i
 			conf = map[string]interface{}{}
 		}
 
-		conf["id"] = *notification.Id
+		conf["id"] = aws.StringValue(notification.Id)
 		conf["events"] = flex.FlattenStringSet(notification.Events)
-		conf["queue_arn"] = *notification.QueueArn
+		conf["queue_arn"] = aws.StringValue(notification.QueueArn)
 		queueNotifications = append(queueNotifications, conf)
 	}
 
@@ -482,9 +482,9 @@ func flattenLambdaFunctionConfigurations(configs []*s3.LambdaFunctionConfigurati
 			conf = map[string]interface{}{}
 		}
 
-		conf["id"] = *notification.Id
+		conf["id"] = aws.StringValue(notification.Id)
 		conf["events"] = flex.FlattenStringSet(notification.Events)
-		conf["lambda_function_arn"] = *notification.LambdaFunctionArn
+		conf["lambda_function_arn"] = aws.StringValue(notification.LambdaFunctionArn)
 		lambdaFunctionNotifications = append(lambdaFunctionNotifications, conf)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
```
$ make testacc TESTARGS='-run=TestAccS3BucketAnalyticsConfiguration_' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3BucketAnalyticsConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketAnalyticsConfiguration_basic
=== PAUSE TestAccS3BucketAnalyticsConfiguration_basic
=== RUN   TestAccS3BucketAnalyticsConfiguration_removed
=== PAUSE TestAccS3BucketAnalyticsConfiguration_removed
=== RUN   TestAccS3BucketAnalyticsConfiguration_updateBasic
=== PAUSE TestAccS3BucketAnalyticsConfiguration_updateBasic
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithFilter_empty
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithFilter_empty
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithFilter_remove
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithFilter_remove
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default
=== RUN   TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full
=== PAUSE TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full
=== CONT  TestAccS3BucketAnalyticsConfiguration_basic
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithFilter_remove
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithFilter_empty
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix
=== CONT  TestAccS3BucketAnalyticsConfiguration_updateBasic
=== CONT  TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full
=== CONT  TestAccS3BucketAnalyticsConfiguration_removed
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (3.77s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (3.80s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (27.36s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (27.36s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (27.58s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (38.36s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (40.43s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (42.56s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (42.75s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (42.85s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (43.06s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (58.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	62.281s
```
```
$ make testacc TESTARGS='-run=TestAccS3BucketMetric_' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3BucketMetric_ -timeout 180m
=== RUN   TestAccS3BucketMetric_basic
=== PAUSE TestAccS3BucketMetric_basic
=== RUN   TestAccS3BucketMetric_withEmptyFilter
=== PAUSE TestAccS3BucketMetric_withEmptyFilter
=== RUN   TestAccS3BucketMetric_withFilterPrefix
=== PAUSE TestAccS3BucketMetric_withFilterPrefix
=== RUN   TestAccS3BucketMetric_withFilterPrefixAndMultipleTags
=== PAUSE TestAccS3BucketMetric_withFilterPrefixAndMultipleTags
=== RUN   TestAccS3BucketMetric_withFilterPrefixAndSingleTag
=== PAUSE TestAccS3BucketMetric_withFilterPrefixAndSingleTag
=== RUN   TestAccS3BucketMetric_withFilterMultipleTags
=== PAUSE TestAccS3BucketMetric_withFilterMultipleTags
=== RUN   TestAccS3BucketMetric_withFilterSingleTag
=== PAUSE TestAccS3BucketMetric_withFilterSingleTag
=== CONT  TestAccS3BucketMetric_basic
=== CONT  TestAccS3BucketMetric_withFilterPrefixAndSingleTag
=== CONT  TestAccS3BucketMetric_withFilterSingleTag
=== CONT  TestAccS3BucketMetric_withFilterMultipleTags
=== CONT  TestAccS3BucketMetric_withFilterPrefix
=== CONT  TestAccS3BucketMetric_withFilterPrefixAndMultipleTags
=== CONT  TestAccS3BucketMetric_withEmptyFilter
--- PASS: TestAccS3BucketMetric_withEmptyFilter (2.36s)
--- PASS: TestAccS3BucketMetric_basic (23.47s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (39.50s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (39.67s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (39.72s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (39.81s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (39.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	43.363s
```
```
$ make testacc TESTARGS='-run=TestAccS3BucketNotification_' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3BucketNotification_ -timeout 180m
=== RUN   TestAccS3BucketNotification_eventbridge
=== PAUSE TestAccS3BucketNotification_eventbridge
=== RUN   TestAccS3BucketNotification_lambdaFunction
=== PAUSE TestAccS3BucketNotification_lambdaFunction
=== RUN   TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias
=== PAUSE TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias
=== RUN   TestAccS3BucketNotification_queue
=== PAUSE TestAccS3BucketNotification_queue
=== RUN   TestAccS3BucketNotification_topic
=== PAUSE TestAccS3BucketNotification_topic
=== RUN   TestAccS3BucketNotification_Topic_multiple
=== PAUSE TestAccS3BucketNotification_Topic_multiple
=== RUN   TestAccS3BucketNotification_update
=== PAUSE TestAccS3BucketNotification_update
=== CONT  TestAccS3BucketNotification_eventbridge
=== CONT  TestAccS3BucketNotification_topic
=== CONT  TestAccS3BucketNotification_Topic_multiple
=== CONT  TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias
=== CONT  TestAccS3BucketNotification_queue
=== CONT  TestAccS3BucketNotification_lambdaFunction
=== CONT  TestAccS3BucketNotification_update
--- PASS: TestAccS3BucketNotification_eventbridge (24.82s)
--- PASS: TestAccS3BucketNotification_topic (25.87s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (26.18s)
--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (37.51s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (41.41s)
--- PASS: TestAccS3BucketNotification_queue (53.16s)
--- PASS: TestAccS3BucketNotification_update (68.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	71.817s
```