### PR TITLE
service/ec2: updates to pass semgrep rule `prefer-aws-go-sdk-pointer-conversion-assignment`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -45,8 +45,6 @@ rules:
     paths:
       include:
         - internal/service
-      exclude:
-        - internal/service/ec2
     patterns:
       - pattern: '$LHS = *$RHS'
       - pattern-not: '*$LHS2 = *$RHS'

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -281,7 +281,7 @@ func resourceEIPRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("network_interface", "")
 	}
 
-	region := *conn.Config.Region
+	region := aws.StringValue(conn.Config.Region)
 	d.Set("private_ip", address.PrivateIpAddress)
 	if address.PrivateIpAddress != nil {
 		d.Set("private_dns", fmt.Sprintf("ip-%s.%s", ConvertIPToDashIP(*address.PrivateIpAddress), RegionalPrivateDNSSuffix(region)))

--- a/internal/service/ec2/ec2_spot_datafeed_subscription.go
+++ b/internal/service/ec2/ec2_spot_datafeed_subscription.go
@@ -72,7 +72,7 @@ func resourceSpotDataFeedSubscriptionRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error describing Spot Datafeed Subscription (%s): %w", d.Id(), err)
 	}
 
-	if resp == nil {
+	if resp == nil || resp.SpotDatafeedSubscription == nil {
 		if d.IsNewResource() {
 			return fmt.Errorf("error describing Spot Datafeed Subscription (%s): empty output after creation", d.Id())
 		}
@@ -81,7 +81,7 @@ func resourceSpotDataFeedSubscriptionRead(d *schema.ResourceData, meta interface
 		return nil
 	}
 
-	subscription := *resp.SpotDatafeedSubscription
+	subscription := resp.SpotDatafeedSubscription
 	d.Set("bucket", subscription.Bucket)
 	d.Set("prefix", subscription.Prefix)
 

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -231,7 +231,7 @@ func resourceSpotInstanceRequestCreate(d *schema.ResourceData, meta interface{})
 			"Expected response with length 1, got: %s", resp)
 	}
 
