### PR TITLE
service/opworks: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -53,7 +53,6 @@ rules:
         - internal/service/emr
         - internal/service/gamelift
         - internal/service/iam
-        - internal/service/opsworks
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -254,7 +254,7 @@ func resourceApplicationValidate(d *schema.ResourceData) error {
 }
 
 func resourceApplicationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 
 	req := &opsworks.DescribeAppsInput{
 		AppIds: []*string{
@@ -264,7 +264,7 @@ func resourceApplicationRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Reading OpsWorks Application: %s", d.Id())
 
-	resp, err := client.DescribeApps(req)
+	resp, err := conn.DescribeApps(req)
 
 	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
 		log.Printf("[DEBUG] OpsWorks Application (%s) not found", d.Id())
@@ -301,7 +301,7 @@ func resourceApplicationRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceApplicationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 
 	err := resourceApplicationValidate(d)
 	if err != nil {
@@ -323,19 +323,18 @@ func resourceApplicationCreate(d *schema.ResourceData, meta interface{}) error {
 		Attributes:       resourceApplicationAttributes(d),
 	}
 
-	resp, err := client.CreateApp(req)
+	resp, err := conn.CreateApp(req)
 	if err != nil {
 		return fmt.Errorf("Error creating OpsWorks application: %s", err)
 	}
 
-	appID := *resp.AppId
-	d.SetId(appID)
+	d.SetId(aws.StringValue(resp.AppId))
 
 	return resourceApplicationRead(d, meta)
 }
 
 func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 
 	err := resourceApplicationValidate(d)
 	if err != nil {
@@ -358,7 +357,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Updating OpsWorks layer: %s", d.Id())
 
-	_, err = client.UpdateApp(req)
+	_, err = conn.UpdateApp(req)
 	if err != nil {
 		return fmt.Errorf("Error updating OpsWorks app: %s", err)
 	}
@@ -367,7 +366,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceApplicationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 
 	req := &opsworks.DeleteAppInput{
 		AppId: aws.String(d.Id()),
@@ -375,7 +374,7 @@ func resourceApplicationDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting OpsWorks application: %s", d.Id())
 
-	_, err := client.DeleteApp(req)
+	_, err := conn.DeleteApp(req)
 
 	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
 		log.Printf("[DEBUG] OpsWorks Application (%s) not found to delete; removed from state", d.Id())
@@ -460,16 +459,16 @@ func resourceSetApplicationSource(d *schema.ResourceData, v *opsworks.Source) er
 	if v != nil {
 		m := make(map[string]interface{})
 		if v.Type != nil {
-			m["type"] = *v.Type
+			m["type"] = aws.StringValue(v.Type)
 		}
 		if v.Url != nil {
-			m["url"] = *v.Url
+			m["url"] = aws.StringValue(v.Url)
 		}
 		if v.Username != nil {
-			m["username"] = *v.Username
+			m["username"] = aws.StringValue(v.Username)
 		}
 		if v.Revision != nil {
-			m["revision"] = *v.Revision
+			m["revision"] = aws.StringValue(v.Revision)
 		}
 
 		// v.Password and v.SshKey will, on read, contain the placeholder string
@@ -539,15 +538,15 @@ func resourceSetApplicationSSL(d *schema.ResourceData, v *opsworks.SslConfigurat
 	if v != nil {
 		m := make(map[string]interface{})
 		if v.PrivateKey != nil {
-			m["private_key"] = *v.PrivateKey
+			m["private_key"] = aws.StringValue(v.PrivateKey)
 			set = true
 		}
 		if v.Certificate != nil {
-			m["certificate"] = *v.Certificate
+			m["certificate"] = aws.StringValue(v.Certificate)
 			set = true
 		}
 		if v.Chain != nil {
-			m["chain"] = *v.Chain
+			m["chain"] = aws.StringValue(v.Chain)
 			set = true
 		}
 		if set {

--- a/internal/service/opsworks/application_test.go
+++ b/internal/service/opsworks/application_test.go
@@ -35,9 +35,10 @@ func TestAccOpsWorksApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "other"),
 					resource.TestCheckResourceAttr(resourceName, "enable_ssl", "false"),
-					resource.TestCheckNoResourceAttr(resourceName, "ssl_configuration"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_configuration.#", "0"),
 					resource.TestCheckNoResourceAttr(resourceName, "domains"),
-					resource.TestCheckNoResourceAttr(resourceName, "app_source"),
+					resource.TestCheckResourceAttr(resourceName, "app_source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_source.0.type", "other"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
 						"key":    "key1",
 						"value":  "value1",

--- a/internal/service/opsworks/consts.go
+++ b/internal/service/opsworks/consts.go
@@ -1,0 +1,15 @@
+package opsworks
+
+const (
+	instanceStatusBooting      = "booting"
+	instanceStatusOnline       = "online"
+	instanceStatusPending      = "pending"
+	instanceStatusRequested    = "requested"
+	instanceStatusRunning      = "running"
+	instanceStatusRunningSetup = "running_setup"
+	instanceStatusShuttingDown = "shutting_down"
+	instanceStatusStopped      = "stopped"
+	instanceStatusStopping     = "stopping"
+	instanceStatusTerminated   = "terminated"
+	instanceStatusTerminating  = "terminating"
+)

--- a/internal/service/opsworks/instance_test.go
+++ b/internal/service/opsworks/instance_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -177,24 +177,30 @@ func testAccCheckInstanceDestroy(s *terraform.State) error {
 			continue
 		}
 		req := &opsworks.DescribeInstancesInput{
-			InstanceIds: []*string{
-				aws.String(rs.Primary.ID),
-			},
+			InstanceIds: aws.StringSlice([]string{rs.Primary.ID}),
 		}
 
-		_, err := conn.DescribeInstances(req)
+		output, err := conn.DescribeInstances(req)
+
+		if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
 		if err != nil {
-			if awserr, ok := err.(awserr.Error); ok {
-				if awserr.Code() == "ResourceNotFoundException" {
-					// not found, good to go
-					return nil
-				}
-			}
 			return err
+		}
+
+		if output != nil && len(output.Instances) > 0 {
+			for _, instance := range output.Instances {
+				if aws.StringValue(instance.InstanceId) != rs.Primary.ID {
+					continue
+				}
+				return fmt.Errorf("Expected OpsWorks instance (%s) to be gone, but was still found", rs.Primary.ID)
+			}
 		}
 	}
 
-	return fmt.Errorf("Fall through error on OpsWorks instance test")
+	return nil
 }
 
 func testAccInstanceUpdateHostNameConfig(rName string) string {

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -251,16 +251,16 @@ func resourceSetStackCustomCookbooksSource(d *schema.ResourceData, v *opsworks.S
 	if v != nil && aws.StringValue(v.Type) != "" {
 		m := make(map[string]interface{})
 		if v.Type != nil {
-			m["type"] = *v.Type
+			m["type"] = aws.StringValue(v.Type)
 		}
 		if v.Url != nil {
-			m["url"] = *v.Url
+			m["url"] = aws.StringValue(v.Url)
 		}
 		if v.Username != nil {
-			m["username"] = *v.Username
+			m["username"] = aws.StringValue(v.Username)
 		}
 		if v.Revision != nil {
-			m["revision"] = *v.Revision
+			m["revision"] = aws.StringValue(v.Revision)
 		}
 
 		// v.Password and v.SshKey will, on read, contain the placeholder string
@@ -281,13 +281,13 @@ func resourceSetStackCustomCookbooksSource(d *schema.ResourceData, v *opsworks.S
 }
 
 func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	var conErr error
 	if v := d.Get("stack_endpoint").(string); v != "" {
-		client, conErr = opsworksConnForRegion(v, meta)
+		conn, conErr = opsworksConnForRegion(v, meta)
 		if conErr != nil {
 			return conErr
 		}
@@ -311,7 +311,7 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 	var dErr error
 
 	for {
-		resp, dErr = client.DescribeStacks(req)
+		resp, dErr = conn.DescribeStacks(req)
 		if dErr != nil {
 			if awserr, ok := dErr.(awserr.Error); ok {
 				if awserr.Code() == "ResourceNotFoundException" {
@@ -319,7 +319,7 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 						// If we haven't already, try us-east-1, legacy connection
 						notFound++
 						var connErr error
-						client, connErr = opsworksConnForRegion("us-east-1", meta) //lintignore:AWSAT003
+						conn, connErr = opsworksConnForRegion("us-east-1", meta) //lintignore:AWSAT003
 						if connErr != nil {
 							return connErr
 						}
@@ -339,7 +339,7 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 			return dErr
 		}
 		// If the stack was found, set the stack_endpoint
-		if region := aws.StringValue(client.Config.Region); region != "" {
+		if region := aws.StringValue(conn.Config.Region); region != "" {
 			log.Printf("[DEBUG] Setting stack_endpoint for (%s) to (%s)", d.Id(), region)
 			if err := d.Set("stack_endpoint", region); err != nil {
 				log.Printf("[WARN] Error setting stack_endpoint: %s", err)
@@ -386,7 +386,7 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	tags, err := ListTags(client, arn)
+	tags, err := ListTags(conn, arn)
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for Opsworks stack (%s): %s", arn, err)
@@ -431,7 +431,7 @@ func opsworksConnForRegion(region string, meta interface{}) (*opsworks.OpsWorks,
 }
 
 func resourceStackCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 
 	err := resourceStackValidate(d)
 	if err != nil {
@@ -469,7 +469,7 @@ func resourceStackCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var resp *opsworks.CreateStackOutput
 	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
-		resp, err = client.CreateStack(req)
+		resp, err = conn.CreateStack(req)
 		if err != nil {
 			// If Terraform is also managing the service IAM role, it may have just been created and not yet be
 			// propagated. AWS doesn't provide a machine-readable code for this specific error, so we're forced
@@ -490,14 +490,13 @@ func resourceStackCreate(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 	if tfresource.TimedOut(err) {
-		resp, err = client.CreateStack(req)
+		resp, err = conn.CreateStack(req)
 	}
 	if err != nil {
 		return fmt.Errorf("Error creating Opsworks stack: %s", err)
 	}
 
-	stackId := *resp.StackId
-	d.SetId(stackId)
+	d.SetId(aws.StringValue(resp.StackId))
 
 	if inVpc && *req.UseOpsworksSecurityGroups {
 		// For VPC-based stacks, OpsWorks asynchronously creates some default
@@ -513,10 +512,10 @@ func resourceStackCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceStackUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 	var conErr error
 	if v := d.Get("stack_endpoint").(string); v != "" {
-		client, conErr = opsworksConnForRegion(v, meta)
+		conn, conErr = opsworksConnForRegion(v, meta)
 		if conErr != nil {
 			return conErr
 		}
@@ -571,7 +570,7 @@ func resourceStackUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Updating OpsWorks stack: %s", req)
 
-	_, err = client.UpdateStack(req)
+	_, err = conn.UpdateStack(req)
 	if err != nil {
 		return err
 	}
@@ -586,7 +585,7 @@ func resourceStackUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(client, arn, o, n); err != nil {
+		if err := UpdateTags(conn, arn, o, n); err != nil {
 			return fmt.Errorf("error updating Opsworks stack (%s) tags: %s", arn, err)
 		}
 	}
@@ -595,10 +594,10 @@ func resourceStackUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceStackDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*conns.AWSClient).OpsWorksConn
+	conn := meta.(*conns.AWSClient).OpsWorksConn
 	var conErr error
 	if v := d.Get("stack_endpoint").(string); v != "" {
-		client, conErr = opsworksConnForRegion(v, meta)
+		conn, conErr = opsworksConnForRegion(v, meta)
 		if conErr != nil {
 			return conErr
 		}
@@ -610,7 +609,7 @@ func resourceStackDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting OpsWorks stack: %s", d.Id())
 
-	_, err := client.DeleteStack(req)
+	_, err := conn.DeleteStack(req)
 
 	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
 		log.Printf("[DEBUG] OpsWorks Stack (%s) not found to delete; removed from state", d.Id())

--- a/internal/service/opsworks/status.go
+++ b/internal/service/opsworks/status.go
@@ -1,0 +1,33 @@
+package opsworks
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func InstanceStatus(conn *opsworks.OpsWorks, instanceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeInstances(&opsworks.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+
+		if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if resp == nil || len(resp.Instances) == 0 || resp.Instances[0] == nil {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		i := resp.Instances[0]
+		return i, aws.StringValue(i.Status), nil
+	}
+}

--- a/internal/service/opsworks/wait.go
+++ b/internal/service/opsworks/wait.go
@@ -1,0 +1,52 @@
+package opsworks
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	InstanceDeleteTimeout = 2 * time.Minute
+)
+
+func waitInstanceDeleted(conn *opsworks.OpsWorks, instanceId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{instanceStatusStopped, instanceStatusTerminating, instanceStatusTerminated},
+		Target:     []string{},
+		Refresh:    InstanceStatus(conn, instanceId),
+		Timeout:    InstanceDeleteTimeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func waitInstanceStarted(conn *opsworks.OpsWorks, instanceId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{instanceStatusRequested, instanceStatusPending, instanceStatusBooting, instanceStatusRunningSetup},
+		Target:     []string{instanceStatusOnline},
+		Refresh:    InstanceStatus(conn, instanceId),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func waitInstanceStopped(conn *opsworks.OpsWorks, instanceId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{instanceStatusStopping, instanceStatusTerminating, instanceStatusShuttingDown, instanceStatusTerminated},
+		Target:     []string{instanceStatusStopped},
+		Refresh:    InstanceStatus(conn, instanceId),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
```
make testacc TESTARGS='-run=TestAccOpsWorksApplication\|TestAccOpsWorksInstance_\|TestAccOpsWorksLayers_\|TestAccOpsWorksStack_' PKG=opsworks
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 20  -run=TestAccOpsWorksApplication\|TestAccOpsWorksInstance_\|TestAccOpsWorksLayers_\|TestAccOpsWorksStack_ -timeout 180m
=== RUN   TestAccOpsWorksApplication_basic
=== PAUSE TestAccOpsWorksApplication_basic
=== RUN   TestAccOpsWorksInstance_basic
=== PAUSE TestAccOpsWorksInstance_basic
=== RUN   TestAccOpsWorksInstance_updateHostNameForceNew
=== PAUSE TestAccOpsWorksInstance_updateHostNameForceNew
=== RUN   TestAccOpsWorksStack_noVPCBasic
=== PAUSE TestAccOpsWorksStack_noVPCBasic
=== RUN   TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew
=== PAUSE TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew
=== RUN   TestAccOpsWorksStack_vpc
=== PAUSE TestAccOpsWorksStack_vpc
=== RUN   TestAccOpsWorksStack_noVPCCreateTags
=== PAUSE TestAccOpsWorksStack_noVPCCreateTags
=== RUN   TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties
=== PAUSE TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties
=== RUN   TestAccOpsWorksStack_classicEndpoints
--- PASS: TestAccOpsWorksStack_classicEndpoints (65.70s)
=== CONT  TestAccOpsWorksApplication_basic
=== CONT  TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew
=== CONT  TestAccOpsWorksInstance_updateHostNameForceNew
=== CONT  TestAccOpsWorksStack_noVPCCreateTags
=== CONT  TestAccOpsWorksInstance_basic
=== CONT  TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties
=== CONT  TestAccOpsWorksStack_vpc
=== CONT  TestAccOpsWorksStack_noVPCBasic
--- PASS: TestAccOpsWorksStack_noVPCBasic (32.22s)
--- PASS: TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties (35.33s)
--- PASS: TestAccOpsWorksStack_noVPCCreateTags (47.92s)
--- PASS: TestAccOpsWorksApplication_basic (49.02s)
--- PASS: TestAccOpsWorksStack_vpc (49.60s)
--- PASS: TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew (56.47s)
--- PASS: TestAccOpsWorksInstance_updateHostNameForceNew (78.89s)
--- PASS: TestAccOpsWorksInstance_basic (84.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	152.982s
```