### PR TITLE
r/rds_security_group: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -55,7 +55,6 @@ rules:
         - internal/service/iam
         - internal/service/lambda
         - internal/service/opsworks
-        - internal/service/rds
         - internal/service/redshift
         - internal/service/route53
         - internal/service/s3

--- a/internal/service/rds/security_group.go
+++ b/internal/service/rds/security_group.go
@@ -172,13 +172,13 @@ func resourceSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
 	for _, g := range sg.EC2SecurityGroups {
 		rule := map[string]interface{}{}
 		if g.EC2SecurityGroupId != nil {
-			rule["security_group_id"] = *g.EC2SecurityGroupId
+			rule["security_group_id"] = aws.StringValue(g.EC2SecurityGroupId)
 		}
 		if g.EC2SecurityGroupName != nil {
-			rule["security_group_name"] = *g.EC2SecurityGroupName
+			rule["security_group_name"] = aws.StringValue(g.EC2SecurityGroupName)
 		}
 		if g.EC2SecurityGroupOwnerId != nil {
-			rule["security_group_owner_id"] = *g.EC2SecurityGroupOwnerId
+			rule["security_group_owner_id"] = aws.StringValue(g.EC2SecurityGroupOwnerId)
 		}
 		rules.Add(rule)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
