### PR TITLE
semgrep: remove `elasticsearch` service from `prefer-aws-go-sdk-pointer-conversion-assignment` rule exclusions

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -48,7 +48,6 @@ rules:
       exclude:
         - internal/service/ec2
         - internal/service/elasticbeanstalk
-        - internal/service/elasticsearch
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from semgrep:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
semgrep
Scanning 2346 files with 30 go rules.
  100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|2346/2346 tasks

Ran 31 rules on 2346 files: 0 findings.
```
