### PR TITLE
service/elb: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -49,7 +49,6 @@ rules:
         - internal/service/ec2
         - internal/service/elasticbeanstalk
         - internal/service/elasticsearch
-        - internal/service/elb
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/elb/flex.go
+++ b/internal/service/elb/flex.go
@@ -19,19 +19,19 @@ func flattenAccessLog(l *elb.AccessLog) []map[string]interface{} {
 
 	r := make(map[string]interface{})
 	if l.S3BucketName != nil {
-		r["bucket"] = *l.S3BucketName
+		r["bucket"] = aws.StringValue(l.S3BucketName)
 	}
 
 	if l.S3BucketPrefix != nil {
-		r["bucket_prefix"] = *l.S3BucketPrefix
+		r["bucket_prefix"] = aws.StringValue(l.S3BucketPrefix)
 	}
 
 	if l.EmitInterval != nil {
-		r["interval"] = *l.EmitInterval
+		r["interval"] = aws.Int64Value(l.EmitInterval)
 	}
 
 	if l.Enabled != nil {
-		r["enabled"] = *l.Enabled
+		r["enabled"] = aws.BoolValue(l.Enabled)
 	}
 
 	result = append(result, r)
@@ -57,11 +57,11 @@ func FlattenHealthCheck(check *elb.HealthCheck) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 
 	chk := make(map[string]interface{})
-	chk["unhealthy_threshold"] = *check.UnhealthyThreshold
-	chk["healthy_threshold"] = *check.HealthyThreshold
-	chk["target"] = *check.Target
-	chk["timeout"] = *check.Timeout
-	chk["interval"] = *check.Interval
+	chk["unhealthy_threshold"] = aws.Int64Value(check.UnhealthyThreshold)
+	chk["healthy_threshold"] = aws.Int64Value(check.HealthyThreshold)
+	chk["target"] = aws.StringValue(check.Target)
+	chk["timeout"] = aws.Int64Value(check.Timeout)
+	chk["interval"] = aws.Int64Value(check.Interval)
 
 	result = append(result, chk)
 
@@ -143,7 +143,7 @@ func flattenListeners(list []*elb.ListenerDescription) []map[string]interface{} 
 		}
 		// SSLCertificateID is optional, and may be nil
 		if i.Listener.SSLCertificateId != nil {
-			l["ssl_certificate_id"] = *i.Listener.SSLCertificateId
+			l["ssl_certificate_id"] = aws.StringValue(i.Listener.SSLCertificateId)
 		}
 		result = append(result, l)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Areas to fix:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Findings:

  internal/service/elb/flex.go
     prefer-aws-go-sdk-pointer-conversion-assignment
        Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g.
        aws.StringValue()

         22┆ r["bucket"] = *l.S3BucketName
          ⋮┆----------------------------------------
         26┆ r["bucket_prefix"] = *l.S3BucketPrefix
          ⋮┆----------------------------------------
         30┆ r["interval"] = *l.EmitInterval
          ⋮┆----------------------------------------
         34┆ r["enabled"] = *l.Enabled
          ⋮┆----------------------------------------
         60┆ chk["unhealthy_threshold"] = *check.UnhealthyThreshold
          ⋮┆----------------------------------------
         61┆ chk["healthy_threshold"] = *check.HealthyThreshold
          ⋮┆----------------------------------------
         62┆ chk["target"] = *check.Target
          ⋮┆----------------------------------------
         63┆ chk["timeout"] = *check.Timeout
          ⋮┆----------------------------------------
         64┆ chk["interval"] = *check.Interval
          ⋮┆----------------------------------------
        146┆ l["ssl_certificate_id"] = *i.Listener.SSLCertificateId
```