-	sir := *resp.SpotInstanceRequests[0]
+	sir := resp.SpotInstanceRequests[0]
 	d.SetId(aws.StringValue(sir.SpotInstanceRequestId))
 
 	if d.Get("wait_for_fulfillment").(bool) {
@@ -425,9 +425,7 @@ func resourceSpotInstanceRequestDelete(d *schema.ResourceData, meta interface{})
 
 // SpotInstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
 // an EC2 spot instance request
-func SpotInstanceStateRefreshFunc(
-	conn *ec2.EC2, sir ec2.SpotInstanceRequest) resource.StateRefreshFunc {
-
+func SpotInstanceStateRefreshFunc(conn *ec2.EC2, sir *ec2.SpotInstanceRequest) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
 			SpotInstanceRequestIds: []*string{sir.SpotInstanceRequestId},

--- a/internal/service/ec2/flex.go
+++ b/internal/service/ec2/flex.go
@@ -13,7 +13,7 @@ import (
 func FlattenGroupIdentifiers(dtos []*ec2.GroupIdentifier) []string {
 	ids := make([]string, 0, len(dtos))
 	for _, v := range dtos {
-		group_id := *v.GroupId
+		group_id := aws.StringValue(v.GroupId)
 		ids = append(ids, group_id)
 	}
 	return ids

--- a/internal/service/ec2/vpc_route_table_data_source.go
+++ b/internal/service/ec2/vpc_route_table_data_source.go
@@ -279,47 +279,47 @@ func dataSourceRoutesRead(conn *ec2.EC2, ec2Routes []*ec2.Route) []map[string]in
 		m := make(map[string]interface{})
 
 		if r.DestinationCidrBlock != nil {
-			m["cidr_block"] = *r.DestinationCidrBlock
+			m["cidr_block"] = aws.StringValue(r.DestinationCidrBlock)
 		}
 		if r.DestinationIpv6CidrBlock != nil {
-			m["ipv6_cidr_block"] = *r.DestinationIpv6CidrBlock
+			m["ipv6_cidr_block"] = aws.StringValue(r.DestinationIpv6CidrBlock)
 		}
 		if r.DestinationPrefixListId != nil {
-			m["destination_prefix_list_id"] = *r.DestinationPrefixListId
+			m["destination_prefix_list_id"] = aws.StringValue(r.DestinationPrefixListId)
 		}
 		if r.CarrierGatewayId != nil {
-			m["carrier_gateway_id"] = *r.CarrierGatewayId
+			m["carrier_gateway_id"] = aws.StringValue(r.CarrierGatewayId)
 		}
 		if r.CoreNetworkArn != nil {
-			m["core_network_arn"] = *r.CoreNetworkArn
+			m["core_network_arn"] = aws.StringValue(r.CoreNetworkArn)
 		}
 		if r.EgressOnlyInternetGatewayId != nil {
-			m["egress_only_gateway_id"] = *r.EgressOnlyInternetGatewayId
+			m["egress_only_gateway_id"] = aws.StringValue(r.EgressOnlyInternetGatewayId)
 		}
 		if r.GatewayId != nil {
 			if strings.HasPrefix(*r.GatewayId, "vpce-") {
-				m["vpc_endpoint_id"] = *r.GatewayId
+				m["vpc_endpoint_id"] = aws.StringValue(r.GatewayId)
 			} else {
-				m["gateway_id"] = *r.GatewayId
+				m["gateway_id"] = aws.StringValue(r.GatewayId)
 			}
 		}
 		if r.NatGatewayId != nil {
-			m["nat_gateway_id"] = *r.NatGatewayId
+			m["nat_gateway_id"] = aws.StringValue(r.NatGatewayId)
 		}
 		if r.LocalGatewayId != nil {
-			m["local_gateway_id"] = *r.LocalGatewayId
+			m["local_gateway_id"] = aws.StringValue(r.LocalGatewayId)
 		}
 		if r.InstanceId != nil {
-			m["instance_id"] = *r.InstanceId
+			m["instance_id"] = aws.StringValue(r.InstanceId)
 		}
 		if r.TransitGatewayId != nil {
-			m["transit_gateway_id"] = *r.TransitGatewayId
+			m["transit_gateway_id"] = aws.StringValue(r.TransitGatewayId)
 		}
 		if r.VpcPeeringConnectionId != nil {
-			m["vpc_peering_connection_id"] = *r.VpcPeeringConnectionId
+			m["vpc_peering_connection_id"] = aws.StringValue(r.VpcPeeringConnectionId)
 		}
 		if r.NetworkInterfaceId != nil {
-			m["network_interface_id"] = *r.NetworkInterfaceId
+			m["network_interface_id"] = aws.StringValue(r.NetworkInterfaceId)
 		}
 
 		routes = append(routes, m)
@@ -333,16 +333,16 @@ func dataSourceAssociationsRead(ec2Assocations []*ec2.RouteTableAssociation) []m
 	for _, a := range ec2Assocations {
 
 		m := make(map[string]interface{})
-		m["route_table_id"] = *a.RouteTableId
-		m["route_table_association_id"] = *a.RouteTableAssociationId
+		m["route_table_id"] = aws.StringValue(a.RouteTableId)
+		m["route_table_association_id"] = aws.StringValue(a.RouteTableAssociationId)
 		// GH[11134]
 		if a.SubnetId != nil {
-			m["subnet_id"] = *a.SubnetId
+			m["subnet_id"] = aws.StringValue(a.SubnetId)
 		}
 		if a.GatewayId != nil {
-			m["gateway_id"] = *a.GatewayId
+			m["gateway_id"] = aws.StringValue(a.GatewayId)
 		}
-		m["main"] = *a.Main
+		m["main"] = aws.BoolValue(a.Main)
 		associations = append(associations, m)
 	}
 	return associations

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -1400,10 +1400,10 @@ func deleteLingeringLambdaENIs(conn *ec2.EC2, filterName, resourceId string, tim
 func initSecurityGroupRule(ruleMap map[string]map[string]interface{}, perm *ec2.IpPermission, desc string) map[string]interface{} {
 	var fromPort, toPort int64
 	if v := perm.FromPort; v != nil {
-		fromPort = *v
+		fromPort = aws.Int64Value(v)
 	}
 	if v := perm.ToPort; v != nil {
-		toPort = *v
+		toPort = aws.Int64Value(v)
 	}
 	k := fmt.Sprintf("%s-%d-%d-%s", *perm.IpProtocol, fromPort, toPort, desc)
 	rule, ok := ruleMap[k]
@@ -1411,7 +1411,7 @@ func initSecurityGroupRule(ruleMap map[string]map[string]interface{}, perm *ec2.
 		rule = make(map[string]interface{})
 		ruleMap[k] = rule
 	}
-	rule["protocol"] = *perm.IpProtocol
+	rule["protocol"] = aws.StringValue(perm.IpProtocol)
 	rule["from_port"] = fromPort
 	rule["to_port"] = toPort
 	if desc != "" {

--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -529,7 +529,7 @@ func IPPermissionIDHash(sg_id, ruleType string, ip *ec2.IpPermission) string {
 	if len(ip.IpRanges) > 0 {
 		s := make([]string, len(ip.IpRanges))
 		for i, r := range ip.IpRanges {
-			s[i] = *r.CidrIp
+			s[i] = aws.StringValue(r.CidrIp)
 		}
 		sort.Strings(s)
 
@@ -541,7 +541,7 @@ func IPPermissionIDHash(sg_id, ruleType string, ip *ec2.IpPermission) string {
 	if len(ip.Ipv6Ranges) > 0 {
 		s := make([]string, len(ip.Ipv6Ranges))
 		for i, r := range ip.Ipv6Ranges {
-			s[i] = *r.CidrIpv6
+			s[i] = aws.StringValue(r.CidrIpv6)
 		}
 		sort.Strings(s)
 
@@ -553,7 +553,7 @@ func IPPermissionIDHash(sg_id, ruleType string, ip *ec2.IpPermission) string {
 	if len(ip.PrefixListIds) > 0 {
 		s := make([]string, len(ip.PrefixListIds))
 		for i, pl := range ip.PrefixListIds {
-			s[i] = *pl.PrefixListId
+			s[i] = aws.StringValue(pl.PrefixListId)
 		}
 		sort.Strings(s)
 


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TESTARGS='-run=TestAccEC2EIP_\|TestAccEC2Instance_\|TestAccEC2SpotDatafeedSubscription_\|TestAccEC2SpotInstanceRequest_\|TestAccEC2RouteTableDataSource_\|TestAccEC2SecurityGroup_\|TestAccEC2SecurityGroupRule_' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2EIP_\|TestAccEC2Instance_\|TestAccEC2SpotDatafeedSubscription_\|TestAccEC2SpotInstanceRequest_\|TestAccEC2RouteTableDataSource_\|TestAccEC2SecurityGroup_\|TestAccEC2SecurityGroupRule_ -timeout 180m
=== RUN   TestAccEC2EIP_basic
=== PAUSE TestAccEC2EIP_basic
=== RUN   TestAccEC2EIP_disappears
=== PAUSE TestAccEC2EIP_disappears
=== RUN   TestAccEC2EIP_instance
=== PAUSE TestAccEC2EIP_instance
=== RUN   TestAccEC2EIP_Instance_reassociate
=== PAUSE TestAccEC2EIP_Instance_reassociate
=== RUN   TestAccEC2EIP_Instance_associatedUserPrivateIP
=== PAUSE TestAccEC2EIP_Instance_associatedUserPrivateIP
=== RUN   TestAccEC2EIP_Instance_notAssociated
=== PAUSE TestAccEC2EIP_Instance_notAssociated
=== RUN   TestAccEC2EIP_Instance_ec2Classic
=== PAUSE TestAccEC2EIP_Instance_ec2Classic
=== RUN   TestAccEC2EIP_networkInterface
=== PAUSE TestAccEC2EIP_networkInterface
=== RUN   TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface
=== PAUSE TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface
=== RUN   TestAccEC2EIP_TagsEC2VPC_withVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2VPC_withVPCTrue
=== RUN   TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue
=== RUN   TestAccEC2EIP_TagsEC2Classic_withVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2Classic_withVPCTrue
=== RUN   TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
=== RUN   TestAccEC2EIP_PublicIPv4Pool_default
=== PAUSE TestAccEC2EIP_PublicIPv4Pool_default
=== RUN   TestAccEC2EIP_PublicIPv4Pool_custom
    ec2_eip_test.go:478: Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set
--- SKIP: TestAccEC2EIP_PublicIPv4Pool_custom (0.00s)
=== RUN   TestAccEC2EIP_customerOwnedIPv4Pool
=== PAUSE TestAccEC2EIP_customerOwnedIPv4Pool
=== RUN   TestAccEC2EIP_networkBorderGroup
=== PAUSE TestAccEC2EIP_networkBorderGroup
=== RUN   TestAccEC2EIP_carrierIP
=== PAUSE TestAccEC2EIP_carrierIP
=== RUN   TestAccEC2EIP_BYOIPAddress_default
=== PAUSE TestAccEC2EIP_BYOIPAddress_default
=== RUN   TestAccEC2EIP_BYOIPAddress_custom
    ec2_eip_test.go:620: Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set
--- SKIP: TestAccEC2EIP_BYOIPAddress_custom (0.00s)
=== RUN   TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool
    ec2_eip_test.go:649: Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set
--- SKIP: TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool (0.00s)
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_disappears
=== PAUSE TestAccEC2Instance_disappears
=== RUN   TestAccEC2Instance_tags
=== PAUSE TestAccEC2Instance_tags
=== RUN   TestAccEC2Instance_inDefaultVPCBySgName
=== PAUSE TestAccEC2Instance_inDefaultVPCBySgName
=== RUN   TestAccEC2Instance_inDefaultVPCBySgID
=== PAUSE TestAccEC2Instance_inDefaultVPCBySgID
=== RUN   TestAccEC2Instance_inEC2Classic
=== PAUSE TestAccEC2Instance_inEC2Classic
=== RUN   TestAccEC2Instance_atLeastOneOtherEBSVolume
=== PAUSE TestAccEC2Instance_atLeastOneOtherEBSVolume
=== RUN   TestAccEC2Instance_EBSBlockDevice_kmsKeyARN
=== PAUSE TestAccEC2Instance_EBSBlockDevice_kmsKeyARN
=== RUN   TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== PAUSE TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== RUN   TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
=== PAUSE TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
=== RUN   TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
=== PAUSE TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
=== RUN   TestAccEC2Instance_RootBlockDevice_kmsKeyARN
=== PAUSE TestAccEC2Instance_RootBlockDevice_kmsKeyARN
=== RUN   TestAccEC2Instance_userDataBase64
=== PAUSE TestAccEC2Instance_userDataBase64
=== RUN   TestAccEC2Instance_userDataBase64_updateWithBashFile
=== PAUSE TestAccEC2Instance_userDataBase64_updateWithBashFile
=== RUN   TestAccEC2Instance_userDataBase64_updateWithZipFile
=== PAUSE TestAccEC2Instance_userDataBase64_updateWithZipFile
=== RUN   TestAccEC2Instance_userDataBase64_update
=== PAUSE TestAccEC2Instance_userDataBase64_update
=== RUN   TestAccEC2Instance_gp2IopsDevice
=== PAUSE TestAccEC2Instance_gp2IopsDevice
=== RUN   TestAccEC2Instance_gp2WithIopsValue
=== PAUSE TestAccEC2Instance_gp2WithIopsValue
=== RUN   TestAccEC2Instance_blockDevices
=== PAUSE TestAccEC2Instance_blockDevices
=== RUN   TestAccEC2Instance_rootInstanceStore
=== PAUSE TestAccEC2Instance_rootInstanceStore
=== RUN   TestAccEC2Instance_noAMIEphemeralDevices
=== PAUSE TestAccEC2Instance_noAMIEphemeralDevices
=== RUN   TestAccEC2Instance_sourceDestCheck
=== PAUSE TestAccEC2Instance_sourceDestCheck
=== RUN   TestAccEC2Instance_autoRecovery
=== PAUSE TestAccEC2Instance_autoRecovery
=== RUN   TestAccEC2Instance_disableAPITermination
=== PAUSE TestAccEC2Instance_disableAPITermination
=== RUN   TestAccEC2Instance_dedicatedInstance
=== PAUSE TestAccEC2Instance_dedicatedInstance
=== RUN   TestAccEC2Instance_outpost
=== PAUSE TestAccEC2Instance_outpost
=== RUN   TestAccEC2Instance_placementGroup
=== PAUSE TestAccEC2Instance_placementGroup
=== RUN   TestAccEC2Instance_placementPartitionNumber
=== PAUSE TestAccEC2Instance_placementPartitionNumber
=== RUN   TestAccEC2Instance_IPv6_supportAddressCount
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCount
=== RUN   TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== RUN   TestAccEC2Instance_networkInstanceSecurityGroups
=== PAUSE TestAccEC2Instance_networkInstanceSecurityGroups
=== RUN   TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups
=== PAUSE TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups
=== RUN   TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs
=== PAUSE TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs
=== RUN   TestAccEC2Instance_BlockDeviceTags_volumeTags
=== PAUSE TestAccEC2Instance_BlockDeviceTags_volumeTags
=== RUN   TestAccEC2Instance_BlockDeviceTags_withAttachedVolume
=== PAUSE TestAccEC2Instance_BlockDeviceTags_withAttachedVolume
=== RUN   TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== PAUSE TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== RUN   TestAccEC2Instance_instanceProfileChange
=== PAUSE TestAccEC2Instance_instanceProfileChange
=== RUN   TestAccEC2Instance_withIAMInstanceProfile
=== PAUSE TestAccEC2Instance_withIAMInstanceProfile
=== RUN   TestAccEC2Instance_withIAMInstanceProfilePath
=== PAUSE TestAccEC2Instance_withIAMInstanceProfilePath
=== RUN   TestAccEC2Instance_privateIP
=== PAUSE TestAccEC2Instance_privateIP
=== RUN   TestAccEC2Instance_associatePublicIPAndPrivateIP
=== PAUSE TestAccEC2Instance_associatePublicIPAndPrivateIP
=== RUN   TestAccEC2Instance_Empty_privateIP
=== PAUSE TestAccEC2Instance_Empty_privateIP
=== RUN   TestAccEC2Instance_keyPairCheck
=== PAUSE TestAccEC2Instance_keyPairCheck
=== RUN   TestAccEC2Instance_rootBlockDeviceMismatch
=== PAUSE TestAccEC2Instance_rootBlockDeviceMismatch
=== RUN   TestAccEC2Instance_forceNewAndTagsDrift
=== PAUSE TestAccEC2Instance_forceNewAndTagsDrift
=== RUN   TestAccEC2Instance_changeInstanceType
=== PAUSE TestAccEC2Instance_changeInstanceType
=== RUN   TestAccEC2Instance_changeInstanceTypeAndUserData
=== PAUSE TestAccEC2Instance_changeInstanceTypeAndUserData
=== RUN   TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
=== PAUSE TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
=== RUN   TestAccEC2Instance_EBSRootDevice_basic
=== PAUSE TestAccEC2Instance_EBSRootDevice_basic
=== RUN   TestAccEC2Instance_EBSRootDevice_modifySize
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifySize
=== RUN   TestAccEC2Instance_EBSRootDevice_modifyType
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifyType
=== RUN   TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1
=== PAUSE TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1
=== RUN   TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2
=== PAUSE TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2
=== RUN   TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3
=== PAUSE TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3
=== RUN   TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination
=== RUN   TestAccEC2Instance_EBSRootDevice_modifyAll
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifyAll
=== RUN   TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize
=== PAUSE TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize
=== RUN   TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination
=== PAUSE TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination
=== RUN   TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices
=== PAUSE TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices
=== RUN   TestAccEC2Instance_gp3RootBlockDevice
=== PAUSE TestAccEC2Instance_gp3RootBlockDevice
=== RUN   TestAccEC2Instance_primaryNetworkInterface
=== PAUSE TestAccEC2Instance_primaryNetworkInterface
=== RUN   TestAccEC2Instance_networkCardIndex
=== PAUSE TestAccEC2Instance_networkCardIndex
=== RUN   TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck
=== PAUSE TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck
=== RUN   TestAccEC2Instance_addSecondaryInterface
=== PAUSE TestAccEC2Instance_addSecondaryInterface
=== RUN   TestAccEC2Instance_addSecurityGroupNetworkInterface
=== PAUSE TestAccEC2Instance_addSecurityGroupNetworkInterface
=== RUN   TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs
=== PAUSE TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs
=== RUN   TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
=== PAUSE TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
=== RUN   TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate
=== PAUSE TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate
=== RUN   TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs
=== PAUSE TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs
=== RUN   TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate
=== PAUSE TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate
=== RUN   TestAccEC2Instance_AssociatePublic_defaultPrivate
=== PAUSE TestAccEC2Instance_AssociatePublic_defaultPrivate
=== RUN   TestAccEC2Instance_AssociatePublic_defaultPublic
=== PAUSE TestAccEC2Instance_AssociatePublic_defaultPublic
=== RUN   TestAccEC2Instance_AssociatePublic_explicitPublic
=== PAUSE TestAccEC2Instance_AssociatePublic_explicitPublic
=== RUN   TestAccEC2Instance_AssociatePublic_explicitPrivate
=== PAUSE TestAccEC2Instance_AssociatePublic_explicitPrivate
=== RUN   TestAccEC2Instance_AssociatePublic_overridePublic
=== PAUSE TestAccEC2Instance_AssociatePublic_overridePublic
=== RUN   TestAccEC2Instance_AssociatePublic_overridePrivate
=== PAUSE TestAccEC2Instance_AssociatePublic_overridePrivate
=== RUN   TestAccEC2Instance_LaunchTemplate_basic
=== PAUSE TestAccEC2Instance_LaunchTemplate_basic
=== RUN   TestAccEC2Instance_LaunchTemplate_overrideTemplate
=== PAUSE TestAccEC2Instance_LaunchTemplate_overrideTemplate
=== RUN   TestAccEC2Instance_LaunchTemplate_setSpecificVersion
=== PAUSE TestAccEC2Instance_LaunchTemplate_setSpecificVersion
=== RUN   TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion
=== PAUSE TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion
=== RUN   TestAccEC2Instance_LaunchTemplate_updateTemplateVersion
=== PAUSE TestAccEC2Instance_LaunchTemplate_updateTemplateVersion
=== RUN   TestAccEC2Instance_LaunchTemplate_swapIDAndName
=== PAUSE TestAccEC2Instance_LaunchTemplate_swapIDAndName
=== RUN   TestAccEC2Instance_GetPasswordData_falseToTrue
=== PAUSE TestAccEC2Instance_GetPasswordData_falseToTrue
=== RUN   TestAccEC2Instance_GetPasswordData_trueToFalse
=== PAUSE TestAccEC2Instance_GetPasswordData_trueToFalse
=== RUN   TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable
=== PAUSE TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable
=== RUN   TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable
=== PAUSE TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable
=== RUN   TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard
=== PAUSE TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard
=== RUN   TestAccEC2Instance_CreditSpecification_standardCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecification_standardCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2
=== PAUSE TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2
=== RUN   TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3
=== PAUSE TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3
=== RUN   TestAccEC2Instance_CreditSpecification_updateCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecification_updateCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable
=== PAUSE TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable
=== RUN   TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited
=== RUN   TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint
=== PAUSE TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint
=== RUN   TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint
=== PAUSE TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint
=== RUN   TestAccEC2Instance_UserData
=== PAUSE TestAccEC2Instance_UserData
=== RUN   TestAccEC2Instance_UserData_update
=== PAUSE TestAccEC2Instance_UserData_update
=== RUN   TestAccEC2Instance_UserData_stringToEncodedString
=== PAUSE TestAccEC2Instance_UserData_stringToEncodedString
=== RUN   TestAccEC2Instance_UserData_emptyStringToUnspecified
=== PAUSE TestAccEC2Instance_UserData_emptyStringToUnspecified
=== RUN   TestAccEC2Instance_UserData_unspecifiedToEmptyString
=== PAUSE TestAccEC2Instance_UserData_unspecifiedToEmptyString
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_On
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_On
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_On_Base64
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_On_Base64
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_Off
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_Off
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64
=== RUN   TestAccEC2Instance_hibernation
=== PAUSE TestAccEC2Instance_hibernation
=== RUN   TestAccEC2Instance_metadataOptions
=== PAUSE TestAccEC2Instance_metadataOptions
=== RUN   TestAccEC2Instance_enclaveOptions
=== PAUSE TestAccEC2Instance_enclaveOptions
=== RUN   TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== PAUSE TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== RUN   TestAccEC2Instance_CapacityReservationPreference_open
=== PAUSE TestAccEC2Instance_CapacityReservationPreference_open
=== RUN   TestAccEC2Instance_CapacityReservationPreference_none
=== PAUSE TestAccEC2Instance_CapacityReservationPreference_none
=== RUN   TestAccEC2Instance_CapacityReservation_targetID
=== PAUSE TestAccEC2Instance_CapacityReservation_targetID
=== RUN   TestAccEC2Instance_CapacityReservation_modifyPreference
=== PAUSE TestAccEC2Instance_CapacityReservation_modifyPreference
=== RUN   TestAccEC2Instance_CapacityReservation_modifyTarget
=== PAUSE TestAccEC2Instance_CapacityReservation_modifyTarget
=== RUN   TestAccEC2SpotDatafeedSubscription_serial
=== RUN   TestAccEC2SpotDatafeedSubscription_serial/basic
=== RUN   TestAccEC2SpotDatafeedSubscription_serial/disappears
--- PASS: TestAccEC2SpotDatafeedSubscription_serial (43.06s)
    --- PASS: TestAccEC2SpotDatafeedSubscription_serial/basic (22.84s)
    --- PASS: TestAccEC2SpotDatafeedSubscription_serial/disappears (20.22s)
=== RUN   TestAccEC2SpotInstanceRequest_basic
=== PAUSE TestAccEC2SpotInstanceRequest_basic
=== RUN   TestAccEC2SpotInstanceRequest_disappears
=== PAUSE TestAccEC2SpotInstanceRequest_disappears
=== RUN   TestAccEC2SpotInstanceRequest_tags
=== PAUSE TestAccEC2SpotInstanceRequest_tags
=== RUN   TestAccEC2SpotInstanceRequest_keyName
=== PAUSE TestAccEC2SpotInstanceRequest_keyName
=== RUN   TestAccEC2SpotInstanceRequest_withLaunchGroup
=== PAUSE TestAccEC2SpotInstanceRequest_withLaunchGroup
=== RUN   TestAccEC2SpotInstanceRequest_withBlockDuration
=== PAUSE TestAccEC2SpotInstanceRequest_withBlockDuration
=== RUN   TestAccEC2SpotInstanceRequest_vpc
=== PAUSE TestAccEC2SpotInstanceRequest_vpc
=== RUN   TestAccEC2SpotInstanceRequest_validUntil
=== PAUSE TestAccEC2SpotInstanceRequest_validUntil
=== RUN   TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== PAUSE TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== RUN   TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
=== PAUSE TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
=== RUN   TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
=== PAUSE TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
=== RUN   TestAccEC2SpotInstanceRequest_getPasswordData
=== PAUSE TestAccEC2SpotInstanceRequest_getPasswordData
=== RUN   TestAccEC2SpotInstanceRequest_interruptStop
=== PAUSE TestAccEC2SpotInstanceRequest_interruptStop
=== RUN   TestAccEC2SpotInstanceRequest_interruptHibernate
=== PAUSE TestAccEC2SpotInstanceRequest_interruptHibernate
=== RUN   TestAccEC2SpotInstanceRequest_interruptUpdate
=== PAUSE TestAccEC2SpotInstanceRequest_interruptUpdate
=== RUN   TestAccEC2RouteTableDataSource_basic
=== PAUSE TestAccEC2RouteTableDataSource_basic
=== RUN   TestAccEC2RouteTableDataSource_main
=== PAUSE TestAccEC2RouteTableDataSource_main
=== RUN   TestAccEC2SecurityGroupRule_Ingress_vpc
=== PAUSE TestAccEC2SecurityGroupRule_Ingress_vpc
=== RUN   TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id
=== PAUSE TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id
=== RUN   TestAccEC2SecurityGroupRule_Ingress_protocol
=== PAUSE TestAccEC2SecurityGroupRule_Ingress_protocol
=== RUN   TestAccEC2SecurityGroupRule_Ingress_icmpv6
=== PAUSE TestAccEC2SecurityGroupRule_Ingress_icmpv6
=== RUN   TestAccEC2SecurityGroupRule_Ingress_ipv6
=== PAUSE TestAccEC2SecurityGroupRule_Ingress_ipv6
=== RUN   TestAccEC2SecurityGroupRule_Ingress_classic
=== PAUSE TestAccEC2SecurityGroupRule_Ingress_classic
=== RUN   TestAccEC2SecurityGroupRule_multiIngress
=== PAUSE TestAccEC2SecurityGroupRule_multiIngress
=== RUN   TestAccEC2SecurityGroupRule_egress
=== PAUSE TestAccEC2SecurityGroupRule_egress
=== RUN   TestAccEC2SecurityGroupRule_selfReference
=== PAUSE TestAccEC2SecurityGroupRule_selfReference
=== RUN   TestAccEC2SecurityGroupRule_expectInvalidTypeError
=== PAUSE TestAccEC2SecurityGroupRule_expectInvalidTypeError
=== RUN   TestAccEC2SecurityGroupRule_expectInvalidCIDR
=== PAUSE TestAccEC2SecurityGroupRule_expectInvalidCIDR
=== RUN   TestAccEC2SecurityGroupRule_PartialMatching_basic
=== PAUSE TestAccEC2SecurityGroupRule_PartialMatching_basic
=== RUN   TestAccEC2SecurityGroupRule_PartialMatching_source
=== PAUSE TestAccEC2SecurityGroupRule_PartialMatching_source
=== RUN   TestAccEC2SecurityGroupRule_issue5310
=== PAUSE TestAccEC2SecurityGroupRule_issue5310
=== RUN   TestAccEC2SecurityGroupRule_race
=== PAUSE TestAccEC2SecurityGroupRule_race
=== RUN   TestAccEC2SecurityGroupRule_selfSource
=== PAUSE TestAccEC2SecurityGroupRule_selfSource
=== RUN   TestAccEC2SecurityGroupRule_prefixListEgress
=== PAUSE TestAccEC2SecurityGroupRule_prefixListEgress
=== RUN   TestAccEC2SecurityGroupRule_ingressDescription
=== PAUSE TestAccEC2SecurityGroupRule_ingressDescription
=== RUN   TestAccEC2SecurityGroupRule_egressDescription
=== PAUSE TestAccEC2SecurityGroupRule_egressDescription
=== RUN   TestAccEC2SecurityGroupRule_IngressDescription_updates
=== PAUSE TestAccEC2SecurityGroupRule_IngressDescription_updates
=== RUN   TestAccEC2SecurityGroupRule_EgressDescription_updates
=== PAUSE TestAccEC2SecurityGroupRule_EgressDescription_updates
=== RUN   TestAccEC2SecurityGroupRule_Description_allPorts
=== PAUSE TestAccEC2SecurityGroupRule_Description_allPorts
=== RUN   TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== PAUSE TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== RUN   TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== PAUSE TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== RUN   TestAccEC2SecurityGroupRule_multiDescription
=== PAUSE TestAccEC2SecurityGroupRule_multiDescription
=== RUN   TestAccEC2SecurityGroup_allowAll
=== PAUSE TestAccEC2SecurityGroup_allowAll
=== RUN   TestAccEC2SecurityGroup_sourceSecurityGroup
=== PAUSE TestAccEC2SecurityGroup_sourceSecurityGroup
=== RUN   TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== PAUSE TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== RUN   TestAccEC2SecurityGroup_ipRangesWithSameRules
=== PAUSE TestAccEC2SecurityGroup_ipRangesWithSameRules
=== RUN   TestAccEC2SecurityGroup_basic
=== PAUSE TestAccEC2SecurityGroup_basic
=== RUN   TestAccEC2SecurityGroup_disappears
=== PAUSE TestAccEC2SecurityGroup_disappears
=== RUN   TestAccEC2SecurityGroup_egressMode
=== PAUSE TestAccEC2SecurityGroup_egressMode
=== RUN   TestAccEC2SecurityGroup_ingressMode
=== PAUSE TestAccEC2SecurityGroup_ingressMode
=== RUN   TestAccEC2SecurityGroup_ruleGathering
=== PAUSE TestAccEC2SecurityGroup_ruleGathering
=== RUN   TestAccEC2SecurityGroup_forceRevokeRulesTrue
=== PAUSE TestAccEC2SecurityGroup_forceRevokeRulesTrue
=== RUN   TestAccEC2SecurityGroup_forceRevokeRulesFalse
=== PAUSE TestAccEC2SecurityGroup_forceRevokeRulesFalse
=== RUN   TestAccEC2SecurityGroup_ipv6
=== PAUSE TestAccEC2SecurityGroup_ipv6
=== RUN   TestAccEC2SecurityGroup_Name_generated
=== PAUSE TestAccEC2SecurityGroup_Name_generated
=== RUN   TestAccEC2SecurityGroup_Name_terraformPrefix
=== PAUSE TestAccEC2SecurityGroup_Name_terraformPrefix
=== RUN   TestAccEC2SecurityGroup_namePrefix
=== PAUSE TestAccEC2SecurityGroup_namePrefix
=== RUN   TestAccEC2SecurityGroup_NamePrefix_terraformPrefix
=== PAUSE TestAccEC2SecurityGroup_NamePrefix_terraformPrefix
=== RUN   TestAccEC2SecurityGroup_name_change
=== PAUSE TestAccEC2SecurityGroup_name_change
=== RUN   TestAccEC2SecurityGroup_self
=== PAUSE TestAccEC2SecurityGroup_self
=== RUN   TestAccEC2SecurityGroup_vpc
=== PAUSE TestAccEC2SecurityGroup_vpc
=== RUN   TestAccEC2SecurityGroup_vpcNegOneIngress
=== PAUSE TestAccEC2SecurityGroup_vpcNegOneIngress
=== RUN   TestAccEC2SecurityGroup_vpcProtoNumIngress
=== PAUSE TestAccEC2SecurityGroup_vpcProtoNumIngress
=== RUN   TestAccEC2SecurityGroup_multiIngress
=== PAUSE TestAccEC2SecurityGroup_multiIngress
=== RUN   TestAccEC2SecurityGroup_change
=== PAUSE TestAccEC2SecurityGroup_change
=== RUN   TestAccEC2SecurityGroup_ruleDescription
=== PAUSE TestAccEC2SecurityGroup_ruleDescription
=== RUN   TestAccEC2SecurityGroup_defaultEgressVPC
=== PAUSE TestAccEC2SecurityGroup_defaultEgressVPC
=== RUN   TestAccEC2SecurityGroup_defaultEgressClassic
=== PAUSE TestAccEC2SecurityGroup_defaultEgressClassic
=== RUN   TestAccEC2SecurityGroup_drift
=== PAUSE TestAccEC2SecurityGroup_drift
=== RUN   TestAccEC2SecurityGroup_driftComplex
=== PAUSE TestAccEC2SecurityGroup_driftComplex
=== RUN   TestAccEC2SecurityGroup_invalidCIDRBlock
=== PAUSE TestAccEC2SecurityGroup_invalidCIDRBlock
=== RUN   TestAccEC2SecurityGroup_tags
=== PAUSE TestAccEC2SecurityGroup_tags
=== RUN   TestAccEC2SecurityGroup_cidrAndGroups
=== PAUSE TestAccEC2SecurityGroup_cidrAndGroups
=== RUN   TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC
=== PAUSE TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC
=== RUN   TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic
=== PAUSE TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic
=== RUN   TestAccEC2SecurityGroup_egressWithPrefixList
=== PAUSE TestAccEC2SecurityGroup_egressWithPrefixList
=== RUN   TestAccEC2SecurityGroup_ingressWithPrefixList
=== PAUSE TestAccEC2SecurityGroup_ingressWithPrefixList
=== RUN   TestAccEC2SecurityGroup_ipv4AndIPv6Egress
=== PAUSE TestAccEC2SecurityGroup_ipv4AndIPv6Egress
=== RUN   TestAccEC2SecurityGroup_failWithDiffMismatch
=== PAUSE TestAccEC2SecurityGroup_failWithDiffMismatch
=== RUN   TestAccEC2SecurityGroup_ruleLimitExceededAppend
=== PAUSE TestAccEC2SecurityGroup_ruleLimitExceededAppend
=== RUN   TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend
=== PAUSE TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend
=== RUN   TestAccEC2SecurityGroup_ruleLimitExceededPrepend
=== PAUSE TestAccEC2SecurityGroup_ruleLimitExceededPrepend
=== RUN   TestAccEC2SecurityGroup_ruleLimitExceededAllNew
=== PAUSE TestAccEC2SecurityGroup_ruleLimitExceededAllNew
=== RUN   TestAccEC2SecurityGroup_rulesDropOnError
=== PAUSE TestAccEC2SecurityGroup_rulesDropOnError
=== CONT  TestAccEC2EIP_basic
=== CONT  TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== CONT  TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts
--- PASS: TestAccEC2EIP_basic (14.48s)
=== CONT  TestAccEC2SecurityGroup_rulesDropOnError
--- PASS: TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts (28.13s)
=== CONT  TestAccEC2SecurityGroup_ruleLimitExceededAllNew
--- PASS: TestAccEC2SecurityGroup_rulesDropOnError (41.35s)
=== CONT  TestAccEC2SecurityGroup_ruleLimitExceededPrepend
=== CONT  TestAccEC2SecurityGroup_ruleLimitExceededAllNew
    vpc_security_group_test.go:2701: Step 2/3, expected an error but got none
--- FAIL: TestAccEC2SecurityGroup_ruleLimitExceededAllNew (47.18s)
=== CONT  TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend
=== CONT  TestAccEC2SecurityGroup_ruleLimitExceededPrepend
    vpc_security_group_test.go:2656: Step 2/3, expected an error but got none
--- FAIL: TestAccEC2SecurityGroup_ruleLimitExceededPrepend (48.70s)
=== CONT  TestAccEC2SecurityGroup_ruleLimitExceededAppend
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (110.11s)
=== CONT  TestAccEC2SecurityGroup_failWithDiffMismatch
=== CONT  TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend
    vpc_security_group_test.go:2595: Step 2/3, expected an error but got none
--- FAIL: TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend (38.93s)
=== CONT  TestAccEC2SecurityGroup_ipv4AndIPv6Egress
--- PASS: TestAccEC2SecurityGroup_failWithDiffMismatch (25.34s)
=== CONT  TestAccEC2SecurityGroup_ingressWithPrefixList
--- PASS: TestAccEC2SecurityGroup_ipv4AndIPv6Egress (31.98s)
=== CONT  TestAccEC2SecurityGroup_egressWithPrefixList
=== CONT  TestAccEC2SecurityGroup_ruleLimitExceededAppend
    vpc_security_group_test.go:2548: Step 2/3, expected an error but got none
--- FAIL: TestAccEC2SecurityGroup_ruleLimitExceededAppend (45.84s)
=== CONT  TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic
    ec2_classic.go:56: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic (0.65s)
=== CONT  TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC
--- PASS: TestAccEC2SecurityGroup_ingressWithPrefixList (35.32s)
=== CONT  TestAccEC2SecurityGroup_cidrAndGroups
--- PASS: TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC (24.58s)
=== CONT  TestAccEC2SecurityGroup_tags
--- PASS: TestAccEC2SecurityGroup_egressWithPrefixList (34.87s)
=== CONT  TestAccEC2SecurityGroup_invalidCIDRBlock
--- PASS: TestAccEC2SecurityGroup_invalidCIDRBlock (2.86s)
=== CONT  TestAccEC2SecurityGroup_driftComplex
--- PASS: TestAccEC2SecurityGroup_cidrAndGroups (28.48s)
=== CONT  TestAccEC2SecurityGroup_drift
--- PASS: TestAccEC2SecurityGroup_driftComplex (24.37s)
=== CONT  TestAccEC2SecurityGroup_defaultEgressClassic
    ec2_classic.go:56: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2SecurityGroup_defaultEgressClassic (0.00s)
=== CONT  TestAccEC2SecurityGroup_defaultEgressVPC
--- PASS: TestAccEC2SecurityGroup_drift (17.78s)
=== CONT  TestAccEC2SecurityGroup_ruleDescription
--- PASS: TestAccEC2SecurityGroup_tags (49.61s)
=== CONT  TestAccEC2SecurityGroup_change
--- PASS: TestAccEC2SecurityGroup_defaultEgressVPC (20.44s)
=== CONT  TestAccEC2SecurityGroup_multiIngress
--- PASS: TestAccEC2SecurityGroup_multiIngress (25.85s)
=== CONT  TestAccEC2SecurityGroup_vpcProtoNumIngress
--- PASS: TestAccEC2SecurityGroup_change (35.85s)
=== CONT  TestAccEC2SecurityGroup_vpcNegOneIngress
--- PASS: TestAccEC2SecurityGroup_ruleDescription (52.47s)
=== CONT  TestAccEC2SecurityGroup_vpc
--- PASS: TestAccEC2SecurityGroup_vpcProtoNumIngress (20.93s)
=== CONT  TestAccEC2SecurityGroup_self
--- PASS: TestAccEC2SecurityGroup_vpcNegOneIngress (21.57s)
=== CONT  TestAccEC2SecurityGroup_name_change
--- PASS: TestAccEC2SecurityGroup_vpc (22.12s)
=== CONT  TestAccEC2SecurityGroup_NamePrefix_terraformPrefix
--- PASS: TestAccEC2SecurityGroup_self (22.85s)
=== CONT  TestAccEC2Instance_changeInstanceTypeAndUserData
--- PASS: TestAccEC2SecurityGroup_NamePrefix_terraformPrefix (19.96s)
=== CONT  TestAccEC2SecurityGroup_namePrefix
--- PASS: TestAccEC2SecurityGroup_namePrefix (19.58s)
=== CONT  TestAccEC2SecurityGroup_Name_terraformPrefix
--- PASS: TestAccEC2SecurityGroup_Name_terraformPrefix (20.19s)
=== CONT  TestAccEC2Instance_enclaveOptions
--- PASS: TestAccEC2SecurityGroup_name_change (131.36s)
=== CONT  TestAccEC2SecurityGroup_Name_generated
--- PASS: TestAccEC2SecurityGroup_Name_generated (18.78s)
=== CONT  TestAccEC2SecurityGroup_ipv6
--- PASS: TestAccEC2SecurityGroup_ipv6 (20.84s)
=== CONT  TestAccEC2Instance_LaunchTemplate_overrideTemplate
--- PASS: TestAccEC2Instance_enclaveOptions (171.48s)
=== CONT  TestAccEC2SecurityGroup_forceRevokeRulesFalse
--- PASS: TestAccEC2Instance_LaunchTemplate_overrideTemplate (102.51s)
=== CONT  TestAccEC2SecurityGroup_forceRevokeRulesTrue
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserData (341.60s)
=== CONT  TestAccEC2SecurityGroup_ruleGathering
--- PASS: TestAccEC2SecurityGroup_ruleGathering (45.76s)
=== CONT  TestAccEC2SecurityGroup_ingressMode
--- PASS: TestAccEC2SecurityGroup_ingressMode (44.65s)
=== CONT  TestAccEC2Instance_LaunchTemplate_setSpecificVersion
--- PASS: TestAccEC2Instance_LaunchTemplate_setSpecificVersion (115.43s)
=== CONT  TestAccEC2Instance_LaunchTemplate_basic
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (119.53s)
=== CONT  TestAccEC2SecurityGroup_egressMode
--- PASS: TestAccEC2SecurityGroup_egressMode (43.78s)
=== CONT  TestAccEC2SecurityGroup_disappears
--- PASS: TestAccEC2SecurityGroup_disappears (17.71s)
=== CONT  TestAccEC2SecurityGroup_basic
--- PASS: TestAccEC2SecurityGroup_basic (19.39s)
=== CONT  TestAccEC2SecurityGroup_ipRangesWithSameRules
--- PASS: TestAccEC2SecurityGroup_ipRangesWithSameRules (21.67s)
=== CONT  TestAccEC2Instance_AssociatePublic_overridePrivate
--- PASS: TestAccEC2Instance_AssociatePublic_overridePrivate (106.13s)
=== CONT  TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules
--- PASS: TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules (24.66s)
=== CONT  TestAccEC2SecurityGroup_sourceSecurityGroup
--- PASS: TestAccEC2SecurityGroup_sourceSecurityGroup (22.20s)
=== CONT  TestAccEC2SecurityGroup_allowAll
--- PASS: TestAccEC2SecurityGroup_allowAll (22.80s)
=== CONT  TestAccEC2Instance_AssociatePublic_overridePublic
--- PASS: TestAccEC2Instance_AssociatePublic_overridePublic (116.91s)
=== CONT  TestAccEC2Instance_metadataOptions
--- PASS: TestAccEC2SecurityGroup_forceRevokeRulesFalse (985.41s)
=== CONT  TestAccEC2Instance_AssociatePublic_explicitPrivate
--- PASS: TestAccEC2Instance_metadataOptions (189.83s)
=== CONT  TestAccEC2SecurityGroupRule_multiDescription
--- PASS: TestAccEC2SecurityGroup_forceRevokeRulesTrue (1007.75s)
=== CONT  TestAccEC2Instance_hibernation
--- PASS: TestAccEC2SecurityGroupRule_multiDescription (64.51s)
=== CONT  TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash
--- PASS: TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash (16.73s)
=== CONT  TestAccEC2SecurityGroupRule_Ingress_vpc
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPrivate (131.03s)
=== CONT  TestAccEC2SecurityGroupRule_PartialMatching_basic
--- PASS: TestAccEC2SecurityGroupRule_Ingress_vpc (17.55s)
=== CONT  TestAccEC2SecurityGroupRule_expectInvalidCIDR
--- PASS: TestAccEC2SecurityGroupRule_expectInvalidCIDR (1.60s)
=== CONT  TestAccEC2SecurityGroupRule_Description_allPorts
--- PASS: TestAccEC2SecurityGroupRule_PartialMatching_basic (29.29s)
=== CONT  TestAccEC2SecurityGroupRule_expectInvalidTypeError
--- PASS: TestAccEC2SecurityGroupRule_expectInvalidTypeError (0.95s)
=== CONT  TestAccEC2Instance_AssociatePublic_explicitPublic
--- PASS: TestAccEC2SecurityGroupRule_Description_allPorts (29.61s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPublic (102.51s)
=== CONT  TestAccEC2SecurityGroupRule_EgressDescription_updates
--- PASS: TestAccEC2SecurityGroupRule_EgressDescription_updates (28.58s)
=== CONT  TestAccEC2Instance_AssociatePublic_defaultPublic
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64 (203.66s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_Off
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPublic (103.67s)
=== CONT  TestAccEC2SecurityGroupRule_selfReference
--- PASS: TestAccEC2SecurityGroupRule_selfReference (22.46s)
=== CONT  TestAccEC2SecurityGroupRule_egress
--- PASS: TestAccEC2SecurityGroupRule_egress (16.98s)
=== CONT  TestAccEC2SecurityGroupRule_IngressDescription_updates
--- PASS: TestAccEC2Instance_hibernation (405.33s)
=== CONT  TestAccEC2SecurityGroupRule_multiIngress
--- PASS: TestAccEC2SecurityGroupRule_IngressDescription_updates (28.23s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_On_Base64
--- PASS: TestAccEC2SecurityGroupRule_multiIngress (19.75s)
=== CONT  TestAccEC2Instance_AssociatePublic_defaultPrivate
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off (188.93s)
=== CONT  TestAccEC2SecurityGroupRule_Ingress_classic
--- PASS: TestAccEC2SecurityGroupRule_Ingress_classic (17.42s)
=== CONT  TestAccEC2SecurityGroupRule_Ingress_ipv6
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPrivate (112.92s)
=== CONT  TestAccEC2SecurityGroupRule_Ingress_icmpv6
--- PASS: TestAccEC2SecurityGroupRule_Ingress_ipv6 (21.11s)
=== CONT  TestAccEC2SecurityGroupRule_egressDescription
--- PASS: TestAccEC2SecurityGroupRule_Ingress_icmpv6 (21.62s)
=== CONT  TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id
--- PASS: TestAccEC2SecurityGroupRule_egressDescription (17.23s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_On
--- PASS: TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id (19.78s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On_Base64 (200.79s)
=== CONT  TestAccEC2SecurityGroupRule_Ingress_protocol
--- PASS: TestAccEC2SecurityGroupRule_Ingress_protocol (23.22s)
=== CONT  TestAccEC2SecurityGroupRule_ingressDescription
--- PASS: TestAccEC2SecurityGroupRule_ingressDescription (17.44s)
=== CONT  TestAccEC2SecurityGroupRule_prefixListEgress
--- PASS: TestAccEC2SecurityGroupRule_prefixListEgress (31.77s)
=== CONT  TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate (148.33s)
=== CONT  TestAccEC2SecurityGroupRule_selfSource
--- PASS: TestAccEC2SecurityGroupRule_selfSource (23.19s)
=== CONT  TestAccEC2SecurityGroupRule_race
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On (201.27s)
=== CONT  TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination (110.92s)
=== CONT  TestAccEC2Instance_UserData_unspecifiedToEmptyString
--- PASS: TestAccEC2SecurityGroupRule_race (145.35s)
=== CONT  TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices
--- PASS: TestAccEC2Instance_UserData_unspecifiedToEmptyString (110.33s)
=== CONT  TestAccEC2Instance_userDataBase64_update
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize (142.60s)
=== CONT  TestAccEC2SecurityGroupRule_issue5310
--- PASS: TestAccEC2SecurityGroupRule_issue5310 (29.30s)
=== CONT  TestAccEC2SecurityGroupRule_PartialMatching_source
--- PASS: TestAccEC2SecurityGroupRule_PartialMatching_source (46.53s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifyAll
--- PASS: TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices (214.63s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs
--- PASS: TestAccEC2Instance_userDataBase64_update (208.77s)
=== CONT  TestAccEC2Instance_changeInstanceType
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyAll (157.16s)
=== CONT  TestAccEC2Instance_UserData_emptyStringToUnspecified
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs (83.87s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination
--- PASS: TestAccEC2Instance_UserData_emptyStringToUnspecified (114.34s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate
--- PASS: TestAccEC2Instance_changeInstanceType (167.70s)
=== CONT  TestAccEC2Instance_UserData_stringToEncodedString
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination (125.44s)
=== CONT  TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate (161.44s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (112.50s)
=== CONT  TestAccEC2Instance_UserData_update
--- PASS: TestAccEC2Instance_UserData_stringToEncodedString (196.84s)
=== CONT  TestAccEC2Instance_networkInstanceSecurityGroups
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs (104.00s)
=== CONT  TestAccEC2Instance_UserData
--- PASS: TestAccEC2Instance_networkInstanceSecurityGroups (108.49s)
=== CONT  TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (0.73s)
=== CONT  TestAccEC2Instance_addSecurityGroupNetworkInterface
--- PASS: TestAccEC2Instance_UserData_update (196.04s)
=== CONT  TestAccEC2Instance_forceNewAndTagsDrift
--- PASS: TestAccEC2Instance_UserData (132.82s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (176.97s)
=== CONT  TestAccEC2Instance_IPv6_supportAddressCount
--- PASS: TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint (174.70s)
=== CONT  TestAccEC2Instance_addSecondaryInterface
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (115.39s)
=== CONT  TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3
--- PASS: TestAccEC2Instance_addSecurityGroupNetworkInterface (418.26s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3 (130.44s)
=== CONT  TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint
--- PASS: TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs (152.56s)
=== CONT  TestAccEC2Instance_rootBlockDeviceMismatch
--- PASS: TestAccEC2Instance_addSecondaryInterface (383.17s)
=== CONT  TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint (188.52s)
=== CONT  TestAccEC2Instance_placementPartitionNumber
--- PASS: TestAccEC2Instance_rootBlockDeviceMismatch (124.73s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifySize
--- PASS: TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck (104.97s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits
--- PASS: TestAccEC2Instance_placementPartitionNumber (84.49s)
=== CONT  TestAccEC2Instance_networkCardIndex
--- PASS: TestAccEC2Instance_EBSRootDevice_modifySize (116.43s)
=== CONT  TestAccEC2Instance_keyPairCheck
--- PASS: TestAccEC2Instance_networkCardIndex (103.25s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifyType
--- PASS: TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits (120.94s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits
--- PASS: TestAccEC2Instance_keyPairCheck (95.68s)
=== CONT  TestAccEC2Instance_primaryNetworkInterface
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits (124.12s)
=== CONT  TestAccEC2Instance_EBSRootDevice_basic
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyType (152.27s)
=== CONT  TestAccEC2Instance_placementGroup
--- PASS: TestAccEC2Instance_primaryNetworkInterface (119.02s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (77.04s)
=== CONT  TestAccEC2Instance_gp3RootBlockDevice
--- PASS: TestAccEC2Instance_placementGroup (103.86s)
=== CONT  TestAccEC2Instance_Empty_privateIP
--- PASS: TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits (125.46s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptStop
--- PASS: TestAccEC2Instance_gp3RootBlockDevice (98.28s)
=== CONT  TestAccEC2RouteTableDataSource_main
--- PASS: TestAccEC2RouteTableDataSource_main (14.58s)
=== CONT  TestAccEC2RouteTableDataSource_basic
--- PASS: TestAccEC2RouteTableDataSource_basic (18.84s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited
--- PASS: TestAccEC2Instance_Empty_privateIP (104.56s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptUpdate
--- PASS: TestAccEC2SpotInstanceRequest_interruptStop (68.46s)
=== CONT  TestAccEC2Instance_outpost
    acctest.go:1308: skipping since no Outposts found
--- SKIP: TestAccEC2Instance_outpost (0.59s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptHibernate
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited (82.91s)
=== CONT  TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
--- PASS: TestAccEC2SpotInstanceRequest_interruptHibernate (100.03s)
=== CONT  TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable
--- PASS: TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable (91.89s)
=== CONT  TestAccEC2Instance_dedicatedInstance
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserDataBase64 (238.32s)
=== CONT  TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1 (160.15s)
=== CONT  TestAccEC2SpotInstanceRequest_basic
--- PASS: TestAccEC2SpotInstanceRequest_interruptUpdate (596.95s)
=== CONT  TestAccEC2Instance_associatePublicIPAndPrivateIP
--- PASS: TestAccEC2Instance_associatePublicIPAndPrivateIP (112.07s)
=== CONT  TestAccEC2SpotInstanceRequest_vpc
--- PASS: TestAccEC2SpotInstanceRequest_basic (331.44s)
=== CONT  TestAccEC2Instance_CreditSpecification_updateCPUCredits
--- PASS: TestAccEC2SpotInstanceRequest_vpc (101.53s)
=== CONT  TestAccEC2Instance_disableAPITermination
--- PASS: TestAccEC2Instance_CreditSpecification_updateCPUCredits (148.72s)
=== CONT  TestAccEC2EIP_BYOIPAddress_default
--- PASS: TestAccEC2Instance_disableAPITermination (137.15s)
=== CONT  TestAccEC2SpotInstanceRequest_withBlockDuration
--- PASS: TestAccEC2EIP_BYOIPAddress_default (13.06s)
=== CONT  TestAccEC2SpotInstanceRequest_getPasswordData
--- PASS: TestAccEC2SpotInstanceRequest_withBlockDuration (66.58s)
=== CONT  TestAccEC2Instance_privateIP
--- PASS: TestAccEC2SpotInstanceRequest_getPasswordData (144.38s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3
--- PASS: TestAccEC2Instance_privateIP (91.67s)
=== CONT  TestAccEC2Instance_autoRecovery
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3 (125.28s)
=== CONT  TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
--- PASS: TestAccEC2Instance_autoRecovery (134.64s)
=== CONT  TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
--- PASS: TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress (115.15s)
=== CONT  TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2 (139.20s)
=== CONT  TestAccEC2SpotInstanceRequest_withLaunchGroup
--- PASS: TestAccEC2SpotInstanceRequest_networkInterfaceAttributes (327.59s)
=== CONT  TestAccEC2SpotInstanceRequest_keyName
--- PASS: TestAccEC2SpotInstanceRequest_withLaunchGroup (81.54s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2
--- PASS: TestAccEC2SpotInstanceRequest_keyName (82.27s)
=== CONT  TestAccEC2SpotInstanceRequest_tags
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2 (94.20s)
=== CONT  TestAccEC2Instance_sourceDestCheck
--- PASS: TestAccEC2SpotInstanceRequest_tags (139.66s)
=== CONT  TestAccEC2SpotInstanceRequest_withoutSpotPrice
--- PASS: TestAccEC2Instance_sourceDestCheck (144.92s)
=== CONT  TestAccEC2SpotInstanceRequest_disappears
--- PASS: TestAccEC2SpotInstanceRequest_withoutSpotPrice (291.48s)
=== CONT  TestAccEC2Instance_withIAMInstanceProfilePath
--- PASS: TestAccEC2SpotInstanceRequest_disappears (293.57s)
=== CONT  TestAccEC2Instance_userDataBase64_updateWithZipFile
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (102.18s)
=== CONT  TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits
--- PASS: TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits (126.39s)
=== CONT  TestAccEC2Instance_noAMIEphemeralDevices
--- PASS: TestAccEC2Instance_userDataBase64_updateWithZipFile (208.18s)
=== CONT  TestAccEC2Instance_withIAMInstanceProfile
--- PASS: TestAccEC2Instance_noAMIEphemeralDevices (89.80s)
=== CONT  TestAccEC2Instance_userDataBase64_updateWithBashFile
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (101.00s)
=== CONT  TestAccEC2Instance_CapacityReservationPreference_none
--- PASS: TestAccEC2Instance_CapacityReservationPreference_none (120.40s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_withAttachedVolume
--- PASS: TestAccEC2Instance_userDataBase64_updateWithBashFile (208.02s)
=== CONT  TestAccEC2SpotInstanceRequest_validUntil
--- PASS: TestAccEC2SpotInstanceRequest_validUntil (98.74s)
=== CONT  TestAccEC2Instance_CapacityReservation_targetID
--- PASS: TestAccEC2Instance_BlockDeviceTags_withAttachedVolume (171.43s)
=== CONT  TestAccEC2Instance_userDataBase64
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (92.66s)
=== CONT  TestAccEC2Instance_CreditSpecification_standardCPUCredits
--- PASS: TestAccEC2Instance_userDataBase64 (111.66s)
=== CONT  TestAccEC2Instance_instanceProfileChange
--- PASS: TestAccEC2Instance_CreditSpecification_standardCPUCredits (120.61s)
=== CONT  TestAccEC2Instance_rootInstanceStore
--- PASS: TestAccEC2Instance_rootInstanceStore (98.85s)
=== CONT  TestAccEC2EIP_TagsEC2VPC_withVPCTrue
--- PASS: TestAccEC2EIP_TagsEC2VPC_withVPCTrue (25.00s)
=== CONT  TestAccEC2Instance_CapacityReservation_modifyTarget
--- PASS: TestAccEC2Instance_dedicatedInstance (115.46s)
=== CONT  TestAccEC2Instance_RootBlockDevice_kmsKeyARN
--- PASS: TestAccEC2Instance_instanceProfileChange (216.34s)
=== CONT  TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard
--- PASS: TestAccEC2Instance_RootBlockDevice_kmsKeyARN (82.63s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
--- PASS: TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard (103.07s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_volumeTags
--- PASS: TestAccEC2Instance_CapacityReservation_modifyTarget (169.63s)
=== CONT  TestAccEC2Instance_CapacityReservation_modifyPreference
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (151.69s)
=== CONT  TestAccEC2Instance_blockDevices
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (182.25s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (176.99s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable
--- PASS: TestAccEC2Instance_blockDevices (99.64s)
=== CONT  TestAccEC2EIP_carrierIP
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccEC2EIP_carrierIP (0.11s)
=== CONT  TestAccEC2EIP_Instance_notAssociated
--- PASS: TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed (115.27s)
=== CONT  TestAccEC2Instance_gp2IopsDevice
--- PASS: TestAccEC2Instance_gp2IopsDevice (69.66s)
=== CONT  TestAccEC2Instance_LaunchTemplate_swapIDAndName
--- PASS: TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable (138.63s)
=== CONT  TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs
--- PASS: TestAccEC2EIP_Instance_notAssociated (124.23s)
=== CONT  TestAccEC2Instance_gp2WithIopsValue
--- PASS: TestAccEC2Instance_gp2WithIopsValue (9.56s)
=== CONT  TestAccEC2EIP_TagsEC2Classic_withVPCTrue
    ec2_classic.go:56: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIP_TagsEC2Classic_withVPCTrue (0.00s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (9.81s)
=== CONT  TestAccEC2EIP_PublicIPv4Pool_default
--- PASS: TestAccEC2EIP_PublicIPv4Pool_default (14.91s)
=== CONT  TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
    ec2_classic.go:56: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue (0.00s)
=== CONT  TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable
--- PASS: TestAccEC2Instance_LaunchTemplate_swapIDAndName (96.11s)
=== CONT  TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups
--- PASS: TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable (70.92s)
=== CONT  TestAccEC2Instance_LaunchTemplate_updateTemplateVersion
--- PASS: TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs (109.86s)
=== CONT  TestAccEC2EIP_networkBorderGroup
--- PASS: TestAccEC2EIP_networkBorderGroup (15.55s)
=== CONT  TestAccEC2EIP_customerOwnedIPv4Pool
    acctest.go:1308: skipping since no Outposts found
--- SKIP: TestAccEC2EIP_customerOwnedIPv4Pool (0.61s)
=== CONT  TestAccEC2Instance_inDefaultVPCBySgName
--- PASS: TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups (125.86s)
=== CONT  TestAccEC2Instance_GetPasswordData_falseToTrue
--- PASS: TestAccEC2Instance_inDefaultVPCBySgName (115.44s)
=== CONT  TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion
--- PASS: TestAccEC2Instance_LaunchTemplate_updateTemplateVersion (208.97s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_kmsKeyARN
--- PASS: TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion (97.77s)
=== CONT  TestAccEC2Instance_inDefaultVPCBySgID
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (161.83s)
=== CONT  TestAccEC2Instance_disappears
--- PASS: TestAccEC2Instance_EBSBlockDevice_kmsKeyARN (71.66s)
=== CONT  TestAccEC2Instance_CapacityReservationPreference_open
--- PASS: TestAccEC2Instance_inDefaultVPCBySgID (101.60s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (10.28s)
=== CONT  TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue
--- PASS: TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue (24.30s)
=== CONT  TestAccEC2Instance_basic
--- PASS: TestAccEC2Instance_CapacityReservationPreference_open (119.60s)
=== CONT  TestAccEC2EIP_Instance_ec2Classic
    ec2_classic.go:56: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIP_Instance_ec2Classic (0.00s)
=== CONT  TestAccEC2Instance_GetPasswordData_trueToFalse
--- PASS: TestAccEC2Instance_basic (88.61s)
=== CONT  TestAccEC2EIP_Instance_reassociate
--- PASS: TestAccEC2Instance_disappears (320.77s)
=== CONT  TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface
--- PASS: TestAccEC2EIP_Instance_reassociate (119.73s)
=== CONT  TestAccEC2EIP_Instance_associatedUserPrivateIP
--- PASS: TestAccEC2Instance_GetPasswordData_trueToFalse (190.20s)
=== CONT  TestAccEC2EIP_instance
--- PASS: TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface (25.25s)
=== CONT  TestAccEC2EIP_networkInterface
--- PASS: TestAccEC2EIP_networkInterface (24.92s)
=== CONT  TestAccEC2EIP_disappears
--- PASS: TestAccEC2EIP_disappears (10.64s)
=== CONT  TestAccEC2Instance_atLeastOneOtherEBSVolume
--- PASS: TestAccEC2EIP_instance (117.49s)
=== CONT  TestAccEC2Instance_inEC2Classic
    ec2_classic.go:56: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2Instance_inEC2Classic (0.00s)
=== CONT  TestAccEC2Instance_tags
--- PASS: TestAccEC2Instance_atLeastOneOtherEBSVolume (164.13s)
--- PASS: TestAccEC2EIP_Instance_associatedUserPrivateIP (247.26s)
--- PASS: TestAccEC2Instance_tags (149.43s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	8880.597s
```
^^ errors above occur in main as well