### PR TITLE
service/iam: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -52,7 +52,6 @@ rules:
         - internal/service/elb
         - internal/service/emr
         - internal/service/gamelift
-        - internal/service/iam
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -312,7 +312,7 @@ func normalizeCert(cert interface{}) string {
 	case string:
 		rawCert = cert
 	case *string:
-		rawCert = *cert
+		rawCert = aws.StringValue(cert)
 	default:
 		return ""
 	}

--- a/internal/service/iam/user_ssh_key.go
+++ b/internal/service/iam/user_ssh_key.go
@@ -139,8 +139,8 @@ func resourceUserSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading IAM User SSH Key (%s): empty response", d.Id())
 	}
 
-	publicKey := *getResp.SSHPublicKey.SSHPublicKeyBody
-	if encoding == "SSH" {
+	publicKey := aws.StringValue(getResp.SSHPublicKey.SSHPublicKeyBody)
+	if encoding == iam.EncodingTypeSsh {
 		publicKey = cleanSSHKey(publicKey)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Areas to fix:

```
semgrep
Running 31 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|31/31

 internal/service/iam/server_certificate.go
     prefer-aws-go-sdk-pointer-conversion-assignment
        Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g.
        aws.StringValue()


        315┆ 		rawCert = *cert


 internal/service/iam/user_ssh_key.go
     prefer-aws-go-sdk-pointer-conversion-assignment
        Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g.
        aws.StringValue()


        142┆ 	publicKey := *getResp.SSHPublicKey.SSHPublicKeyBody
ran 31 rules on 2346 files: 2 findings
````
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIAMServerCertificate_\|TestAccIAMUserSSHKey_' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20  -run=TestAccIAMServerCertificate_\|TestAccIAMUserSSHKey_ -timeout 180m
=== RUN   TestAccIAMServerCertificate_basic
=== PAUSE TestAccIAMServerCertificate_basic
=== RUN   TestAccIAMServerCertificate_tags
=== PAUSE TestAccIAMServerCertificate_tags
=== RUN   TestAccIAMServerCertificate_Name_prefix
=== PAUSE TestAccIAMServerCertificate_Name_prefix
=== RUN   TestAccIAMServerCertificate_disappears
=== PAUSE TestAccIAMServerCertificate_disappears
=== RUN   TestAccIAMServerCertificate_file
=== PAUSE TestAccIAMServerCertificate_file
=== RUN   TestAccIAMServerCertificate_path
=== PAUSE TestAccIAMServerCertificate_path
=== RUN   TestAccIAMUserSSHKey_basic
=== PAUSE TestAccIAMUserSSHKey_basic
=== RUN   TestAccIAMUserSSHKey_pemEncoding
=== PAUSE TestAccIAMUserSSHKey_pemEncoding
=== CONT  TestAccIAMServerCertificate_basic
=== CONT  TestAccIAMServerCertificate_file
=== CONT  TestAccIAMServerCertificate_path
=== CONT  TestAccIAMUserSSHKey_basic
=== CONT  TestAccIAMUserSSHKey_pemEncoding
=== CONT  TestAccIAMServerCertificate_tags
=== CONT  TestAccIAMServerCertificate_disappears
=== CONT  TestAccIAMServerCertificate_Name_prefix
--- PASS: TestAccIAMServerCertificate_disappears (16.24s)
--- PASS: TestAccIAMServerCertificate_Name_prefix (18.62s)
--- PASS: TestAccIAMServerCertificate_path (18.89s)
--- PASS: TestAccIAMServerCertificate_basic (20.98s)
--- PASS: TestAccIAMUserSSHKey_pemEncoding (20.77s)
--- PASS: TestAccIAMUserSSHKey_basic (20.99s)
--- PASS: TestAccIAMServerCertificate_file (28.72s)
--- PASS: TestAccIAMServerCertificate_tags (39.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	43.629s
```
