### PR TITLE
service/lambda: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -53,7 +53,6 @@ rules:
         - internal/service/emr
         - internal/service/gamelift
         - internal/service/iam
-        - internal/service/lambda
         - internal/service/opsworks
         - internal/service/rds
         - internal/service/redshift

--- a/internal/service/lambda/flex.go
+++ b/internal/service/lambda/flex.go
@@ -44,7 +44,7 @@ func flattenVPCConfigResponse(s *lambda.VpcConfigResponse) []map[string]interfac
 	settings["subnet_ids"] = flex.FlattenStringSet(s.SubnetIds)
 	settings["security_group_ids"] = flex.FlattenStringSet(s.SecurityGroupIds)
 	if s.VpcId != nil {
-		settings["vpc_id"] = *s.VpcId
+		settings["vpc_id"] = aws.StringValue(s.VpcId)
 	}
 
 	return []map[string]interface{}{settings}

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -841,7 +841,7 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	// Assume `PassThrough` on partitions that don't support tracing config
 	tracingConfigMode := "PassThrough"
 	if function.TracingConfig != nil {
-		tracingConfigMode = *function.TracingConfig.Mode
+		tracingConfigMode = aws.StringValue(function.TracingConfig.Mode)
 	}
 	d.Set("tracing_config", []interface{}{
 		map[string]interface{}{
@@ -864,8 +864,8 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 		}, func(p *lambda.ListVersionsByFunctionOutput, lastPage bool) bool {
 			if lastPage {
 				last := p.Versions[len(p.Versions)-1]
-				lastVersion = *last.Version
-				lastQualifiedArn = *last.FunctionArn
+				lastVersion = aws.StringValue(last.Version)
+				lastQualifiedArn = aws.StringValue(last.FunctionArn)
 				return false
 			}
 			return true
@@ -1444,8 +1444,8 @@ func flattenFileSystemConfigs(fscList []*lambda.FileSystemConfig) []map[string]i
 	results := make([]map[string]interface{}, 0, len(fscList))
 	for _, fsc := range fscList {
 		f := make(map[string]interface{})
-		f["arn"] = *fsc.Arn
-		f["local_mount_path"] = *fsc.LocalMountPath
+		f["arn"] = aws.StringValue(fsc.Arn)
+		f["local_mount_path"] = aws.StringValue(fsc.LocalMountPath)
 
 		results = append(results, f)
 	}


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31
ran 31 rules on 2344 files: 0 findings
```
