### PR TITLE
d/aws_secretsmanager_secrets - new data source

### DIFF
--- a/.changelog/24514.txt
+++ b/.changelog/24514.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_secretsmanager_secrets
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 ## 4.13.0 (Unreleased)
+
+FEATURES:
+
+* **New Data Source:** `aws_emrcontainers_virtual_cluster` ([#20003](https://github.com/hashicorp/terraform-provider-aws/issues/20003))
+* **New Resource:** `aws_emrcontainers_virtual_cluster` ([#20003](https://github.com/hashicorp/terraform-provider-aws/issues/20003))
+
+ENHANCEMENTS:
+
+* data-source/aws_msk_cluster: Add `bootstrap_brokers_public_sasl_iam`, `bootstrap_brokers_public_sasl_scram` and `bootstrap_brokers_public_tls` attributes ([#21005](https://github.com/hashicorp/terraform-provider-aws/issues/21005))
+* resource/aws_msk_cluster: Add `bootstrap_brokers_public_sasl_iam`, `bootstrap_brokers_public_sasl_scram` and `bootstrap_brokers_public_tls` attributes ([#21005](https://github.com/hashicorp/terraform-provider-aws/issues/21005))
+* resource/aws_msk_cluster: Add `broker_node_group_info.connectivity_info` argument to support [public access](https://docs.aws.amazon.com/msk/latest/developerguide/public-access.html) ([#21005](https://github.com/hashicorp/terraform-provider-aws/issues/21005))
+* resource/aws_msk_cluster: Add `client_authentication.unauthenticated` argument ([#21005](https://github.com/hashicorp/terraform-provider-aws/issues/21005))
+* resource/aws_msk_cluster: Allow in-place update of `client_authentication` and `encryption_info.encryption_in_transit.client_broker` ([#21005](https://github.com/hashicorp/terraform-provider-aws/issues/21005))
+
 ## 4.12.1 (April 29, 2022)
 
 ENHANCEMENTS:

--- a/internal/generate/namevaluesfilters/generators/servicefilters/main.go
+++ b/internal/generate/namevaluesfilters/generators/servicefilters/main.go
@@ -29,10 +29,10 @@ var sliceServiceNames = []string{
 	"imagebuilder",
 	"licensemanager",
 	"neptune",
-	"opensearchservice",
 	"rds",
 	"resourcegroupstaggingapi",
 	"route53resolver",
+	"secretsmanager",
 }
 
 type TemplateData struct {

--- a/internal/generate/namevaluesfilters/service_filters_gen.go
+++ b/internal/generate/namevaluesfilters/service_filters_gen.go
@@ -17,6 +17,7 @@ import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
 // []*SERVICE.Filter handling
@@ -298,6 +299,28 @@ func (filters NameValuesFilters) Route53resolverFilters() []*route53resolver.Fil
 	for k, v := range m {
 		filter := &route53resolver.Filter{
 			Name:   aws.String(k),
+			Values: aws.StringSlice(v),
+		}
+
+		result = append(result, filter)
+	}
+
+	return result
+}
+
+// SecretsmanagerFilters returns secretsmanager service filters.
+func (filters NameValuesFilters) SecretsmanagerFilters() []*secretsmanager.Filter {
+	m := filters.Map()
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	result := make([]*secretsmanager.Filter, 0, len(m))
+
+	for k, v := range m {
+		filter := &secretsmanager.Filter{
+			Key:    aws.String(k),
 			Values: aws.StringSlice(v),
 		}
 

--- a/internal/generate/namevaluesfilters/service_generation_customizations.go
+++ b/internal/generate/namevaluesfilters/service_generation_customizations.go
@@ -23,7 +23,7 @@ func ServiceFilterType(serviceName string) string {
 // ServiceFilterTypeNameField determines the service filter type name field.
 func ServiceFilterTypeNameField(serviceName string) string {
 	switch serviceName {
-	case "resourcegroupstaggingapi":
+	case "resourcegroupstaggingapi", "secretsmanager":
 		return "Key"
 	default:
 		return "Name"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -820,6 +820,7 @@ func Provider() *schema.Provider {
 			"aws_secretsmanager_secret":          secretsmanager.DataSourceSecret(),
 			"aws_secretsmanager_secret_rotation": secretsmanager.DataSourceSecretRotation(),
 			"aws_secretsmanager_secret_version":  secretsmanager.DataSourceSecretVersion(),
+			"aws_secretsmanager_secrets":         secretsmanager.DataSourceSecrets(),
 
 			"aws_serverlessapplicationrepository_application": serverlessrepo.DataSourceApplication(),
 

--- a/internal/service/secretsmanager/secrets_data_source.go
+++ b/internal/service/secretsmanager/secrets_data_source.go
@@ -1,6 +1,8 @@
 package secretsmanager
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,7 +40,7 @@ func dataSourceSecretsRead(d *schema.ResourceData, meta interface{}) error {
 
 	var results []*secretsmanager.SecretListEntry
 
-	conn.ListSecretsPages(input, func(page *secretsmanager.ListSecretsOutput, lastPage bool) bool {
+	err := conn.ListSecretsPages(input, func(page *secretsmanager.ListSecretsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
@@ -53,6 +55,10 @@ func dataSourceSecretsRead(d *schema.ResourceData, meta interface{}) error {
 
 		return !lastPage
 	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Secrets Manager secrets: %w", err)
+	}
 
 	var arns, names []string
 

--- a/internal/service/secretsmanager/secrets_data_source.go
+++ b/internal/service/secretsmanager/secrets_data_source.go
@@ -1,0 +1,69 @@
+package secretsmanager
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
+)
+
+func DataSourceSecrets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSecretsRead,
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": namevaluesfilters.Schema(),
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceSecretsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SecretsManagerConn
+
+	input := &secretsmanager.ListSecretsInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = namevaluesfilters.New(v.(*schema.Set)).SecretsmanagerFilters()
+	}
+
+	var results []*secretsmanager.SecretListEntry
+
+	conn.ListSecretsPages(input, func(page *secretsmanager.ListSecretsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, secretListEntry := range page.SecretList {
+			if secretListEntry == nil {
+				continue
+			}
+
+			results = append(results, secretListEntry)
+		}
+
+		return !lastPage
+	})
+
+	var arns, names []string
+
+	for _, r := range results {
+		arns = append(arns, aws.StringValue(r.ARN))
+		names = append(names, aws.StringValue(r.Name))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/secretsmanager/secrets_data_source_test.go
+++ b/internal/service/secretsmanager/secrets_data_source_test.go
@@ -1,0 +1,73 @@
+package secretsmanager_test
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccSecretsManagerSecretsDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret.test"
+	dataSourceName := "data.aws_secretsmanager_secrets.test"
+
+	propagationSleep := func() resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			log.Print("[DEBUG] Test: Sleep to allow secrets become visible in the list.")
+			time.Sleep(30 * time.Second)
+			return nil
+		}
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, secretsmanager.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSecretDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigSecrets_filter(rName),
+				Check:  propagationSleep(),
+			},
+			{
+				Config: testAccConfigSecretsWithDataSource_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arns.0", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigSecrets_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccConfigSecretsWithDataSource_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+data "aws_secretsmanager_secrets" "test" {
+  filter {
+    name   = "name"
+    values = [aws_secretsmanager_secret.test.name]
+  }
+}
+`, rName)
+}

--- a/internal/service/secretsmanager/secrets_data_source_test.go
+++ b/internal/service/secretsmanager/secrets_data_source_test.go
@@ -58,16 +58,14 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 func testAccConfigSecretsWithDataSource_filter(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_secretsmanager_secret" "test" {
-  name = %[1]q
-}
-
+	return acctest.ConfigCompose(
+		testAccConfigSecrets_filter(rName),
+		`
 data "aws_secretsmanager_secrets" "test" {
   filter {
     name   = "name"
     values = [aws_secretsmanager_secret.test.name]
   }
 }
-`, rName)
+`)
 }

--- a/website/docs/d/secretsmanager_secrets.html.markdown
+++ b/website/docs/d/secretsmanager_secrets.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Secrets Manager"
+layout: "aws"
+page_title: "AWS: aws_secretsmanager_secrets"
+description: |-
+    Get information on Secrets Manager secrets.
+---
+
+# Data Source: aws_secretsmanager_secrets
+
+Use this data source to get the ARNs and names of Secrets Manager secrets matching the specified criteria.
+
+## Example Usage
+
+```terraform
+data "aws_secretsmanager_secrets" "example" {
+  filter {
+    name   = "name"
+    values = ["example]
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+## filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Secrets Manager ListSecrets API Reference](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_ListSecrets.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `arns` - Set of ARNs of the matched Secrets Manager secrets.
+* `names` - Set of names of the matched Secrets Manager secrets.

--- a/website/docs/d/secretsmanager_secrets.html.markdown
+++ b/website/docs/d/secretsmanager_secrets.html.markdown
@@ -16,7 +16,7 @@ Use this data source to get the ARNs and names of Secrets Manager secrets matchi
 data "aws_secretsmanager_secrets" "example" {
   filter {
     name   = "name"
-    values = ["example]
+    values = ["example"]
   }
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24421.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=secretsmanager TESTS="TestAccSecretsManagerSecretsDataSource_filter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretsDataSource_filter'  -timeout 180m
=== RUN   TestAccSecretsManagerSecretsDataSource_filter
=== PAUSE TestAccSecretsManagerSecretsDataSource_filter
=== CONT  TestAccSecretsManagerSecretsDataSource_filter
--- PASS: TestAccSecretsManagerSecretsDataSource_filter (69.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     71.278s
```
