### PR TITLE
Clean function names

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -234,7 +234,13 @@ jobs:
           if [ "${pkg}" = "" ]; then
             continue
           fi
-          if [[ "${pkg}" == */test-fixtures ]]; then
+          if [[ "${pkg}" == */test-fixtures/* ]]; then
+            continue
+          fi
+          if [[ "${pkg}" == */testdata/* ]]; then
+            continue
+          fi
+          if [ "${pkg}" = internal/sweep/* ]; then
             continue
           fi
           if [[ "${pkg}" == internal/generate/* ]]; then

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -223,58 +223,59 @@ jobs:
       run: |
         touch /tmp/dirs_changed_all
         for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-          if [[ "${file}" == internal/* ]]; then
-            echo $( dirname "${file}" | xargs ) >> /tmp/dirs_changed_all
+          if [ "${file}" = "" ]; then
+            continue
           fi
+          if [[ "${file}" != internal/* ]] || [[ "${file}" =~ /test-fixtures/|/testdata|^internal/sweep/.*|^internal/generate/.* ]]; then
+            echo "Skipping changed file: ${file}"
+            continue
+          fi
+          echo $( dirname "${file}" | xargs ) >> /tmp/dirs_changed_all
         done
         cat /tmp/dirs_changed_all | sort | uniq > /tmp/pkgs_changed
         echo "All packages changed:"
         cat /tmp/pkgs_changed
         while read pkg; do
-          echo -n "Checking ${pkg}: "
           if [ "${pkg}" = "" ]; then
             continue
           fi
-          if [[ "${pkg}" == */test-fixtures/* ]]; then
+          echo -n "Finding dependents for ${pkg}? "
+          if [[ "${pkg}" =~ /test-fixtures/|/testdata|^internal/sweep|^internal/generate ]]; then
+            echo "No"
             continue
           fi
-          if [[ "${pkg}" == */testdata/* ]]; then
-            continue
-          fi
-          if [ "${pkg}" = internal/sweep/* ]; then
-            continue
-          fi
-          if [[ "${pkg}" == internal/generate/* ]]; then
-            continue
-          fi
-          echo "Included"
+          c=0
           while read file; do
             if [ "${file}" = "" ]; then
               continue
             fi
+            if [[ "${file}" != *.go ]]; then
+              continue
+            fi
+            if [[ "${file}" =~ /test-fixtures/|/testdata|^internal/sweep|^internal/generate ]]; then
+              continue
+            fi
+            c=$((c+1))
             echo $( dirname "${file}" | xargs ) >> /tmp/dep_dirs_all
-          done <<< $( grep -l "github.com/hashicorp/terraform-provider-aws/${pkg}" internal/**/*.go )
+          done <<< $( grep -rl "\"github.com/hashicorp/terraform-provider-aws/${pkg}\"" internal/* )
+          echo "Yes, ${c} found"
         done </tmp/pkgs_changed
+        echo "Just dependents:"
+        cat /tmp/dep_dirs_all | sort | uniq
         cat /tmp/pkgs_changed >> /tmp/dep_dirs_all
         cat /tmp/dep_dirs_all | sort | uniq > /tmp/dep_pkgs
-        echo "All dependent packages:"
+        echo "All packages to test:"
         cat /tmp/dep_pkgs
       id: changed-packages
     - name: Run tests for changed packages
       run: |
-        while read pkg; do
-          if [ "${pkg}" = "internal/sweep" ]; then
-            continue
-          fi
-          if [[ "${pkg}" == */test-fixtures ]]; then
-            continue
-          fi
-          if [[ "${pkg}" == internal/generate/* ]]; then
-            continue
-          fi
-          go test -run ^Test[^A][^c][^c] "github.com/hashicorp/terraform-provider-aws/${pkg}"
-        done </tmp/dep_pkgs
-
+        if [ $( cat /tmp/dep_pkgs | wc -l | xargs ) -gt 150 ]; then
+          go test ./...
+        else
+          while read pkg; do
+            go test -run ^Test[^A][^c][^c] "github.com/hashicorp/terraform-provider-aws/${pkg}"
+          done </tmp/dep_pkgs
+        fi
   golangci-lint:
     needs: [go_build]
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -226,7 +226,7 @@ jobs:
           if [ "${file}" = "" ]; then
             continue
           fi
-          if [[ "${file}" != internal/* ]] || [[ "${file}" =~ /test-fixtures/|/testdata|^internal/sweep/.*|^internal/generate/.* ]]; then
+          if [[ ! "${file}" =~ ^internal/|^names/ ]] || [[ "${file}" =~ /test-fixtures/|/testdata|^internal/sweep/.*|^internal/generate/.* ]]; then
             echo "Skipping changed file: ${file}"
             continue
           fi

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -231,6 +231,7 @@ jobs:
         echo "All packages changed:"
         cat /tmp/pkgs_changed
         while read pkg; do
+          echo -n "Checking ${pkg}: "
           if [ "${pkg}" = "" ]; then
             continue
           fi
@@ -245,7 +246,8 @@ jobs:
           fi
           if [[ "${pkg}" == internal/generate/* ]]; then
             continue
-          fi          
+          fi
+          echo "Included"
           while read file; do
             if [ "${file}" = "" ]; then
               continue

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -42,10 +42,10 @@ test: fmtcheck
 testacc: fmtcheck
 	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \
 		echo ""; \
-		echo "Error: Skipping example acceptance testing pattern. Update TESTARGS to match the test naming in the relevant *_test.go file."; \
+		echo "Error: Skipping example acceptance testing pattern. Update PKG and TESTS for the relevant *_test.go file."; \
 		echo ""; \
-		echo "For example if updating aws/resource_aws_acm_certificate.go, use the test names in aws/resource_aws_acm_certificate_test.go starting with TestAcc and up to the underscore:"; \
-		echo "make testacc TESTARGS='-run=TestAccAWSAcmCertificate_'"; \
+		echo "For example if updating internal/service/acm/certificate.go, use the test names in internal/service/acm/certificate_test.go starting with TestAcc and up to the underscore:"; \
+		echo "make testacc TESTS=TestAccACMCertificate_ PKG=acm"; \
 		echo ""; \
 		echo "See the contributing guide for more information: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md"; \
 		exit 1; \

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -133,7 +133,7 @@ func factoriesInit(providers *[]*schema.Provider, providerNames []string) map[st
 
 // FactoriesInternal creates ProviderFactories for provider configuration testing
 //
-// This should only be used for TestAccAWSProvider_ tests which need to
+// This should only be used for TestAccProvider_ tests which need to
 // reference the provider instance itself. Other testing should use
 // ProviderFactories or other related functions.
 func FactoriesInternal(providers *[]*schema.Provider) map[string]func() (*schema.Provider, error) {

--- a/internal/service/accessanalyzer/analyzer.go
+++ b/internal/service/accessanalyzer/analyzer.go
@@ -22,8 +22,8 @@ const (
 	// Maximum amount of time to wait for Organizations eventual consistency on creation
 	// This timeout value is much higher than usual since the cross-service validation
 	// appears to be consistently caching for 5 minutes:
-	// --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/Type_Organization (315.86s)
-	accessAnalyzerOrganizationCreationTimeout = 10 * time.Minute
+	// --- PASS: TestAccAccessAnalyzer_serial/Analyzer/Type_Organization (315.86s)
+	organizationCreationTimeout = 10 * time.Minute
 )
 
 func ResourceAnalyzer() *schema.Resource {
@@ -82,7 +82,7 @@ func resourceAnalyzerCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Handle Organizations eventual consistency
-	err := resource.Retry(accessAnalyzerOrganizationCreationTimeout, func() *resource.RetryError {
+	err := resource.Retry(organizationCreationTimeout, func() *resource.RetryError {
 		_, err := conn.CreateAnalyzer(input)
 
 		if tfawserr.ErrMessageContains(err, accessanalyzer.ErrCodeValidationException, "You must create an organization") {

--- a/internal/service/accessanalyzer/analyzer_test.go
+++ b/internal/service/accessanalyzer/analyzer_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-// This test can be run via the pattern: TestAccAWSAccessAnalyzer
 func testAccAnalyzer_basic(t *testing.T) {
 	var analyzer accessanalyzer.AnalyzerSummary
 
@@ -25,7 +24,7 @@ func testAccAnalyzer_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAccessAnalyzerAnalyzerDestroy,
+		CheckDestroy: testAccCheckAnalyzerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerAnalyzerNameConfig(rName),
@@ -46,7 +45,6 @@ func testAccAnalyzer_basic(t *testing.T) {
 	})
 }
 
-// This test can be run via the pattern: TestAccAWSAccessAnalyzer
 func testAccAnalyzer_disappears(t *testing.T) {
 	var analyzer accessanalyzer.AnalyzerSummary
 
@@ -57,7 +55,7 @@ func testAccAnalyzer_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAccessAnalyzerAnalyzerDestroy,
+		CheckDestroy: testAccCheckAnalyzerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerAnalyzerNameConfig(rName),
@@ -71,7 +69,6 @@ func testAccAnalyzer_disappears(t *testing.T) {
 	})
 }
 
-// This test can be run via the pattern: TestAccAWSAccessAnalyzer
 func testAccAnalyzer_Tags(t *testing.T) {
 	var analyzer accessanalyzer.AnalyzerSummary
 
@@ -82,7 +79,7 @@ func testAccAnalyzer_Tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAccessAnalyzerAnalyzerDestroy,
+		CheckDestroy: testAccCheckAnalyzerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerTags1Config(rName, "key1", "value1"),
@@ -118,7 +115,6 @@ func testAccAnalyzer_Tags(t *testing.T) {
 	})
 }
 
-// This test can be run via the pattern: TestAccAWSAccessAnalyzer
 func testAccAnalyzer_Type_Organization(t *testing.T) {
 	var analyzer accessanalyzer.AnalyzerSummary
 
@@ -133,7 +129,7 @@ func testAccAnalyzer_Type_Organization(t *testing.T) {
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAccessAnalyzerAnalyzerDestroy,
+		CheckDestroy: testAccCheckAnalyzerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerTypeOrganizationConfig(rName),
@@ -151,7 +147,7 @@ func testAccAnalyzer_Type_Organization(t *testing.T) {
 	})
 }
 
-func testAccCheckAccessAnalyzerAnalyzerDestroy(s *terraform.State) error {
+func testAccCheckAnalyzerDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -27,7 +27,7 @@ func TestAccAPIGatewayStage_basic(t *testing.T) {
 		CheckDestroy: testAccCheckStageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/restapis/.+/stages/prod`)),
@@ -64,7 +64,7 @@ func TestAccAPIGatewayStage_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/restapis/.+/stages/prod`)),
@@ -93,7 +93,7 @@ func TestAccAPIGatewayStage_cache(t *testing.T) {
 		CheckDestroy: testAccCheckStageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", "false"),
@@ -123,7 +123,7 @@ func TestAccAPIGatewayStage_cache(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", "false"),
@@ -146,7 +146,7 @@ func TestAccAPIGatewayStage_cache_size_cache_disabled(t *testing.T) {
 		CheckDestroy: testAccCheckStageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", "false"),
@@ -358,7 +358,7 @@ func TestAccAPIGatewayStage_accessLogSettings(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/restapis/.+/stages/prod`)),
@@ -426,7 +426,7 @@ func TestAccAPIGatewayStage_AccessLogSettings_kinesis(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/restapis/.+/stages/prod`)),
@@ -449,13 +449,13 @@ func TestAccAPIGatewayStage_waf(t *testing.T) {
 		CheckDestroy: testAccCheckStageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayStageConfigWafAcl(rName),
+				Config: testAccStageConfig_wafACL(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayStageConfigWafAcl(rName),
+				Config: testAccStageConfig_wafACL(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "web_acl_arn", "aws_wafregional_web_acl.test", "arn"),
@@ -483,7 +483,7 @@ func TestAccAPIGatewayStage_canarySettings(t *testing.T) {
 		CheckDestroy: testAccCheckStageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayStageConfig_canarySettings(rName),
+				Config: testAccStageConfig_canarySettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
@@ -499,14 +499,14 @@ func TestAccAPIGatewayStage_canarySettings(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStageConfigBasic(rName),
+				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.#", "0"),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayStageConfig_canarySettingsUpdated(rName),
+				Config: testAccStageConfig_canarySettingsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
@@ -713,7 +713,7 @@ resource "aws_api_gateway_deployment" "test2" {
 `)
 }
 
-func testAccStageConfigBasic(rName string) string {
+func testAccStageConfig_basic(rName string) string {
 	return testAccStageConfig_base(rName) + `
 resource "aws_api_gateway_stage" "test" {
   rest_api_id   = aws_api_gateway_rest_api.test.id
@@ -865,8 +865,8 @@ resource "aws_api_gateway_stage" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSAPIGatewayStageConfigWafAcl(rName string) string {
-	return testAccStageConfigBasic(rName) + fmt.Sprintf(`
+func testAccStageConfig_wafACL(rName string) string {
+	return testAccStageConfig_basic(rName) + fmt.Sprintf(`
 resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = "test"
@@ -882,7 +882,7 @@ resource "aws_wafregional_web_acl_association" "test" {
 `, rName)
 }
 
-func testAccAWSAPIGatewayStageConfig_canarySettings(rName string) string {
+func testAccStageConfig_canarySettings(rName string) string {
 	return testAccStageConfig_base(rName) + `
 resource "aws_api_gateway_stage" "test" {
   rest_api_id   = aws_api_gateway_rest_api.test.id
@@ -904,7 +904,7 @@ resource "aws_api_gateway_stage" "test" {
 `
 }
 
-func testAccAWSAPIGatewayStageConfig_canarySettingsUpdated(rName string) string {
+func testAccStageConfig_canarySettingsUpdated(rName string) string {
 	return testAccStageConfig_base(rName) + `
 resource "aws_api_gateway_stage" "test" {
   rest_api_id   = aws_api_gateway_rest_api.test.id

--- a/internal/service/autoscaling/attachment_test.go
+++ b/internal/service/autoscaling/attachment_test.go
@@ -215,7 +215,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "TestAccAutoScalingAttachment_albTargetGroup"
   }
 }
 
@@ -244,7 +244,7 @@ resource "aws_lb_target_group" "another_test" {
   }
 
   tags = {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "TestAccAutoScalingAttachment_albTargetGroup"
   }
 }
 

--- a/internal/service/cloudformation/stack_set_instance_test.go
+++ b/internal/service/cloudformation/stack_set_instance_test.go
@@ -163,7 +163,7 @@ func TestAccCloudFormationStackSetInstance_parameterOverrides(t *testing.T) {
 	})
 }
 
-// TestAccAWSCloudFrontDistribution_RetainStack verifies retain_stack = true
+// TestAccCloudFormationStackSetInstance_retainStack verifies retain_stack = true
 // This acceptance test performs the following steps:
 //  * Trigger a Terraform destroy of the resource, which should only remove the instance from the StackSet
 //  * Check it still exists outside Terraform

--- a/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/README.md
+++ b/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/README.md
@@ -4,4 +4,4 @@ This directory contains the source for a valid CloudFormation Type. The files we
 
 These files are for acceptance testing the Terraform `aws_cloudformation_type` managed resource and data source. The `bin/handler` file is included in the `.gitignore` since it is large. To generate it, run `make build` in this directory.
 
-Since the deployed `.rpdk-config` and `schema.json` must match the `RegisterType` API `TypeName` parameter, the acceptance testing includes a helper function, `testAccAwsCloudformationTypeZipGenerator`, which can create valid zip files to match randomized `TypeName` and prevent race conditions in the testing.
+Since the deployed `.rpdk-config` and `schema.json` must match the `RegisterType` API `TypeName` parameter, the acceptance testing includes a helper function, `testAccTypeZipGenerator`, which can create valid zip files to match randomized `TypeName` and prevent race conditions in the testing.

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -124,8 +124,7 @@ func TestAccCloudFrontDistribution_s3OriginWithTags(t *testing.T) {
 	})
 }
 
-// TestAccAWSCloudFrontDistribution_customOriginruns an
-// aws_cloudfront_distribution acceptance test with a single custom origin.
+// TestAccCloudFrontDistribution_customOrigin tests a single custom origin.
 //
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.

--- a/internal/service/cloudfront/field_level_encryption_config_test.go
+++ b/internal/service/cloudfront/field_level_encryption_config_test.go
@@ -26,7 +26,7 @@ func TestAccCloudFrontFieldLevelEncryptionConfig_basic(t *testing.T) {
 		CheckDestroy: testAccCheckFieldLevelEncryptionConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSFieldLevelEncryptionConfig(rName),
+				Config: testAccFieldLevelEncryptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFieldLevelEncryptionConfigExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "comment", "some comment"),
@@ -50,7 +50,7 @@ func TestAccCloudFrontFieldLevelEncryptionConfig_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSFieldLevelEncryptionUpdatedConfig(rName),
+				Config: testAccFieldLevelEncryptionConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFieldLevelEncryptionConfigExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "comment", "some other comment"),
@@ -90,7 +90,7 @@ func TestAccCloudFrontFieldLevelEncryptionConfig_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckFieldLevelEncryptionConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSFieldLevelEncryptionConfig(rName),
+				Config: testAccFieldLevelEncryptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFieldLevelEncryptionConfigExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcloudfront.ResourceFieldLevelEncryptionConfig(), resourceName),
@@ -151,7 +151,7 @@ func testAccCheckFieldLevelEncryptionConfigExists(r string, v *cloudfront.GetFie
 	}
 }
 
-func testAccAWSFieldLevelEncryptionBaseConfig(rName string) string {
+func testAccFieldLevelEncryptionConfig_base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudfront_public_key" "test" {
   comment     = "test key"
@@ -177,8 +177,8 @@ resource "aws_cloudfront_field_level_encryption_profile" "test" {
 `, rName)
 }
 
-func testAccAWSFieldLevelEncryptionConfig(rName string) string {
-	return acctest.ConfigCompose(testAccAWSFieldLevelEncryptionBaseConfig(rName), `
+func testAccFieldLevelEncryptionConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccFieldLevelEncryptionConfig_base(rName), `
 resource "aws_cloudfront_field_level_encryption_config" "test" {
   comment = "some comment"
 
@@ -201,8 +201,8 @@ resource "aws_cloudfront_field_level_encryption_config" "test" {
 `)
 }
 
-func testAccAWSFieldLevelEncryptionUpdatedConfig(rName string) string {
-	return acctest.ConfigCompose(testAccAWSFieldLevelEncryptionBaseConfig(rName), `
+func testAccFieldLevelEncryptionConfig_updated(rName string) string {
+	return acctest.ConfigCompose(testAccFieldLevelEncryptionConfig_base(rName), `
 resource "aws_cloudfront_field_level_encryption_config" "test" {
   comment = "some other comment"
 

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1583,7 +1583,7 @@ func TestAccDynamoDBTable_tableClassInfrequentAccess(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTable_backup_encryption(t *testing.T) {
+func TestAccDynamoDBTable_backupEncryption(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -1600,7 +1600,7 @@ func TestAccDynamoDBTable_backup_encryption(t *testing.T) {
 		CheckDestroy: testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDynamoDbBackupConfigInitialStateWithEncryption(rName),
+				Config: testAccTableConfig_backupInitialStateEncryption(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confBYOK),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
@@ -1639,7 +1639,7 @@ func TestAccDynamoDBTable_backup_overrideEncryption(t *testing.T) {
 		CheckDestroy: testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDynamoDbBackupConfigInitialStateWithOverrideEncryption(rName),
+				Config: testAccTableConfig_backupInitialStateOverrideEncryption(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confBYOK),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
@@ -2763,7 +2763,7 @@ resource "aws_dynamodb_table" "test" {
 `, rName, tableClass)
 }
 
-func testAccAWSDynamoDbBackupConfigInitialStateWithOverrideEncryption(rName string) string {
+func testAccTableConfig_backupInitialStateOverrideEncryption(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "source" {
   name           = "%[1]s-source"
@@ -2802,7 +2802,7 @@ resource "aws_dynamodb_table" "test" {
 `, rName)
 }
 
-func testAccAWSDynamoDbBackupConfigInitialStateWithEncryption(rName string) string {
+func testAccTableConfig_backupInitialStateEncryption(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "source" {
   name           = "%[1]s-source"

--- a/internal/service/ec2/ebs_snapshot_create_volume_permission_test.go
+++ b/internal/service/ec2/ebs_snapshot_create_volume_permission_test.go
@@ -13,7 +13,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2SnapshotCreateVolumePermission_basic(t *testing.T) {
+func TestAccEC2EBSSnapshotCreateVolumePermission_basic(t *testing.T) {
 	var snapshotId string
 	accountId := "111122223333"
 
@@ -42,7 +42,7 @@ func TestAccEC2SnapshotCreateVolumePermission_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SnapshotCreateVolumePermission_disappears(t *testing.T) {
+func TestAccEC2EBSSnapshotCreateVolumePermission_disappears(t *testing.T) {
 	var snapshotId string
 	accountId := "111122223333"
 

--- a/internal/service/ec2/ebs_volume_attachment_test.go
+++ b/internal/service/ec2/ebs_volume_attachment_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2VolumeAttachment_basic(t *testing.T) {
+func TestAccEC2EBSVolumeAttachment_basic(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
@@ -47,7 +47,7 @@ func TestAccEC2VolumeAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VolumeAttachment_skipDestroy(t *testing.T) {
+func TestAccEC2EBSVolumeAttachment_skipDestroy(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
@@ -81,7 +81,7 @@ func TestAccEC2VolumeAttachment_skipDestroy(t *testing.T) {
 	})
 }
 
-func TestAccEC2VolumeAttachment_attachStopped(t *testing.T) {
+func TestAccEC2EBSVolumeAttachment_attachStopped(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
@@ -129,7 +129,7 @@ func TestAccEC2VolumeAttachment_attachStopped(t *testing.T) {
 	})
 }
 
-func TestAccEC2VolumeAttachment_update(t *testing.T) {
+func TestAccEC2EBSVolumeAttachment_update(t *testing.T) {
 	resourceName := "aws_volume_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -177,7 +177,7 @@ func TestAccEC2VolumeAttachment_update(t *testing.T) {
 	})
 }
 
-func TestAccEC2VolumeAttachment_disappears(t *testing.T) {
+func TestAccEC2EBSVolumeAttachment_disappears(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
@@ -203,7 +203,7 @@ func TestAccEC2VolumeAttachment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VolumeAttachment_stopInstance(t *testing.T) {
+func TestAccEC2EBSVolumeAttachment_stopInstance(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"

--- a/internal/service/ec2/ec2_eip_test.go
+++ b/internal/service/ec2/ec2_eip_test.go
@@ -131,7 +131,7 @@ func TestAccEC2EIP_Instance_reassociate(t *testing.T) {
 	})
 }
 
-// This test is an expansion of TestAccAWSEIP_instance, by testing the
+// This test is an expansion of TestAccEC2EIP_Instance_associatedUserPrivateIP, by testing the
 // associated Private EIPs of two instances
 func TestAccEC2EIP_Instance_associatedUserPrivateIP(t *testing.T) {
 	var one ec2.Address

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -65,7 +65,7 @@ const (
 	ErrCodeInvalidSpotFleetRequestConfig                  = "InvalidSpotFleetRequestConfig"
 	ErrCodeInvalidSpotFleetRequestIdNotFound              = "InvalidSpotFleetRequestId.NotFound"
 	ErrCodeInvalidSpotInstanceRequestIDNotFound           = "InvalidSpotInstanceRequestID.NotFound"
-	ErrCodeInvalidSubnetCidrReservationIDNotFound         = "InvalidSubnetCidrReservationID.NotFound"
+	ErrCodeInvalidSubnetCIDRReservationIDNotFound         = "InvalidSubnetCidrReservationID.NotFound"
 	ErrCodeInvalidSubnetIDNotFound                        = "InvalidSubnetID.NotFound"
 	ErrCodeInvalidSubnetIdNotFound                        = "InvalidSubnetId.NotFound"
 	ErrCodeInvalidTransitGatewayAttachmentIDNotFound      = "InvalidTransitGatewayAttachmentID.NotFound"

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -1953,7 +1953,7 @@ func FindSubnets(conn *ec2.EC2, input *ec2.DescribeSubnetsInput) ([]*ec2.Subnet,
 	return output, nil
 }
 
-func FindSubnetCidrReservationBySubnetIDAndReservationID(conn *ec2.EC2, subnetID, reservationID string) (*ec2.SubnetCidrReservation, error) {
+func FindSubnetCIDRReservationBySubnetIDAndReservationID(conn *ec2.EC2, subnetID, reservationID string) (*ec2.SubnetCidrReservation, error) {
 	input := &ec2.GetSubnetCidrReservationsInput{
 		SubnetId: aws.String(subnetID),
 	}

--- a/internal/service/ec2/ipam_byoip_test.go
+++ b/internal/service/ec2/ipam_byoip_test.go
@@ -16,7 +16,7 @@ import (
 // multiple steps in order to share the dependencies
 
 // IPAM IPv6 BYOIP Tests
-func TestAccVPCIpam_ByoipIPv6(t *testing.T) {
+func TestAccIPAM_byoipIPv6(t *testing.T) {
 	if os.Getenv("IPAM_BYOIP_IPV6_MESSAGE") == "" || os.Getenv("IPAM_BYOIP_IPV6_SIGNATURE") == "" || os.Getenv("IPAM_BYOIP_IPV6_PROVISIONED_CIDR") == "" {
 		t.Skip("Environment variable IPAM_BYOIP_IPV6_MESSAGE, IPAM_BYOIP_IPV6_SIGNATURE, or IPAM_BYOIP_IPV6_PROVISIONED_CIDR is not set")
 	}

--- a/internal/service/ec2/ipam_organization_admin_account_test.go
+++ b/internal/service/ec2/ipam_organization_admin_account_test.go
@@ -15,7 +15,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccVPCIpamOrganizationAdminAccount_basic(t *testing.T) {
+func TestAccIPAMOrganizationAdminAccount_basic(t *testing.T) {
 	var providers []*schema.Provider
 	var organization organizations.DelegatedAdministrator
 	resourceName := "aws_vpc_ipam_organization_admin_account.test"

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccVPCIpamPoolAllocation_ipv4Basic(t *testing.T) {
+func TestAccIPAMPoolAllocation_ipv4Basic(t *testing.T) {
 	var allocation ec2.IpamPoolAllocation
 	resourceName := "aws_vpc_ipam_pool_cidr_allocation.test"
 	cidr := "172.2.0.0/28"
@@ -46,7 +46,7 @@ func TestAccVPCIpamPoolAllocation_ipv4Basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamPoolAllocation_ipv4BasicNetmask(t *testing.T) {
+func TestAccIPAMPoolAllocation_ipv4BasicNetmask(t *testing.T) {
 	var allocation ec2.IpamPoolAllocation
 	resourceName := "aws_vpc_ipam_pool_cidr_allocation.test"
 	netmask := "28"
@@ -74,7 +74,7 @@ func TestAccVPCIpamPoolAllocation_ipv4BasicNetmask(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamPoolAllocation_ipv4DisallowedCidr(t *testing.T) {
+func TestAccIPAMPoolAllocation_ipv4DisallowedCidr(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool_cidr_allocation.test"
 	disallowedCidr := "172.2.0.0/28"
 	netmaskLength := "28"

--- a/internal/service/ec2/ipam_pool_cidr_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccVPCIpamPoolCidr_ipv4Basic(t *testing.T) {
+func TestAccIPAMPoolCidr_ipv4Basic(t *testing.T) {
 	var cidr ec2.IpamPoolCidr
 	resourceName := "aws_vpc_ipam_pool_cidr.test"
 	cidr_range := "10.0.0.0/24"

--- a/internal/service/ec2/ipam_pool_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccDataSourceVPCIpamPool_basic(t *testing.T) {
+func TestAccIPAMPoolDataSource_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 	dataSourceName := "data.aws_vpc_ipam_pool.test"
 

--- a/internal/service/ec2/ipam_pool_test.go
+++ b/internal/service/ec2/ipam_pool_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccVPCIpamPool_basic(t *testing.T) {
+func TestAccIPAMPool_basic(t *testing.T) {
 	var pool ec2.IpamPool
 	resourceName := "aws_vpc_ipam_pool.test"
 
@@ -56,7 +56,7 @@ func TestAccVPCIpamPool_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamPool_tags(t *testing.T) {
+func TestAccIPAMPool_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -96,7 +96,7 @@ func TestAccVPCIpamPool_tags(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamPool_ipv6Basic(t *testing.T) {
+func TestAccIPAMPool_ipv6Basic(t *testing.T) {
 	var pool ec2.IpamPool
 	resourceName := "aws_vpc_ipam_pool.test"
 

--- a/internal/service/ec2/ipam_preview_next_cidr_data_source_test.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccDataSourceVPCIpamPreviewNextCidr_ipv4Basic(t *testing.T) {
+func TestAccIPAMPreviewNextCIDRDataSource_ipv4Basic(t *testing.T) {
 	datasourceName := "data.aws_vpc_ipam_preview_next_cidr.test"
 	netmaskLength := "28"
 
@@ -31,7 +31,7 @@ func TestAccDataSourceVPCIpamPreviewNextCidr_ipv4Basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceVPCIpamPreviewNextCidr_ipv4Allocated(t *testing.T) {
+func TestAccIPAMPreviewNextCIDRDataSource_ipv4Allocated(t *testing.T) {
 	datasourceName := "data.aws_vpc_ipam_preview_next_cidr.test"
 	netmaskLength := "28"
 	allocatedCidr := "172.2.0.0/28"
@@ -63,7 +63,7 @@ func TestAccDataSourceVPCIpamPreviewNextCidr_ipv4Allocated(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceVPCIpamPreviewNextCidr_ipv4DisallowedCidr(t *testing.T) {
+func TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCidr(t *testing.T) {
 	datasourceName := "data.aws_vpc_ipam_preview_next_cidr.test"
 	disallowedCidr := "172.2.0.0/28"
 	netmaskLength := "28"

--- a/internal/service/ec2/ipam_preview_next_cidr_test.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccVPCIpamPreviewNextCidr_ipv4Basic(t *testing.T) {
+func TestAccIPAMPreviewNextCidr_ipv4Basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_preview_next_cidr.test"
 	netmaskLength := "28"
 
@@ -32,7 +32,7 @@ func TestAccVPCIpamPreviewNextCidr_ipv4Basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamPreviewNextCidr_ipv4Allocated(t *testing.T) {
+func TestAccIPAMPreviewNextCidr_ipv4Allocated(t *testing.T) {
 	resourceName := "aws_vpc_ipam_preview_next_cidr.test"
 	netmaskLength := "28"
 	allocatedCidr := "172.2.0.0/28"
@@ -66,7 +66,7 @@ func TestAccVPCIpamPreviewNextCidr_ipv4Allocated(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr(t *testing.T) {
+func TestAccIPAMPreviewNextCidr_ipv4DisallowedCidr(t *testing.T) {
 	resourceName := "aws_vpc_ipam_preview_next_cidr.test"
 	disallowedCidr := "172.2.0.0/28"
 	netmaskLength := "28"

--- a/internal/service/ec2/ipam_scope_test.go
+++ b/internal/service/ec2/ipam_scope_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccVPCIpamScope_basic(t *testing.T) {
+func TestAccIPAMScope_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_scope.test"
 	ipamName := "aws_vpc_ipam.test"
 
@@ -51,7 +51,7 @@ func TestAccVPCIpamScope_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpamScope_tags(t *testing.T) {
+func TestAccIPAMScope_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam_scope.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/ipam_test.go
+++ b/internal/service/ec2/ipam_test.go
@@ -20,7 +20,7 @@ func testAccIPAMPreCheck(t *testing.T) {
 	acctest.PreCheckIAMServiceLinkedRole(t, "/aws-service-role/ipam.amazonaws.com")
 }
 
-func TestAccVPCIpam_basic(t *testing.T) {
+func TestAccIPAM_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,7 +49,7 @@ func TestAccVPCIpam_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpam_modify(t *testing.T) {
+func TestAccIPAM_modify(t *testing.T) {
 	var providers []*schema.Provider
 	resourceName := "aws_vpc_ipam.test"
 
@@ -96,7 +96,7 @@ func TestAccVPCIpam_modify(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpam_cascade(t *testing.T) {
+func TestAccIPAM_cascade(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -126,7 +126,7 @@ func TestAccVPCIpam_cascade(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpam_tags(t *testing.T) {
+func TestAccIPAM_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/outposts_coip_pool_data_source_test.go
+++ b/internal/service/ec2/outposts_coip_pool_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2CoIPPoolDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsCoIPPoolDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_coip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -29,7 +29,7 @@ func TestAccEC2CoIPPoolDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2CoIPPoolDataSource_id(t *testing.T) {
+func TestAccEC2OutpostsCoIPPoolDataSource_id(t *testing.T) {
 	dataSourceName := "data.aws_ec2_coip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/outposts_coip_pools_data_source_test.go
+++ b/internal/service/ec2/outposts_coip_pools_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2CoIPPoolsDataSource_basic(t *testing.T) {
+func TestAccEC2OutpostsCoIPPoolsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_coip_pools.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccEC2CoIPPoolsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2CoIPPoolsDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsCoIPPoolsDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_coip_pools.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/outposts_local_gateway_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewayDataSource_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/outposts_local_gateway_route_table_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewayRouteTableDataSource_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccEC2LocalGatewayRouteTableDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRouteTableDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -51,7 +51,7 @@ func TestAccEC2LocalGatewayRouteTableDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRouteTableDataSource_localGatewayID(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_localGatewayID(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -72,7 +72,7 @@ func TestAccEC2LocalGatewayRouteTableDataSource_localGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRouteTableDataSource_outpostARN(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_outpostARN(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/outposts_local_gateway_route_table_vpc_association_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_vpc_association_test.go
@@ -14,7 +14,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2LocalGatewayRouteTableVPCAssociation_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	localGatewayRouteTableDataSourceName := "data.aws_ec2_local_gateway_route_table.test"
 	resourceName := "aws_ec2_local_gateway_route_table_vpc_association.test"
@@ -45,7 +45,7 @@ func TestAccEC2LocalGatewayRouteTableVPCAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRouteTableVPCAssociation_disappears(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_local_gateway_route_table_vpc_association.test"
 
@@ -67,7 +67,7 @@ func TestAccEC2LocalGatewayRouteTableVPCAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRouteTableVPCAssociation_tags(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_local_gateway_route_table_vpc_association.test"
 

--- a/internal/service/ec2/outposts_local_gateway_route_tables_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_tables_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewayRouteTablesDataSource_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_route_tables.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccEC2LocalGatewayRouteTablesDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRouteTablesDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_route_tables.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/outposts_local_gateway_route_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_test.go
@@ -14,7 +14,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2LocalGatewayRoute_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRoute_basic(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 255)
 	destinationCidrBlock := fmt.Sprintf("172.16.%d.0/24", rInt)
 	localGatewayRouteTableDataSourceName := "data.aws_ec2_local_gateway_route_table.test"
@@ -45,7 +45,7 @@ func TestAccEC2LocalGatewayRoute_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayRoute_disappears(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayRoute_disappears(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 255)
 	destinationCidrBlock := fmt.Sprintf("172.16.%d.0/24", rInt)
 	resourceName := "aws_ec2_local_gateway_route.test"

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewayVirtualInterfaceDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,7 +35,7 @@ func TestAccEC2LocalGatewayVirtualInterfaceDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayVirtualInterfaceDataSource_id(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_id(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -59,7 +59,7 @@ func TestAccEC2LocalGatewayVirtualInterfaceDataSource_id(t *testing.T) {
 	})
 }
 
-func TestAccEC2LocalGatewayVirtualInterfaceDataSource_tags(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	sourceDataSourceName := "data.aws_ec2_local_gateway_virtual_interface.source"
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface.test"

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_group_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_group_data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewayVirtualInterfaceGroupDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -31,7 +31,7 @@ func TestAccEC2LocalGatewayVirtualInterfaceGroupDataSource_filter(t *testing.T) 
 	})
 }
 
-func TestAccEC2LocalGatewayVirtualInterfaceGroupDataSource_localGatewayID(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_localGatewayID(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -51,7 +51,7 @@ func TestAccEC2LocalGatewayVirtualInterfaceGroupDataSource_localGatewayID(t *tes
 	})
 }
 
-func TestAccEC2LocalGatewayVirtualInterfaceGroupDataSource_tags(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	sourceDataSourceName := "data.aws_ec2_local_gateway_virtual_interface_group.source"
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface_group.test"

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_groups_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_groups_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewayVirtualInterfaceGroupsDataSource_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface_groups.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -29,7 +29,7 @@ func TestAccEC2LocalGatewayVirtualInterfaceGroupsDataSource_basic(t *testing.T) 
 	})
 }
 
-func TestAccEC2LocalGatewayVirtualInterfaceGroupsDataSource_filter(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface_groups.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccEC2LocalGatewayVirtualInterfaceGroupsDataSource_filter(t *testing.T)
 	})
 }
 
-func TestAccEC2LocalGatewayVirtualInterfaceGroupsDataSource_tags(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_ec2_local_gateway_virtual_interface_groups.test"
 

--- a/internal/service/ec2/outposts_local_gateways_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateways_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2LocalGatewaysDataSource_basic(t *testing.T) {
+func TestAccEC2OutpostsLocalGatewaysDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_local_gateways.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -17,7 +17,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2TransitGateway_serial(t *testing.T) {
+func TestAccTransitGateway_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Connect": {
 			"basic":      testAccTransitGatewayConnect_basic,

--- a/internal/service/ec2/vpc_data_source_test.go
+++ b/internal/service/ec2/vpc_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCDataSource_basic(t *testing.T) {
+func TestAccVPCDataSource_basic(t *testing.T) {
 	rInt1 := sdkacctest.RandIntRange(1, 128)
 	rInt2 := sdkacctest.RandIntRange(128, 254)
 	cidr := fmt.Sprintf("10.%d.%d.0/28", rInt1, rInt2)
@@ -61,7 +61,7 @@ func TestAccEC2VPCDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDataSource_CIDRBlockAssociations_multiple(t *testing.T) {
+func TestAccVPCDataSource_CIDRBlockAssociations_multiple(t *testing.T) {
 	dataSourceName := "data.aws_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_default_network_acl_test.go
+++ b/internal/service/ec2/vpc_default_network_acl_test.go
@@ -15,7 +15,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2DefaultNetworkACL_basic(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_basic(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	vpcResourceName := "aws_vpc.test"
@@ -49,7 +49,7 @@ func TestAccEC2DefaultNetworkACL_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultNetworkACL_basicIPv6VPC(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_basicIPv6VPC(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -77,7 +77,7 @@ func TestAccEC2DefaultNetworkACL_basicIPv6VPC(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultNetworkACL_tags(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_tags(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -122,7 +122,7 @@ func TestAccEC2DefaultNetworkACL_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultNetworkACL_Deny_ingress(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_Deny_ingress(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -158,7 +158,7 @@ func TestAccEC2DefaultNetworkACL_Deny_ingress(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultNetworkACL_withIPv6Ingress(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_withIPv6Ingress(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -194,7 +194,7 @@ func TestAccEC2DefaultNetworkACL_withIPv6Ingress(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultNetworkACL_subnetRemoval(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -238,7 +238,7 @@ func TestAccEC2DefaultNetworkACL_subnetRemoval(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultNetworkACL_subnetReassign(t *testing.T) {
+func TestAccVPCDefaultNetworkACL_subnetReassign(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_default_route_table_test.go
+++ b/internal/service/ec2/vpc_default_route_table_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2DefaultRouteTable_basic(t *testing.T) {
+func TestAccVPCDefaultRouteTable_basic(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	vpcResourceName := "aws_vpc.test"
@@ -61,7 +61,7 @@ func TestAccEC2DefaultRouteTable_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_Disappears_vpc(t *testing.T) {
+func TestAccVPCDefaultRouteTable_Disappears_vpc(t *testing.T) {
 	var routeTable ec2.RouteTable
 	var vpc ec2.Vpc
 	resourceName := "aws_default_route_table.test"
@@ -87,7 +87,7 @@ func TestAccEC2DefaultRouteTable_Disappears_vpc(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_Route_mode(t *testing.T) {
+func TestAccVPCDefaultRouteTable_Route_mode(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -155,7 +155,7 @@ func TestAccEC2DefaultRouteTable_Route_mode(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_swap(t *testing.T) {
+func TestAccVPCDefaultRouteTable_swap(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -223,7 +223,7 @@ func TestAccEC2DefaultRouteTable_swap(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_ipv4ToTransitGateway(t *testing.T) {
+func TestAccVPCDefaultRouteTable_ipv4ToTransitGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -259,7 +259,7 @@ func TestAccEC2DefaultRouteTable_ipv4ToTransitGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
+func TestAccVPCDefaultRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -304,7 +304,7 @@ func TestAccEC2DefaultRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_vpcEndpointAssociation(t *testing.T) {
+func TestAccVPCDefaultRouteTable_vpcEndpointAssociation(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -336,7 +336,7 @@ func TestAccEC2DefaultRouteTable_vpcEndpointAssociation(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_tags(t *testing.T) {
+func TestAccVPCDefaultRouteTable_tags(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -376,7 +376,7 @@ func TestAccEC2DefaultRouteTable_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_conditionalCIDRBlock(t *testing.T) {
+func TestAccVPCDefaultRouteTable_conditionalCIDRBlock(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -414,7 +414,7 @@ func TestAccEC2DefaultRouteTable_conditionalCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_prefixListToInternetGateway(t *testing.T) {
+func TestAccVPCDefaultRouteTable_prefixListToInternetGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -455,7 +455,7 @@ func TestAccEC2DefaultRouteTable_prefixListToInternetGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultRouteTable_revokeExistingRules(t *testing.T) {
+func TestAccVPCDefaultRouteTable_revokeExistingRules(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	rtResourceName := "aws_route_table.test"

--- a/internal/service/ec2/vpc_default_security_group_test.go
+++ b/internal/service/ec2/vpc_default_security_group_test.go
@@ -13,7 +13,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2DefaultSecurityGroup_VPC_basic(t *testing.T) {
+func TestAccVPCDefaultSecurityGroup_VPC_basic(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_default_security_group.test"
 	vpcResourceName := "aws_vpc.test"
@@ -67,7 +67,7 @@ func TestAccEC2DefaultSecurityGroup_VPC_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultSecurityGroup_VPC_empty(t *testing.T) {
+func TestAccVPCDefaultSecurityGroup_VPC_empty(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_default_security_group.test"
 
@@ -95,7 +95,7 @@ func TestAccEC2DefaultSecurityGroup_VPC_empty(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultSecurityGroup_Classic_basic(t *testing.T) {
+func TestAccVPCDefaultSecurityGroup_Classic_basic(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_default_security_group.test"
 
@@ -142,7 +142,7 @@ func TestAccEC2DefaultSecurityGroup_Classic_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultSecurityGroup_Classic_empty(t *testing.T) {
+func TestAccVPCDefaultSecurityGroup_Classic_empty(t *testing.T) {
 
 	acctest.Skip(t, "This resource does not currently clear tags when adopting the resource")
 	// Additional references:

--- a/internal/service/ec2/vpc_default_subnet_test.go
+++ b/internal/service/ec2/vpc_default_subnet_test.go
@@ -73,7 +73,7 @@ func testAccPreCheckDefaultSubnetNotFound(t *testing.T) {
 	}
 }
 
-func testAccEC2DefaultSubnet_Existing_basic(t *testing.T) {
+func testAccDefaultSubnet_Existing_basic(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_default_subnet.test"
 
@@ -117,7 +117,7 @@ func testAccEC2DefaultSubnet_Existing_basic(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultSubnet_Existing_forceDestroy(t *testing.T) {
+func testAccDefaultSubnet_Existing_forceDestroy(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_default_subnet.test"
 
@@ -143,7 +143,7 @@ func testAccEC2DefaultSubnet_Existing_forceDestroy(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultSubnet_Existing_ipv6(t *testing.T) {
+func testAccDefaultSubnet_Existing_ipv6(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_default_subnet.test"
 
@@ -187,7 +187,7 @@ func testAccEC2DefaultSubnet_Existing_ipv6(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultSubnet_Existing_privateDnsNameOptionsOnLaunch(t *testing.T) {
+func testAccDefaultSubnet_Existing_privateDnsNameOptionsOnLaunch(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_default_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -233,7 +233,7 @@ func testAccEC2DefaultSubnet_Existing_privateDnsNameOptionsOnLaunch(t *testing.T
 	})
 }
 
-func testAccEC2DefaultSubnet_NotFound_basic(t *testing.T) {
+func testAccDefaultSubnet_NotFound_basic(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_default_subnet.test"
 
@@ -277,7 +277,7 @@ func testAccEC2DefaultSubnet_NotFound_basic(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultSubnet_NotFound_ipv6Native(t *testing.T) {
+func testAccDefaultSubnet_NotFound_ipv6Native(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_default_subnet.test"
 

--- a/internal/service/ec2/vpc_default_vpc_dhcp_options_test.go
+++ b/internal/service/ec2/vpc_default_vpc_dhcp_options_test.go
@@ -11,7 +11,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2DefaultVPCDHCPOptions_basic(t *testing.T) {
+func TestAccVPCDefaultVPCDHCPOptions_basic(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_default_vpc_dhcp_options.test"
 
@@ -37,7 +37,7 @@ func TestAccEC2DefaultVPCDHCPOptions_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2DefaultVPCDHCPOptions_owner(t *testing.T) {
+func TestAccVPCDefaultVPCDHCPOptions_owner(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_default_vpc_dhcp_options.test"
 

--- a/internal/service/ec2/vpc_default_vpc_test.go
+++ b/internal/service/ec2/vpc_default_vpc_test.go
@@ -17,23 +17,23 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2DefaultVPCAndSubnet_serial(t *testing.T) {
+func TestAccVPCDefaultVPCAndSubnet_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"VPC": {
-			"existing.basic":                        testAccEC2DefaultVPC_Existing_basic,
-			"existing.assignGeneratedIPv6CIDRBlock": testAccEC2DefaultVPC_Existing_assignGeneratedIPv6CIDRBlock,
-			"existing.forceDestroy":                 testAccEC2DefaultVPC_Existing_forceDestroy,
-			"notFound.basic":                        testAccEC2DefaultVPC_NotFound_basic,
-			"notFound.assignGeneratedIPv6CIDRBlock": testAccEC2DefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock,
-			"notFound.forceDestroy":                 testAccEC2DefaultVPC_NotFound_forceDestroy,
+			"existing.basic":                        testAccDefaultVPC_Existing_basic,
+			"existing.assignGeneratedIPv6CIDRBlock": testAccDefaultVPC_Existing_assignGeneratedIPv6CIDRBlock,
+			"existing.forceDestroy":                 testAccDefaultVPC_Existing_forceDestroy,
+			"notFound.basic":                        testAccDefaultVPC_NotFound_basic,
+			"notFound.assignGeneratedIPv6CIDRBlock": testAccDefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock,
+			"notFound.forceDestroy":                 testAccDefaultVPC_NotFound_forceDestroy,
 		},
 		"Subnet": {
-			"existing.basic":                         testAccEC2DefaultSubnet_Existing_basic,
-			"existing.forceDestroy":                  testAccEC2DefaultSubnet_Existing_forceDestroy,
-			"existing.ipv6":                          testAccEC2DefaultSubnet_Existing_ipv6,
-			"existing.privateDnsNameOptionsOnLaunch": testAccEC2DefaultSubnet_Existing_privateDnsNameOptionsOnLaunch,
-			"notFound.basic":                         testAccEC2DefaultSubnet_NotFound_basic,
-			"notFound.ipv6Native":                    testAccEC2DefaultSubnet_NotFound_ipv6Native,
+			"existing.basic":                         testAccDefaultSubnet_Existing_basic,
+			"existing.forceDestroy":                  testAccDefaultSubnet_Existing_forceDestroy,
+			"existing.ipv6":                          testAccDefaultSubnet_Existing_ipv6,
+			"existing.privateDnsNameOptionsOnLaunch": testAccDefaultSubnet_Existing_privateDnsNameOptionsOnLaunch,
+			"notFound.basic":                         testAccDefaultSubnet_NotFound_basic,
+			"notFound.ipv6Native":                    testAccDefaultSubnet_NotFound_ipv6Native,
 		},
 	}
 
@@ -78,7 +78,7 @@ func testAccPreCheckDefaultVPCNotFound(t *testing.T) {
 	}
 }
 
-func testAccEC2DefaultVPC_Existing_basic(t *testing.T) {
+func testAccDefaultVPC_Existing_basic(t *testing.T) {
 	var v ec2.Vpc
 	resourceName := "aws_default_vpc.test"
 
@@ -124,7 +124,7 @@ func testAccEC2DefaultVPC_Existing_basic(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultVPC_Existing_assignGeneratedIPv6CIDRBlock(t *testing.T) {
+func testAccDefaultVPC_Existing_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 	var v ec2.Vpc
 	resourceName := "aws_default_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -172,7 +172,7 @@ func testAccEC2DefaultVPC_Existing_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultVPC_Existing_forceDestroy(t *testing.T) {
+func testAccDefaultVPC_Existing_forceDestroy(t *testing.T) {
 	var v ec2.Vpc
 	resourceName := "aws_default_vpc.test"
 
@@ -199,7 +199,7 @@ func testAccEC2DefaultVPC_Existing_forceDestroy(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultVPC_NotFound_basic(t *testing.T) {
+func testAccDefaultVPC_NotFound_basic(t *testing.T) {
 	var v ec2.Vpc
 	resourceName := "aws_default_vpc.test"
 
@@ -245,7 +245,7 @@ func testAccEC2DefaultVPC_NotFound_basic(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock(t *testing.T) {
+func testAccDefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 	var v ec2.Vpc
 	resourceName := "aws_default_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -293,7 +293,7 @@ func testAccEC2DefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 	})
 }
 
-func testAccEC2DefaultVPC_NotFound_forceDestroy(t *testing.T) {
+func testAccDefaultVPC_NotFound_forceDestroy(t *testing.T) {
 	var v ec2.Vpc
 	resourceName := "aws_default_vpc.test"
 

--- a/internal/service/ec2/vpc_dhcp_options_association_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCDHCPOptionsAssociation_basic(t *testing.T) {
+func TestAccVPCDHCPOptionsAssociation_basic(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -40,7 +40,7 @@ func TestAccEC2VPCDHCPOptionsAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptionsAssociation_Disappears_vpc(t *testing.T) {
+func TestAccVPCDHCPOptionsAssociation_Disappears_vpc(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -62,7 +62,7 @@ func TestAccEC2VPCDHCPOptionsAssociation_Disappears_vpc(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptionsAssociation_Disappears_dhcp(t *testing.T) {
+func TestAccVPCDHCPOptionsAssociation_Disappears_dhcp(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -84,7 +84,7 @@ func TestAccEC2VPCDHCPOptionsAssociation_Disappears_dhcp(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptionsAssociation_disappears(t *testing.T) {
+func TestAccVPCDHCPOptionsAssociation_disappears(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -106,7 +106,7 @@ func TestAccEC2VPCDHCPOptionsAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptionsAssociation_default(t *testing.T) {
+func TestAccVPCDHCPOptionsAssociation_default(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_dhcp_options_data_source_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCDHCPOptionsDataSource_basic(t *testing.T) {
+func TestAccVPCDHCPOptionsDataSource_basic(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options.test"
 	datasourceName := "data.aws_vpc_dhcp_options.test"
 
@@ -47,7 +47,7 @@ func TestAccEC2VPCDHCPOptionsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptionsDataSource_filter(t *testing.T) {
+func TestAccVPCDHCPOptionsDataSource_filter(t *testing.T) {
 	rInt := sdkacctest.RandInt()
 	resourceName := "aws_vpc_dhcp_options.test.0"
 	datasourceName := "data.aws_vpc_dhcp_options.test"

--- a/internal/service/ec2/vpc_dhcp_options_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCDHCPOptions_basic(t *testing.T) {
+func TestAccVPCDHCPOptions_basic(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_vpc_dhcp_options.test"
 	rName := sdkacctest.RandString(5)
@@ -50,7 +50,7 @@ func TestAccEC2VPCDHCPOptions_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptions_tags(t *testing.T) {
+func TestAccVPCDHCPOptions_tags(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_vpc_dhcp_options.test"
 	rName := sdkacctest.RandString(5)
@@ -95,7 +95,7 @@ func TestAccEC2VPCDHCPOptions_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCDHCPOptions_disappears(t *testing.T) {
+func TestAccVPCDHCPOptions_disappears(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_vpc_dhcp_options.test"
 	rName := sdkacctest.RandString(5)

--- a/internal/service/ec2/vpc_egress_only_internet_gateway_test.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2EgressOnlyInternetGateway_basic(t *testing.T) {
+func TestAccVPCEgressOnlyInternetGateway_basic(t *testing.T) {
 	var v ec2.EgressOnlyInternetGateway
 	resourceName := "aws_egress_only_internet_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -41,7 +41,7 @@ func TestAccEC2EgressOnlyInternetGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2EgressOnlyInternetGateway_tags(t *testing.T) {
+func TestAccVPCEgressOnlyInternetGateway_tags(t *testing.T) {
 	var v ec2.EgressOnlyInternetGateway
 	resourceName := "aws_egress_only_internet_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_endpoint_connection_accepter_test.go
+++ b/internal/service/ec2/vpc_endpoint_connection_accepter_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCEndpointConnectionAccepter_crossAccount(t *testing.T) {
+func TestAccVPCEndpointConnectionAccepter_crossAccount(t *testing.T) {
 	var providers []*schema.Provider
 	resourceName := "aws_vpc_endpoint_connection_accepter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_endpoint_connection_notification_test.go
+++ b/internal/service/ec2/vpc_endpoint_connection_notification_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccVPCEndpointConnectionNotification_basic(t *testing.T) {
-	lbName := fmt.Sprintf("testAccAWSnlb-basic-%s", sdkacctest.RandString(10))
+	lbName := fmt.Sprintf("testAccNLB-basic-%s", sdkacctest.RandString(10))
 	resourceName := "aws_vpc_endpoint_connection_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_endpoint_connection_notification_test.go
+++ b/internal/service/ec2/vpc_endpoint_connection_notification_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-func TestAccEC2VPCEndpointConnectionNotification_basic(t *testing.T) {
+func TestAccVPCEndpointConnectionNotification_basic(t *testing.T) {
 	lbName := fmt.Sprintf("testAccAWSnlb-basic-%s", sdkacctest.RandString(10))
 	resourceName := "aws_vpc_endpoint_connection_notification.test"
 

--- a/internal/service/ec2/vpc_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoint_data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCEndpointDataSource_gatewayBasic(t *testing.T) {
+func TestAccVPCEndpointDataSource_gatewayBasic(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -41,7 +41,7 @@ func TestAccEC2VPCEndpointDataSource_gatewayBasic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointDataSource_byID(t *testing.T) {
+func TestAccVPCEndpointDataSource_byID(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -71,7 +71,7 @@ func TestAccEC2VPCEndpointDataSource_byID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointDataSource_byFilter(t *testing.T) {
+func TestAccVPCEndpointDataSource_byFilter(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -101,7 +101,7 @@ func TestAccEC2VPCEndpointDataSource_byFilter(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointDataSource_byTags(t *testing.T) {
+func TestAccVPCEndpointDataSource_byTags(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -131,7 +131,7 @@ func TestAccEC2VPCEndpointDataSource_byTags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointDataSource_gatewayWithRouteTableAndTags(t *testing.T) {
+func TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -162,7 +162,7 @@ func TestAccEC2VPCEndpointDataSource_gatewayWithRouteTableAndTags(t *testing.T) 
 	})
 }
 
-func TestAccEC2VPCEndpointDataSource_interface(t *testing.T) {
+func TestAccVPCEndpointDataSource_interface(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_endpoint_policy_test.go
+++ b/internal/service/ec2/vpc_endpoint_policy_test.go
@@ -11,7 +11,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2VPCEndpointPolicy_basic(t *testing.T) {
+func TestAccVPCEndpointPolicy_basic(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 
 	resourceName := "aws_vpc_endpoint_policy.test"
@@ -44,7 +44,7 @@ func TestAccEC2VPCEndpointPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointPolicy_disappears(t *testing.T) {
+func TestAccVPCEndpointPolicy_disappears(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -67,7 +67,7 @@ func TestAccEC2VPCEndpointPolicy_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointPolicy_disappears_endpoint(t *testing.T) {
+func TestAccVPCEndpointPolicy_disappears_endpoint(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_endpoint_route_table_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_route_table_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCEndpointRouteTableAssociation_basic(t *testing.T) {
+func TestAccVPCEndpointRouteTableAssociation_basic(t *testing.T) {
 	resourceName := "aws_vpc_endpoint_route_table_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -40,7 +40,7 @@ func TestAccEC2VPCEndpointRouteTableAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointRouteTableAssociation_disappears(t *testing.T) {
+func TestAccVPCEndpointRouteTableAssociation_disappears(t *testing.T) {
 	resourceName := "aws_vpc_endpoint_route_table_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_endpoint_security_group_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_security_group_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCEndpointSecurityGroupAssociation_basic(t *testing.T) {
+func TestAccVPCEndpointSecurityGroupAssociation_basic(t *testing.T) {
 	var v ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_security_group_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -36,7 +36,7 @@ func TestAccEC2VPCEndpointSecurityGroupAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointSecurityGroupAssociation_disappears(t *testing.T) {
+func TestAccVPCEndpointSecurityGroupAssociation_disappears(t *testing.T) {
 	var v ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_security_group_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -59,7 +59,7 @@ func TestAccEC2VPCEndpointSecurityGroupAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointSecurityGroupAssociation_multiple(t *testing.T) {
+func TestAccVPCEndpointSecurityGroupAssociation_multiple(t *testing.T) {
 	var v ec2.VpcEndpoint
 	resourceName0 := "aws_vpc_endpoint_security_group_association.test.0"
 	resourceName1 := "aws_vpc_endpoint_security_group_association.test.1"
@@ -85,7 +85,7 @@ func TestAccEC2VPCEndpointSecurityGroupAssociation_multiple(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointSecurityGroupAssociation_replaceDefaultAssociation(t *testing.T) {
+func TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation(t *testing.T) {
 	var v ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_security_group_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccVPCEndpointServiceAllowedPrincipal_basic(t *testing.T) {
-	lbName := fmt.Sprintf("testAccAWSnlb-basic-%s", sdkacctest.RandString(10))
+	lbName := fmt.Sprintf("testAccNLB-basic-%s", sdkacctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-func TestAccEC2VPCEndpointServiceAllowedPrincipal_basic(t *testing.T) {
+func TestAccVPCEndpointServiceAllowedPrincipal_basic(t *testing.T) {
 	lbName := fmt.Sprintf("testAccAWSnlb-basic-%s", sdkacctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_endpoint_service_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_data_source_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCEndpointServiceDataSource_gateway(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_gateway(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -40,7 +40,7 @@ func TestAccEC2VPCEndpointServiceDataSource_gateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointServiceDataSource_interface(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_interface(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,7 +67,7 @@ func TestAccEC2VPCEndpointServiceDataSource_interface(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointServiceDataSource_custom(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_custom(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -94,7 +94,7 @@ func TestAccEC2VPCEndpointServiceDataSource_custom(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointServiceDataSource_Custom_filter(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_Custom_filter(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -121,7 +121,7 @@ func TestAccEC2VPCEndpointServiceDataSource_Custom_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointServiceDataSource_CustomFilter_tags(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_CustomFilter_tags(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -148,7 +148,7 @@ func TestAccEC2VPCEndpointServiceDataSource_CustomFilter_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointServiceDataSource_ServiceType_gateway(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_ServiceType_gateway(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -167,7 +167,7 @@ func TestAccEC2VPCEndpointServiceDataSource_ServiceType_gateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointServiceDataSource_ServiceType_interface(t *testing.T) {
+func TestAccVPCEndpointServiceDataSource_ServiceType_interface(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_endpoint_service_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2VPCEndpointService_basic(t *testing.T) {
+func TestAccVPCEndpointService_basic(t *testing.T) {
 	var svcCfg ec2.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -50,7 +50,7 @@ func TestAccEC2VPCEndpointService_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointService_allowedPrincipals(t *testing.T) {
+func TestAccVPCEndpointService_allowedPrincipals(t *testing.T) {
 	var svcCfg ec2.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -95,7 +95,7 @@ func TestAccEC2VPCEndpointService_allowedPrincipals(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointService_disappears(t *testing.T) {
+func TestAccVPCEndpointService_disappears(t *testing.T) {
 	var svcCfg ec2.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -119,7 +119,7 @@ func TestAccEC2VPCEndpointService_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointService_gatewayLoadBalancerARNs(t *testing.T) {
+func TestAccVPCEndpointService_gatewayLoadBalancerARNs(t *testing.T) {
 	var svcCfg ec2.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName := sdkacctest.RandomWithPrefix("tfacctest") // 32 character limit
@@ -153,7 +153,7 @@ func TestAccEC2VPCEndpointService_gatewayLoadBalancerARNs(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointService_tags(t *testing.T) {
+func TestAccVPCEndpointService_tags(t *testing.T) {
 	var svcCfg ec2.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -199,7 +199,7 @@ func TestAccEC2VPCEndpointService_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointService_PrivateDNS_name(t *testing.T) {
+func TestAccVPCEndpointService_PrivateDNS_name(t *testing.T) {
 	var svcCfg ec2.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_endpoint_subnet_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_subnet_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCEndpointSubnetAssociation_basic(t *testing.T) {
+func TestAccVPCEndpointSubnetAssociation_basic(t *testing.T) {
 	var vpce ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_subnet_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -41,7 +41,7 @@ func TestAccEC2VPCEndpointSubnetAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointSubnetAssociation_disappears(t *testing.T) {
+func TestAccVPCEndpointSubnetAssociation_disappears(t *testing.T) {
 	var vpce ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_subnet_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -64,7 +64,7 @@ func TestAccEC2VPCEndpointSubnetAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpointSubnetAssociation_multiple(t *testing.T) {
+func TestAccVPCEndpointSubnetAssociation_multiple(t *testing.T) {
 	var vpce ec2.VpcEndpoint
 	resourceName0 := "aws_vpc_endpoint_subnet_association.test.0"
 	resourceName1 := "aws_vpc_endpoint_subnet_association.test.1"

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCEndpoint_gatewayBasic(t *testing.T) {
+func TestAccVPCEndpoint_gatewayBasic(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -54,7 +54,7 @@ func TestAccEC2VPCEndpoint_gatewayBasic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_gatewayWithRouteTableAndPolicy(t *testing.T) {
+func TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	var routeTable ec2.RouteTable
 	resourceName := "aws_vpc_endpoint.test"
@@ -114,7 +114,7 @@ func TestAccEC2VPCEndpoint_gatewayWithRouteTableAndPolicy(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_gatewayPolicy(t *testing.T) {
+func TestAccVPCEndpoint_gatewayPolicy(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	// This policy checks the DiffSuppressFunc
 	policy1 := `
@@ -182,7 +182,7 @@ func TestAccEC2VPCEndpoint_gatewayPolicy(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_ignoreEquivalent(t *testing.T) {
+func TestAccVPCEndpoint_ignoreEquivalent(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -207,7 +207,7 @@ func TestAccEC2VPCEndpoint_ignoreEquivalent(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_interfaceBasic(t *testing.T) {
+func TestAccVPCEndpoint_interfaceBasic(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -245,7 +245,7 @@ func TestAccEC2VPCEndpoint_interfaceBasic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
+func TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -303,7 +303,7 @@ func TestAccEC2VPCEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnCreate(t *testing.T) {
+func TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -344,7 +344,7 @@ func TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnCreate(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate(t *testing.T) {
+func TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -405,7 +405,7 @@ func TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_disappears(t *testing.T) {
+func TestAccVPCEndpoint_disappears(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -428,7 +428,7 @@ func TestAccEC2VPCEndpoint_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_tags(t *testing.T) {
+func TestAccVPCEndpoint_tags(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -473,7 +473,7 @@ func TestAccEC2VPCEndpoint_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCEndpoint_VPCEndpointType_gatewayLoadBalancer(t *testing.T) {
+func TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	vpcEndpointServiceResourceName := "aws_vpc_endpoint_service.test"
 	resourceName := "aws_vpc_endpoint.test"

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2FlowLog_vpcID(t *testing.T) {
+func TestAccVPCFlowLog_vpcID(t *testing.T) {
 	var flowLog ec2.FlowLog
 	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -56,7 +56,7 @@ func TestAccEC2FlowLog_vpcID(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_logFormat(t *testing.T) {
+func TestAccVPCFlowLog_logFormat(t *testing.T) {
 	var flowLog ec2.FlowLog
 	resourceName := "aws_flow_log.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -88,7 +88,7 @@ func TestAccEC2FlowLog_logFormat(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_subnetID(t *testing.T) {
+func TestAccVPCFlowLog_subnetID(t *testing.T) {
 	var flowLog ec2.FlowLog
 	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -124,7 +124,7 @@ func TestAccEC2FlowLog_subnetID(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
 	var flowLog ec2.FlowLog
 	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 	resourceName := "aws_flow_log.test"
@@ -155,7 +155,7 @@ func TestAccEC2FlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationType_s3(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationType_s3(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
@@ -185,7 +185,7 @@ func TestAccEC2FlowLog_LogDestinationType_s3(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationTypeS3_invalid(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationTypeS3_invalid(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test-flow-log-s3-invalid")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -202,7 +202,7 @@ func TestAccEC2FlowLog_LogDestinationTypeS3_invalid(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationTypeS3DO_plainText(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
@@ -233,7 +233,7 @@ func TestAccEC2FlowLog_LogDestinationTypeS3DO_plainText(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
@@ -266,7 +266,7 @@ func TestAccEC2FlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible(t *testing
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationTypeS3DO_parquet(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
@@ -297,7 +297,7 @@ func TestAccEC2FlowLog_LogDestinationTypeS3DO_parquet(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationTypeS3DOParquet_hiveCompatible(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
@@ -329,7 +329,7 @@ func TestAccEC2FlowLog_LogDestinationTypeS3DOParquet_hiveCompatible(t *testing.T
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
@@ -362,7 +362,7 @@ func TestAccEC2FlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour(t *te
 	})
 }
 
-func TestAccEC2FlowLog_LogDestinationType_maxAggregationInterval(t *testing.T) {
+func TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval(t *testing.T) {
 	var flowLog ec2.FlowLog
 	resourceName := "aws_flow_log.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -389,7 +389,7 @@ func TestAccEC2FlowLog_LogDestinationType_maxAggregationInterval(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_tags(t *testing.T) {
+func TestAccVPCFlowLog_tags(t *testing.T) {
 	var flowLog ec2.FlowLog
 	resourceName := "aws_flow_log.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -434,7 +434,7 @@ func TestAccEC2FlowLog_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2FlowLog_disappears(t *testing.T) {
+func TestAccVPCFlowLog_disappears(t *testing.T) {
 	var flowLog ec2.FlowLog
 	resourceName := "aws_flow_log.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_internet_gateway_attachment_test.go
+++ b/internal/service/ec2/vpc_internet_gateway_attachment_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2InternetGatewayAttachment_basic(t *testing.T) {
+func TestAccVPCInternetGatewayAttachment_basic(t *testing.T) {
 	var v ec2.InternetGatewayAttachment
 	resourceName := "aws_internet_gateway_attachment.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -44,7 +44,7 @@ func TestAccEC2InternetGatewayAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2InternetGatewayAttachment_disappears(t *testing.T) {
+func TestAccVPCInternetGatewayAttachment_disappears(t *testing.T) {
 	var v ec2.InternetGatewayAttachment
 	resourceName := "aws_internet_gateway_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_internet_gateway_data_source_test.go
+++ b/internal/service/ec2/vpc_internet_gateway_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2InternetGatewayDataSource_basic(t *testing.T) {
+func TestAccVPCInternetGatewayDataSource_basic(t *testing.T) {
 	igwResourceName := "aws_internet_gateway.test"
 	vpcResourceName := "aws_vpc.test"
 	ds1ResourceName := "data.aws_internet_gateway.by_id"

--- a/internal/service/ec2/vpc_internet_gateway_test.go
+++ b/internal/service/ec2/vpc_internet_gateway_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2InternetGateway_basic(t *testing.T) {
+func TestAccVPCInternetGateway_basic(t *testing.T) {
 	var v ec2.InternetGateway
 	resourceName := "aws_internet_gateway.test"
 
@@ -44,7 +44,7 @@ func TestAccEC2InternetGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2InternetGateway_disappears(t *testing.T) {
+func TestAccVPCInternetGateway_disappears(t *testing.T) {
 	var v ec2.InternetGateway
 	resourceName := "aws_internet_gateway.test"
 
@@ -66,7 +66,7 @@ func TestAccEC2InternetGateway_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2InternetGateway_Attachment(t *testing.T) {
+func TestAccVPCInternetGateway_Attachment(t *testing.T) {
 	var v ec2.InternetGateway
 	resourceName := "aws_internet_gateway.test"
 	vpc1ResourceName := "aws_vpc.test1"
@@ -102,7 +102,7 @@ func TestAccEC2InternetGateway_Attachment(t *testing.T) {
 	})
 }
 
-func TestAccEC2InternetGateway_Tags(t *testing.T) {
+func TestAccVPCInternetGateway_Tags(t *testing.T) {
 	var v ec2.InternetGateway
 	resourceName := "aws_internet_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_main_route_table_association_test.go
+++ b/internal/service/ec2/vpc_main_route_table_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2MainRouteTableAssociation_basic(t *testing.T) {
+func TestAccVPCMainRouteTableAssociation_basic(t *testing.T) {
 	var rta ec2.RouteTableAssociation
 	resourceName := "aws_main_route_table_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
@@ -36,7 +36,7 @@ func testAccManagedPrefixListGetIdByNameDataSource(name string, id *string, arn 
 	}
 }
 
-func TestAccEC2ManagedPrefixListDataSource_basic(t *testing.T) {
+func TestAccVPCManagedPrefixListDataSource_basic(t *testing.T) {
 	prefixListName := fmt.Sprintf("com.amazonaws.%s.s3", acctest.Region())
 	prefixListId := ""
 	prefixListArn := ""
@@ -92,7 +92,7 @@ data "aws_prefix_list" "s3_by_id" {
 }
 `
 
-func TestAccEC2ManagedPrefixListDataSource_filter(t *testing.T) {
+func TestAccVPCManagedPrefixListDataSource_filter(t *testing.T) {
 	prefixListName := fmt.Sprintf("com.amazonaws.%s.s3", acctest.Region())
 	prefixListId := ""
 	prefixListArn := ""
@@ -151,7 +151,7 @@ data "aws_ec2_managed_prefix_list" "s3_by_id" {
 }
 `
 
-func TestAccEC2ManagedPrefixListDataSource_matchesTooMany(t *testing.T) {
+func TestAccVPCManagedPrefixListDataSource_matchesTooMany(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),

--- a/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2ManagedPrefixListEntry_ipv4(t *testing.T) {
+func TestAccVPCManagedPrefixListEntry_ipv4(t *testing.T) {
 	var entry ec2.PrefixListEntry
 	resourceName := "aws_ec2_managed_prefix_list_entry.test"
 	plResourceName := "aws_ec2_managed_prefix_list.test"
@@ -46,7 +46,7 @@ func TestAccEC2ManagedPrefixListEntry_ipv4(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixListEntry_ipv6(t *testing.T) {
+func TestAccVPCManagedPrefixListEntry_ipv6(t *testing.T) {
 	var entry ec2.PrefixListEntry
 	resourceName := "aws_ec2_managed_prefix_list_entry.test"
 	plResourceName := "aws_ec2_managed_prefix_list.test"
@@ -77,7 +77,7 @@ func TestAccEC2ManagedPrefixListEntry_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixListEntry_expectInvalidTypeError(t *testing.T) {
+func TestAccVPCManagedPrefixListEntry_expectInvalidTypeError(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,7 +94,7 @@ func TestAccEC2ManagedPrefixListEntry_expectInvalidTypeError(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixListEntry_expectInvalidCIDR(t *testing.T) {
+func TestAccVPCManagedPrefixListEntry_expectInvalidCIDR(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -115,7 +115,7 @@ func TestAccEC2ManagedPrefixListEntry_expectInvalidCIDR(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixListEntry_description(t *testing.T) {
+func TestAccVPCManagedPrefixListEntry_description(t *testing.T) {
 	var entry ec2.PrefixListEntry
 	resourceName := "aws_ec2_managed_prefix_list_entry.test"
 	plResourceName := "aws_ec2_managed_prefix_list.test"
@@ -146,7 +146,7 @@ func TestAccEC2ManagedPrefixListEntry_description(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixListEntry_disappears(t *testing.T) {
+func TestAccVPCManagedPrefixListEntry_disappears(t *testing.T) {
 	var entry ec2.PrefixListEntry
 	resourceName := "aws_ec2_managed_prefix_list_entry.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2ManagedPrefixList_basic(t *testing.T) {
+func TestAccVPCManagedPrefixList_basic(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -57,7 +57,7 @@ func TestAccEC2ManagedPrefixList_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixList_disappears(t *testing.T) {
+func TestAccVPCManagedPrefixList_disappears(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -79,7 +79,7 @@ func TestAccEC2ManagedPrefixList_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixList_AddressFamily_ipv6(t *testing.T) {
+func TestAccVPCManagedPrefixList_AddressFamily_ipv6(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -106,7 +106,7 @@ func TestAccEC2ManagedPrefixList_AddressFamily_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixList_Entry_cidr(t *testing.T) {
+func TestAccVPCManagedPrefixList_Entry_cidr(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -164,7 +164,7 @@ func TestAccEC2ManagedPrefixList_Entry_cidr(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixList_Entry_description(t *testing.T) {
+func TestAccVPCManagedPrefixList_Entry_description(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -217,7 +217,7 @@ func TestAccEC2ManagedPrefixList_Entry_description(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixList_name(t *testing.T) {
+func TestAccVPCManagedPrefixList_name(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -255,7 +255,7 @@ func TestAccEC2ManagedPrefixList_name(t *testing.T) {
 	})
 }
 
-func TestAccEC2ManagedPrefixList_tags(t *testing.T) {
+func TestAccVPCManagedPrefixList_tags(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_nat_gateway_data_source_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2NATGatewayDataSource_basic(t *testing.T) {
+func TestAccVPCNATGatewayDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceNameById := "data.aws_nat_gateway.test_by_id"
 	dataSourceNameBySubnetId := "data.aws_nat_gateway.test_by_subnet_id"

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NATGateway_basic(t *testing.T) {
+func TestAccVPCNATGateway_basic(t *testing.T) {
 	var natGateway ec2.NatGateway
 	resourceName := "aws_nat_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -46,7 +46,7 @@ func TestAccEC2NATGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NATGateway_disappears(t *testing.T) {
+func TestAccVPCNATGateway_disappears(t *testing.T) {
 	var natGateway ec2.NatGateway
 	resourceName := "aws_nat_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -69,7 +69,7 @@ func TestAccEC2NATGateway_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NATGateway_ConnectivityType_private(t *testing.T) {
+func TestAccVPCNATGateway_ConnectivityType_private(t *testing.T) {
 	var natGateway ec2.NatGateway
 	resourceName := "aws_nat_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -102,7 +102,7 @@ func TestAccEC2NATGateway_ConnectivityType_private(t *testing.T) {
 	})
 }
 
-func TestAccEC2NATGateway_tags(t *testing.T) {
+func TestAccVPCNATGateway_tags(t *testing.T) {
 	var natGateway ec2.NatGateway
 	resourceName := "aws_nat_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_nat_gateways_data_source_test.go
+++ b/internal/service/ec2/vpc_nat_gateways_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2NATGatewaysDataSource_basic(t *testing.T) {
+func TestAccVPCNATGatewaysDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_network_acl_association_test.go
+++ b/internal/service/ec2/vpc_network_acl_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkACLAssociation_basic(t *testing.T) {
+func TestAccVPCNetworkACLAssociation_basic(t *testing.T) {
 	var v ec2.NetworkAclAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_association.test"
@@ -44,7 +44,7 @@ func TestAccEC2NetworkACLAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLAssociation_disappears(t *testing.T) {
+func TestAccVPCNetworkACLAssociation_disappears(t *testing.T) {
 	var v ec2.NetworkAclAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_association.test"
@@ -67,7 +67,7 @@ func TestAccEC2NetworkACLAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLAssociation_disappears_NACL(t *testing.T) {
+func TestAccVPCNetworkACLAssociation_disappears_NACL(t *testing.T) {
 	var v ec2.NetworkAclAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_association.test"
@@ -91,7 +91,7 @@ func TestAccEC2NetworkACLAssociation_disappears_NACL(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLAssociation_disappears_Subnet(t *testing.T) {
+func TestAccVPCNetworkACLAssociation_disappears_Subnet(t *testing.T) {
 	var v ec2.NetworkAclAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_association.test"
@@ -115,7 +115,7 @@ func TestAccEC2NetworkACLAssociation_disappears_Subnet(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLAssociation_twoAssociations(t *testing.T) {
+func TestAccVPCNetworkACLAssociation_twoAssociations(t *testing.T) {
 	var v1, v2 ec2.NetworkAclAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resource1Name := "aws_network_acl_association.test1"
@@ -155,7 +155,7 @@ func TestAccEC2NetworkACLAssociation_twoAssociations(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLAssociation_associateWithDefaultNACL(t *testing.T) {
+func TestAccVPCNetworkACLAssociation_associateWithDefaultNACL(t *testing.T) {
 	var v ec2.NetworkAclAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_association.test"

--- a/internal/service/ec2/vpc_network_acl_rule_test.go
+++ b/internal/service/ec2/vpc_network_acl_rule_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkACLRule_basic(t *testing.T) {
+func TestAccVPCNetworkACLRule_basic(t *testing.T) {
 	resource1Name := "aws_network_acl_rule.test1"
 	resource2Name := "aws_network_acl_rule.test2"
 	resource3Name := "aws_network_acl_rule.test3"
@@ -86,7 +86,7 @@ func TestAccEC2NetworkACLRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLRule_disappears(t *testing.T) {
+func TestAccVPCNetworkACLRule_disappears(t *testing.T) {
 	resourceName := "aws_network_acl_rule.test1"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -108,7 +108,7 @@ func TestAccEC2NetworkACLRule_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLRule_Disappears_networkACL(t *testing.T) {
+func TestAccVPCNetworkACLRule_Disappears_networkACL(t *testing.T) {
 	resourceName := "aws_network_acl_rule.test1"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -130,7 +130,7 @@ func TestAccEC2NetworkACLRule_Disappears_networkACL(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLRule_Disappears_ingressEgressSameNumber(t *testing.T) {
+func TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber(t *testing.T) {
 	resourceName := "aws_network_acl_rule.test1"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -152,7 +152,7 @@ func TestAccEC2NetworkACLRule_Disappears_ingressEgressSameNumber(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLRule_ipv6(t *testing.T) {
+func TestAccVPCNetworkACLRule_ipv6(t *testing.T) {
 	resourceName := "aws_network_acl_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -186,7 +186,7 @@ func TestAccEC2NetworkACLRule_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLRule_ipv6ICMP(t *testing.T) {
+func TestAccVPCNetworkACLRule_ipv6ICMP(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_rule.test"
 
@@ -221,7 +221,7 @@ func TestAccEC2NetworkACLRule_ipv6ICMP(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6710
-func TestAccEC2NetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(t *testing.T) {
+func TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(t *testing.T) {
 	var v ec2.Vpc
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	vpcResourceName := "aws_vpc.test"
@@ -260,7 +260,7 @@ func TestAccEC2NetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(t *testi
 	})
 }
 
-func TestAccEC2NetworkACLRule_allProtocol(t *testing.T) {
+func TestAccVPCNetworkACLRule_allProtocol(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_rule.test"
 
@@ -292,7 +292,7 @@ func TestAccEC2NetworkACLRule_allProtocol(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLRule_tcpProtocol(t *testing.T) {
+func TestAccVPCNetworkACLRule_tcpProtocol(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_network_acl_rule.test"
 

--- a/internal/service/ec2/vpc_network_acl_test.go
+++ b/internal/service/ec2/vpc_network_acl_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkACL_basic(t *testing.T) {
+func TestAccVPCNetworkACL_basic(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	vpcResourceName := "aws_vpc.test"
@@ -49,7 +49,7 @@ func TestAccEC2NetworkACL_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_disappears(t *testing.T) {
+func TestAccVPCNetworkACL_disappears(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -72,7 +72,7 @@ func TestAccEC2NetworkACL_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_tags(t *testing.T) {
+func TestAccVPCNetworkACL_tags(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -117,7 +117,7 @@ func TestAccEC2NetworkACL_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_Egress_mode(t *testing.T) {
+func TestAccVPCNetworkACL_Egress_mode(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -168,7 +168,7 @@ func TestAccEC2NetworkACL_Egress_mode(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_Ingress_mode(t *testing.T) {
+func TestAccVPCNetworkACL_Ingress_mode(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -219,7 +219,7 @@ func TestAccEC2NetworkACL_Ingress_mode(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_egressAndIngressRules(t *testing.T) {
+func TestAccVPCNetworkACL_egressAndIngressRules(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -261,7 +261,7 @@ func TestAccEC2NetworkACL_egressAndIngressRules(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_OnlyIngressRules_basic(t *testing.T) {
+func TestAccVPCNetworkACL_OnlyIngressRules_basic(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -295,7 +295,7 @@ func TestAccEC2NetworkACL_OnlyIngressRules_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_OnlyIngressRules_update(t *testing.T) {
+func TestAccVPCNetworkACL_OnlyIngressRules_update(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -349,7 +349,7 @@ func TestAccEC2NetworkACL_OnlyIngressRules_update(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_caseSensitivityNoChanges(t *testing.T) {
+func TestAccVPCNetworkACL_caseSensitivityNoChanges(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -375,7 +375,7 @@ func TestAccEC2NetworkACL_caseSensitivityNoChanges(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_onlyEgressRules(t *testing.T) {
+func TestAccVPCNetworkACL_onlyEgressRules(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -401,7 +401,7 @@ func TestAccEC2NetworkACL_onlyEgressRules(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_subnetChange(t *testing.T) {
+func TestAccVPCNetworkACL_subnetChange(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -438,7 +438,7 @@ func TestAccEC2NetworkACL_subnetChange(t *testing.T) {
 
 }
 
-func TestAccEC2NetworkACL_subnets(t *testing.T) {
+func TestAccVPCNetworkACL_subnets(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -477,7 +477,7 @@ func TestAccEC2NetworkACL_subnets(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_subnetsDelete(t *testing.T) {
+func TestAccVPCNetworkACL_subnetsDelete(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -514,7 +514,7 @@ func TestAccEC2NetworkACL_subnetsDelete(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_ipv6Rules(t *testing.T) {
+func TestAccVPCNetworkACL_ipv6Rules(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -550,7 +550,7 @@ func TestAccEC2NetworkACL_ipv6Rules(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_ipv6ICMPRules(t *testing.T) {
+func TestAccVPCNetworkACL_ipv6ICMPRules(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -571,7 +571,7 @@ func TestAccEC2NetworkACL_ipv6ICMPRules(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_ipv6VPCRules(t *testing.T) {
+func TestAccVPCNetworkACL_ipv6VPCRules(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -601,7 +601,7 @@ func TestAccEC2NetworkACL_ipv6VPCRules(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACL_espProtocol(t *testing.T) {
+func TestAccVPCNetworkACL_espProtocol(t *testing.T) {
 	var v ec2.NetworkAcl
 	resourceName := "aws_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_network_acls_data_source_test.go
+++ b/internal/service/ec2/vpc_network_acls_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2NetworkACLsDataSource_basic(t *testing.T) {
+func TestAccVPCNetworkACLsDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_network_acls.test"
 
@@ -30,7 +30,7 @@ func TestAccEC2NetworkACLsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLsDataSource_filter(t *testing.T) {
+func TestAccVPCNetworkACLsDataSource_filter(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_network_acls.test"
 
@@ -50,7 +50,7 @@ func TestAccEC2NetworkACLsDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLsDataSource_tags(t *testing.T) {
+func TestAccVPCNetworkACLsDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_network_acls.test"
 
@@ -70,7 +70,7 @@ func TestAccEC2NetworkACLsDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLsDataSource_vpcID(t *testing.T) {
+func TestAccVPCNetworkACLsDataSource_vpcID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_network_acls.test"
 
@@ -91,7 +91,7 @@ func TestAccEC2NetworkACLsDataSource_vpcID(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkACLsDataSource_empty(t *testing.T) {
+func TestAccVPCNetworkACLsDataSource_empty(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_network_acls.test"
 

--- a/internal/service/ec2/vpc_network_insights_path_test.go
+++ b/internal/service/ec2/vpc_network_insights_path_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccNetworkInsightsPath_basic(t *testing.T) {
+func TestAccVPCNetworkInsightsPath_basic(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -48,7 +48,7 @@ func TestAccNetworkInsightsPath_basic(t *testing.T) {
 	})
 }
 
-func TestAccNetworkInsightsPath_disappears(t *testing.T) {
+func TestAccVPCNetworkInsightsPath_disappears(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -70,7 +70,7 @@ func TestAccNetworkInsightsPath_disappears(t *testing.T) {
 	})
 }
 
-func TestAccNetworkInsightsPath_tags(t *testing.T) {
+func TestAccVPCNetworkInsightsPath_tags(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -114,7 +114,7 @@ func TestAccNetworkInsightsPath_tags(t *testing.T) {
 	})
 }
 
-func TestAccNetworkInsightsPath_sourceIP(t *testing.T) {
+func TestAccVPCNetworkInsightsPath_sourceIP(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -147,7 +147,7 @@ func TestAccNetworkInsightsPath_sourceIP(t *testing.T) {
 	})
 }
 
-func TestAccNetworkInsightsPath_destinationIP(t *testing.T) {
+func TestAccVPCNetworkInsightsPath_destinationIP(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -180,7 +180,7 @@ func TestAccNetworkInsightsPath_destinationIP(t *testing.T) {
 	})
 }
 
-func TestAccNetworkInsightsPath_destinationPort(t *testing.T) {
+func TestAccVPCNetworkInsightsPath_destinationPort(t *testing.T) {
 	resourceName := "aws_ec2_network_insights_path.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_network_interface_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_attachment_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2NetworkInterfaceAttachment_basic(t *testing.T) {
+func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_network_interface_data_source_test.go
+++ b/internal/service/ec2/vpc_network_interface_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2NetworkInterfaceDataSource_basic(t *testing.T) {
+func TestAccVPCNetworkInterfaceDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_network_interface.test"
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -41,7 +41,7 @@ func TestAccEC2NetworkInterfaceDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceDataSource_filters(t *testing.T) {
+func TestAccVPCNetworkInterfaceDataSource_filters(t *testing.T) {
 	datasourceName := "data.aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -61,7 +61,7 @@ func TestAccEC2NetworkInterfaceDataSource_filters(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceDataSource_carrierIPAssociation(t *testing.T) {
+func TestAccVPCNetworkInterfaceDataSource_carrierIPAssociation(t *testing.T) {
 	datasourceName := "data.aws_network_interface.test"
 	resourceName := "aws_network_interface.test"
 	eipResourceName := "aws_eip.test"
@@ -109,7 +109,7 @@ func TestAccEC2NetworkInterfaceDataSource_carrierIPAssociation(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceDataSource_publicIPAssociation(t *testing.T) {
+func TestAccVPCNetworkInterfaceDataSource_publicIPAssociation(t *testing.T) {
 	datasourceName := "data.aws_network_interface.test"
 	resourceName := "aws_network_interface.test"
 	eipResourceName := "aws_eip.test"
@@ -158,7 +158,7 @@ func TestAccEC2NetworkInterfaceDataSource_publicIPAssociation(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceDataSource_attachment(t *testing.T) {
+func TestAccVPCNetworkInterfaceDataSource_attachment(t *testing.T) {
 	datasourceName := "data.aws_network_interface.test"
 	resourceName := "aws_network_interface.test"
 	instanceResourceName := "aws_instance.test"

--- a/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkInterfaceSgAttachment_basic(t *testing.T) {
+func TestAccVPCNetworkInterfaceSgAttachment_basic(t *testing.T) {
 	networkInterfaceResourceName := "aws_network_interface.test"
 	securityGroupResourceName := "aws_security_group.test"
 	resourceName := "aws_network_interface_sg_attachment.test"
@@ -38,7 +38,7 @@ func TestAccEC2NetworkInterfaceSgAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceSgAttachment_disappears(t *testing.T) {
+func TestAccVPCNetworkInterfaceSgAttachment_disappears(t *testing.T) {
 	resourceName := "aws_network_interface_sg_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -60,7 +60,7 @@ func TestAccEC2NetworkInterfaceSgAttachment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceSgAttachment_instance(t *testing.T) {
+func TestAccVPCNetworkInterfaceSgAttachment_instance(t *testing.T) {
 	instanceResourceName := "aws_instance.test"
 	securityGroupResourceName := "aws_security_group.test"
 	resourceName := "aws_network_interface_sg_attachment.test"
@@ -84,7 +84,7 @@ func TestAccEC2NetworkInterfaceSgAttachment_instance(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceSgAttachment_multiple(t *testing.T) {
+func TestAccVPCNetworkInterfaceSgAttachment_multiple(t *testing.T) {
 	networkInterfaceResourceName := "aws_network_interface.test"
 	securityGroupResourceName1 := "aws_security_group.test.0"
 	securityGroupResourceName2 := "aws_security_group.test.1"

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkInterface_basic(t *testing.T) {
+func TestAccVPCNetworkInterface_basic(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	subnetResourceName := "aws_subnet.test"
@@ -64,7 +64,7 @@ func TestAccEC2NetworkInterface_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ipv6(t *testing.T) {
+func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -109,7 +109,7 @@ func TestAccEC2NetworkInterface_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_tags(t *testing.T) {
+func TestAccVPCNetworkInterface_tags(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var conf ec2.NetworkInterface
@@ -155,7 +155,7 @@ func TestAccEC2NetworkInterface_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ipv6Count(t *testing.T) {
+func TestAccVPCNetworkInterface_ipv6Count(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -204,7 +204,7 @@ func TestAccEC2NetworkInterface_ipv6Count(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_disappears(t *testing.T) {
+func TestAccVPCNetworkInterface_disappears(t *testing.T) {
 	var networkInterface ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -227,7 +227,7 @@ func TestAccEC2NetworkInterface_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_description(t *testing.T) {
+func TestAccVPCNetworkInterface_description(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	subnetResourceName := "aws_subnet.test"
@@ -296,7 +296,7 @@ func TestAccEC2NetworkInterface_description(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_attachment(t *testing.T) {
+func TestAccVPCNetworkInterface_attachment(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -334,7 +334,7 @@ func TestAccEC2NetworkInterface_attachment(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ignoreExternalAttachment(t *testing.T) {
+func TestAccVPCNetworkInterface_ignoreExternalAttachment(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -362,7 +362,7 @@ func TestAccEC2NetworkInterface_ignoreExternalAttachment(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_sourceDestCheck(t *testing.T) {
+func TestAccVPCNetworkInterface_sourceDestCheck(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -404,7 +404,7 @@ func TestAccEC2NetworkInterface_sourceDestCheck(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_privateIPsCount(t *testing.T) {
+func TestAccVPCNetworkInterface_privateIPsCount(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -471,7 +471,7 @@ func TestAccEC2NetworkInterface_privateIPsCount(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENIInterfaceType_efa(t *testing.T) {
+func TestAccVPCNetworkInterface_ENIInterfaceType_efa(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -499,7 +499,7 @@ func TestAccEC2NetworkInterface_ENIInterfaceType_efa(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ipv4Prefix(t *testing.T) {
+func TestAccVPCNetworkInterface_ENI_ipv4Prefix(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -544,7 +544,7 @@ func TestAccEC2NetworkInterface_ENI_ipv4Prefix(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ipv4PrefixCount(t *testing.T) {
+func TestAccVPCNetworkInterface_ENI_ipv4PrefixCount(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -593,7 +593,7 @@ func TestAccEC2NetworkInterface_ENI_ipv4PrefixCount(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ipv6Prefix(t *testing.T) {
+func TestAccVPCNetworkInterface_ENI_ipv6Prefix(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -638,7 +638,7 @@ func TestAccEC2NetworkInterface_ENI_ipv6Prefix(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ipv6PrefixCount(t *testing.T) {
+func TestAccVPCNetworkInterface_ENI_ipv6PrefixCount(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -687,7 +687,7 @@ func TestAccEC2NetworkInterface_ENI_ipv6PrefixCount(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_privateIPSet(t *testing.T) {
+func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 	var networkInterface, lastInterface ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -778,7 +778,7 @@ func TestAccEC2NetworkInterface_privateIPSet(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_privateIPList(t *testing.T) {
+func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}

--- a/internal/service/ec2/vpc_network_interfaces_data_source_test.go
+++ b/internal/service/ec2/vpc_network_interfaces_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2NetworkInterfacesDataSource_filter(t *testing.T) {
+func TestAccVPCNetworkInterfacesDataSource_filter(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -29,7 +29,7 @@ func TestAccEC2NetworkInterfacesDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfacesDataSource_tags(t *testing.T) {
+func TestAccVPCNetworkInterfacesDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccEC2NetworkInterfacesDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfacesDataSource_empty(t *testing.T) {
+func TestAccVPCNetworkInterfacesDataSource_empty(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_peering_connection_accepter_test.go
+++ b/internal/service/ec2/vpc_peering_connection_accepter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCPeeringConnectionAccepter_sameRegionSameAccount(t *testing.T) {
+func TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	resourceNameMainVpc := "aws_vpc.main"                              // Requester
 	resourceNamePeerVpc := "aws_vpc.peer"                              // Accepter
@@ -65,7 +65,7 @@ func TestAccEC2VPCPeeringConnectionAccepter_sameRegionSameAccount(t *testing.T) 
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionAccepter_differentRegionSameAccount(t *testing.T) {
+func TestAccVPCPeeringConnectionAccepter_differentRegionSameAccount(t *testing.T) {
 	var vMain, vPeer ec2.VpcPeeringConnection
 	var providers []*schema.Provider
 	resourceNameMainVpc := "aws_vpc.main"                              // Requester
@@ -111,7 +111,7 @@ func TestAccEC2VPCPeeringConnectionAccepter_differentRegionSameAccount(t *testin
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionAccepter_sameRegionDifferentAccount(t *testing.T) {
+func TestAccVPCPeeringConnectionAccepter_sameRegionDifferentAccount(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	var providers []*schema.Provider
 	resourceNameMainVpc := "aws_vpc.main"                              // Requester
@@ -148,7 +148,7 @@ func TestAccEC2VPCPeeringConnectionAccepter_sameRegionDifferentAccount(t *testin
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionAccepter_differentRegionDifferentAccount(t *testing.T) {
+func TestAccVPCPeeringConnectionAccepter_differentRegionDifferentAccount(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	var providers []*schema.Provider
 	resourceNameMainVpc := "aws_vpc.main"                              // Requester

--- a/internal/service/ec2/vpc_peering_connection_accepter_test.go
+++ b/internal/service/ec2/vpc_peering_connection_accepter_test.go
@@ -92,7 +92,6 @@ func TestAccVPCPeeringConnectionAccepter_differentRegionSameAccount(t *testing.T
 					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_vpc_id", resourceNamePeerVpc, "id"),
 					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_owner_id", resourceNamePeerVpc, "owner_id"),
 					resource.TestCheckResourceAttr(resourceNameConnection, "peer_region", acctest.AlternateRegion()),
-					// ** TODO See TestAccAWSVPCPeeringConnectionAccepter_sameRegion()
 					// resource.TestCheckResourceAttrPair(resourceNameAccepter, "vpc_id", resourceNamePeerVpc, "id"),
 					// resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_vpc_id", resourceNameMainVpc, "id"),
 					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_owner_id", resourceNameMainVpc, "owner_id"),

--- a/internal/service/ec2/vpc_peering_connection_data_source_test.go
+++ b/internal/service/ec2/vpc_peering_connection_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCPeeringConnectionDataSource_cidrBlock(t *testing.T) {
+func TestAccVPCPeeringConnectionDataSource_cidrBlock(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpc_peering_connection.test"
 	resourceName := "aws_vpc_peering_connection.test"
@@ -32,7 +32,7 @@ func TestAccEC2VPCPeeringConnectionDataSource_cidrBlock(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionDataSource_id(t *testing.T) {
+func TestAccVPCPeeringConnectionDataSource_id(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpc_peering_connection.test"
 	resourceName := "aws_vpc_peering_connection.test"
@@ -72,7 +72,7 @@ func TestAccEC2VPCPeeringConnectionDataSource_id(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionDataSource_peerCIDRBlock(t *testing.T) {
+func TestAccVPCPeeringConnectionDataSource_peerCIDRBlock(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpc_peering_connection.test"
 	resourceName := "aws_vpc_peering_connection.test"
@@ -94,7 +94,7 @@ func TestAccEC2VPCPeeringConnectionDataSource_peerCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionDataSource_peerVPCID(t *testing.T) {
+func TestAccVPCPeeringConnectionDataSource_peerVPCID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpc_peering_connection.test"
 	resourceName := "aws_vpc_peering_connection.test"
@@ -115,7 +115,7 @@ func TestAccEC2VPCPeeringConnectionDataSource_peerVPCID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionDataSource_vpcID(t *testing.T) {
+func TestAccVPCPeeringConnectionDataSource_vpcID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpc_peering_connection.test"
 	resourceName := "aws_vpc_peering_connection.test"

--- a/internal/service/ec2/vpc_peering_connection_options_test.go
+++ b/internal/service/ec2/vpc_peering_connection_options_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2VPCPeeringConnectionOptions_basic(t *testing.T) {
+func TestAccVPCPeeringConnectionOptions_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection_options.test"
 	pcxResourceName := "aws_vpc_peering_connection.test"
@@ -104,7 +104,7 @@ func TestAccEC2VPCPeeringConnectionOptions_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionOptions_differentRegionSameAccount(t *testing.T) {
+func TestAccVPCPeeringConnectionOptions_differentRegionSameAccount(t *testing.T) {
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection_options.test"         // Requester
@@ -201,7 +201,7 @@ func TestAccEC2VPCPeeringConnectionOptions_differentRegionSameAccount(t *testing
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionOptions_sameRegionDifferentAccount(t *testing.T) {
+func TestAccVPCPeeringConnectionOptions_sameRegionDifferentAccount(t *testing.T) {
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection_options.test"     // Requester

--- a/internal/service/ec2/vpc_peering_connection_test.go
+++ b/internal/service/ec2/vpc_peering_connection_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPCPeeringConnection_basic(t *testing.T) {
+func TestAccVPCPeeringConnection_basic(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection.test"
@@ -48,7 +48,7 @@ func TestAccEC2VPCPeeringConnection_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnection_disappears(t *testing.T) {
+func TestAccVPCPeeringConnection_disappears(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection.test"
@@ -71,7 +71,7 @@ func TestAccEC2VPCPeeringConnection_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnection_tags(t *testing.T) {
+func TestAccVPCPeeringConnection_tags(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection.test"
@@ -119,7 +119,7 @@ func TestAccEC2VPCPeeringConnection_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnection_options(t *testing.T) {
+func TestAccVPCPeeringConnection_options(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection.test"
@@ -261,7 +261,7 @@ func TestAccEC2VPCPeeringConnection_options(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnection_failedState(t *testing.T) {
+func TestAccVPCPeeringConnection_failedState(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -278,7 +278,7 @@ func TestAccEC2VPCPeeringConnection_failedState(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
+func TestAccVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -299,7 +299,7 @@ func TestAccEC2VPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnection_region(t *testing.T) {
+func TestAccVPCPeeringConnection_region(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -333,7 +333,7 @@ func TestAccEC2VPCPeeringConnection_region(t *testing.T) {
 }
 
 // Tests the peering connection acceptance functionality for same region, same account.
-func TestAccEC2VPCPeeringConnection_accept(t *testing.T) {
+func TestAccVPCPeeringConnection_accept(t *testing.T) {
 	var v ec2.VpcPeeringConnection
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpc_peering_connection.test"
@@ -400,7 +400,7 @@ func TestAccEC2VPCPeeringConnection_accept(t *testing.T) {
 }
 
 // Tests that VPC peering connection options can't be set on non-active connection.
-func TestAccEC2VPCPeeringConnection_optionsNoAutoAccept(t *testing.T) {
+func TestAccVPCPeeringConnection_optionsNoAutoAccept(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_peering_connections_data_source_test.go
+++ b/internal/service/ec2/vpc_peering_connections_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCPeeringConnectionsDataSource_basic(t *testing.T) {
+func TestAccVPCPeeringConnectionsDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -28,7 +28,7 @@ func TestAccEC2VPCPeeringConnectionsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCPeeringConnectionsDataSource_NoMatches(t *testing.T) {
+func TestAccVPCPeeringConnectionsDataSource_NoMatches(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_prefix_list_data_source_test.go
@@ -15,7 +15,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2PrefixListDataSource_basic(t *testing.T) {
+func TestAccVPCPrefixListDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -32,7 +32,7 @@ func TestAccEC2PrefixListDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2PrefixListDataSource_filter(t *testing.T) {
+func TestAccVPCPrefixListDataSource_filter(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -49,7 +49,7 @@ func TestAccEC2PrefixListDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2PrefixListDataSource_nameDoesNotOverrideFilter(t *testing.T) {
+func TestAccVPCPrefixListDataSource_nameDoesNotOverrideFilter(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),

--- a/internal/service/ec2/vpc_route_data_source_test.go
+++ b/internal/service/ec2/vpc_route_data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2RouteDataSource_basic(t *testing.T) {
+func TestAccVPCRouteDataSource_basic(t *testing.T) {
 	instanceRouteResourceName := "aws_route.instance"
 	pcxRouteResourceName := "aws_route.vpc_peering_connection"
 	rtResourceName := "aws_route_table.test"
@@ -49,7 +49,7 @@ func TestAccEC2RouteDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteDataSource_transitGatewayID(t *testing.T) {
+func TestAccVPCRouteDataSource_transitGatewayID(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -76,7 +76,7 @@ func TestAccEC2RouteDataSource_transitGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteDataSource_ipv6DestinationCIDR(t *testing.T) {
+func TestAccVPCRouteDataSource_ipv6DestinationCIDR(t *testing.T) {
 	dataSourceName := "data.aws_route.test"
 	resourceName := "aws_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -98,7 +98,7 @@ func TestAccEC2RouteDataSource_ipv6DestinationCIDR(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteDataSource_localGatewayID(t *testing.T) {
+func TestAccVPCRouteDataSource_localGatewayID(t *testing.T) {
 	dataSourceName := "data.aws_route.by_local_gateway_id"
 	resourceName := "aws_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -121,7 +121,7 @@ func TestAccEC2RouteDataSource_localGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteDataSource_carrierGatewayID(t *testing.T) {
+func TestAccVPCRouteDataSource_carrierGatewayID(t *testing.T) {
 	dataSourceName := "data.aws_route.test"
 	resourceName := "aws_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -144,7 +144,7 @@ func TestAccEC2RouteDataSource_carrierGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteDataSource_destinationPrefixListID(t *testing.T) {
+func TestAccVPCRouteDataSource_destinationPrefixListID(t *testing.T) {
 	dataSourceName := "data.aws_route.test"
 	resourceName := "aws_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -167,7 +167,7 @@ func TestAccEC2RouteDataSource_destinationPrefixListID(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteDataSource_gatewayVPCEndpoint(t *testing.T) {
+func TestAccVPCRouteDataSource_gatewayVPCEndpoint(t *testing.T) {
 	var routeTable ec2.RouteTable
 	var vpce ec2.VpcEndpoint
 	rtResourceName := "aws_route_table.test"

--- a/internal/service/ec2/vpc_route_table_association_test.go
+++ b/internal/service/ec2/vpc_route_table_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2RouteTableAssociation_Subnet_basic(t *testing.T) {
+func TestAccVPCRouteTableAssociation_Subnet_basic(t *testing.T) {
 	var rta ec2.RouteTableAssociation
 	resourceName := "aws_route_table_association.test"
 	resourceNameRouteTable := "aws_route_table.test"
@@ -45,7 +45,7 @@ func TestAccEC2RouteTableAssociation_Subnet_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTableAssociation_Subnet_changeRouteTable(t *testing.T) {
+func TestAccVPCRouteTableAssociation_Subnet_changeRouteTable(t *testing.T) {
 	var rta ec2.RouteTableAssociation
 	resourceName := "aws_route_table_association.test"
 	resourceNameRouteTable1 := "aws_route_table.test"
@@ -79,7 +79,7 @@ func TestAccEC2RouteTableAssociation_Subnet_changeRouteTable(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTableAssociation_Gateway_basic(t *testing.T) {
+func TestAccVPCRouteTableAssociation_Gateway_basic(t *testing.T) {
 	var rta ec2.RouteTableAssociation
 	resourceName := "aws_route_table_association.test"
 	resourceNameRouteTable := "aws_route_table.test"
@@ -110,7 +110,7 @@ func TestAccEC2RouteTableAssociation_Gateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTableAssociation_Gateway_changeRouteTable(t *testing.T) {
+func TestAccVPCRouteTableAssociation_Gateway_changeRouteTable(t *testing.T) {
 	var rta ec2.RouteTableAssociation
 	resourceName := "aws_route_table_association.test"
 	resourceNameRouteTable1 := "aws_route_table.test"
@@ -144,7 +144,7 @@ func TestAccEC2RouteTableAssociation_Gateway_changeRouteTable(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTableAssociation_disappears(t *testing.T) {
+func TestAccVPCRouteTableAssociation_disappears(t *testing.T) {
 	var rta ec2.RouteTableAssociation
 	resourceName := "aws_route_table_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_route_table_data_source_test.go
+++ b/internal/service/ec2/vpc_route_table_data_source_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2RouteTableDataSource_basic(t *testing.T) {
+func TestAccVPCRouteTableDataSource_basic(t *testing.T) {
 	rtResourceName := "aws_route_table.test"
 	snResourceName := "aws_subnet.test"
 	vpcResourceName := "aws_vpc.test"
@@ -98,7 +98,7 @@ func TestAccEC2RouteTableDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTableDataSource_main(t *testing.T) {
+func TestAccVPCRouteTableDataSource_main(t *testing.T) {
 	datasourceName := "data.aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_route_table_test.go
+++ b/internal/service/ec2/vpc_route_table_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2RouteTable_basic(t *testing.T) {
+func TestAccVPCRouteTable_basic(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -49,7 +49,7 @@ func TestAccEC2RouteTable_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_disappears(t *testing.T) {
+func TestAccVPCRouteTable_disappears(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -72,7 +72,7 @@ func TestAccEC2RouteTable_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_Disappears_subnetAssociation(t *testing.T) {
+func TestAccVPCRouteTable_Disappears_subnetAssociation(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -95,7 +95,7 @@ func TestAccEC2RouteTable_Disappears_subnetAssociation(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToInternetGateway(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToInternetGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -149,7 +149,7 @@ func TestAccEC2RouteTable_ipv4ToInternetGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToInstance(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToInstance(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	instanceResourceName := "aws_instance.test"
@@ -185,7 +185,7 @@ func TestAccEC2RouteTable_ipv4ToInstance(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
+func TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	eoigwResourceName := "aws_egress_only_internet_gateway.test"
@@ -226,7 +226,7 @@ func TestAccEC2RouteTable_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_tags(t *testing.T) {
+func TestAccVPCRouteTable_tags(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -271,7 +271,7 @@ func TestAccEC2RouteTable_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_requireRouteDestination(t *testing.T) {
+func TestAccVPCRouteTable_requireRouteDestination(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -292,7 +292,7 @@ func TestAccEC2RouteTable_requireRouteDestination(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_requireRouteTarget(t *testing.T) {
+func TestAccVPCRouteTable_requireRouteTarget(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -309,7 +309,7 @@ func TestAccEC2RouteTable_requireRouteTarget(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_Route_mode(t *testing.T) {
+func TestAccVPCRouteTable_Route_mode(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -385,7 +385,7 @@ func TestAccEC2RouteTable_Route_mode(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToTransitGateway(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToTransitGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -425,7 +425,7 @@ func TestAccEC2RouteTable_ipv4ToTransitGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToVPCEndpoint(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -465,7 +465,7 @@ func TestAccEC2RouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToCarrierGateway(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToCarrierGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	cgwResourceName := "aws_ec2_carrier_gateway.test"
@@ -501,7 +501,7 @@ func TestAccEC2RouteTable_ipv4ToCarrierGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToLocalGateway(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToLocalGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	lgwDataSourceName := "data.aws_ec2_local_gateway.first"
@@ -537,7 +537,7 @@ func TestAccEC2RouteTable_ipv4ToLocalGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToVPCPeeringConnection(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToVPCPeeringConnection(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	pcxResourceName := "aws_vpc_peering_connection.test"
@@ -573,7 +573,7 @@ func TestAccEC2RouteTable_ipv4ToVPCPeeringConnection(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_vgwRoutePropagation(t *testing.T) {
+func TestAccVPCRouteTable_vgwRoutePropagation(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	vgwResourceName1 := "aws_vpn_gateway.test1"
@@ -623,7 +623,7 @@ func TestAccEC2RouteTable_vgwRoutePropagation(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_conditionalCIDRBlock(t *testing.T) {
+func TestAccVPCRouteTable_conditionalCIDRBlock(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -660,7 +660,7 @@ func TestAccEC2RouteTable_conditionalCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_ipv4ToNatGateway(t *testing.T) {
+func TestAccVPCRouteTable_ipv4ToNatGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	ngwResourceName := "aws_nat_gateway.test"
@@ -696,7 +696,7 @@ func TestAccEC2RouteTable_ipv4ToNatGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_IPv6ToNetworkInterface_unattached(t *testing.T) {
+func TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	eniResourceName := "aws_network_interface.test"
@@ -732,7 +732,7 @@ func TestAccEC2RouteTable_IPv6ToNetworkInterface_unattached(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
+func TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	eni1ResourceName := "aws_network_interface.test1"
@@ -811,7 +811,7 @@ func TestAccEC2RouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_vpcMultipleCIDRs(t *testing.T) {
+func TestAccVPCRouteTable_vpcMultipleCIDRs(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -844,7 +844,7 @@ func TestAccEC2RouteTable_vpcMultipleCIDRs(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_vpcClassicLink(t *testing.T) {
+func TestAccVPCRouteTable_vpcClassicLink(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -877,7 +877,7 @@ func TestAccEC2RouteTable_vpcClassicLink(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_gatewayVPCEndpoint(t *testing.T) {
+func TestAccVPCRouteTable_gatewayVPCEndpoint(t *testing.T) {
 	var routeTable ec2.RouteTable
 	var vpce ec2.VpcEndpoint
 	resourceName := "aws_route_table.test"
@@ -916,7 +916,7 @@ func TestAccEC2RouteTable_gatewayVPCEndpoint(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_multipleRoutes(t *testing.T) {
+func TestAccVPCRouteTable_multipleRoutes(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	eoigwResourceName := "aws_egress_only_internet_gateway.test"
@@ -1001,7 +1001,7 @@ func TestAccEC2RouteTable_multipleRoutes(t *testing.T) {
 	})
 }
 
-func TestAccEC2RouteTable_prefixListToInternetGateway(t *testing.T) {
+func TestAccVPCRouteTable_prefixListToInternetGateway(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"

--- a/internal/service/ec2/vpc_route_tables_data_source_test.go
+++ b/internal/service/ec2/vpc_route_tables_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2RouteTablesDataSource_basic(t *testing.T) {
+func TestAccVPCRouteTablesDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_route_test.go
+++ b/internal/service/ec2/vpc_route_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // IPv4 to Internet Gateway.
-func TestAccEC2Route_basic(t *testing.T) {
+func TestAccVPCRoute_basic(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route.test"
@@ -66,7 +66,7 @@ func TestAccEC2Route_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_disappears(t *testing.T) {
+func TestAccVPCRoute_disappears(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -90,7 +90,7 @@ func TestAccEC2Route_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_Disappears_routeTable(t *testing.T) {
+func TestAccVPCRoute_Disappears_routeTable(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	rtResourceName := "aws_route_table.test"
@@ -115,7 +115,7 @@ func TestAccEC2Route_Disappears_routeTable(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
+func TestAccVPCRoute_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eoigwResourceName := "aws_egress_only_internet_gateway.test"
@@ -166,7 +166,7 @@ func TestAccEC2Route_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToInternetGateway(t *testing.T) {
+func TestAccVPCRoute_ipv6ToInternetGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -212,7 +212,7 @@ func TestAccEC2Route_ipv6ToInternetGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToInstance(t *testing.T) {
+func TestAccVPCRoute_ipv6ToInstance(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	instanceResourceName := "aws_instance.test"
@@ -258,7 +258,7 @@ func TestAccEC2Route_ipv6ToInstance(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_IPv6ToNetworkInterface_unattached(t *testing.T) {
+func TestAccVPCRoute_IPv6ToNetworkInterface_unattached(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eniResourceName := "aws_network_interface.test"
@@ -304,7 +304,7 @@ func TestAccEC2Route_IPv6ToNetworkInterface_unattached(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToVPCPeeringConnection(t *testing.T) {
+func TestAccVPCRoute_ipv6ToVPCPeeringConnection(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	pcxResourceName := "aws_vpc_peering_connection.test"
@@ -350,7 +350,7 @@ func TestAccEC2Route_ipv6ToVPCPeeringConnection(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToVPNGateway(t *testing.T) {
+func TestAccVPCRoute_ipv6ToVPNGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	vgwResourceName := "aws_vpn_gateway.test"
@@ -396,7 +396,7 @@ func TestAccEC2Route_ipv6ToVPNGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToVPNGateway(t *testing.T) {
+func TestAccVPCRoute_ipv4ToVPNGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	vgwResourceName := "aws_vpn_gateway.test"
@@ -442,7 +442,7 @@ func TestAccEC2Route_ipv4ToVPNGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToInstance(t *testing.T) {
+func TestAccVPCRoute_ipv4ToInstance(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	instanceResourceName := "aws_instance.test"
@@ -488,7 +488,7 @@ func TestAccEC2Route_ipv4ToInstance(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_IPv4ToNetworkInterface_unattached(t *testing.T) {
+func TestAccVPCRoute_IPv4ToNetworkInterface_unattached(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eniResourceName := "aws_network_interface.test"
@@ -534,7 +534,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_unattached(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_IPv4ToNetworkInterface_attached(t *testing.T) {
+func TestAccVPCRoute_IPv4ToNetworkInterface_attached(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eniResourceName := "aws_network_interface.test"
@@ -581,7 +581,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_attached(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
+func TestAccVPCRoute_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eni1ResourceName := "aws_network_interface.test1"
@@ -652,7 +652,7 @@ func TestAccEC2Route_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToVPCPeeringConnection(t *testing.T) {
+func TestAccVPCRoute_ipv4ToVPCPeeringConnection(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	pcxResourceName := "aws_vpc_peering_connection.test"
@@ -698,7 +698,7 @@ func TestAccEC2Route_ipv4ToVPCPeeringConnection(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToNatGateway(t *testing.T) {
+func TestAccVPCRoute_ipv4ToNatGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	ngwResourceName := "aws_nat_gateway.test"
@@ -744,7 +744,7 @@ func TestAccEC2Route_ipv4ToNatGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToNatGateway(t *testing.T) {
+func TestAccVPCRoute_ipv6ToNatGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	ngwResourceName := "aws_nat_gateway.test"
@@ -790,7 +790,7 @@ func TestAccEC2Route_ipv6ToNatGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_doesNotCrashWithVPCEndpoint(t *testing.T) {
+func TestAccVPCRoute_doesNotCrashWithVPCEndpoint(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
 	resourceName := "aws_route.test"
@@ -821,7 +821,7 @@ func TestAccEC2Route_doesNotCrashWithVPCEndpoint(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToTransitGateway(t *testing.T) {
+func TestAccVPCRoute_ipv4ToTransitGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -871,7 +871,7 @@ func TestAccEC2Route_ipv4ToTransitGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToTransitGateway(t *testing.T) {
+func TestAccVPCRoute_ipv6ToTransitGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -921,7 +921,7 @@ func TestAccEC2Route_ipv6ToTransitGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToCarrierGateway(t *testing.T) {
+func TestAccVPCRoute_ipv4ToCarrierGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	cgwResourceName := "aws_ec2_carrier_gateway.test"
@@ -967,7 +967,7 @@ func TestAccEC2Route_ipv4ToCarrierGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToLocalGateway(t *testing.T) {
+func TestAccVPCRoute_ipv4ToLocalGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	localGatewayDataSourceName := "data.aws_ec2_local_gateway.first"
@@ -1013,7 +1013,7 @@ func TestAccEC2Route_ipv4ToLocalGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv6ToLocalGateway(t *testing.T) {
+func TestAccVPCRoute_ipv6ToLocalGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	localGatewayDataSourceName := "data.aws_ec2_local_gateway.first"
@@ -1059,7 +1059,7 @@ func TestAccEC2Route_ipv6ToLocalGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_conditionalCIDRBlock(t *testing.T) {
+func TestAccVPCRoute_conditionalCIDRBlock(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1098,7 +1098,7 @@ func TestAccEC2Route_conditionalCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_IPv4Update_target(t *testing.T) {
+func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -1317,7 +1317,7 @@ func TestAccEC2Route_IPv4Update_target(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_IPv6Update_target(t *testing.T) {
+func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -1487,7 +1487,7 @@ func TestAccEC2Route_IPv6Update_target(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_ipv4ToVPCEndpoint(t *testing.T) {
+func TestAccVPCRoute_ipv4ToVPCEndpoint(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -1538,7 +1538,7 @@ func TestAccEC2Route_ipv4ToVPCEndpoint(t *testing.T) {
 }
 
 // https://github.com/hashicorp/terraform-provider-aws/issues/11455.
-func TestAccEC2Route_localRoute(t *testing.T) {
+func TestAccVPCRoute_localRoute(t *testing.T) {
 	var routeTable ec2.RouteTable
 	var vpc ec2.Vpc
 	resourceName := "aws_route.test"
@@ -1577,7 +1577,7 @@ func TestAccEC2Route_localRoute(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToInternetGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToInternetGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	igwResourceName := "aws_internet_gateway.test"
@@ -1623,7 +1623,7 @@ func TestAccEC2Route_prefixListToInternetGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToVPNGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToVPNGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	vgwResourceName := "aws_vpn_gateway.test"
@@ -1669,7 +1669,7 @@ func TestAccEC2Route_prefixListToVPNGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToInstance(t *testing.T) {
+func TestAccVPCRoute_prefixListToInstance(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	instanceResourceName := "aws_instance.test"
@@ -1715,7 +1715,7 @@ func TestAccEC2Route_prefixListToInstance(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_PrefixListToNetworkInterface_unattached(t *testing.T) {
+func TestAccVPCRoute_PrefixListToNetworkInterface_unattached(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eniResourceName := "aws_network_interface.test"
@@ -1761,7 +1761,7 @@ func TestAccEC2Route_PrefixListToNetworkInterface_unattached(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_PrefixListToNetworkInterface_attached(t *testing.T) {
+func TestAccVPCRoute_PrefixListToNetworkInterface_attached(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eniResourceName := "aws_network_interface.test"
@@ -1808,7 +1808,7 @@ func TestAccEC2Route_PrefixListToNetworkInterface_attached(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToVPCPeeringConnection(t *testing.T) {
+func TestAccVPCRoute_prefixListToVPCPeeringConnection(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	pcxResourceName := "aws_vpc_peering_connection.test"
@@ -1854,7 +1854,7 @@ func TestAccEC2Route_prefixListToVPCPeeringConnection(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToNatGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToNatGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	ngwResourceName := "aws_nat_gateway.test"
@@ -1900,7 +1900,7 @@ func TestAccEC2Route_prefixListToNatGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToTransitGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToTransitGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -1950,7 +1950,7 @@ func TestAccEC2Route_prefixListToTransitGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToCarrierGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToCarrierGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	cgwResourceName := "aws_ec2_carrier_gateway.test"
@@ -2000,7 +2000,7 @@ func TestAccEC2Route_prefixListToCarrierGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToLocalGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToLocalGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	localGatewayDataSourceName := "data.aws_ec2_local_gateway.first"
@@ -2050,7 +2050,7 @@ func TestAccEC2Route_prefixListToLocalGateway(t *testing.T) {
 	})
 }
 
-func TestAccEC2Route_prefixListToEgressOnlyInternetGateway(t *testing.T) {
+func TestAccVPCRoute_prefixListToEgressOnlyInternetGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
 	eoigwResourceName := "aws_egress_only_internet_gateway.test"

--- a/internal/service/ec2/vpc_security_group_data_source_test.go
+++ b/internal/service/ec2/vpc_security_group_data_source_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2SecurityGroupDataSource_basic(t *testing.T) {
+func TestAccVPCSecurityGroupDataSource_basic(t *testing.T) {
 	rInt := sdkacctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -113,7 +113,7 @@ func TestIpPermissionIDHash(t *testing.T) {
 	}
 }
 
-func TestAccEC2SecurityGroupRule_Ingress_vpc(t *testing.T) {
+func TestAccVPCSecurityGroupRule_Ingress_vpc(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -158,7 +158,7 @@ func TestAccEC2SecurityGroupRule_Ingress_vpc(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id(t *testing.T) {
+func TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	rInt := sdkacctest.RandInt()
@@ -193,7 +193,7 @@ func TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_Ingress_protocol(t *testing.T) {
+func TestAccVPCSecurityGroupRule_Ingress_protocol(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testRuleCount := func(*terraform.State) error {
@@ -237,7 +237,7 @@ func TestAccEC2SecurityGroupRule_Ingress_protocol(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_Ingress_icmpv6(t *testing.T) {
+func TestAccVPCSecurityGroupRule_Ingress_icmpv6(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group_rule.test"
 	sgResourceName := "aws_security_group.test"
@@ -270,7 +270,7 @@ func TestAccEC2SecurityGroupRule_Ingress_icmpv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_Ingress_ipv6(t *testing.T) {
+func TestAccVPCSecurityGroupRule_Ingress_ipv6(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testRuleCount := func(*terraform.State) error {
@@ -317,7 +317,7 @@ func TestAccEC2SecurityGroupRule_Ingress_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_Ingress_classic(t *testing.T) {
+func TestAccVPCSecurityGroupRule_Ingress_classic(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -362,7 +362,7 @@ func TestAccEC2SecurityGroupRule_Ingress_classic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_multiIngress(t *testing.T) {
+func TestAccVPCSecurityGroupRule_multiIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testMultiRuleCount := func(*terraform.State) error {
@@ -409,7 +409,7 @@ func TestAccEC2SecurityGroupRule_multiIngress(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_egress(t *testing.T) {
+func TestAccVPCSecurityGroupRule_egress(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -436,7 +436,7 @@ func TestAccEC2SecurityGroupRule_egress(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_selfReference(t *testing.T) {
+func TestAccVPCSecurityGroupRule_selfReference(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -461,7 +461,7 @@ func TestAccEC2SecurityGroupRule_selfReference(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_expectInvalidTypeError(t *testing.T) {
+func TestAccVPCSecurityGroupRule_expectInvalidTypeError(t *testing.T) {
 	rInt := sdkacctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -477,7 +477,7 @@ func TestAccEC2SecurityGroupRule_expectInvalidTypeError(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_expectInvalidCIDR(t *testing.T) {
+func TestAccVPCSecurityGroupRule_expectInvalidCIDR(t *testing.T) {
 	rInt := sdkacctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -498,7 +498,7 @@ func TestAccEC2SecurityGroupRule_expectInvalidCIDR(t *testing.T) {
 }
 
 // testing partial match implementation
-func TestAccEC2SecurityGroupRule_PartialMatching_basic(t *testing.T) {
+func TestAccVPCSecurityGroupRule_PartialMatching_basic(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -559,7 +559,7 @@ func TestAccEC2SecurityGroupRule_PartialMatching_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_PartialMatching_source(t *testing.T) {
+func TestAccVPCSecurityGroupRule_PartialMatching_source(t *testing.T) {
 	var group ec2.SecurityGroup
 	var nat ec2.SecurityGroup
 	var p ec2.IpPermission
@@ -610,7 +610,7 @@ func TestAccEC2SecurityGroupRule_PartialMatching_source(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_issue5310(t *testing.T) {
+func TestAccVPCSecurityGroupRule_issue5310(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -635,7 +635,7 @@ func TestAccEC2SecurityGroupRule_issue5310(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_race(t *testing.T) {
+func TestAccVPCSecurityGroupRule_race(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -654,7 +654,7 @@ func TestAccEC2SecurityGroupRule_race(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_selfSource(t *testing.T) {
+func TestAccVPCSecurityGroupRule_selfSource(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -680,7 +680,7 @@ func TestAccEC2SecurityGroupRule_selfSource(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_prefixListEgress(t *testing.T) {
+func TestAccVPCSecurityGroupRule_prefixListEgress(t *testing.T) {
 	var group ec2.SecurityGroup
 	var endpoint ec2.VpcEndpoint
 	var p ec2.IpPermission
@@ -743,7 +743,7 @@ func TestAccEC2SecurityGroupRule_prefixListEgress(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_ingressDescription(t *testing.T) {
+func TestAccVPCSecurityGroupRule_ingressDescription(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -771,7 +771,7 @@ func TestAccEC2SecurityGroupRule_ingressDescription(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_egressDescription(t *testing.T) {
+func TestAccVPCSecurityGroupRule_egressDescription(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -799,7 +799,7 @@ func TestAccEC2SecurityGroupRule_egressDescription(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_IngressDescription_updates(t *testing.T) {
+func TestAccVPCSecurityGroupRule_IngressDescription_updates(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -836,7 +836,7 @@ func TestAccEC2SecurityGroupRule_IngressDescription_updates(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_EgressDescription_updates(t *testing.T) {
+func TestAccVPCSecurityGroupRule_EgressDescription_updates(t *testing.T) {
 	var group ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()
 
@@ -873,7 +873,7 @@ func TestAccEC2SecurityGroupRule_EgressDescription_updates(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_Description_allPorts(t *testing.T) {
+func TestAccVPCSecurityGroupRule_Description_allPorts(t *testing.T) {
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	securityGroupResourceName := "aws_security_group.test"
@@ -931,7 +931,7 @@ func TestAccEC2SecurityGroupRule_Description_allPorts(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts(t *testing.T) {
+func TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts(t *testing.T) {
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	securityGroupResourceName := "aws_security_group.test"
@@ -990,7 +990,7 @@ func TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts(t *testing.T) 
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6416
-func TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash(t *testing.T) {
+func TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash(t *testing.T) {
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	securityGroupResourceName := "aws_security_group.test"
@@ -1037,7 +1037,7 @@ func TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash(t *testi
 	})
 }
 
-func TestAccEC2SecurityGroupRule_multiDescription(t *testing.T) {
+func TestAccVPCSecurityGroupRule_multiDescription(t *testing.T) {
 	var group ec2.SecurityGroup
 	var nat ec2.SecurityGroup
 	rInt := sdkacctest.RandInt()

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -496,7 +496,7 @@ func TestSecurityGroupIPPermGather(t *testing.T) {
 	}
 }
 
-func TestAccEC2SecurityGroup_allowAll(t *testing.T) {
+func TestAccVPCSecurityGroup_allowAll(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -522,7 +522,7 @@ func TestAccEC2SecurityGroup_allowAll(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_sourceSecurityGroup(t *testing.T) {
+func TestAccVPCSecurityGroup_sourceSecurityGroup(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -548,7 +548,7 @@ func TestAccEC2SecurityGroup_sourceSecurityGroup(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules(t *testing.T) {
+func TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -574,7 +574,7 @@ func TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules(t *testing.T) 
 	})
 }
 
-func TestAccEC2SecurityGroup_ipRangesWithSameRules(t *testing.T) {
+func TestAccVPCSecurityGroup_ipRangesWithSameRules(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -600,7 +600,7 @@ func TestAccEC2SecurityGroup_ipRangesWithSameRules(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_basic(t *testing.T) {
+func TestAccVPCSecurityGroup_basic(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -643,7 +643,7 @@ func TestAccEC2SecurityGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_disappears(t *testing.T) {
+func TestAccVPCSecurityGroup_disappears(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -665,7 +665,7 @@ func TestAccEC2SecurityGroup_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_egressMode(t *testing.T) {
+func TestAccVPCSecurityGroup_egressMode(t *testing.T) {
 	var securityGroup1, securityGroup2, securityGroup3 ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -706,7 +706,7 @@ func TestAccEC2SecurityGroup_egressMode(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ingressMode(t *testing.T) {
+func TestAccVPCSecurityGroup_ingressMode(t *testing.T) {
 	var securityGroup1, securityGroup2, securityGroup3 ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -747,7 +747,7 @@ func TestAccEC2SecurityGroup_ingressMode(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ruleGathering(t *testing.T) {
+func TestAccVPCSecurityGroup_ruleGathering(t *testing.T) {
 	var group ec2.SecurityGroup
 	sgName := fmt.Sprintf("tf-acc-security-group-%s", sdkacctest.RandString(7))
 	resourceName := "aws_security_group.test"
@@ -852,7 +852,7 @@ func TestAccEC2SecurityGroup_ruleGathering(t *testing.T) {
 // 'aws_vpc' and 'aws_security_group' that cleans these up, however, the test is
 // written to allow Terraform to clean it up because we do go and revoke the
 // cyclic rules that were added.
-func TestAccEC2SecurityGroup_forceRevokeRulesTrue(t *testing.T) {
+func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 	var primary ec2.SecurityGroup
 	var secondary ec2.SecurityGroup
 	resourceName := "aws_security_group.primary"
@@ -932,7 +932,7 @@ func TestAccEC2SecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_forceRevokeRulesFalse(t *testing.T) {
+func TestAccVPCSecurityGroup_forceRevokeRulesFalse(t *testing.T) {
 	var primary ec2.SecurityGroup
 	var secondary ec2.SecurityGroup
 	resourceName := "aws_security_group.primary"
@@ -994,7 +994,7 @@ func TestAccEC2SecurityGroup_forceRevokeRulesFalse(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ipv6(t *testing.T) {
+func TestAccVPCSecurityGroup_ipv6(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1046,7 +1046,7 @@ func TestAccEC2SecurityGroup_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_Name_generated(t *testing.T) {
+func TestAccVPCSecurityGroup_Name_generated(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1075,7 +1075,7 @@ func TestAccEC2SecurityGroup_Name_generated(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17017
-func TestAccEC2SecurityGroup_Name_terraformPrefix(t *testing.T) {
+func TestAccVPCSecurityGroup_Name_terraformPrefix(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1103,7 +1103,7 @@ func TestAccEC2SecurityGroup_Name_terraformPrefix(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_namePrefix(t *testing.T) {
+func TestAccVPCSecurityGroup_namePrefix(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1132,7 +1132,7 @@ func TestAccEC2SecurityGroup_namePrefix(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17017
-func TestAccEC2SecurityGroup_NamePrefix_terraformPrefix(t *testing.T) {
+func TestAccVPCSecurityGroup_NamePrefix_terraformPrefix(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1161,7 +1161,7 @@ func TestAccEC2SecurityGroup_NamePrefix_terraformPrefix(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23708
-func TestAccEC2SecurityGroup_name_change(t *testing.T) {
+func TestAccVPCSecurityGroup_name_change(t *testing.T) {
 	var group ec2.SecurityGroup
 	var instance ec2.Instance
 	sgResourceName := "aws_security_group.test"
@@ -1213,7 +1213,7 @@ func TestAccEC2SecurityGroup_name_change(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_self(t *testing.T) {
+func TestAccVPCSecurityGroup_self(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1262,7 +1262,7 @@ func TestAccEC2SecurityGroup_self(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_vpc(t *testing.T) {
+func TestAccVPCSecurityGroup_vpc(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1306,7 +1306,7 @@ func TestAccEC2SecurityGroup_vpc(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_vpcNegOneIngress(t *testing.T) {
+func TestAccVPCSecurityGroup_vpcNegOneIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1343,7 +1343,7 @@ func TestAccEC2SecurityGroup_vpcNegOneIngress(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_vpcProtoNumIngress(t *testing.T) {
+func TestAccVPCSecurityGroup_vpcProtoNumIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1379,7 +1379,7 @@ func TestAccEC2SecurityGroup_vpcProtoNumIngress(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_multiIngress(t *testing.T) {
+func TestAccVPCSecurityGroup_multiIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1405,7 +1405,7 @@ func TestAccEC2SecurityGroup_multiIngress(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_change(t *testing.T) {
+func TestAccVPCSecurityGroup_change(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1438,7 +1438,7 @@ func TestAccEC2SecurityGroup_change(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ruleDescription(t *testing.T) {
+func TestAccVPCSecurityGroup_ruleDescription(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1550,7 +1550,7 @@ func TestAccEC2SecurityGroup_ruleDescription(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_defaultEgressVPC(t *testing.T) {
+func TestAccVPCSecurityGroup_defaultEgressVPC(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	// VPC
@@ -1576,7 +1576,7 @@ func TestAccEC2SecurityGroup_defaultEgressVPC(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_defaultEgressClassic(t *testing.T) {
+func TestAccVPCSecurityGroup_defaultEgressClassic(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1605,7 +1605,7 @@ func TestAccEC2SecurityGroup_defaultEgressClassic(t *testing.T) {
 }
 
 // Testing drift detection with groups containing the same port and types
-func TestAccEC2SecurityGroup_drift(t *testing.T) {
+func TestAccVPCSecurityGroup_drift(t *testing.T) {
 	resourceName := "aws_security_group.test"
 	var group ec2.SecurityGroup
 
@@ -1659,7 +1659,7 @@ func TestAccEC2SecurityGroup_drift(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_driftComplex(t *testing.T) {
+func TestAccVPCSecurityGroup_driftComplex(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1737,7 +1737,7 @@ func TestAccEC2SecurityGroup_driftComplex(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_invalidCIDRBlock(t *testing.T) {
+func TestAccVPCSecurityGroup_invalidCIDRBlock(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -1764,7 +1764,7 @@ func TestAccEC2SecurityGroup_invalidCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_tags(t *testing.T) {
+func TestAccVPCSecurityGroup_tags(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1810,7 +1810,7 @@ func TestAccEC2SecurityGroup_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_cidrAndGroups(t *testing.T) {
+func TestAccVPCSecurityGroup_cidrAndGroups(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1837,7 +1837,7 @@ func TestAccEC2SecurityGroup_cidrAndGroups(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC(t *testing.T) {
+func TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1889,7 +1889,7 @@ func TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic(t *testing.T) {
+func TestAccVPCSecurityGroup_ingressWithCIDRAndSGsClassic(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1930,7 +1930,7 @@ func TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_egressWithPrefixList(t *testing.T) {
+func TestAccVPCSecurityGroup_egressWithPrefixList(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1958,7 +1958,7 @@ func TestAccEC2SecurityGroup_egressWithPrefixList(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ingressWithPrefixList(t *testing.T) {
+func TestAccVPCSecurityGroup_ingressWithPrefixList(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -1986,7 +1986,7 @@ func TestAccEC2SecurityGroup_ingressWithPrefixList(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ipv4AndIPv6Egress(t *testing.T) {
+func TestAccVPCSecurityGroup_ipv4AndIPv6Egress(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
 
@@ -2515,7 +2515,7 @@ func testAccCheckSecurityGroupExistsWithoutDefault(n string) resource.TestCheckF
 	}
 }
 
-func TestAccEC2SecurityGroup_failWithDiffMismatch(t *testing.T) {
+func TestAccVPCSecurityGroup_failWithDiffMismatch(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	resourceName := "aws_security_group.nat"
@@ -2538,7 +2538,7 @@ func TestAccEC2SecurityGroup_failWithDiffMismatch(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ruleLimitExceededAppend(t *testing.T) {
+func TestAccVPCSecurityGroup_ruleLimitExceededAppend(t *testing.T) {
 	ruleLimit := testAccSecurityGroupRulesPerGroupLimitFromEnv()
 
 	var group ec2.SecurityGroup
@@ -2585,7 +2585,7 @@ func TestAccEC2SecurityGroup_ruleLimitExceededAppend(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend(t *testing.T) {
+func TestAccVPCSecurityGroup_ruleLimitCIDRBlockExceededAppend(t *testing.T) {
 	ruleLimit := testAccSecurityGroupRulesPerGroupLimitFromEnv()
 
 	var group ec2.SecurityGroup
@@ -2646,7 +2646,7 @@ func TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
+func TestAccVPCSecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
 	ruleLimit := testAccSecurityGroupRulesPerGroupLimitFromEnv()
 
 	var group ec2.SecurityGroup
@@ -2691,7 +2691,7 @@ func TestAccEC2SecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
+func TestAccVPCSecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
 	ruleLimit := testAccSecurityGroupRulesPerGroupLimitFromEnv()
 
 	var group ec2.SecurityGroup
@@ -2736,7 +2736,7 @@ func TestAccEC2SecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroup_rulesDropOnError(t *testing.T) {
+func TestAccVPCSecurityGroup_rulesDropOnError(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	resourceName := "aws_security_group.test"

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -2049,7 +2049,7 @@ func testAccSecurityGroupCheckVPCIDExists(group *ec2.SecurityGroup) resource.Tes
 
 // cycleIpPermForGroup returns an IpPermission struct with a configured
 // UserIdGroupPair for the groupid given. Used in
-// TestAccAWSSecurityGroup_forceRevokeRules_should_fail to create a cyclic rule
+// TestAccVPCSecurityGroup_forceRevokeRulesTrue to create a cyclic rule
 // between 2 security groups
 func cycleIpPermForGroup(groupId string) *ec2.IpPermission {
 	var perm ec2.IpPermission
@@ -2069,10 +2069,10 @@ func cycleIpPermForGroup(groupId string) *ec2.IpPermission {
 func testAddRuleCycle(primary, secondary *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if primary.GroupId == nil {
-			return fmt.Errorf("Primary SG not set for TestAccAWSSecurityGroup_forceRevokeRules_should_fail")
+			return fmt.Errorf("Primary SG not set for TestAccVPCSecurityGroup_forceRevokeRulesTrue")
 		}
 		if secondary.GroupId == nil {
-			return fmt.Errorf("Secondary SG not set for TestAccAWSSecurityGroup_forceRevokeRules_should_fail")
+			return fmt.Errorf("Secondary SG not set for TestAccVPCSecurityGroup_forceRevokeRulesTrue")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
@@ -2109,10 +2109,10 @@ func testAddRuleCycle(primary, secondary *ec2.SecurityGroup) resource.TestCheckF
 func testRemoveRuleCycle(primary, secondary *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if primary.GroupId == nil {
-			return fmt.Errorf("Primary SG not set for TestAccAWSSecurityGroup_forceRevokeRules_should_fail")
+			return fmt.Errorf("Primary SG not set for TestAccVPCSecurityGroup_forceRevokeRulesTrue")
 		}
 		if secondary.GroupId == nil {
-			return fmt.Errorf("Secondary SG not set for TestAccAWSSecurityGroup_forceRevokeRules_should_fail")
+			return fmt.Errorf("Secondary SG not set for TestAccVPCSecurityGroup_forceRevokeRulesTrue")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn

--- a/internal/service/ec2/vpc_security_groups_data_source_test.go
+++ b/internal/service/ec2/vpc_security_groups_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2SecurityGroupsDataSource_tag(t *testing.T) {
+func TestAccVPCSecurityGroupsDataSource_tag(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_security_groups.test"
 
@@ -31,7 +31,7 @@ func TestAccEC2SecurityGroupsDataSource_tag(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupsDataSource_filter(t *testing.T) {
+func TestAccVPCSecurityGroupsDataSource_filter(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_security_groups.test"
 
@@ -52,7 +52,7 @@ func TestAccEC2SecurityGroupsDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2SecurityGroupsDataSource_empty(t *testing.T) {
+func TestAccVPCSecurityGroupsDataSource_empty(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_security_groups.test"
 

--- a/internal/service/ec2/vpc_subnet_cidr_reservation.go
+++ b/internal/service/ec2/vpc_subnet_cidr_reservation.go
@@ -95,7 +95,7 @@ func resourceSubnetCIDRReservationCreate(d *schema.ResourceData, meta interface{
 func resourceSubnetCIDRReservationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	output, err := FindSubnetCidrReservationBySubnetIDAndReservationID(conn, d.Get("subnet_id").(string), d.Id())
+	output, err := FindSubnetCIDRReservationBySubnetIDAndReservationID(conn, d.Get("subnet_id").(string), d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EC2 Subnet CIDR Reservation (%s) not found, removing from state", d.Id())
@@ -124,7 +124,7 @@ func resourceSubnetCIDRReservationDelete(d *schema.ResourceData, meta interface{
 		SubnetCidrReservationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidSubnetCidrReservationIDNotFound) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidSubnetCIDRReservationIDNotFound) {
 		return nil
 	}
 

--- a/internal/service/ec2/vpc_subnet_cidr_reservation_test.go
+++ b/internal/service/ec2/vpc_subnet_cidr_reservation_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2SubnetCidrReservation_basic(t *testing.T) {
+func TestAccVPCSubnetCIDRReservation_basic(t *testing.T) {
 	var res ec2.SubnetCidrReservation
 	resourceName := "aws_ec2_subnet_cidr_reservation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -23,12 +23,12 @@ func TestAccEC2SubnetCidrReservation_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckSubnetCidrReservationDestroy,
+		CheckDestroy: testAccCheckSubnetCIDRReservationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testSubnetCidrReservationConfig_ipv4(rName),
+				Config: testSubnetCIDRReservationConfig_ipv4(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetCidrReservationExists(resourceName, &res),
+					testAccCheckSubnetCIDRReservationExists(resourceName, &res),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.1.16/28"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test"),
 					resource.TestCheckResourceAttr(resourceName, "reservation_type", "prefix"),
@@ -38,14 +38,14 @@ func TestAccEC2SubnetCidrReservation_basic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccSubnetCidrReservationImportStateIdFunc(resourceName),
+				ImportStateIdFunc: testAccSubnetCIDRReservationImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccEC2SubnetCidrReservation_ipv6(t *testing.T) {
+func TestAccVPCSubnetCIDRReservation_ipv6(t *testing.T) {
 	var res ec2.SubnetCidrReservation
 	resourceName := "aws_ec2_subnet_cidr_reservation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -54,12 +54,12 @@ func TestAccEC2SubnetCidrReservation_ipv6(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckSubnetCidrReservationDestroy,
+		CheckDestroy: testAccCheckSubnetCIDRReservationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testSubnetCidrReservationConfig_ipv6(rName),
+				Config: testSubnetCIDRReservationConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetCidrReservationExists(resourceName, &res),
+					testAccCheckSubnetCIDRReservationExists(resourceName, &res),
 					resource.TestCheckResourceAttr(resourceName, "reservation_type", "explicit"),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
@@ -67,14 +67,14 @@ func TestAccEC2SubnetCidrReservation_ipv6(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccSubnetCidrReservationImportStateIdFunc(resourceName),
+				ImportStateIdFunc: testAccSubnetCIDRReservationImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccEC2SubnetCidrReservation_disappears(t *testing.T) {
+func TestAccVPCSubnetCIDRReservation_disappears(t *testing.T) {
 	var res ec2.SubnetCidrReservation
 	resourceName := "aws_ec2_subnet_cidr_reservation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -83,12 +83,12 @@ func TestAccEC2SubnetCidrReservation_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckSubnetCidrReservationDestroy,
+		CheckDestroy: testAccCheckSubnetCIDRReservationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testSubnetCidrReservationConfig_ipv4(rName),
+				Config: testSubnetCIDRReservationConfig_ipv4(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetCidrReservationExists(resourceName, &res),
+					testAccCheckSubnetCIDRReservationExists(resourceName, &res),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSubnetCIDRReservation(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -97,7 +97,7 @@ func TestAccEC2SubnetCidrReservation_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckSubnetCidrReservationExists(n string, v *ec2.SubnetCidrReservation) resource.TestCheckFunc {
+func testAccCheckSubnetCIDRReservationExists(n string, v *ec2.SubnetCidrReservation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -110,7 +110,7 @@ func testAccCheckSubnetCidrReservationExists(n string, v *ec2.SubnetCidrReservat
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 
-		output, err := tfec2.FindSubnetCidrReservationBySubnetIDAndReservationID(conn, rs.Primary.Attributes["subnet_id"], rs.Primary.ID)
+		output, err := tfec2.FindSubnetCIDRReservationBySubnetIDAndReservationID(conn, rs.Primary.Attributes["subnet_id"], rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -122,7 +122,7 @@ func testAccCheckSubnetCidrReservationExists(n string, v *ec2.SubnetCidrReservat
 	}
 }
 
-func testAccCheckSubnetCidrReservationDestroy(s *terraform.State) error {
+func testAccCheckSubnetCIDRReservationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 
 	for _, rs := range s.RootModule().Resources {
@@ -130,7 +130,7 @@ func testAccCheckSubnetCidrReservationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfec2.FindSubnetCidrReservationBySubnetIDAndReservationID(conn, rs.Primary.Attributes["subnet_id"], rs.Primary.ID)
+		_, err := tfec2.FindSubnetCIDRReservationBySubnetIDAndReservationID(conn, rs.Primary.Attributes["subnet_id"], rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -146,7 +146,7 @@ func testAccCheckSubnetCidrReservationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccSubnetCidrReservationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccSubnetCIDRReservationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -157,7 +157,7 @@ func testAccSubnetCidrReservationImportStateIdFunc(resourceName string) resource
 	}
 }
 
-func testSubnetCidrReservationConfig_ipv4(rName string) string {
+func testSubnetCIDRReservationConfig_ipv4(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -185,7 +185,7 @@ resource "aws_ec2_subnet_cidr_reservation" "test" {
 `, rName)
 }
 
-func testSubnetCidrReservationConfig_ipv6(rName string) string {
+func testSubnetCIDRReservationConfig_ipv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_subnet_data_source_test.go
+++ b/internal/service/ec2/vpc_subnet_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2SubnetDataSource_basic(t *testing.T) {
+func TestAccVPCSubnetDataSource_basic(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 256)
 	cidr := fmt.Sprintf("172.%d.123.0/24", rInt)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -137,7 +137,7 @@ func TestAccEC2SubnetDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SubnetDataSource_ipv6ByIPv6Filter(t *testing.T) {
+func TestAccVPCSubnetDataSource_ipv6ByIPv6Filter(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 256)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -160,7 +160,7 @@ func TestAccEC2SubnetDataSource_ipv6ByIPv6Filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock(t *testing.T) {
+func TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 256)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_subnet_ids_data_source_test.go
+++ b/internal/service/ec2/vpc_subnet_ids_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2SubnetIDsDataSource_basic(t *testing.T) {
+func TestAccVPCSubnetIDsDataSource_basic(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 256)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -34,7 +34,7 @@ func TestAccEC2SubnetIDsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SubnetIDsDataSource_filter(t *testing.T) {
+func TestAccVPCSubnetIDsDataSource_filter(t *testing.T) {
 	rInt := sdkacctest.RandIntRange(0, 256)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpc_subnet_test.go
+++ b/internal/service/ec2/vpc_subnet_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2Subnet_basic(t *testing.T) {
+func TestAccVPCSubnet_basic(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -59,7 +59,7 @@ func TestAccEC2Subnet_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_tags(t *testing.T) {
+func TestAccVPCSubnet_tags(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -103,7 +103,7 @@ func TestAccEC2Subnet_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_DefaultTags_providerOnly(t *testing.T) {
+func TestAccVPCSubnet_DefaultTags_providerOnly(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -161,7 +161,7 @@ func TestAccEC2Subnet_DefaultTags_providerOnly(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_DefaultTags_updateToProviderOnly(t *testing.T) {
+func TestAccVPCSubnet_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -204,7 +204,7 @@ func TestAccEC2Subnet_DefaultTags_updateToProviderOnly(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_DefaultTags_updateToResourceOnly(t *testing.T) {
+func TestAccVPCSubnet_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -247,7 +247,7 @@ func TestAccEC2Subnet_DefaultTags_updateToResourceOnly(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag(t *testing.T) {
+func TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -312,7 +312,7 @@ func TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag(t *testin
 	})
 }
 
-func TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag(t *testing.T) {
+func TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -373,7 +373,7 @@ func TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag(t *testing.T
 	})
 }
 
-func TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag(t *testing.T) {
+func TestAccVPCSubnet_DefaultTagsProviderAndResource_duplicateTag(t *testing.T) {
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -395,7 +395,7 @@ func TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag(t *testing.T) 
 	})
 }
 
-func TestAccEC2Subnet_defaultAndIgnoreTags(t *testing.T) {
+func TestAccVPCSubnet_defaultAndIgnoreTags(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -433,12 +433,12 @@ func TestAccEC2Subnet_defaultAndIgnoreTags(t *testing.T) {
 	})
 }
 
-// TestAccEC2Subnet_updateTagsKnownAtApply ensures computed "tags_all"
+// TestAccVPCSubnet_updateTagsKnownAtApply ensures computed "tags_all"
 // attributes are correctly determined when the provider-level default_tags block
 // is left unused and resource tags are only known at apply time, thereby
 // eliminating "Inconsistent final plan" errors
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18366
-func TestAccEC2Subnet_updateTagsKnownAtApply(t *testing.T) {
+func TestAccVPCSubnet_updateTagsKnownAtApply(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -474,7 +474,7 @@ func TestAccEC2Subnet_updateTagsKnownAtApply(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_ignoreTags(t *testing.T) {
+func TestAccVPCSubnet_ignoreTags(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
@@ -506,7 +506,7 @@ func TestAccEC2Subnet_ignoreTags(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_ipv6(t *testing.T) {
+func TestAccVPCSubnet_ipv6(t *testing.T) {
 	var before, after ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -547,7 +547,7 @@ func TestAccEC2Subnet_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_enableIPv6(t *testing.T) {
+func TestAccVPCSubnet_enableIPv6(t *testing.T) {
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -591,7 +591,7 @@ func TestAccEC2Subnet_enableIPv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_availabilityZoneID(t *testing.T) {
+func TestAccVPCSubnet_availabilityZoneID(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -619,7 +619,7 @@ func TestAccEC2Subnet_availabilityZoneID(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_disappears(t *testing.T) {
+func TestAccVPCSubnet_disappears(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -642,7 +642,7 @@ func TestAccEC2Subnet_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_customerOwnedIPv4Pool(t *testing.T) {
+func TestAccVPCSubnet_customerOwnedIPv4Pool(t *testing.T) {
 	var subnet ec2.Subnet
 	coipDataSourceName := "data.aws_ec2_coip_pool.test"
 	resourceName := "aws_subnet.test"
@@ -670,7 +670,7 @@ func TestAccEC2Subnet_customerOwnedIPv4Pool(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch(t *testing.T) {
+func TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch(t *testing.T) {
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -697,7 +697,7 @@ func TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_mapPublicIPOnLaunch(t *testing.T) {
+func TestAccVPCSubnet_mapPublicIPOnLaunch(t *testing.T) {
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -738,7 +738,7 @@ func TestAccEC2Subnet_mapPublicIPOnLaunch(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_outpost(t *testing.T) {
+func TestAccVPCSubnet_outpost(t *testing.T) {
 	var v ec2.Subnet
 	outpostDataSourceName := "data.aws_outposts_outpost.test"
 	resourceName := "aws_subnet.test"
@@ -766,7 +766,7 @@ func TestAccEC2Subnet_outpost(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_enableDNS64(t *testing.T) {
+func TestAccVPCSubnet_enableDNS64(t *testing.T) {
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -807,7 +807,7 @@ func TestAccEC2Subnet_enableDNS64(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
+func TestAccVPCSubnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -854,7 +854,7 @@ func TestAccEC2Subnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
 	})
 }
 
-func TestAccEC2Subnet_ipv6Native(t *testing.T) {
+func TestAccVPCSubnet_ipv6Native(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_subnets_data_source_test.go
+++ b/internal/service/ec2/vpc_subnets_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2SubnetsDataSource_basic(t *testing.T) {
+func TestAccVPCSubnetsDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +34,7 @@ func TestAccEC2SubnetsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2SubnetsDataSource_filter(t *testing.T) {
+func TestAccVPCSubnetsDataSource_filter(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpc_traffic_mirror_filter_rule_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_rule_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2TrafficMirrorFilterRule_basic(t *testing.T) {
+func TestAccVPCTrafficMirrorFilterRule_basic(t *testing.T) {
 	resourceName := "aws_ec2_traffic_mirror_filter_rule.test"
 	dstCidr := "10.0.0.0/8"
 	srcCidr := "0.0.0.0/0"
@@ -105,7 +105,7 @@ func TestAccEC2TrafficMirrorFilterRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorFilterRule_disappears(t *testing.T) {
+func TestAccVPCTrafficMirrorFilterRule_disappears(t *testing.T) {
 	resourceName := "aws_ec2_traffic_mirror_filter_rule.test"
 	dstCidr := "10.0.0.0/8"
 	srcCidr := "0.0.0.0/0"

--- a/internal/service/ec2/vpc_traffic_mirror_filter_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_test.go
@@ -15,7 +15,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2TrafficMirrorFilter_basic(t *testing.T) {
+func TestAccVPCTrafficMirrorFilter_basic(t *testing.T) {
 	var v ec2.TrafficMirrorFilter
 	resourceName := "aws_ec2_traffic_mirror_filter.test"
 	description := "test filter"
@@ -66,7 +66,7 @@ func TestAccEC2TrafficMirrorFilter_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorFilter_tags(t *testing.T) {
+func TestAccVPCTrafficMirrorFilter_tags(t *testing.T) {
 	var v ec2.TrafficMirrorFilter
 	resourceName := "aws_ec2_traffic_mirror_filter.test"
 
@@ -113,7 +113,7 @@ func TestAccEC2TrafficMirrorFilter_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorFilter_disappears(t *testing.T) {
+func TestAccVPCTrafficMirrorFilter_disappears(t *testing.T) {
 	var v ec2.TrafficMirrorFilter
 	resourceName := "aws_ec2_traffic_mirror_filter.test"
 	description := "test filter"

--- a/internal/service/ec2/vpc_traffic_mirror_session_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session_test.go
@@ -17,7 +17,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2TrafficMirrorSession_basic(t *testing.T) {
+func TestAccVPCTrafficMirrorSession_basic(t *testing.T) {
 	var v ec2.TrafficMirrorSession
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	description := "test session"
@@ -81,7 +81,7 @@ func TestAccEC2TrafficMirrorSession_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorSession_tags(t *testing.T) {
+func TestAccVPCTrafficMirrorSession_tags(t *testing.T) {
 	var v ec2.TrafficMirrorSession
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	session := sdkacctest.RandIntRange(1, 32766)
@@ -130,7 +130,7 @@ func TestAccEC2TrafficMirrorSession_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorSession_disappears(t *testing.T) {
+func TestAccVPCTrafficMirrorSession_disappears(t *testing.T) {
 	var v ec2.TrafficMirrorSession
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	session := sdkacctest.RandIntRange(1, 32766)

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2TrafficMirrorTarget_nlb(t *testing.T) {
+func TestAccVPCTrafficMirrorTarget_nlb(t *testing.T) {
 	var v ec2.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	description := "test nlb target"
@@ -51,7 +51,7 @@ func TestAccEC2TrafficMirrorTarget_nlb(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorTarget_eni(t *testing.T) {
+func TestAccVPCTrafficMirrorTarget_eni(t *testing.T) {
 	var v ec2.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
@@ -84,7 +84,7 @@ func TestAccEC2TrafficMirrorTarget_eni(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorTarget_tags(t *testing.T) {
+func TestAccVPCTrafficMirrorTarget_tags(t *testing.T) {
 	var v ec2.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	description := "test nlb target"
@@ -133,7 +133,7 @@ func TestAccEC2TrafficMirrorTarget_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2TrafficMirrorTarget_disappears(t *testing.T) {
+func TestAccVPCTrafficMirrorTarget_disappears(t *testing.T) {
 	var v ec2.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	description := "test nlb target"

--- a/internal/service/ec2/vpc_vpcs_data_source_test.go
+++ b/internal/service/ec2/vpc_vpcs_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPCsDataSource_basic(t *testing.T) {
+func TestAccVPCsDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -28,7 +28,7 @@ func TestAccEC2VPCsDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCsDataSource_tags(t *testing.T) {
+func TestAccVPCsDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,7 +46,7 @@ func TestAccEC2VPCsDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCsDataSource_filters(t *testing.T) {
+func TestAccVPCsDataSource_filters(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -64,7 +64,7 @@ func TestAccEC2VPCsDataSource_filters(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPCsDataSource_empty(t *testing.T) {
+func TestAccVPCsDataSource_empty(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/ec2/vpnsite_connection_route_test.go
+++ b/internal/service/ec2/vpnsite_connection_route_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPNConnectionRoute_basic(t *testing.T) {
+func TestAccVPNSiteConnectionRoute_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection_route.test"
@@ -35,7 +35,7 @@ func TestAccEC2VPNConnectionRoute_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnectionRoute_disappears(t *testing.T) {
+func TestAccVPNSiteConnectionRoute_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection_route.test"

--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -146,7 +146,7 @@ func TestXmlConfigToTunnelInfo(t *testing.T) {
 	}
 }
 
-func TestAccEC2VPNConnection_basic(t *testing.T) {
+func TestAccVPNSiteConnection_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -234,7 +234,7 @@ func TestAccEC2VPNConnection_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_transitGatewayID(t *testing.T) {
+func TestAccVPNSiteConnection_transitGatewayID(t *testing.T) {
 	var vpn ec2.VpnConnection
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
@@ -264,7 +264,7 @@ func TestAccEC2VPNConnection_transitGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_tunnel1InsideCIDR(t *testing.T) {
+func TestAccVPNSiteConnection_tunnel1InsideCIDR(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -293,7 +293,7 @@ func TestAccEC2VPNConnection_tunnel1InsideCIDR(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_tunnel1InsideIPv6CIDR(t *testing.T) {
+func TestAccVPNSiteConnection_tunnel1InsideIPv6CIDR(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -322,7 +322,7 @@ func TestAccEC2VPNConnection_tunnel1InsideIPv6CIDR(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_tunnel1PreSharedKey(t *testing.T) {
+func TestAccVPNSiteConnection_tunnel1PreSharedKey(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -351,7 +351,7 @@ func TestAccEC2VPNConnection_tunnel1PreSharedKey(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_tunnelOptions(t *testing.T) {
+func TestAccVPNSiteConnection_tunnelOptions(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	badCidrRangeErr := regexp.MustCompile(`expected \w+ to not be any of \[[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/30\s?]+\]`)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
@@ -482,8 +482,8 @@ func TestAccEC2VPNConnection_tunnelOptions(t *testing.T) {
 	})
 }
 
-// TestAccEC2VPNConnection_tunnelOptionsLesser tests less algorithms such as those supported in GovCloud.
-func TestAccEC2VPNConnection_tunnelOptionsLesser(t *testing.T) {
+// TestAccVPNSiteConnection_tunnelOptionsLesser tests less algorithms such as those supported in GovCloud.
+func TestAccVPNSiteConnection_tunnelOptionsLesser(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1032,7 +1032,7 @@ func TestAccEC2VPNConnection_tunnelOptionsLesser(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_withStaticRoutes(t *testing.T) {
+func TestAccVPNSiteConnection_withStaticRoutes(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1060,7 +1060,7 @@ func TestAccEC2VPNConnection_withStaticRoutes(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_withEnableAcceleration(t *testing.T) {
+func TestAccVPNSiteConnection_withEnableAcceleration(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1088,7 +1088,7 @@ func TestAccEC2VPNConnection_withEnableAcceleration(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_withIPv6(t *testing.T) {
+func TestAccVPNSiteConnection_withIPv6(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1115,7 +1115,7 @@ func TestAccEC2VPNConnection_withIPv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_tags(t *testing.T) {
+func TestAccVPNSiteConnection_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1161,7 +1161,7 @@ func TestAccEC2VPNConnection_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_specifyIPv4(t *testing.T) {
+func TestAccVPNSiteConnection_specifyIPv4(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1198,7 +1198,7 @@ func TestAccEC2VPNConnection_specifyIPv4(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_specifyIPv6(t *testing.T) {
+func TestAccVPNSiteConnection_specifyIPv6(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1222,7 +1222,7 @@ func TestAccEC2VPNConnection_specifyIPv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_disappears(t *testing.T) {
+func TestAccVPNSiteConnection_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1246,7 +1246,7 @@ func TestAccEC2VPNConnection_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_updateCustomerGatewayID(t *testing.T) {
+func TestAccVPNSiteConnection_updateCustomerGatewayID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn1 := sdkacctest.RandIntRange(64512, 65534)
 	rBgpAsn2 := sdkacctest.RandIntRange(64512, 65534)
@@ -1283,7 +1283,7 @@ func TestAccEC2VPNConnection_updateCustomerGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_updateVPNGatewayID(t *testing.T) {
+func TestAccVPNSiteConnection_updateVPNGatewayID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1319,7 +1319,7 @@ func TestAccEC2VPNConnection_updateVPNGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_updateTransitGatewayID(t *testing.T) {
+func TestAccVPNSiteConnection_updateTransitGatewayID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1357,7 +1357,7 @@ func TestAccEC2VPNConnection_updateTransitGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_vpnGatewayIDToTransitGatewayID(t *testing.T) {
+func TestAccVPNSiteConnection_vpnGatewayIDToTransitGatewayID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
@@ -1395,7 +1395,7 @@ func TestAccEC2VPNConnection_vpnGatewayIDToTransitGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNConnection_transitGatewayIDToVPNGatewayID(t *testing.T) {
+func TestAccVPNSiteConnection_transitGatewayIDToVPNGatewayID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"

--- a/internal/service/ec2/vpnsite_customer_gateway_data_source_test.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2CustomerGatewayDataSource_filter(t *testing.T) {
+func TestAccVPNSiteCustomerGatewayDataSource_filter(t *testing.T) {
 	dataSourceName := "data.aws_customer_gateway.test"
 	resourceName := "aws_customer_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -39,7 +39,7 @@ func TestAccEC2CustomerGatewayDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2CustomerGatewayDataSource_id(t *testing.T) {
+func TestAccVPNSiteCustomerGatewayDataSource_id(t *testing.T) {
 	dataSourceName := "data.aws_customer_gateway.test"
 	resourceName := "aws_customer_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpnsite_customer_gateway_test.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2CustomerGateway_basic(t *testing.T) {
+func TestAccVPNSiteCustomerGateway_basic(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
@@ -49,7 +49,7 @@ func TestAccEC2CustomerGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2CustomerGateway_disappears(t *testing.T) {
+func TestAccVPNSiteCustomerGateway_disappears(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
@@ -72,7 +72,7 @@ func TestAccEC2CustomerGateway_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2CustomerGateway_tags(t *testing.T) {
+func TestAccVPNSiteCustomerGateway_tags(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
@@ -114,7 +114,7 @@ func TestAccEC2CustomerGateway_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2CustomerGateway_deviceName(t *testing.T) {
+func TestAccVPNSiteCustomerGateway_deviceName(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -142,7 +142,7 @@ func TestAccEC2CustomerGateway_deviceName(t *testing.T) {
 	})
 }
 
-func TestAccEC2CustomerGateway_4ByteASN(t *testing.T) {
+func TestAccVPNSiteCustomerGateway_4ByteASN(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	rBgpAsn := strconv.FormatInt(int64(sdkacctest.RandIntRange(64512, 65534))*10000, 10)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -170,7 +170,7 @@ func TestAccEC2CustomerGateway_4ByteASN(t *testing.T) {
 	})
 }
 
-func TestAccEC2CustomerGateway_certificate(t *testing.T) {
+func TestAccVPNSiteCustomerGateway_certificate(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	var caRoot acmpca.CertificateAuthority
 	var caSubordinate acmpca.CertificateAuthority

--- a/internal/service/ec2/vpnsite_gateway_attachment_test.go
+++ b/internal/service/ec2/vpnsite_gateway_attachment_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPNGatewayAttachment_basic(t *testing.T) {
+func TestAccVPNSiteGatewayAttachment_basic(t *testing.T) {
 	var v ec2.VpcAttachment
 	resourceName := "aws_vpn_gateway_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -35,7 +35,7 @@ func TestAccEC2VPNGatewayAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGatewayAttachment_disappears(t *testing.T) {
+func TestAccVPNSiteGatewayAttachment_disappears(t *testing.T) {
 	var v ec2.VpcAttachment
 	resourceName := "aws_vpn_gateway_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpnsite_gateway_data_source_test.go
+++ b/internal/service/ec2/vpnsite_gateway_data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2VPNGatewayDataSource_unattached(t *testing.T) {
+func TestAccVPNSiteGatewayDataSource_unattached(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceNameById := "data.aws_vpn_gateway.test_by_id"
 	dataSourceNameByTags := "data.aws_vpn_gateway.test_by_tags"
@@ -40,7 +40,7 @@ func TestAccEC2VPNGatewayDataSource_unattached(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGatewayDataSource_attached(t *testing.T) {
+func TestAccVPNSiteGatewayDataSource_attached(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpn_gateway.test"
 

--- a/internal/service/ec2/vpnsite_gateway_route_propagation_test.go
+++ b/internal/service/ec2/vpnsite_gateway_route_propagation_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2VPNGatewayRoutePropagation_basic(t *testing.T) {
+func TestAccVPNSiteGatewayRoutePropagation_basic(t *testing.T) {
 	resourceName := "aws_vpn_gateway_route_propagation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -34,7 +34,7 @@ func TestAccEC2VPNGatewayRoutePropagation_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGatewayRoutePropagation_disappears(t *testing.T) {
+func TestAccVPNSiteGatewayRoutePropagation_disappears(t *testing.T) {
 	resourceName := "aws_vpn_gateway_route_propagation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/ec2/vpnsite_gateway_test.go
+++ b/internal/service/ec2/vpnsite_gateway_test.go
@@ -18,7 +18,7 @@ import (
 
 // add sweeper to delete known test VPN Gateways
 
-func TestAccEC2VPNGateway_basic(t *testing.T) {
+func TestAccVPNSiteGateway_basic(t *testing.T) {
 	var v1, v2 ec2.VpnGateway
 	resourceName := "aws_vpn_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,7 +68,7 @@ func TestAccEC2VPNGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGateway_withAvailabilityZoneSetToState(t *testing.T) {
+func TestAccVPNSiteGateway_withAvailabilityZoneSetToState(t *testing.T) {
 	var v ec2.VpnGateway
 	resourceName := "aws_vpn_gateway.test"
 	azDataSourceName := "data.aws_availability_zones.available"
@@ -97,7 +97,7 @@ func TestAccEC2VPNGateway_withAvailabilityZoneSetToState(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGateway_withAmazonSideASN(t *testing.T) {
+func TestAccVPNSiteGateway_withAmazonSideASN(t *testing.T) {
 	var v ec2.VpnGateway
 	resourceName := "aws_vpn_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -125,7 +125,7 @@ func TestAccEC2VPNGateway_withAmazonSideASN(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGateway_disappears(t *testing.T) {
+func TestAccVPNSiteGateway_disappears(t *testing.T) {
 	var v ec2.VpnGateway
 	resourceName := "aws_vpn_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -148,7 +148,7 @@ func TestAccEC2VPNGateway_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGateway_reattach(t *testing.T) {
+func TestAccVPNSiteGateway_reattach(t *testing.T) {
 	var vpc1, vpc2 ec2.Vpc
 	var vgw1, vgw2 ec2.VpnGateway
 	vpcResourceName1 := "aws_vpc.test1"
@@ -238,7 +238,7 @@ func TestAccEC2VPNGateway_reattach(t *testing.T) {
 	})
 }
 
-func TestAccEC2VPNGateway_tags(t *testing.T) {
+func TestAccVPNSiteGateway_tags(t *testing.T) {
 	var v ec2.VpnGateway
 	resourceName := "aws_vpn_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/wavelength_carrier_gateway_test.go
+++ b/internal/service/ec2/wavelength_carrier_gateway_test.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-func TestAccEC2CarrierGateway_basic(t *testing.T) {
+func TestAccWavelengthCarrierGateway_basic(t *testing.T) {
 	var v ec2.CarrierGateway
 	resourceName := "aws_ec2_carrier_gateway.test"
 	vpcResourceName := "aws_vpc.test"
@@ -47,7 +47,7 @@ func TestAccEC2CarrierGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2CarrierGateway_disappears(t *testing.T) {
+func TestAccWavelengthCarrierGateway_disappears(t *testing.T) {
 	var v ec2.CarrierGateway
 	resourceName := "aws_ec2_carrier_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -70,7 +70,7 @@ func TestAccEC2CarrierGateway_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2CarrierGateway_tags(t *testing.T) {
+func TestAccWavelengthCarrierGateway_tags(t *testing.T) {
 	var v ec2.CarrierGateway
 	resourceName := "aws_ec2_carrier_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ecrpublic/repository_policy_test.go
+++ b/internal/service/ecrpublic/repository_policy_test.go
@@ -25,7 +25,7 @@ func TestAccECRPublicRepositoryPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRepositoryPolicy(rName),
+				Config: testAccRepositoryPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -37,7 +37,7 @@ func TestAccECRPublicRepositoryPolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRepositoryPolicyUpdated(rName),
+				Config: testAccRepositoryPolicyConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -58,7 +58,7 @@ func TestAccECRPublicRepositoryPolicy_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRepositoryPolicy(rName),
+				Config: testAccRepositoryPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -82,7 +82,7 @@ func TestAccECRPublicRepositoryPolicy_Disappears_repository(t *testing.T) {
 		CheckDestroy: testAccCheckRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRepositoryPolicy(rName),
+				Config: testAccRepositoryPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -105,7 +105,7 @@ func TestAccECRPublicRepositoryPolicy_iam(t *testing.T) {
 		CheckDestroy: testAccCheckRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRepositoryPolicyWithIAMRole(rName),
+				Config: testAccRepositoryPolicyConfig_iamRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -117,7 +117,7 @@ func TestAccECRPublicRepositoryPolicy_iam(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRepositoryPolicyWithIAMRoleUpdated(rName),
+				Config: testAccRepositoryPolicyConfig_iamRoleUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -174,7 +174,7 @@ func testAccCheckRepositoryPolicyExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccRepositoryPolicy(rName string) string {
+func testAccRepositoryPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecrpublic_repository" "test" {
   repository_name = %[1]q
@@ -200,7 +200,7 @@ EOF
 `, rName)
 }
 
-func testAccRepositoryPolicyUpdated(rName string) string {
+func testAccRepositoryPolicyConfig_updated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecrpublic_repository" "test" {
   repository_name = %[1]q
@@ -229,11 +229,11 @@ EOF
 `, rName)
 }
 
-// testAccAwsEcrPublicRepositoryPolicyWithIAMRole creates a new IAM Role and tries
+// testAccRepositoryPolicyConfig_iamRole creates a new IAM Role and tries
 // to use it's ARN in an ECR Repository Policy. IAM changes need some time to
 // be propagated to other services - like ECR. So the following code should
 // exercise our retry logic, since we try to use the new resource instantly.
-func testAccRepositoryPolicyWithIAMRole(rName string) string {
+func testAccRepositoryPolicyConfig_iamRole(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecrpublic_repository" "test" {
   repository_name = %[1]q
@@ -280,7 +280,7 @@ EOF
 `, rName)
 }
 
-func testAccRepositoryPolicyWithIAMRoleUpdated(rName string) string {
+func testAccRepositoryPolicyConfig_iamRoleUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecrpublic_repository" "test" {
   repository_name = %[1]q

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -1395,7 +1395,7 @@ resource "aws_security_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSElastiCacheCluster_basic"
+    Name = %[1]q
   }
 }
 

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2324,7 +2324,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 }
 
 // Test for out-of-band deletion
-// Naming to allow grouping all TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_* tests
+// Naming to allow grouping all TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_* tests
 func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -332,7 +332,7 @@ func TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate(t *tes
 	testCheck := func(*terraform.State) error {
 		if len(conf.ListenerDescriptions) != 1 {
 			return fmt.Errorf(
-				"TestAccAWSELB_iam_server_cert expected 1 listener, got %d",
+				"TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate expected 1 listener, got %d",
 				len(conf.ListenerDescriptions))
 		}
 		return nil

--- a/internal/service/elbv2/listener_data_source_test.go
+++ b/internal/service/elbv2/listener_data_source_test.go
@@ -161,7 +161,7 @@ resource "aws_lb" "test" {
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
+    TestName = "TestAccELBV2ListenerDataSource_basic"
   }
 }
 
@@ -217,7 +217,7 @@ resource "aws_alb" "test" {
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
+    TestName = "TestAccELBV2ListenerDataSource_basic"
   }
 }
 
@@ -275,7 +275,7 @@ resource "aws_lb" "test" {
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
+    TestName = "TestAccELBV2ListenerDataSource_basic"
   }
 
   depends_on = [aws_internet_gateway.gw]
@@ -304,7 +304,7 @@ resource "aws_internet_gateway" "gw" {
 
   tags = {
     Name     = %[1]q
-    TestName = "TestAccAWSALB_basic"
+    TestName = "TestAccELBV2ListenerDataSource_basic"
   }
 }
 

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -1421,7 +1421,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -1430,12 +1430,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1506,7 +1506,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName)
@@ -1553,7 +1553,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -1562,12 +1562,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test1" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1585,7 +1585,7 @@ resource "aws_lb_target_group" "test1" {
 }
 
 resource "aws_lb_target_group" "test2" {
-  name     = "%s"
+  name     = %[3]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1656,7 +1656,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName1, targetGroupName2)
@@ -1708,7 +1708,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -1717,12 +1717,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test1" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1740,7 +1740,7 @@ resource "aws_lb_target_group" "test1" {
 }
 
 resource "aws_lb_target_group" "test2" {
-  name     = "%s"
+  name     = %[3]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1811,7 +1811,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName1, targetGroupName2)
@@ -1847,7 +1847,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -1856,12 +1856,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test1" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1879,7 +1879,7 @@ resource "aws_lb_target_group" "test1" {
 }
 
 resource "aws_lb_target_group" "test2" {
-  name     = "%s"
+  name     = %[3]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1950,7 +1950,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName1, targetGroupName2)
@@ -1986,7 +1986,7 @@ resource "aws_alb_listener" "front_end" {
 }
 
 resource "aws_alb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -1995,12 +1995,12 @@ resource "aws_alb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -2071,7 +2071,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName)
@@ -2131,7 +2131,7 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_redirect"
+    Name = %[1]q
   }
 }
 
@@ -2189,7 +2189,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_redirect"
+    Name = %[1]q
   }
 }
 `, lbName, query)
@@ -2206,7 +2206,7 @@ resource "aws_lb_listener_rule" "static" {
 
     fixed_response {
       content_type = "text/plain"
-      message_body = "%s"
+      message_body = %[1]q
       status_code  = "200"
     }
   }
@@ -2235,7 +2235,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[2]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -2244,7 +2244,7 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_fixedResponse"
+    Name = %[2]q
   }
 }
 
@@ -2302,7 +2302,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_fixedresponse"
+    Name = %[2]q
   }
 }
 `, response, lbName)
@@ -2338,7 +2338,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -2347,12 +2347,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -2423,7 +2423,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName)
@@ -2470,7 +2470,7 @@ resource "aws_lb_listener" "front_end_ruleupdate" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -2479,12 +2479,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -2555,7 +2555,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName)
@@ -2575,7 +2575,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -2584,12 +2584,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[2]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -2660,7 +2660,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName)
@@ -2856,9 +2856,9 @@ resource "aws_lb_listener_rule" "cognito" {
 }
 
 resource "aws_iam_server_certificate" "test" {
-  name             = "%[1]s"
-  certificate_body = "%[2]s"
-  private_key      = "%[3]s"
+  name             = %[1]q
+  certificate_body = %[2]q
+  private_key      = %[3]q
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -2875,7 +2875,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%[1]s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -2884,12 +2884,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_cognito"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%[1]s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -2960,7 +2960,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_cognito"
+    Name = %[1]q
   }
 }
 
@@ -3023,9 +3023,9 @@ resource "aws_lb_listener_rule" "oidc" {
 }
 
 resource "aws_iam_server_certificate" "test" {
-  name             = "%[1]s"
-  certificate_body = "%[2]s"
-  private_key      = "%[3]s"
+  name             = %[1]q
+  certificate_body = %[2]q
+  private_key      = %[3]q
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -3042,7 +3042,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%[1]s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -3051,12 +3051,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_cognito"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%[1]s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -3127,7 +3127,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_cognito"
+    Name = %[1]q
   }
 }
 `, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key))
@@ -3183,9 +3183,9 @@ resource "aws_lb_listener_rule" "test" {
 }
 
 resource "aws_iam_server_certificate" "test" {
-  certificate_body = "%[2]s"
+  certificate_body = %[2]q
   name             = var.rName
-  private_key      = "%[3]s"
+  private_key      = %[3]q
 }
 
 resource "aws_lb_listener" "test" {
@@ -3369,7 +3369,7 @@ condition {
 `)
 }
 
-func testAccListenerRuleConfig_condition_base(condition, name, lbName string) string {
+func testAccListenerRuleConfig_conditionBase(condition, lbName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = aws_lb_listener.front_end.arn
@@ -3385,7 +3385,7 @@ resource "aws_lb_listener_rule" "static" {
     }
   }
 
-  %s
+  %[1]s
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -3405,7 +3405,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[2]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -3414,7 +3414,7 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_condition%s"
+    Name = %[2]q
   }
 }
 
@@ -3436,7 +3436,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "TestAccAWSALB_condition%s"
+    Name = %[2]q
   }
 }
 
@@ -3448,7 +3448,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "TestAccAWSALB_condition%s-${count.index}"
+    Name = "%[2]s-${count.index}"
   }
 }
 
@@ -3472,24 +3472,24 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_condition%s"
+    Name = %[2]q
   }
 }
-`, condition, lbName, name, name, name, name)
+`, condition, lbName)
 }
 
 func testAccListenerRuleConfig_conditionHostHeader(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   host_header {
     values = ["example.com", "www.example.com"]
   }
 }
-`, "HostHeader", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionHTTPHeader(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   http_header {
     http_header_name = "X-Forwarded-For"
@@ -3503,7 +3503,7 @@ condition {
     values           = ["RFC7230 Validity"]
   }
 }
-`, "HttpHeader", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionHTTPHeader_invalid() string {
@@ -3537,27 +3537,27 @@ resource "aws_lb_listener_rule" "static" {
 }
 
 func testAccListenerRuleConfig_conditionHTTPRequestMethod(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   http_request_method {
     values = ["GET", "POST"]
   }
 }
-`, "HttpRequestMethod", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionPathPattern(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   path_pattern {
     values = ["/public/*", "/cgi-bin/*"]
   }
 }
-`, "PathPattern", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionQueryString(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   query_string {
     value = "surprise"
@@ -3580,11 +3580,11 @@ condition {
     value = "baz"
   }
 }
-`, "QueryString", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionSourceIP(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   source_ip {
     values = [
@@ -3593,11 +3593,11 @@ condition {
     ]
   }
 }
-`, "SourceIp", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionMixed(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   path_pattern {
     values = ["/public/*"]
@@ -3611,12 +3611,12 @@ condition {
     ]
   }
 }
-`, "Mixed", lbName)
+`, lbName)
 }
 
 // Update new style condition without modifying deprecated. Issue GH-11323
 func testAccListenerRuleConfig_conditionMixed_updated(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   path_pattern {
     values = ["/public/*"]
@@ -3630,12 +3630,12 @@ condition {
     ]
   }
 }
-`, "Mixed", lbName)
+`, lbName)
 }
 
 // Then update deprecated syntax without touching new. Issue GH-11362
 func testAccListenerRuleConfig_conditionMixed_updated2(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   path_pattern {
     values = ["/cgi-bin/*"]
@@ -3649,12 +3649,12 @@ condition {
     ]
   }
 }
-`, "Mixed", lbName)
+`, lbName)
 }
 
 // Currently a maximum of 5 condition values per rule
 func testAccListenerRuleConfig_conditionMultiple(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   host_header {
     values = ["example.com"]
@@ -3685,11 +3685,11 @@ condition {
     values = ["192.168.0.0/16"]
   }
 }
-`, "Multiple", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleConfig_conditionMultiple_updated(lbName string) string {
-	return testAccListenerRuleConfig_condition_base(`
+	return testAccListenerRuleConfig_conditionBase(`
 condition {
   host_header {
     values = ["example.com"]
@@ -3720,7 +3720,7 @@ condition {
     values = ["192.168.0.0/24"]
   }
 }
-`, "Multiple", lbName)
+`, lbName)
 }
 
 func testAccListenerRuleTags1Config(lbName, targetGroupName, tagKey1, tagValue1 string) string {
@@ -3766,7 +3766,7 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -3842,7 +3842,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName, tagKey1, tagValue1)
@@ -3892,7 +3892,7 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -3968,7 +3968,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 `, lbName, targetGroupName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -271,7 +271,7 @@ func TestAccELBV2LoadBalancer_ALB_outpost(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_outpost"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_mapping.0.outpost_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_owned_ipv4_pool"),
@@ -813,7 +813,7 @@ func TestAccELBV2LoadBalancer_updatedIPAddressType(t *testing.T) {
 	})
 }
 
-// TestAccAWSALB_noSecurityGroup regression tests the issue in #8264,
+// TestAccELBV2LoadBalancer_noSecurityGroup regression tests the issue in #8264,
 // where if an ALB is created without a security group, a default one
 // is assigned.
 func TestAccELBV2LoadBalancer_noSecurityGroup(t *testing.T) {
@@ -1218,7 +1218,7 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBConfig_desyncMitigationMode(rName, "strictest"),
+				Config: testAccLBConfig_desyncMitigationMode(rName, "strictest"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "strictest"),
@@ -1231,7 +1231,7 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSLBConfig_desyncMitigationMode(rName, "monitor"),
+				Config: testAccLBConfig_desyncMitigationMode(rName, "monitor"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &mid),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "monitor"),
@@ -1244,7 +1244,7 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSLBConfig_desyncMitigationMode(rName, "defensive"),
+				Config: testAccLBConfig_desyncMitigationMode(rName, "defensive"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "defensive"),
@@ -1676,7 +1676,9 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccLoadBalancerConfig_outpost(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
 data "aws_outposts_outpost" "test" {
@@ -3078,7 +3080,7 @@ resource "aws_security_group" "alb_test" {
 `, rName))
 }
 
-func testAccAWSLBConfig_desyncMitigationMode(rName string, mode string) string {
+func testAccLBConfig_desyncMitigationMode(rName string, mode string) string {
 	return fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = %[1]q

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -63,7 +63,7 @@ func TestLBCloudwatchSuffixFromARN(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_ALB_basic(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -73,23 +73,23 @@ func TestAccELBV2LoadBalancer_ALB_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_basic(lbName),
+				Config: testAccLoadBalancerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/app/%s/.+", lbName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/app/%s/.+", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
 					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "idle_timeout", "30"),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", "application"),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
 					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "defensive"),
@@ -101,7 +101,7 @@ func TestAccELBV2LoadBalancer_ALB_basic(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_NLB_basic(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -111,20 +111,20 @@ func TestAccELBV2LoadBalancer_NLB_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_networkLoadbalancer(lbName, false),
+				Config: testAccLoadBalancerConfig_networkLoadbalancer(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/net/%s/.+", lbName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/net/%s/.+", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
 					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", "network"),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
 				),
 			},
@@ -246,7 +246,7 @@ func TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalanci
 
 func TestAccELBV2LoadBalancer_ALB_outpost(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-outpost-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -256,18 +256,18 @@ func TestAccELBV2LoadBalancer_ALB_outpost(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_outpost(lbName),
+				Config: testAccLoadBalancerConfig_outpost(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/app/%s/.+", lbName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/app/%s/.+", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
 					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "idle_timeout", "30"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", "application"),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -286,7 +286,7 @@ func TestAccELBV2LoadBalancer_ALB_outpost(t *testing.T) {
 func TestAccELBV2LoadBalancer_networkLoadBalancerEIP(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	resourceName := "aws_lb.lb_test"
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -295,10 +295,10 @@ func TestAccELBV2LoadBalancer_networkLoadBalancerEIP(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_networkLoadBalancerEIP(lbName),
+				Config: testAccLoadBalancerConfig_networkLoadBalancerEIP(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "internal", "false"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
 					resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
@@ -315,7 +315,7 @@ func TestAccELBV2LoadBalancer_networkLoadBalancerEIP(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_NLB_privateIPv4Address(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-pipv4a-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -325,7 +325,7 @@ func TestAccELBV2LoadBalancer_NLB_privateIPv4Address(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_networkLoadBalancerPrivateIPV4Address(lbName),
+				Config: testAccLoadBalancerConfig_networkLoadBalancerPrivateIPV4Address(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
@@ -344,7 +344,7 @@ func TestAccELBV2LoadBalancer_NLB_privateIPv4Address(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_backwardsCompatibility(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -354,15 +354,15 @@ func TestAccELBV2LoadBalancer_backwardsCompatibility(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerBackwardsCompatibilityConfig(lbName),
+				Config: testAccLoadBalancerBackwardsCompatibilityConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "idle_timeout", "30"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
@@ -379,6 +379,7 @@ func TestAccELBV2LoadBalancer_backwardsCompatibility(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_generatedName(t *testing.T) {
 	var conf elbv2.LoadBalancer
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -388,7 +389,7 @@ func TestAccELBV2LoadBalancer_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_generatedName(),
+				Config: testAccLoadBalancerConfig_generatedName(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -400,6 +401,7 @@ func TestAccELBV2LoadBalancer_generatedName(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_generatesNameForZeroValue(t *testing.T) {
 	var conf elbv2.LoadBalancer
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -409,7 +411,7 @@ func TestAccELBV2LoadBalancer_generatesNameForZeroValue(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_zeroValueName(),
+				Config: testAccLoadBalancerConfig_zeroValueName(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -421,6 +423,7 @@ func TestAccELBV2LoadBalancer_generatesNameForZeroValue(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_namePrefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -430,7 +433,7 @@ func TestAccELBV2LoadBalancer_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_namePrefix(),
+				Config: testAccLoadBalancerConfig_namePrefix(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -444,7 +447,7 @@ func TestAccELBV2LoadBalancer_namePrefix(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_tags(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -454,15 +457,15 @@ func TestAccELBV2LoadBalancer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_basic(lbName),
+				Config: testAccLoadBalancerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_updatedTags(lbName),
+				Config: testAccLoadBalancerConfig_updatedTags(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -471,11 +474,11 @@ func TestAccELBV2LoadBalancer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_basic(lbName),
+				Config: testAccLoadBalancerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -484,7 +487,7 @@ func TestAccELBV2LoadBalancer_tags(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-nlbcz-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -498,7 +501,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) 
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_networkLoadbalancer(lbName, true),
+				Config: testAccLoadBalancerConfig_networkLoadbalancer(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					testAccCheckLoadBalancerAttribute(resourceName, "load_balancing.cross_zone.enabled", "true"),
@@ -506,7 +509,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_networkLoadbalancer(lbName, false),
+				Config: testAccLoadBalancerConfig_networkLoadbalancer(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &mid),
 					testAccCheckLoadBalancerAttribute(resourceName, "load_balancing.cross_zone.enabled", "false"),
@@ -515,7 +518,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_networkLoadbalancer(lbName, true),
+				Config: testAccLoadBalancerConfig_networkLoadbalancer(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					testAccCheckLoadBalancerAttribute(resourceName, "load_balancing.cross_zone.enabled", "true"),
@@ -529,7 +532,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) 
 
 func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSalb-http2-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -543,7 +546,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_enableHTTP2(lbName, false),
+				Config: testAccLoadBalancerConfig_enableHTTP2(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http2.enabled", "false"),
@@ -551,7 +554,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_enableHTTP2(lbName, true),
+				Config: testAccLoadBalancerConfig_enableHTTP2(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &mid),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http2.enabled", "true"),
@@ -560,7 +563,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_enableHTTP2(lbName, false),
+				Config: testAccLoadBalancerConfig_enableHTTP2(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http2.enabled", "false"),
@@ -574,7 +577,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 
 func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSalb-headers-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -587,7 +590,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFie
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(lbName, false),
+				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists("aws_lb.lb_test", &pre),
 					testAccCheckLoadBalancerAttribute("aws_lb.lb_test", "routing.http.drop_invalid_header_fields.enabled", "false"),
@@ -595,7 +598,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFie
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(lbName, true),
+				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists("aws_lb.lb_test", &mid),
 					testAccCheckLoadBalancerAttribute("aws_lb.lb_test", "routing.http.drop_invalid_header_fields.enabled", "true"),
@@ -604,7 +607,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFie
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(lbName, false),
+				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists("aws_lb.lb_test", &post),
 					testAccCheckLoadBalancerAttribute("aws_lb.lb_test", "routing.http.drop_invalid_header_fields.enabled", "false"),
@@ -618,7 +621,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFie
 
 func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSalb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -632,7 +635,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_enableDeletionProtection(lbName, false),
+				Config: testAccLoadBalancerConfig_enableDeletionProtection(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					testAccCheckLoadBalancerAttribute(resourceName, "deletion_protection.enabled", "false"),
@@ -640,7 +643,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_enableDeletionProtection(lbName, true),
+				Config: testAccLoadBalancerConfig_enableDeletionProtection(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &mid),
 					testAccCheckLoadBalancerAttribute(resourceName, "deletion_protection.enabled", "true"),
@@ -649,7 +652,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_enableDeletionProtection(lbName, false),
+				Config: testAccLoadBalancerConfig_enableDeletionProtection(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					testAccCheckLoadBalancerAttribute(resourceName, "deletion_protection.enabled", "false"),
@@ -663,7 +666,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t
 
 func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSalb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -677,7 +680,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen(t *testi
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLBConfig_enableWafFailOpen(lbName, false),
+				Config: testAccLBConfig_enableWafFailOpen(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "enable_waf_fail_open", "false"),
@@ -689,7 +692,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen(t *testi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLBConfig_enableWafFailOpen(lbName, true),
+				Config: testAccLBConfig_enableWafFailOpen(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &mid),
 					resource.TestCheckResourceAttr(resourceName, "enable_waf_fail_open", "true"),
@@ -702,7 +705,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen(t *testi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLBConfig_enableWafFailOpen(lbName, false),
+				Config: testAccLBConfig_enableWafFailOpen(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					resource.TestCheckResourceAttr(resourceName, "enable_waf_fail_open", "false"),
@@ -715,7 +718,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen(t *testi
 
 func TestAccELBV2LoadBalancer_updatedSecurityGroups(t *testing.T) {
 	var pre, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -729,14 +732,14 @@ func TestAccELBV2LoadBalancer_updatedSecurityGroups(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_basic(lbName),
+				Config: testAccLoadBalancerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_updateSecurityGroups(lbName),
+				Config: testAccLoadBalancerConfig_updateSecurityGroups(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
@@ -749,7 +752,7 @@ func TestAccELBV2LoadBalancer_updatedSecurityGroups(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_updatedSubnets(t *testing.T) {
 	var pre, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -763,14 +766,14 @@ func TestAccELBV2LoadBalancer_updatedSubnets(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_basic(lbName),
+				Config: testAccLoadBalancerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "2"),
 				),
 			},
 			{
-				Config: testAccLoadBalancerConfig_updateSubnets(lbName),
+				Config: testAccLoadBalancerConfig_updateSubnets(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "3"),
@@ -783,7 +786,7 @@ func TestAccELBV2LoadBalancer_updatedSubnets(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_updatedIPAddressType(t *testing.T) {
 	var pre, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -793,14 +796,14 @@ func TestAccELBV2LoadBalancer_updatedIPAddressType(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerWithIPAddressTypeConfig(lbName),
+				Config: testAccLoadBalancerWithIPAddressTypeConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
 				),
 			},
 			{
-				Config: testAccLoadBalancerWithIPAddressTypeUpdatedConfig(lbName),
+				Config: testAccLoadBalancerWithIPAddressTypeUpdatedConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "dualstack"),
@@ -815,7 +818,7 @@ func TestAccELBV2LoadBalancer_updatedIPAddressType(t *testing.T) {
 // is assigned.
 func TestAccELBV2LoadBalancer_noSecurityGroup(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-nosg-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -825,15 +828,15 @@ func TestAccELBV2LoadBalancer_noSecurityGroup(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_nosg(lbName),
+				Config: testAccLoadBalancerConfig_nosg(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(resourceName, "subnets.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "idle_timeout", "30"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -847,8 +850,7 @@ func TestAccELBV2LoadBalancer_noSecurityGroup(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("tf-test-access-logs-%s", sdkacctest.RandString(6))
-	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
 	if testing.Short() {
@@ -862,14 +864,14 @@ func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerALBAccessLogsConfig(true, lbName, bucketName, ""),
+				Config: testAccLoadBalancerALBAccessLogsConfig(true, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -880,14 +882,14 @@ func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerALBAccessLogsConfig(false, lbName, bucketName, ""),
+				Config: testAccLoadBalancerALBAccessLogsConfig(false, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "false"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -898,14 +900,14 @@ func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerALBAccessLogsConfig(true, lbName, bucketName, ""),
+				Config: testAccLoadBalancerALBAccessLogsConfig(true, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -916,14 +918,14 @@ func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerALBAccessLogsNoBlocksConfig(lbName, bucketName),
+				Config: testAccLoadBalancerALBAccessLogsNoBlocksConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "false"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -939,8 +941,7 @@ func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_ALBAccessLogs_prefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("tf-test-access-logs-%s", sdkacctest.RandString(6))
-	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
 	if testing.Short() {
@@ -954,14 +955,14 @@ func TestAccELBV2LoadBalancer_ALBAccessLogs_prefix(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerALBAccessLogsConfig(true, lbName, bucketName, "prefix1"),
+				Config: testAccLoadBalancerALBAccessLogsConfig(true, rName, "prefix1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", "prefix1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", "prefix1"),
 				),
@@ -972,14 +973,14 @@ func TestAccELBV2LoadBalancer_ALBAccessLogs_prefix(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerALBAccessLogsConfig(true, lbName, bucketName, ""),
+				Config: testAccLoadBalancerALBAccessLogsConfig(true, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -990,14 +991,14 @@ func TestAccELBV2LoadBalancer_ALBAccessLogs_prefix(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerALBAccessLogsConfig(true, lbName, bucketName, "prefix1"),
+				Config: testAccLoadBalancerALBAccessLogsConfig(true, rName, "prefix1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", "prefix1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", "prefix1"),
 				),
@@ -1013,8 +1014,7 @@ func TestAccELBV2LoadBalancer_ALBAccessLogs_prefix(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("tf-test-access-logs-%s", sdkacctest.RandString(6))
-	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
 	if testing.Short() {
@@ -1028,14 +1028,14 @@ func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerNLBAccessLogsConfig(true, lbName, bucketName, ""),
+				Config: testAccLoadBalancerNLBAccessLogsConfig(true, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -1046,14 +1046,14 @@ func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerNLBAccessLogsConfig(false, lbName, bucketName, ""),
+				Config: testAccLoadBalancerNLBAccessLogsConfig(false, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "false"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -1064,14 +1064,14 @@ func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerNLBAccessLogsConfig(true, lbName, bucketName, ""),
+				Config: testAccLoadBalancerNLBAccessLogsConfig(true, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -1082,14 +1082,14 @@ func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerNLBAccessLogsNoBlocksConfig(lbName, bucketName),
+				Config: testAccLoadBalancerNLBAccessLogsNoBlocksConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "false"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -1105,8 +1105,7 @@ func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_NLBAccessLogs_prefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("tf-test-access-logs-%s", sdkacctest.RandString(6))
-	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
 	if testing.Short() {
@@ -1120,14 +1119,14 @@ func TestAccELBV2LoadBalancer_NLBAccessLogs_prefix(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerNLBAccessLogsConfig(true, lbName, bucketName, "prefix1"),
+				Config: testAccLoadBalancerNLBAccessLogsConfig(true, rName, "prefix1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", "prefix1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", "prefix1"),
 				),
@@ -1138,14 +1137,14 @@ func TestAccELBV2LoadBalancer_NLBAccessLogs_prefix(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerNLBAccessLogsConfig(true, lbName, bucketName, ""),
+				Config: testAccLoadBalancerNLBAccessLogsConfig(true, rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", ""),
 				),
@@ -1156,14 +1155,14 @@ func TestAccELBV2LoadBalancer_NLBAccessLogs_prefix(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLoadBalancerNLBAccessLogsConfig(true, lbName, bucketName, "prefix1"),
+				Config: testAccLoadBalancerNLBAccessLogsConfig(true, rName, "prefix1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", bucketName),
+					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.bucket", rName),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.enabled", "true"),
 					testAccCheckLoadBalancerAttribute(resourceName, "access_logs.s3.prefix", "prefix1"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.prefix", "prefix1"),
 				),
@@ -1179,7 +1178,7 @@ func TestAccELBV2LoadBalancer_NLBAccessLogs_prefix(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1189,13 +1188,13 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoadBalancerConfig_networkLoadbalancer_subnets(lbName),
+				Config: testAccLoadBalancerConfig_networkLoadbalancer_subnets(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "testAccLoadBalancerConfig_networkLoadbalancer_subnets"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", "network"),
 				),
 			},
@@ -1205,7 +1204,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change(t *testing.T) {
 
 func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
-	lbName := fmt.Sprintf("testaccawsalb-desync-%s", sdkacctest.RandString(4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb.lb_test"
 
 	if testing.Short() {
@@ -1219,7 +1218,7 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBConfig_desyncMitigationMode(lbName, "strictest"),
+				Config: testAccAWSLBConfig_desyncMitigationMode(rName, "strictest"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &pre),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "strictest"),
@@ -1232,7 +1231,7 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSLBConfig_desyncMitigationMode(lbName, "monitor"),
+				Config: testAccAWSLBConfig_desyncMitigationMode(rName, "monitor"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &mid),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "monitor"),
@@ -1245,7 +1244,7 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSLBConfig_desyncMitigationMode(lbName, "defensive"),
+				Config: testAccAWSLBConfig_desyncMitigationMode(rName, "defensive"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &post),
 					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "defensive"),
@@ -1383,10 +1382,10 @@ func testAccPreCheckElbv2GatewayLoadBalancer(t *testing.T) {
 	t.Skip("skipping acceptance testing: region does not support ELBv2 Gateway Load Balancers")
 }
 
-func testAccLoadBalancerWithIPAddressTypeUpdatedConfig(lbName string) string {
+func testAccLoadBalancerWithIPAddressTypeUpdatedConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   security_groups = [aws_security_group.alb_test.id]
   subnets         = [aws_subnet.alb_test_1.id, aws_subnet.alb_test_2.id]
 
@@ -1396,7 +1395,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1412,7 +1411,7 @@ resource "aws_lb_listener" "test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 80
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1445,7 +1444,7 @@ resource "aws_vpc" "alb_test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-lb-with-ip-address-type-updated"
+    Name = %[1]q
   }
 }
 
@@ -1461,7 +1460,7 @@ resource "aws_subnet" "alb_test_1" {
   ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)
 
   tags = {
-    Name = "tf-acc-lb-with-ip-address-type-updated-1"
+    Name = %[1]q
   }
 }
 
@@ -1473,7 +1472,7 @@ resource "aws_subnet" "alb_test_2" {
   ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)
 
   tags = {
-    Name = "tf-acc-lb-with-ip-address-type-updated-2"
+    Name = %[1]q
   }
 }
 
@@ -1490,16 +1489,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerWithIPAddressTypeConfig(lbName string) string {
+func testAccLoadBalancerWithIPAddressTypeConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   security_groups = [aws_security_group.alb_test.id]
   subnets         = [aws_subnet.alb_test_1.id, aws_subnet.alb_test_2.id]
 
@@ -1509,7 +1508,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1525,7 +1524,7 @@ resource "aws_lb_listener" "test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 80
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -1558,7 +1557,7 @@ resource "aws_vpc" "alb_test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-lb-with-ip-address-type"
+    Name = %[1]q
   }
 }
 
@@ -1574,7 +1573,7 @@ resource "aws_subnet" "alb_test_1" {
   ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)
 
   tags = {
-    Name = "tf-acc-lb-with-ip-address-type-1"
+    Name = %[1]q
   }
 }
 
@@ -1586,7 +1585,7 @@ resource "aws_subnet" "alb_test_2" {
   ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)
 
   tags = {
-    Name = "tf-acc-lb-with-ip-address-type-2"
+    Name = %[1]q
   }
 }
 
@@ -1603,16 +1602,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_basic(lbName string) string {
+func testAccLoadBalancerConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -1621,7 +1620,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1634,7 +1633,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-basic"
+    Name = %[1]q
   }
 }
 
@@ -1646,7 +1645,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-basic"
+    Name = %[1]q
   }
 }
 
@@ -1670,13 +1669,13 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_outpost(lbName string) string {
+func testAccLoadBalancerConfig_outpost(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -1706,7 +1705,7 @@ resource "aws_route_table_association" "a" {
 }
 
 resource "aws_lb" "lb_test" {
-  name                       = "%s"
+  name                       = %[1]q
   security_groups            = [aws_security_group.alb_test.id]
   customer_owned_ipv4_pool   = tolist(data.aws_ec2_coip_pools.test.pool_ids)[0]
   idle_timeout               = 30
@@ -1714,7 +1713,7 @@ resource "aws_lb" "lb_test" {
   subnets                    = [aws_subnet.alb_test.id]
 
   tags = {
-    Name = "TestAccAWSALB_outpost"
+    Name = %[1]q
   }
 }
 
@@ -1722,7 +1721,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-outpost"
+    Name = %[1]q
   }
 }
 
@@ -1733,7 +1732,7 @@ resource "aws_subnet" "alb_test" {
   outpost_arn       = data.aws_outposts_outpost.test.arn
 
   tags = {
-    Name = "tf-acc-lb-outpost"
+    Name = %[1]q
   }
 }
 
@@ -1757,16 +1756,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_outpost"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_enableHTTP2(lbName string, http2 bool) string {
+func testAccLoadBalancerConfig_enableHTTP2(rName string, http2 bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -1774,10 +1773,10 @@ resource "aws_lb" "lb_test" {
   idle_timeout               = 30
   enable_deletion_protection = false
 
-  enable_http2 = %t
+  enable_http2 = %[2]t
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1790,7 +1789,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-basic"
+    Name = %[1]q
   }
 }
 
@@ -1826,16 +1825,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName, http2))
+`, rName, http2))
 }
 
-func testAccLoadBalancerConfig_enableDropInvalidHeaderFields(lbName string, dropInvalid bool) string {
+func testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName string, dropInvalid bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -1843,10 +1842,10 @@ resource "aws_lb" "lb_test" {
   idle_timeout               = 30
   enable_deletion_protection = false
 
-  drop_invalid_header_fields = %t
+  drop_invalid_header_fields = %[2]t
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1859,7 +1858,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-basic"
+    Name = %[1]q
   }
 }
 
@@ -1895,25 +1894,25 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName, dropInvalid))
+`, rName, dropInvalid))
 }
 
-func testAccLoadBalancerConfig_enableDeletionProtection(lbName string, deletion_protection bool) string {
+func testAccLoadBalancerConfig_enableDeletionProtection(rName string, deletionProtection bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
 
   idle_timeout               = 30
-  enable_deletion_protection = %t
+  enable_deletion_protection = %[2]t
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1926,7 +1925,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-basic"
+    Name = %[1]q
   }
 }
 
@@ -1962,13 +1961,13 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName, deletion_protection))
+`, rName, deletionProtection))
 }
 
-func testAccLBConfig_enableWafFailOpen(lbName string, wafFailOpen bool) string {
+func testAccLBConfig_enableWafFailOpen(rName string, wafFailOpen bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1984,7 +1983,7 @@ resource "aws_lb" "lb_test" {
   enable_waf_fail_open = %[2]t
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -1997,7 +1996,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-basic"
+    Name = %[1]q
   }
 }
 
@@ -2033,24 +2032,24 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName, wafFailOpen))
+`, rName, wafFailOpen))
 }
 
-func testAccLoadBalancerConfig_networkLoadbalancer_subnets(lbName string) string {
+func testAccLoadBalancerConfig_networkLoadbalancer_subnets(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-network-load-balancer-subnets"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb" "lb_test" {
-  name = "%s"
+  name = %[1]q
 
   subnets = [
     aws_subnet.alb_test_1.id,
@@ -2065,7 +2064,7 @@ resource "aws_lb" "lb_test" {
   enable_cross_zone_load_balancing = false
 
   tags = {
-    Name = "testAccLoadBalancerConfig_networkLoadbalancer_subnets"
+    Name = %[1]q
   }
 }
 
@@ -2075,7 +2074,7 @@ resource "aws_subnet" "alb_test_1" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-lb-network-load-balancer-subnets-1"
+    Name = %[1]q
   }
 }
 
@@ -2085,7 +2084,7 @@ resource "aws_subnet" "alb_test_2" {
   availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
-    Name = "tf-acc-lb-network-load-balancer-subnets-2"
+    Name = %[1]q
   }
 }
 
@@ -2095,28 +2094,28 @@ resource "aws_subnet" "alb_test_3" {
   availability_zone = data.aws_availability_zones.available.names[2]
 
   tags = {
-    Name = "tf-acc-lb-network-load-balancer-subnets-3"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_networkLoadbalancer(lbName string, cz bool) string {
+func testAccLoadBalancerConfig_networkLoadbalancer(rName string, cz bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name               = "%s"
+  name               = %[1]q
   internal           = true
   load_balancer_type = "network"
 
   enable_deletion_protection       = false
-  enable_cross_zone_load_balancing = %t
+  enable_cross_zone_load_balancing = %[2]t
 
   subnet_mapping {
     subnet_id = aws_subnet.alb_test.id
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2124,7 +2123,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-network-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2135,10 +2134,10 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-network-load-balancer"
+    Name = %[1]q
   }
 }
-`, lbName, cz))
+`, rName, cz))
 }
 
 func testAccLoadBalancerConfig_LoadBalancerType_Gateway(rName string) string {
@@ -2149,7 +2148,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.10.10.0/25"
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2159,7 +2158,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2183,7 +2182,7 @@ resource "aws_vpc" "test" {
   cidr_block                       = "10.10.10.0/25"
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2191,7 +2190,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "main"
+    Name = %[1]q
   }
 }
 
@@ -2202,7 +2201,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2217,7 +2216,7 @@ resource "aws_lb" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_ipv6address"
+    Name = %[1]q
   }
 
   depends_on = [aws_internet_gateway.gw]
@@ -2233,7 +2232,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.10.10.0/25"
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2243,7 +2242,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -2259,13 +2258,13 @@ resource "aws_lb" "test" {
 `, rName, enableCrossZoneLoadBalancing))
 }
 
-func testAccLoadBalancerConfig_networkLoadBalancerEIP(lbName string) string {
+func testAccLoadBalancerConfig_networkLoadBalancerEIP(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-network-load-balancer-eip"
+    Name = %[1]q
   }
 }
 
@@ -2300,7 +2299,7 @@ resource "aws_route_table_association" "a" {
 }
 
 resource "aws_lb" "lb_test" {
-  name               = "%s"
+  name               = %[1]q
   load_balancer_type = "network"
 
   subnet_mapping {
@@ -2319,13 +2318,13 @@ resource "aws_lb" "lb_test" {
 resource "aws_eip" "lb" {
   count = "2"
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_networkLoadBalancerPrivateIPV4Address(lbName string) string {
+func testAccLoadBalancerConfig_networkLoadBalancerPrivateIPV4Address(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "test" {
-  name                       = "%s"
+  name                       = %[1]q
   internal                   = true
   load_balancer_type         = "network"
   enable_deletion_protection = false
@@ -2336,7 +2335,7 @@ resource "aws_lb" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_privateipv4address"
+    Name = %[1]q
   }
 }
 
@@ -2344,7 +2343,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "TestAccAWSALB_privateipv4address"
+    Name = %[1]q
   }
 }
 
@@ -2355,16 +2354,16 @@ resource "aws_subnet" "test" {
   availability_zone       = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "TestAccAWSALB_privateipv4address"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerBackwardsCompatibilityConfig(lbName string) string {
+func testAccLoadBalancerBackwardsCompatibilityConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_alb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -2373,7 +2372,7 @@ resource "aws_alb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2386,7 +2385,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-bc"
+    Name = %[1]q
   }
 }
 
@@ -2422,16 +2421,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_updateSubnets(lbName string) string {
+func testAccLoadBalancerConfig_updateSubnets(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -2440,7 +2439,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2453,7 +2452,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-update-subnets"
+    Name = %[1]q
   }
 }
 
@@ -2489,14 +2488,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_generatedName() string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+func testAccLoadBalancerConfig_generatedName(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
@@ -2506,7 +2507,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2519,7 +2520,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-generated-name"
+    Name = %[1]q
   }
 }
 
@@ -2527,7 +2528,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.alb_test.id
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2539,7 +2540,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-generated-name-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
@@ -2563,14 +2564,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`)
+`, rName))
 }
 
-func testAccLoadBalancerConfig_zeroValueName() string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+func testAccLoadBalancerConfig_zeroValueName(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = ""
   internal        = true
@@ -2581,7 +2584,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2599,7 +2602,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-zero-value-name"
+    Name = %[1]q
   }
 }
 
@@ -2607,7 +2610,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.alb_test.id
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2643,14 +2646,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`)
+`, rName))
 }
 
-func testAccLoadBalancerConfig_namePrefix() string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+func testAccLoadBalancerConfig_namePrefix(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name_prefix     = "tf-lb-"
   internal        = true
@@ -2661,7 +2666,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2674,7 +2679,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-name-prefix"
+    Name = %[1]q
   }
 }
 
@@ -2686,7 +2691,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-name-prefix-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
@@ -2710,16 +2715,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`)
+`, rName))
 }
 
-func testAccLoadBalancerConfig_updatedTags(lbName string) string {
+func testAccLoadBalancerConfig_updatedTags(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -2742,7 +2747,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-updated-tags"
+    Name = %[1]q
   }
 }
 
@@ -2754,7 +2759,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-updated-tags-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
@@ -2778,13 +2783,13 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerALBAccessLogsBaseConfig(bucketName string) string {
+func testAccLoadBalancerALBAccessLogsBaseConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_elb_service_account" "current" {}
 
@@ -2792,7 +2797,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-access-logs"
+    Name = %[1]q
   }
 }
 
@@ -2830,11 +2835,11 @@ resource "aws_s3_bucket_policy" "test" {
   bucket = aws_s3_bucket.test.bucket
   policy = data.aws_iam_policy_document.test.json
 }
-`, bucketName))
+`, rName))
 }
 
-func testAccLoadBalancerALBAccessLogsConfig(enabled bool, lbName, bucketName, bucketPrefix string) string {
-	return acctest.ConfigCompose(testAccLoadBalancerALBAccessLogsBaseConfig(bucketName), fmt.Sprintf(`
+func testAccLoadBalancerALBAccessLogsConfig(enabled bool, rName, bucketPrefix string) string {
+	return acctest.ConfigCompose(testAccLoadBalancerALBAccessLogsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
@@ -2846,20 +2851,20 @@ resource "aws_lb" "test" {
     prefix  = %[3]q
   }
 }
-`, lbName, enabled, bucketPrefix))
+`, rName, enabled, bucketPrefix))
 }
 
-func testAccLoadBalancerALBAccessLogsNoBlocksConfig(lbName, bucketName string) string {
-	return acctest.ConfigCompose(testAccLoadBalancerALBAccessLogsBaseConfig(bucketName), fmt.Sprintf(`
+func testAccLoadBalancerALBAccessLogsNoBlocksConfig(rName string) string {
+	return acctest.ConfigCompose(testAccLoadBalancerALBAccessLogsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
   subnets  = aws_subnet.alb_test.*.id
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerNLBAccessLogsBaseConfig(bucketName string) string {
+func testAccLoadBalancerNLBAccessLogsBaseConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_elb_service_account" "current" {}
 
@@ -2867,7 +2872,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-access-logs"
+    Name = %[1]q
   }
 }
 
@@ -2916,11 +2921,11 @@ resource "aws_s3_bucket_policy" "test" {
   bucket = aws_s3_bucket.test.bucket
   policy = data.aws_iam_policy_document.test.json
 }
-`, bucketName))
+`, rName))
 }
 
-func testAccLoadBalancerNLBAccessLogsConfig(enabled bool, lbName, bucketName, bucketPrefix string) string {
-	return acctest.ConfigCompose(testAccLoadBalancerNLBAccessLogsBaseConfig(bucketName), fmt.Sprintf(`
+func testAccLoadBalancerNLBAccessLogsConfig(enabled bool, rName, bucketPrefix string) string {
+	return acctest.ConfigCompose(testAccLoadBalancerNLBAccessLogsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_lb" "test" {
   internal           = true
   load_balancer_type = "network"
@@ -2933,24 +2938,24 @@ resource "aws_lb" "test" {
     prefix  = %[3]q
   }
 }
-`, lbName, enabled, bucketPrefix))
+`, rName, enabled, bucketPrefix))
 }
 
-func testAccLoadBalancerNLBAccessLogsNoBlocksConfig(lbName, bucketName string) string {
-	return acctest.ConfigCompose(testAccLoadBalancerNLBAccessLogsBaseConfig(bucketName), fmt.Sprintf(`
+func testAccLoadBalancerNLBAccessLogsNoBlocksConfig(rName string) string {
+	return acctest.ConfigCompose(testAccLoadBalancerNLBAccessLogsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_lb" "test" {
   internal           = true
   load_balancer_type = "network"
   name               = %[1]q
   subnets            = aws_subnet.alb_test.*.id
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_nosg(lbName string) string {
+func testAccLoadBalancerConfig_nosg(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name     = "%s"
+  name     = %[1]q
   internal = true
   subnets  = aws_subnet.alb_test.*.id
 
@@ -2958,7 +2963,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -2971,7 +2976,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-no-sg"
+    Name = %[1]q
   }
 }
 
@@ -2986,13 +2991,13 @@ resource "aws_subnet" "alb_test" {
     Name = "tf-acc-lb-no-sg-${count.index}"
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccLoadBalancerConfig_updateSecurityGroups(lbName string) string {
+func testAccLoadBalancerConfig_updateSecurityGroups(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id, aws_security_group.alb_test_2.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -3001,7 +3006,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
@@ -3014,7 +3019,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-update-security-groups"
+    Name = %[1]q
   }
 }
 
@@ -3043,7 +3048,7 @@ resource "aws_security_group" "alb_test_2" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic_2"
+    Name = %[1]q
   }
 }
 
@@ -3067,16 +3072,16 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
-`, lbName))
+`, rName))
 }
 
-func testAccAWSLBConfig_desyncMitigationMode(lbName string, mode string) string {
+func testAccAWSLBConfig_desyncMitigationMode(rName string, mode string) string {
 	return fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
@@ -3084,10 +3089,10 @@ resource "aws_lb" "lb_test" {
   idle_timeout               = 30
   enable_deletion_protection = false
 
-  desync_mitigation_mode = %q
+  desync_mitigation_mode = %[2]q
 
   tags = {
-    Name = "TestAccAWSALB_desync"
+    Name = %[1]q
   }
 }
 
@@ -3109,7 +3114,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-desync"
+    Name = %[1]q
   }
 }
 
@@ -3145,8 +3150,8 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    Name = "TestAccAWSALB_desync"
+    Name = %[1]q
   }
 }
-`, lbName, mode)
+`, rName, mode)
 }

--- a/internal/service/lakeformation/resource_test.go
+++ b/internal/service/lakeformation/resource_test.go
@@ -163,7 +163,7 @@ func TestAccLakeFormationResource_updateSLRToRole(t *testing.T) {
 // AWS does not support changing from an IAM role to an SLR. No error is thrown
 // but the registration is not changed (the IAM role continues in the registration).
 //
-// func TestAccAWSLakeFormationResource_updateRoleToSLR(t *testing.T) {
+// func TestAccLakeFormationResource_updateRoleToSLR(t *testing.T) {
 
 func testAccCheckResourceDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn

--- a/internal/service/pinpoint/adm_channel_test.go
+++ b/internal/service/pinpoint/adm_channel_test.go
@@ -21,12 +21,12 @@ import (
  ADM_CLIENT_SECRET - Amazon ADM OAuth Credentials Client Secret
 **/
 
-type testAccAWSPinpointADMChannelConfiguration struct {
+type testAccADMChannelConfiguration struct {
 	ClientID     string
 	ClientSecret string
 }
 
-func testAccADMChannelConfigurationFromEnv(t *testing.T) *testAccAWSPinpointADMChannelConfiguration {
+func testAccADMChannelConfigurationFromEnv(t *testing.T) *testAccADMChannelConfiguration {
 	if os.Getenv("ADM_CLIENT_ID") == "" {
 		t.Skipf("ADM_CLIENT_ID ENV is missing")
 	}
@@ -35,7 +35,7 @@ func testAccADMChannelConfigurationFromEnv(t *testing.T) *testAccAWSPinpointADMC
 		t.Skipf("ADM_CLIENT_SECRET ENV is missing")
 	}
 
-	conf := testAccAWSPinpointADMChannelConfiguration{
+	conf := testAccADMChannelConfiguration{
 		ClientID:     os.Getenv("ADM_CLIENT_ID"),
 		ClientSecret: os.Getenv("ADM_CLIENT_SECRET"),
 	}
@@ -108,7 +108,7 @@ func testAccCheckADMChannelExists(n string, channel *pinpoint.ADMChannelResponse
 	}
 }
 
-func testAccADMChannelConfig_basic(conf *testAccAWSPinpointADMChannelConfiguration) string {
+func testAccADMChannelConfig_basic(conf *testAccADMChannelConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 

--- a/internal/service/pinpoint/apns_channel_test.go
+++ b/internal/service/pinpoint/apns_channel_test.go
@@ -31,26 +31,26 @@ import (
  APNS_CERTIFICATE_PRIVATE_KEY - APNs Certificate Private Key File content
 **/
 
-type testAccAWSPinpointAPNSChannelCertConfiguration struct {
+type testAccAPNSChannelCertConfiguration struct {
 	Certificate string
 	PrivateKey  string
 }
 
-type testAccAWSPinpointAPNSChannelTokenConfiguration struct {
+type testAccAPNSChannelTokenConfiguration struct {
 	BundleId   string
 	TeamId     string
 	TokenKey   string
 	TokenKeyId string
 }
 
-func testAccAPNSChannelCertConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSChannelCertConfiguration {
-	var conf *testAccAWSPinpointAPNSChannelCertConfiguration
+func testAccAPNSChannelCertConfigurationFromEnv(t *testing.T) *testAccAPNSChannelCertConfiguration {
+	var conf *testAccAPNSChannelCertConfiguration
 	if os.Getenv("APNS_CERTIFICATE") != "" {
 		if os.Getenv("APNS_CERTIFICATE_PRIVATE_KEY") == "" {
 			t.Fatalf("APNS_CERTIFICATE set but missing APNS_CERTIFICATE_PRIVATE_KEY")
 		}
 
-		conf = &testAccAWSPinpointAPNSChannelCertConfiguration{
+		conf = &testAccAPNSChannelCertConfiguration{
 			Certificate: fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_CERTIFICATE"))),
 			PrivateKey:  fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_CERTIFICATE_PRIVATE_KEY"))),
 		}
@@ -63,7 +63,7 @@ func testAccAPNSChannelCertConfigurationFromEnv(t *testing.T) *testAccAWSPinpoin
 	return conf
 }
 
-func testAccAPNSChannelTokenConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSChannelTokenConfiguration {
+func testAccAPNSChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSChannelTokenConfiguration {
 	if os.Getenv("APNS_BUNDLE_ID") == "" {
 		t.Skipf("APNS_BUNDLE_ID env is missing, skipping test")
 	}
@@ -80,7 +80,7 @@ func testAccAPNSChannelTokenConfigurationFromEnv(t *testing.T) *testAccAWSPinpoi
 		t.Skipf("APNS_TOKEN_KEY_ID env is missing, skipping test")
 	}
 
-	conf := testAccAWSPinpointAPNSChannelTokenConfiguration{
+	conf := testAccAPNSChannelTokenConfiguration{
 		BundleId:   strconv.Quote(strings.TrimSpace(os.Getenv("APNS_BUNDLE_ID"))),
 		TeamId:     strconv.Quote(strings.TrimSpace(os.Getenv("APNS_TEAM_ID"))),
 		TokenKey:   fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_TOKEN_KEY"))),
@@ -187,7 +187,7 @@ func testAccCheckAPNSChannelExists(n string, channel *pinpoint.APNSChannelRespon
 	}
 }
 
-func testAccAPNSChannelConfig_basicCertificate(conf *testAccAWSPinpointAPNSChannelCertConfiguration) string {
+func testAccAPNSChannelConfig_basicCertificate(conf *testAccAPNSChannelCertConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
@@ -201,7 +201,7 @@ resource "aws_pinpoint_apns_channel" "test_apns_channel" {
 `, conf.Certificate, conf.PrivateKey)
 }
 
-func testAccAPNSChannelConfig_basicToken(conf *testAccAWSPinpointAPNSChannelTokenConfiguration) string {
+func testAccAPNSChannelConfig_basicToken(conf *testAccAPNSChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 

--- a/internal/service/pinpoint/apns_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_sandbox_channel_test.go
@@ -31,26 +31,26 @@ import (
  APNS_SANDBOX_CERTIFICATE_PRIVATE_KEY - APNs Certificate Private Key File content
 **/
 
-type testAccAWSPinpointAPNSSandboxChannelCertConfiguration struct {
+type testAccAPNSSandboxChannelCertConfiguration struct {
 	Certificate string
 	PrivateKey  string
 }
 
-type testAccAWSPinpointAPNSSandboxChannelTokenConfiguration struct {
+type testAccAPNSSandboxChannelTokenConfiguration struct {
 	BundleId   string
 	TeamId     string
 	TokenKey   string
 	TokenKeyId string
 }
 
-func testAccAPNSSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSSandboxChannelCertConfiguration {
-	var conf *testAccAWSPinpointAPNSSandboxChannelCertConfiguration
+func testAccAPNSSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAccAPNSSandboxChannelCertConfiguration {
+	var conf *testAccAPNSSandboxChannelCertConfiguration
 	if os.Getenv("APNS_SANDBOX_CERTIFICATE") != "" {
 		if os.Getenv("APNS_SANDBOX_CERTIFICATE_PRIVATE_KEY") == "" {
 			t.Fatalf("APNS_SANDBOX_CERTIFICATE set but missing APNS_SANDBOX_CERTIFICATE_PRIVATE_KEY")
 		}
 
-		conf = &testAccAWSPinpointAPNSSandboxChannelCertConfiguration{
+		conf = &testAccAPNSSandboxChannelCertConfiguration{
 			Certificate: fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_SANDBOX_CERTIFICATE"))),
 			PrivateKey:  fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_SANDBOX_CERTIFICATE_PRIVATE_KEY"))),
 		}
@@ -63,7 +63,7 @@ func testAccAPNSSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAccAWS
 	return conf
 }
 
-func testAccAPNSSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSSandboxChannelTokenConfiguration {
+func testAccAPNSSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSSandboxChannelTokenConfiguration {
 	if os.Getenv("APNS_SANDBOX_BUNDLE_ID") == "" {
 		t.Skipf("APNS_SANDBOX_BUNDLE_ID env is missing, skipping test")
 	}
@@ -80,7 +80,7 @@ func testAccAPNSSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAW
 		t.Skipf("APNS_SANDBOX_TOKEN_KEY_ID env is missing, skipping test")
 	}
 
-	conf := testAccAWSPinpointAPNSSandboxChannelTokenConfiguration{
+	conf := testAccAPNSSandboxChannelTokenConfiguration{
 		BundleId:   strconv.Quote(strings.TrimSpace(os.Getenv("APNS_SANDBOX_BUNDLE_ID"))),
 		TeamId:     strconv.Quote(strings.TrimSpace(os.Getenv("APNS_SANDBOX_TEAM_ID"))),
 		TokenKey:   fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_SANDBOX_TOKEN_KEY"))),
@@ -187,7 +187,7 @@ func testAccCheckAPNSSandboxChannelExists(n string, channel *pinpoint.APNSSandbo
 	}
 }
 
-func testAccAPNSSandboxChannelConfig_basicCertificate(conf *testAccAWSPinpointAPNSSandboxChannelCertConfiguration) string {
+func testAccAPNSSandboxChannelConfig_basicCertificate(conf *testAccAPNSSandboxChannelCertConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
@@ -201,7 +201,7 @@ resource "aws_pinpoint_apns_sandbox_channel" "test_channel" {
 `, conf.Certificate, conf.PrivateKey)
 }
 
-func testAccAPNSSandboxChannelConfig_basicToken(conf *testAccAWSPinpointAPNSSandboxChannelTokenConfiguration) string {
+func testAccAPNSSandboxChannelConfig_basicToken(conf *testAccAPNSSandboxChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 

--- a/internal/service/pinpoint/apns_voip_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_channel_test.go
@@ -31,26 +31,26 @@ import (
  APNS_VOIP_CERTIFICATE_PRIVATE_KEY - APNs Certificate Private Key File content
 **/
 
-type testAccAWSPinpointAPNSVoipChannelCertConfiguration struct {
+type testAccAPNSVoipChannelCertConfiguration struct {
 	Certificate string
 	PrivateKey  string
 }
 
-type testAccAWSPinpointAPNSVoipChannelTokenConfiguration struct {
+type testAccAPNSVoipChannelTokenConfiguration struct {
 	BundleId   string
 	TeamId     string
 	TokenKey   string
 	TokenKeyId string
 }
 
-func testAccAPNSVoIPChannelCertConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSVoipChannelCertConfiguration {
-	var conf *testAccAWSPinpointAPNSVoipChannelCertConfiguration
+func testAccAPNSVoIPChannelCertConfigurationFromEnv(t *testing.T) *testAccAPNSVoipChannelCertConfiguration {
+	var conf *testAccAPNSVoipChannelCertConfiguration
 	if os.Getenv("APNS_VOIP_CERTIFICATE") != "" {
 		if os.Getenv("APNS_VOIP_CERTIFICATE_PRIVATE_KEY") == "" {
 			t.Fatalf("APNS_VOIP_CERTIFICATE set but missing APNS_VOIP_CERTIFICATE_PRIVATE_KEY")
 		}
 
-		conf = &testAccAWSPinpointAPNSVoipChannelCertConfiguration{
+		conf = &testAccAPNSVoipChannelCertConfiguration{
 			Certificate: fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_CERTIFICATE"))),
 			PrivateKey:  fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_CERTIFICATE_PRIVATE_KEY"))),
 		}
@@ -63,7 +63,7 @@ func testAccAPNSVoIPChannelCertConfigurationFromEnv(t *testing.T) *testAccAWSPin
 	return conf
 }
 
-func testAccAPNSVoIPChannelTokenConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSVoipChannelTokenConfiguration {
+func testAccAPNSVoIPChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSVoipChannelTokenConfiguration {
 	if os.Getenv("APNS_VOIP_BUNDLE_ID") == "" {
 		t.Skipf("APNS_VOIP_BUNDLE_ID env is missing, skipping test")
 	}
@@ -80,7 +80,7 @@ func testAccAPNSVoIPChannelTokenConfigurationFromEnv(t *testing.T) *testAccAWSPi
 		t.Skipf("APNS_VOIP_TOKEN_KEY_ID env is missing, skipping test")
 	}
 
-	conf := testAccAWSPinpointAPNSVoipChannelTokenConfiguration{
+	conf := testAccAPNSVoipChannelTokenConfiguration{
 		BundleId:   strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_BUNDLE_ID"))),
 		TeamId:     strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_TEAM_ID"))),
 		TokenKey:   fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_TOKEN_KEY"))),
@@ -187,7 +187,7 @@ func testAccCheckAPNSVoIPChannelExists(n string, channel *pinpoint.APNSVoipChann
 	}
 }
 
-func testAccAPNSVoIPChannelConfig_basicCertificate(conf *testAccAWSPinpointAPNSVoipChannelCertConfiguration) string {
+func testAccAPNSVoIPChannelConfig_basicCertificate(conf *testAccAPNSVoipChannelCertConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
@@ -201,7 +201,7 @@ resource "aws_pinpoint_apns_voip_channel" "test_channel" {
 `, conf.Certificate, conf.PrivateKey)
 }
 
-func testAccAPNSVoIPChannelConfig_basicToken(conf *testAccAWSPinpointAPNSVoipChannelTokenConfiguration) string {
+func testAccAPNSVoIPChannelConfig_basicToken(conf *testAccAPNSVoipChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 

--- a/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
@@ -31,26 +31,26 @@ import (
  APNS_VOIP_CERTIFICATE_PRIVATE_KEY - APNs Certificate Private Key File content
 **/
 
-type testAccAWSPinpointAPNSVoipSandboxChannelCertConfiguration struct {
+type testAccAPNSVoipSandboxChannelCertConfiguration struct {
 	Certificate string
 	PrivateKey  string
 }
 
-type testAccAWSPinpointAPNSVoipSandboxChannelTokenConfiguration struct {
+type testAccAPNSVoipSandboxChannelTokenConfiguration struct {
 	BundleId   string
 	TeamId     string
 	TokenKey   string
 	TokenKeyId string
 }
 
-func testAccAPNSVoIPSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSVoipSandboxChannelCertConfiguration {
-	var conf *testAccAWSPinpointAPNSVoipSandboxChannelCertConfiguration
+func testAccAPNSVoIPSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAccAPNSVoipSandboxChannelCertConfiguration {
+	var conf *testAccAPNSVoipSandboxChannelCertConfiguration
 	if os.Getenv("APNS_VOIP_CERTIFICATE") != "" {
 		if os.Getenv("APNS_VOIP_CERTIFICATE_PRIVATE_KEY") == "" {
 			t.Fatalf("APNS_VOIP_CERTIFICATE set but missing APNS_VOIP_CERTIFICATE_PRIVATE_KEY")
 		}
 
-		conf = &testAccAWSPinpointAPNSVoipSandboxChannelCertConfiguration{
+		conf = &testAccAPNSVoipSandboxChannelCertConfiguration{
 			Certificate: fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_CERTIFICATE"))),
 			PrivateKey:  fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_CERTIFICATE_PRIVATE_KEY"))),
 		}
@@ -63,7 +63,7 @@ func testAccAPNSVoIPSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAc
 	return conf
 }
 
-func testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAWSPinpointAPNSVoipSandboxChannelTokenConfiguration {
+func testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSVoipSandboxChannelTokenConfiguration {
 	if os.Getenv("APNS_VOIP_BUNDLE_ID") == "" {
 		t.Skipf("APNS_VOIP_BUNDLE_ID env is missing, skipping test")
 	}
@@ -80,7 +80,7 @@ func testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testA
 		t.Skipf("APNS_VOIP_TOKEN_KEY_ID env is missing, skipping test")
 	}
 
-	conf := testAccAWSPinpointAPNSVoipSandboxChannelTokenConfiguration{
+	conf := testAccAPNSVoipSandboxChannelTokenConfiguration{
 		BundleId:   strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_BUNDLE_ID"))),
 		TeamId:     strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_TEAM_ID"))),
 		TokenKey:   fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_TOKEN_KEY"))),
@@ -187,7 +187,7 @@ func testAccCheckAPNSVoIPSandboxChannelExists(n string, channel *pinpoint.APNSVo
 	}
 }
 
-func testAccAPNSVoIPSandboxChannelConfig_basicCertificate(conf *testAccAWSPinpointAPNSVoipSandboxChannelCertConfiguration) string {
+func testAccAPNSVoIPSandboxChannelConfig_basicCertificate(conf *testAccAPNSVoipSandboxChannelCertConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
@@ -201,7 +201,7 @@ resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {
 `, conf.Certificate, conf.PrivateKey)
 }
 
-func testAccAPNSVoIPSandboxChannelConfig_basicToken(conf *testAccAWSPinpointAPNSVoipSandboxChannelTokenConfiguration) string {
+func testAccAPNSVoIPSandboxChannelConfig_basicToken(conf *testAccAPNSVoipSandboxChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -93,7 +93,7 @@ func TestAccRDSCluster_allowMajorVersionUpgrade(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 	// If these hardcoded versions become a maintenance burden, use DescribeDBEngineVersions
 	// either by having a new data source created or implementing the testing similar
-	// to TestAccAWSDmsReplicationInstance_EngineVersion
+	// to TestAccDMSReplicationInstance_engineVersion
 	engine := "aurora-postgresql"
 	engineVersion1 := "12.9"
 	engineVersion2 := "13.5"
@@ -150,7 +150,7 @@ func TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm(t *t
 	resourceName := "aws_rds_cluster.test"
 	// If these hardcoded versions become a maintenance burden, use DescribeDBEngineVersions
 	// either by having a new data source created or implementing the testing similar
-	// to TestAccAWSDmsReplicationInstance_EngineVersion
+	// to TestAccDMSReplicationInstance_engineVersion
 	engine := "aurora-postgresql"
 	engineVersion1 := "12.9"
 	engineVersion2 := "13.5"
@@ -193,7 +193,7 @@ func TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters(t *testing.T
 	resourceName := "aws_rds_cluster.test"
 	// If these hardcoded versions become a maintenance burden, use DescribeDBEngineVersions
 	// either by having a new data source created or implementing the testing similar
-	// to TestAccAWSDmsReplicationInstance_EngineVersion
+	// to TestAccDMSReplicationInstance_engineVersion
 	engine := "aurora-postgresql"
 	engineVersion1 := "12.9"
 	engineVersion2 := "13.5"
@@ -250,7 +250,7 @@ func TestAccRDSCluster_onlyMajorVersion(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 	// If these hardcoded versions become a maintenance burden, use DescribeDBEngineVersions
 	// either by having a new data source created or implementing the testing similar
-	// to TestAccAWSDmsReplicationInstance_EngineVersion
+	// to TestAccDMSReplicationInstance_engineVersion
 	engine := "aurora-postgresql"
 	engineVersion1 := "11"
 

--- a/internal/service/s3/bucket_public_access_block_test.go
+++ b/internal/service/s3/bucket_public_access_block_test.go
@@ -350,20 +350,20 @@ func testAccCheckBucketPublicAccessBlockDisappears(n string) resource.TestCheckF
 func testAccBucketPublicAccessBlockConfig(bucketName, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
+  bucket = %[1]q
 
   tags = {
-    TestName = "TestAccAWSS3BucketPublicAccessBlock_basic"
+    TestName = %[1]q
   }
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
   bucket = aws_s3_bucket.bucket.bucket
 
-  block_public_acls       = "%s"
-  block_public_policy     = "%s"
-  ignore_public_acls      = "%s"
-  restrict_public_buckets = "%s"
+  block_public_acls       = %[2]q
+  block_public_policy     = %[3]q
+  ignore_public_acls      = %[4]q
+  restrict_public_buckets = %[5]q
 }
 `, bucketName, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets)
 }

--- a/internal/service/s3control/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3control/bucket_lifecycle_configuration_test.go
@@ -311,7 +311,7 @@ func TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags(t *testing.T) 
 			// does not get populated from the XML response. Reference:
 			// https://github.com/aws/aws-sdk-go/issues/3591
 			// {
-			// 	Config: testAccAWSS3ControlBucketLifecycleConfigurationConfig_Rule_Filter_Tags2(rName, "key1", "value1updated", "key2", "value2"),
+			// 	Config: testAccS3ControlBucketLifecycleConfigurationConfig_Rule_Filter_Tags2(rName, "key1", "value1updated", "key2", "value2"),
 			// 	Check: resource.ComposeTestCheckFunc(
 			// 		testAccCheckBucketLifecycleConfigurationExists(resourceName),
 			// 		resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
@@ -672,7 +672,7 @@ resource "aws_s3control_bucket_lifecycle_configuration" "test" {
 }
 
 // See TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags note about XML handling bug.
-// func testAccAWSS3ControlBucketLifecycleConfigurationConfig_Rule_Filter_Tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+// func testAccS3ControlBucketLifecycleConfigurationConfig_Rule_Filter_Tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 // 	return fmt.Sprintf(`
 // data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -42,7 +42,7 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 			// InvalidRequestException: A previous rotation isn’t complete. That rotation will be reattempted.
 			/*
 				{
-					Config: testAccAWSSecretsManagerSecretConfig_Updated(rName),
+					Config: testAccSecretsManagerSecretConfig_Updated(rName),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckSecretRotationExists(resourceName, &secret),
 						resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -277,7 +277,7 @@ func TestAccSecretsManagerSecret_rotationLambdaARN(t *testing.T) {
 			// InvalidRequestException: A previous rotation isn’t complete. That rotation will be reattempted.
 			/*
 				{
-					Config: testAccAWSSecretsManagerSecretConfig_RotationLambdaARN_Updated(rName),
+					Config: testAccSecretsManagerSecretConfig_RotationLambdaARN_Updated(rName),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckSecretExists(resourceName, &secret),
 						resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),

--- a/internal/service/sns/platform_application_test.go
+++ b/internal/service/sns/platform_application_test.go
@@ -29,21 +29,21 @@ import (
  APNS_SANDBOX_PRINCIPAL_PATH - Apple Push Notification Sandbox Certificate file location
 **/
 
-type testAccAWSSnsPlatformApplicationPlatform struct {
+type testAccPlatformApplicationPlatform struct {
 	Name       string
 	Credential string
 	Principal  string
 }
 
-func testAccPlatformApplicationPlatformFromEnv(t *testing.T) []*testAccAWSSnsPlatformApplicationPlatform {
-	platforms := make([]*testAccAWSSnsPlatformApplicationPlatform, 0, 2)
+func testAccPlatformApplicationPlatformFromEnv(t *testing.T) []*testAccPlatformApplicationPlatform {
+	platforms := make([]*testAccPlatformApplicationPlatform, 0, 2)
 
 	if os.Getenv("APNS_SANDBOX_CREDENTIAL") != "" {
 		if os.Getenv("APNS_SANDBOX_PRINCIPAL") == "" {
 			t.Fatalf("APNS_SANDBOX_CREDENTIAL set but missing APNS_SANDBOX_PRINCIPAL")
 		}
 
-		platform := &testAccAWSSnsPlatformApplicationPlatform{
+		platform := &testAccPlatformApplicationPlatform{
 			Name:       "APNS_SANDBOX",
 			Credential: fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_SANDBOX_CREDENTIAL"))),
 			Principal:  fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_SANDBOX_PRINCIPAL"))),
@@ -54,7 +54,7 @@ func testAccPlatformApplicationPlatformFromEnv(t *testing.T) []*testAccAWSSnsPla
 			t.Fatalf("APNS_SANDBOX_CREDENTIAL_PATH set but missing APNS_SANDBOX_PRINCIPAL_PATH")
 		}
 
-		platform := &testAccAWSSnsPlatformApplicationPlatform{
+		platform := &testAccPlatformApplicationPlatform{
 			Name:       "APNS_SANDBOX",
 			Credential: strconv.Quote(fmt.Sprintf("${file(pathexpand(%q))}", os.Getenv("APNS_SANDBOX_CREDENTIAL_PATH"))),
 			Principal:  strconv.Quote(fmt.Sprintf("${file(pathexpand(%q))}", os.Getenv("APNS_SANDBOX_PRINCIPAL_PATH"))),
@@ -63,7 +63,7 @@ func testAccPlatformApplicationPlatformFromEnv(t *testing.T) []*testAccAWSSnsPla
 	}
 
 	if os.Getenv("GCM_API_KEY") != "" {
-		platform := &testAccAWSSnsPlatformApplicationPlatform{
+		platform := &testAccPlatformApplicationPlatform{
 			Name:       "GCM",
 			Credential: strconv.Quote(os.Getenv("GCM_API_KEY")),
 		}
@@ -397,7 +397,7 @@ func testAccCheckPlatformApplicationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccPlatformApplicationConfig_basic(name string, platform *testAccAWSSnsPlatformApplicationPlatform) string {
+func testAccPlatformApplicationConfig_basic(name string, platform *testAccPlatformApplicationPlatform) string {
 	if platform.Principal == "" {
 		return fmt.Sprintf(`
 resource "aws_sns_platform_application" "test" {
@@ -417,7 +417,7 @@ resource "aws_sns_platform_application" "test" {
 `, name, platform.Name, platform.Credential, platform.Principal)
 }
 
-func testAccPlatformApplicationConfig_basicAttribute(name string, platform *testAccAWSSnsPlatformApplicationPlatform, attributeKey, attributeValue string) string {
+func testAccPlatformApplicationConfig_basicAttribute(name string, platform *testAccPlatformApplicationPlatform, attributeKey, attributeValue string) string {
 	if platform.Principal == "" {
 		return fmt.Sprintf(`
 resource "aws_sns_platform_application" "test" {
@@ -439,7 +439,7 @@ resource "aws_sns_platform_application" "test" {
 `, name, platform.Name, platform.Credential, platform.Principal, attributeKey, attributeValue)
 }
 
-func testAccPlatformApplicationConfig_iamRoleAttribute(name string, platform *testAccAWSSnsPlatformApplicationPlatform, attributeKey, iamRoleName string) string {
+func testAccPlatformApplicationConfig_iamRoleAttribute(name string, platform *testAccPlatformApplicationPlatform, attributeKey, iamRoleName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -469,7 +469,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, iamRoleName, testAccPlatformApplicationConfig_basicAttribute(name, platform, attributeKey, "${aws_iam_role.test.arn}"))
 }
 
-func testAccPlatformApplicationConfig_snsTopicAttribute(name string, platform *testAccAWSSnsPlatformApplicationPlatform, attributeKey, snsTopicName string) string {
+func testAccPlatformApplicationConfig_snsTopicAttribute(name string, platform *testAccPlatformApplicationPlatform, attributeKey, snsTopicName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = "%s"

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -1358,7 +1358,7 @@ func TestAccWAFV2RuleGroup_RuleAction_customResponse(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2RuleGroupConfig_RuleActionBlock_CustomResponseBody(ruleGroupName, "test_body_1"),
+				Config: testAccRuleGroupConfig_RuleActionBlock_CustomResponseBody(ruleGroupName, "test_body_1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
@@ -1390,7 +1390,7 @@ func TestAccWAFV2RuleGroup_RuleAction_customResponse(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2RuleGroupConfig_RuleActionBlock_CustomResponseBody(ruleGroupName, "test_body_2"),
+				Config: testAccRuleGroupConfig_RuleActionBlock_CustomResponseBody(ruleGroupName, "test_body_2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
@@ -2108,7 +2108,7 @@ resource "aws_wafv2_rule_group" "test" {
 `, name)
 }
 
-func testAccAwsWafv2RuleGroupConfig_RuleActionBlock_CustomResponseBody(name string, customBodyKey string) string {
+func testAccRuleGroupConfig_RuleActionBlock_CustomResponseBody(name string, customBodyKey string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -1428,7 +1428,7 @@ func TestAccWAFV2WebACL_Custom_response(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_CustomResponseBody(webACLName, 404, 429),
+				Config: testAccWebACLConfig_CustomResponseBody(webACLName, 404, 429),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -2151,7 +2151,7 @@ resource "aws_wafv2_web_acl" "test" {
 `, name, defaultStatusCode, countryBlockStatusCode, countryHeaderName)
 }
 
-func testAccAwsWafv2WebACLConfig_CustomResponseBody(name string, defaultStatusCode int, countryBlockStatusCode int) string {
+func testAccWebACLConfig_CustomResponseBody(name string, defaultStatusCode int, countryBlockStatusCode int) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
   name        = "%[1]s"

--- a/providerlint/passes/AWSAT002/README.md
+++ b/providerlint/passes/AWSAT002/README.md
@@ -5,8 +5,8 @@ The AWSAT002 analyzer reports hardcoded AMI IDs. AMI IDs are region dependent an
 ## Flagged Code
 
 ```go
-func testAccAWSSpotFleetRequestConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccEC2SpotFleetRequestConfig(rName string, rInt int, validUntil string) string {
+	return testAccEC2SpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     launch_specification {
         instance_type = "m1.small"
@@ -20,8 +20,8 @@ resource "aws_spot_fleet_request" "test" {
 ## Passing Code
 
 ```go
-func testAccAWSSpotFleetRequestConfig(rName string, rInt int, validUntil string) string {
-    return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccEC2SpotFleetRequestConfig(rName string, rInt int, validUntil string) string {
+    return testAccEC2SpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]

--- a/providerlint/passes/AWSAT004/README.md
+++ b/providerlint/passes/AWSAT004/README.md
@@ -9,13 +9,13 @@ configurations.
 ## Flagged Code
 
 ```go
-func TestAccAWSELB_basic(t *testing.T) {
+func TestAccELBV2LoadBalancer_basic(t *testing.T) {
   ...
 	resource.ParallelTest(t, resource.TestCase{
     ...
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSELBConfig,
+				Config: testELBV2LoadBalancerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
           ...
 					resource.TestCheckResourceAttr(resourceName, "listener.206423021.instance_port", "8000"),
@@ -36,27 +36,26 @@ func TestAccAWSELB_basic(t *testing.T) {
 The flagged code above can be replaced with the following passing code:
 
 ```go
-func TestAccAWSELB_basic(t *testing.T) {
+func TestAccELBV2LoadBalancer_basic(t *testing.T) {
   ...
-	resource.ParallelTest(t, resource.TestCase{
+    resource.ParallelTest(t, resource.TestCase{
     ...
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSELBConfig,
-				Check: resource.ComposeTestCheckFunc(
-          ...
-          resource.TestCheckTypeSetElemNestedAttrs(resourceName, "listener.*", map[string]string{
- 						"instance_port":     "8000",
-            "instance_protocol": "http",
-            "lb_port":           "80",
-            "lb_protocol":       "http",
- 					}),
-          ...
-				),
-			},
-      ...
-		},
-	})
+        Steps: []resource.TestStep{
+            {
+                Config: testAccELBV2LoadBalancerConfig_basic,
+                Check: resource.ComposeTestCheckFunc(
+                ...
+                    resource.TestCheckTypeSetElemNestedAttrs(resourceName, "listener.*", map[string]string{
+                        "instance_port":     "8000",
+                        "instance_protocol": "http",
+                        "lb_port":           "80",
+                        "lb_protocol":       "http",
+                ),
+                ...
+            },
+        ...
+        },
+    })
 }
 ```
 

--- a/providerlint/passes/AWSAT005/README.md
+++ b/providerlint/passes/AWSAT005/README.md
@@ -6,7 +6,7 @@ work across AWS partitions, the partitions should not be hardcoded.
 ## Flagged Code
 
 ```go
-func testAccAWSSpotFleetRequestConfig(role string) string {
+func testAccEC2SpotFleetRequestConfig(role string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role_policy_attachment" "test-AmazonEKSClusterPolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
@@ -19,7 +19,7 @@ resource "aws_iam_role_policy_attachment" "test-AmazonEKSClusterPolicy" {
 ## Passing Code
 
 ```go
-func testAccAWSSpotFleetRequestConfig(role string) string {
+func testAccEC2SpotFleetRequestConfig(role string) string {
     return fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/providerlint/passes/AWSAT006/README.md
+++ b/providerlint/passes/AWSAT006/README.md
@@ -6,7 +6,7 @@ to work across AWS partitions, the DNS suffixes should not be hardcoded.
 ## Flagged Code
 
 ```go
-func testAccAWSMisericordiamHumilitatemPulchritudo(name string) string {
+func testAccEKSMisericordiamHumilitatemPulchritudo(name string) string {
     return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = "%s"
@@ -33,7 +33,7 @@ POLICY
 ## Passing Code
 
 ```go
-func testAccAWSMisericordiamHumilitatemPulchritudo(name string) string {
+func testAccEKSMisericordiamHumilitatemPulchritudo(name string) string {
     return fmt.Sprintf(`
 data "aws_partition" "current" {}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccELBV2ListenerRule_ PKG=elbv2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRule_'  -timeout 180m
--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (3.80s)
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (34.20s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (232.54s)
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (238.47s)
--- PASS: TestAccELBV2ListenerRule_oidc (244.03s)
--- PASS: TestAccELBV2ListenerRule_Action_order (251.79s)
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (251.75s)
--- PASS: TestAccELBV2ListenerRule_fixedResponse (254.29s)
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (257.45s)
--- PASS: TestAccELBV2ListenerRule_basic (268.76s)
--- PASS: TestAccELBV2ListenerRule_redirect (271.61s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (271.91s)
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (273.30s)
--- PASS: TestAccELBV2ListenerRule_cognito (277.34s)
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (277.91s)
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (280.16s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (294.31s)
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (299.06s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (301.29s)
--- PASS: TestAccELBV2ListenerRule_ActionOrder_recreates (306.53s)
--- PASS: TestAccELBV2ListenerRule_tags (273.90s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMixed (308.37s)
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (245.85s)
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (242.47s)
--- PASS: TestAccELBV2ListenerRule_priority (375.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	615.360s
% make testacc TESTS=TestAccELBV2LoadBalancer PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer'  -timeout 180m
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (1.46s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change (219.10s)
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (232.64s)
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (242.33s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (262.32s)
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (271.26s)
--- PASS: TestAccELBV2LoadBalancer_updatedSubnets (287.19s)
--- PASS: TestAccELBV2LoadBalancer_noSecurityGroup (292.82s)
--- PASS: TestAccELBV2LoadBalancer_updatedIPAddressType (302.82s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (304.52s)
--- PASS: TestAccELBV2LoadBalancer_tags (314.49s)
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (0.53s)
--- PASS: TestAccELBV2LoadBalancer_updatedSecurityGroups (317.03s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (321.17s)
--- PASS: TestAccELBV2LoadBalancer_ALBAccessLogs_prefix (321.74s)
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (336.86s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen (337.50s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (341.80s)
--- PASS: TestAccELBV2LoadBalancer_NLBAccessLogs_prefix (343.35s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (345.56s)
--- PASS: TestAccELBV2LoadBalancer_ALB_accessLogs (371.97s)
--- PASS: TestAccELBV2LoadBalancer_NLB_accessLogs (372.22s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (99.81s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (145.73s)
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (228.06s)
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (241.03s)
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (208.85s)
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (250.98s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (239.70s)
--- PASS: TestAccELBV2LoadBalancer_generatedName (233.30s)
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (242.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	546.767s
```
