### PR TITLE
r/gamelift_alias: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -51,7 +51,6 @@ rules:
         - internal/service/elasticsearch
         - internal/service/elb
         - internal/service/emr
-        - internal/service/gamelift
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/gamelift/alias.go
+++ b/internal/service/gamelift/alias.go
@@ -207,12 +207,12 @@ func flattenRoutingStrategy(rs *gamelift.RoutingStrategy) []interface{} {
 
 	m := make(map[string]interface{})
 	if rs.FleetId != nil {
-		m["fleet_id"] = *rs.FleetId
+		m["fleet_id"] = aws.StringValue(rs.FleetId)
 	}
 	if rs.Message != nil {
-		m["message"] = *rs.Message
+		m["message"] = aws.StringValue(rs.Message)
 	}
-	m["type"] = *rs.Type
+	m["type"] = aws.StringValue(rs.Type)
 
 	return []interface{}{m}
 }


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Areas to fix:
```
semgrep
Scanning 2346 files with 30 go rules.
  100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|2346/2346 tasks

Findings:

  internal/service/gamelift/alias.go
     prefer-aws-go-sdk-pointer-conversion-assignment
        Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g.
        aws.StringValue()

        210┆ m["fleet_id"] = *rs.FleetId
          ⋮┆----------------------------------------
        213┆ m["message"] = *rs.Message
          ⋮┆----------------------------------------
        215┆ m["type"] = *rs.Type
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
