### PR TITLE
add lambda function urls auth type support in lambda permission resource

### DIFF
--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -47,6 +48,12 @@ func ResourcePermission() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validFunctionName(),
+			},
+			"function_url_auth_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(lambda.FunctionUrlAuthType_Values(), false),
 			},
 			"principal_org_id": {
 				Type:     schema.TypeString,
@@ -124,6 +131,9 @@ func resourcePermissionCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("event_source_token"); ok {
 		input.EventSourceToken = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("function_url_auth_type"); ok {
+		input.FunctionUrlAuthType = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("qualifier"); ok {
 		input.Qualifier = aws.String(v.(string))
@@ -306,6 +316,7 @@ func resourcePermissionRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("source_account", stringEquals["AWS:SourceAccount"])
 		d.Set("event_source_token", stringEquals["lambda:EventSourceToken"])
 		d.Set("principal_org_id", stringEquals["aws:PrincipalOrgID"])
+		d.Set("function_url_auth_type", stringEquals["lambda:FunctionUrlAuthType"])
 	}
 
 	if arnLike, ok := statement.Condition["ArnLike"]; ok {

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -184,6 +184,7 @@ EOF
 * `action` - (Required) The AWS Lambda action you want to allow in this statement. (e.g., `lambda:InvokeFunction`)
 * `event_source_token` - (Optional) The Event Source Token to validate.  Used with [Alexa Skills][1].
 * `function_name` - (Required) Name of the Lambda function whose resource policy you are updating
+* `function_url_auth_type` - (Optional) Lambda Function URLs [authentication type][3]. Valid values are: `AWS_IAM` or `NONE`.
 * `principal` - (Required) The principal who is getting this permission e.g., `s3.amazonaws.com`, an AWS account ID, or any valid AWS service principal such as `events.amazonaws.com` or `sns.amazonaws.com`.
 * `qualifier` - (Optional) Query parameter to specify function version or alias name. The permission will then apply to the specific qualified ARN e.g., `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
 * `source_account` - (Optional) This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner.
@@ -198,6 +199,7 @@ EOF
 
 [1]: https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli
 [2]: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #24325

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccLambdaPermission_FunctionUrls PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaPermission_FunctionUrls'  -timeout 180m
=== RUN   TestAccLambdaPermission_FunctionUrls_AwsIam
=== PAUSE TestAccLambdaPermission_FunctionUrls_AwsIam
=== RUN   TestAccLambdaPermission_FunctionUrls_None
=== PAUSE TestAccLambdaPermission_FunctionUrls_None
=== CONT  TestAccLambdaPermission_FunctionUrls_AwsIam
=== CONT  TestAccLambdaPermission_FunctionUrls_None
--- PASS: TestAccLambdaPermission_FunctionUrls_AwsIam (30.05s)
--- PASS: TestAccLambdaPermission_FunctionUrls_None (35.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     35.334s

...
```
