### PR TITLE
doc and test of security_group for change name use-case

### DIFF
--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -4475,9 +4475,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-	vpc_id            = aws_vpc.test.id
-	cidr_block        = "10.0.0.0/24"
-	availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 }
 
 resource "aws_security_group" "test" {
@@ -4485,17 +4485,17 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 
   lifecycle {
-	# Necessary if changing 'name' or 'name_prefix' properties.
-    create_before_destroy = true 
+    # Necessary if changing 'name' or 'name_prefix' properties.
+    create_before_destroy = true
   }
 }
 
 resource "aws_instance" "test" {
-	ami               = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-	instance_type     = "t2.micro"
-	vpc_security_group_ids   = [aws_security_group.test.id]
-	subnet_id         = aws_subnet.test.id
-	availability_zone = data.aws_availability_zones.available.names[0]
+  ami                    = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [aws_security_group.test.id]
+  subnet_id              = aws_subnet.test.id
+  availability_zone      = data.aws_availability_zones.available.names[0]
 }
 `, sgName))
 }

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -98,18 +98,18 @@ You can also find a specific Prefix List using the `aws_prefix_list` data source
 
 ### Change of name or name-prefix value
 
-The `name` and `name-prefix` arguments force the creation of a new Security Group resource when they change value. In that case, Terraform first deletes the existing Security Group resource and then it creates a new one. If the existing Security Group is associated to a Network Interface resource, the deletion cannot complete. The reason is that Network Interface resources cannot be left with no Security Group attached and the new one is not yet available at that point.
+Security Group's Name [cannot be edited after the resource is created](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#creating-security-group). In fact, the `name` and `name-prefix` arguments force the creation of a new Security Group resource when they change value. In that case, Terraform first deletes the existing Security Group resource and then it creates a new one. If the existing Security Group is associated to a Network Interface resource, the deletion cannot complete. The reason is that Network Interface resources cannot be left with no Security Group attached and the new one is not yet available at that point.
 
-So, it is required to invert the default behavior of Terraform. That is, first the new Security Group resource must be created, then associated to possible Network Interface resources and finally the old Security Group can be detached and deleted. To force this behavior, you must set the [create_before_destroy](https://www.terraform.io/language/meta-arguments/lifecycle#create_before_destroy) property:
+It is required to invert the default behavior of Terraform. That is, first the new Security Group resource must be created, then associated to possible Network Interface resources and finally the old Security Group can be detached and deleted. To force this behavior, you must set the [create_before_destroy](https://www.terraform.io/language/meta-arguments/lifecycle#create_before_destroy) property:
 
 ```terraform
 resource "aws_security_group" "sg_with_changeable_name" {
-  name   = "changeable-name"
+  name = "changeable-name"
   # ... other configuration ...
 
   lifecycle {
-	  # Necessary if changing 'name' or 'name_prefix' properties.
-    create_before_destroy = true 
+    # Necessary if changing 'name' or 'name_prefix' properties.
+    create_before_destroy = true
   }
 }
 ```

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -96,6 +96,24 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 
 You can also find a specific Prefix List using the `aws_prefix_list` data source.
 
+### Change of name or name-prefix value
+
+The `name` and `name-prefix` arguments force the creation of a new Security Group resource when they change value. In that case, Terraform first deletes the existing Security Group resource and then it creates a new one. If the existing Security Group is associated to a Network Interface resource, the deletion cannot complete. The reason is that Network Interface resources cannot be left with no Security Group attached and the new one is not yet available at that point.
+
+So, it is required to invert the default behavior of Terraform. That is, first the new Security Group resource must be created, then associated to possible Network Interface resources and finally the old Security Group can be detached and deleted. To force this behavior, you must set the [create_before_destroy](https://www.terraform.io/language/meta-arguments/lifecycle#create_before_destroy) property:
+
+```terraform
+resource "aws_security_group" "sg_with_changeable_name" {
+  name   = "changeable-name"
+  # ... other configuration ...
+
+  lifecycle {
+	  # Necessary if changing 'name' or 'name_prefix' properties.
+    create_before_destroy = true 
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
### Changes
1. Added a new Acceptance Test to make sure that user can change `name` or `name-prefix` arguments to Security Group resource when they specify `create_before_destroy = true` property.
2. Extended Security Group documentation to provide this use-case as example. 

Closes #23708

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2SecurityGroup_name_change PKG=ec2 ACCTEST_PARALLELISM=2  | tee test_output.txt
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2 -run='TestAccEC2SecurityGroup_name_change'  -timeout 180m
=== RUN   TestAccEC2SecurityGroup_name_change
=== PAUSE TestAccEC2SecurityGroup_name_change
=== CONT  TestAccEC2SecurityGroup_name_change
--- PASS: TestAccEC2SecurityGroup_name_change (281.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	283.749s
```
