### PR TITLE
r/route53_record: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -57,7 +57,6 @@ rules:
         - internal/service/opsworks
         - internal/service/rds
         - internal/service/redshift
-        - internal/service/route53
         - internal/service/s3
         - internal/service/servicediscovery
         - internal/service/ssm

--- a/internal/service/route53/flex.go
+++ b/internal/service/route53/flex.go
@@ -23,8 +23,8 @@ func FlattenResourceRecords(recs []*route53.ResourceRecord, typeStr string) []st
 	strs := make([]string, 0, len(recs))
 	for _, r := range recs {
 		if r.Value != nil {
-			s := *r.Value
-			if typeStr == "TXT" || typeStr == "SPF" {
+			s := aws.StringValue(r.Value)
+			if typeStr == route53.RRTypeTxt || typeStr == route53.RRTypeSpf {
 				s = expandTxtEntry(s)
 			}
 			strs = append(strs, s)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
```
make testacc TESTARGS='-run=TestAccRoute53Record_' PKG=route53
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20  -run=TestAccRoute53Record_ -timeout 180m
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_underscored
=== PAUSE TestAccRoute53Record_underscored
=== RUN   TestAccRoute53Record_disappears
=== PAUSE TestAccRoute53Record_disappears
=== RUN   TestAccRoute53Record_Disappears_multipleRecords
=== PAUSE TestAccRoute53Record_Disappears_multipleRecords
=== RUN   TestAccRoute53Record_Basic_fqdn
=== PAUSE TestAccRoute53Record_Basic_fqdn
=== RUN   TestAccRoute53Record_Basic_trailingPeriodAndZoneID
=== PAUSE TestAccRoute53Record_Basic_trailingPeriodAndZoneID
=== RUN   TestAccRoute53Record_txtSupport
=== PAUSE TestAccRoute53Record_txtSupport
=== RUN   TestAccRoute53Record_spfSupport
=== PAUSE TestAccRoute53Record_spfSupport
=== RUN   TestAccRoute53Record_caaSupport
=== PAUSE TestAccRoute53Record_caaSupport
=== RUN   TestAccRoute53Record_dsSupport
=== PAUSE TestAccRoute53Record_dsSupport
=== RUN   TestAccRoute53Record_generatesSuffix
=== PAUSE TestAccRoute53Record_generatesSuffix
=== RUN   TestAccRoute53Record_wildcard
=== PAUSE TestAccRoute53Record_wildcard
=== RUN   TestAccRoute53Record_failover
=== PAUSE TestAccRoute53Record_failover
=== RUN   TestAccRoute53Record_Weighted_basic
=== PAUSE TestAccRoute53Record_Weighted_basic
=== RUN   TestAccRoute53Record_WeightedToSimple_basic
=== PAUSE TestAccRoute53Record_WeightedToSimple_basic
=== RUN   TestAccRoute53Record_Alias_elb
=== PAUSE TestAccRoute53Record_Alias_elb
=== RUN   TestAccRoute53Record_Alias_s3
=== PAUSE TestAccRoute53Record_Alias_s3
=== RUN   TestAccRoute53Record_Alias_vpcEndpoint
=== PAUSE TestAccRoute53Record_Alias_vpcEndpoint
=== RUN   TestAccRoute53Record_Alias_uppercase
=== PAUSE TestAccRoute53Record_Alias_uppercase
=== RUN   TestAccRoute53Record_Weighted_alias
=== PAUSE TestAccRoute53Record_Weighted_alias
=== RUN   TestAccRoute53Record_Geolocation_basic
=== PAUSE TestAccRoute53Record_Geolocation_basic
=== RUN   TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== PAUSE TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== RUN   TestAccRoute53Record_HealthCheckID_typeChange
=== PAUSE TestAccRoute53Record_HealthCheckID_typeChange
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53Record_typeChange
=== PAUSE TestAccRoute53Record_typeChange
=== RUN   TestAccRoute53Record_nameChange
=== PAUSE TestAccRoute53Record_nameChange
=== RUN   TestAccRoute53Record_setIdentifierChange
=== PAUSE TestAccRoute53Record_setIdentifierChange
=== RUN   TestAccRoute53Record_aliasChange
=== PAUSE TestAccRoute53Record_aliasChange
=== RUN   TestAccRoute53Record_empty
=== PAUSE TestAccRoute53Record_empty
=== RUN   TestAccRoute53Record_longTXTrecord
=== PAUSE TestAccRoute53Record_longTXTrecord
=== RUN   TestAccRoute53Record_MultiValueAnswer_basic
=== PAUSE TestAccRoute53Record_MultiValueAnswer_basic
=== RUN   TestAccRoute53Record_doNotAllowOverwrite
=== PAUSE TestAccRoute53Record_doNotAllowOverwrite
=== RUN   TestAccRoute53Record_allowOverwrite
=== PAUSE TestAccRoute53Record_allowOverwrite
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53Record_Alias_vpcEndpoint
=== CONT  TestAccRoute53Record_Alias_s3
=== CONT  TestAccRoute53Record_dsSupport
=== CONT  TestAccRoute53Record_generatesSuffix
=== CONT  TestAccRoute53Record_nameChange
=== CONT  TestAccRoute53Record_typeChange
=== CONT  TestAccRoute53Record_WeightedToSimple_basic
=== CONT  TestAccRoute53Record_Weighted_basic
=== CONT  TestAccRoute53Record_failover
=== CONT  TestAccRoute53Record_wildcard
=== CONT  TestAccRoute53Record_Latency_basic
=== CONT  TestAccRoute53Record_HealthCheckID_typeChange
=== CONT  TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== CONT  TestAccRoute53Record_Geolocation_basic
=== CONT  TestAccRoute53Record_Weighted_alias
=== CONT  TestAccRoute53Record_Alias_uppercase
=== CONT  TestAccRoute53Record_Basic_fqdn
=== CONT  TestAccRoute53Record_longTXTrecord
=== CONT  TestAccRoute53Record_Alias_elb
--- PASS: TestAccRoute53Record_basic (318.35s)
=== CONT  TestAccRoute53Record_caaSupport
--- PASS: TestAccRoute53Record_longTXTrecord (139.11s)
=== CONT  TestAccRoute53Record_spfSupport
--- PASS: TestAccRoute53Record_Latency_basic (721.95s)
=== CONT  TestAccRoute53Record_txtSupport
--- PASS: TestAccRoute53Record_Alias_elb (722.44s)
=== CONT  TestAccRoute53Record_Basic_trailingPeriodAndZoneID
--- PASS: TestAccRoute53Record_generatesSuffix (754.83s)
=== CONT  TestAccRoute53Record_aliasChange
--- PASS: TestAccRoute53Record_failover (982.03s)
=== CONT  TestAccRoute53Record_empty
--- PASS: TestAccRoute53Record_Geolocation_basic (986.79s)
=== CONT  TestAccRoute53Record_allowOverwrite
--- PASS: TestAccRoute53Record_Weighted_basic (1205.12s)
=== CONT  TestAccRoute53Record_disappears
=== CONT  TestAccRoute53Record_doNotAllowOverwrite
--- PASS: TestAccRoute53Record_Alias_s3 (1205.17s)
--- PASS: TestAccRoute53Record_WeightedToSimple_basic (1236.04s)
=== CONT  TestAccRoute53Record_Disappears_multipleRecords
--- PASS: TestAccRoute53Record_dsSupport (1290.65s)
=== CONT  TestAccRoute53Record_MultiValueAnswer_basic
--- PASS: TestAccRoute53Record_caaSupport (987.15s)
=== CONT  TestAccRoute53Record_setIdentifierChange
--- PASS: TestAccRoute53Record_Basic_fqdn (1335.71s)
=== CONT  TestAccRoute53Record_underscored
--- PASS: TestAccRoute53Record_typeChange (1336.83s)
--- PASS: TestAccRoute53Record_Alias_uppercase (1337.78s)
--- PASS: TestAccRoute53Record_spfSupport (1266.74s)
--- PASS: TestAccRoute53Record_Basic_trailingPeriodAndZoneID (1041.87s)
--- PASS: TestAccRoute53Record_HealthCheckID_setIdentifierChange (1783.53s)
--- PASS: TestAccRoute53Record_wildcard (1783.93s)
--- PASS: TestAccRoute53Record_empty (805.90s)
--- PASS: TestAccRoute53Record_allowOverwrite (801.18s)
--- PASS: TestAccRoute53Record_txtSupport (1067.73s)
--- PASS: TestAccRoute53Record_doNotAllowOverwrite (604.68s)
--- PASS: TestAccRoute53Record_aliasChange (1070.94s)
--- PASS: TestAccRoute53Record_MultiValueAnswer_basic (537.73s)
--- PASS: TestAccRoute53Record_disappears (625.71s)
--- PASS: TestAccRoute53Record_underscored (518.21s)
--- PASS: TestAccRoute53Record_nameChange (1855.83s)
--- PASS: TestAccRoute53Record_Weighted_alias (1886.15s)
--- PASS: TestAccRoute53Record_Disappears_multipleRecords (663.89s)
--- PASS: TestAccRoute53Record_setIdentifierChange (631.52s)
--- PASS: TestAccRoute53Record_HealthCheckID_typeChange (1983.08s)
--- PASS: TestAccRoute53Record_Alias_vpcEndpoint (2331.42s)
```