### PR TITLE
service/redshift: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -54,7 +54,6 @@ rules:
         - internal/service/gamelift
         - internal/service/iam
         - internal/service/opsworks
-        - internal/service/redshift
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/redshift/flex.go
+++ b/internal/service/redshift/flex.go
@@ -36,10 +36,10 @@ func flattenLogging(ls *redshift.LoggingStatus) []interface{} {
 	cfg := make(map[string]interface{})
 	cfg["enable"] = aws.BoolValue(ls.LoggingEnabled)
 	if ls.BucketName != nil {
-		cfg["bucket_name"] = *ls.BucketName
+		cfg["bucket_name"] = aws.StringValue(ls.BucketName)
 	}
 	if ls.S3KeyPrefix != nil {
-		cfg["s3_key_prefix"] = *ls.S3KeyPrefix
+		cfg["s3_key_prefix"] = aws.StringValue(ls.S3KeyPrefix)
 	}
 	return []interface{}{cfg}
 }
@@ -63,13 +63,13 @@ func flattenSnapshotCopy(scs *redshift.ClusterSnapshotCopyStatus) []interface{} 
 
 	cfg := make(map[string]interface{})
 	if scs.DestinationRegion != nil {
-		cfg["destination_region"] = *scs.DestinationRegion
+		cfg["destination_region"] = aws.StringValue(scs.DestinationRegion)
 	}
 	if scs.RetentionPeriod != nil {
-		cfg["retention_period"] = *scs.RetentionPeriod
+		cfg["retention_period"] = aws.Int64Value(scs.RetentionPeriod)
 	}
 	if scs.SnapshotCopyGrantName != nil {
-		cfg["grant_name"] = *scs.SnapshotCopyGrantName
+		cfg["grant_name"] = aws.StringValue(scs.SnapshotCopyGrantName)
 	}
 
 	return []interface{}{cfg}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
