### PR TITLE
r/aws_acm_certificate: Add support for ECDSA and PEM-encrypted private keys in acm_certificate

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -911,6 +911,15 @@ provider "aws" {
 `, region)
 }
 
+func ConfigACMPassphraseProvider(passphrase string) string {
+	//lintignore:AT004
+	return fmt.Sprintf(`
+provider "aws" {
+  acm_private_key_passphrase = %[1]q
+}
+`, passphrase)
+}
+
 func RegionProviderFunc(region string, providers *[]*schema.Provider) func() *schema.Provider {
 	return func() *schema.Provider {
 		if region == "" {

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -1,12 +1,15 @@
 package acctest
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -15,8 +18,10 @@ import (
 const (
 	pemBlockTypeCertificate        = `CERTIFICATE`
 	pemBlockTypeRsaPrivateKey      = `RSA PRIVATE KEY`
+	pemBlockTypeEcPrivateKey       = `EC PRIVATE KEY`
 	pemBlockTypePublicKey          = `PUBLIC KEY`
 	pemBlockTypeCertificateRequest = `CERTIFICATE REQUEST`
+	pemBlockProcTypeEncrypted      = `Proc-Type: 4,ENCRYPTED`
 )
 
 var tlsX509CertificateSerialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128) //nolint:gomnd
@@ -40,20 +45,50 @@ func TLSRSAPrivateKeyPEM(bits int) string {
 	return string(pem.EncodeToMemory(block))
 }
 
-// TLSRSAPublicKeyPEM generates a RSA public key PEM string.
-// Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
-// configurations such as: public_key_pem = "%[1]s"
-func TLSRSAPublicKeyPEM(keyPem string) string {
+// TLSPrivateKey returns the private key from a RSA or ECDSA PEM string.
+func TLSPrivateKey(keyPem string) interface{} {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
-	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
-
-	if err != nil {
-		//lintignore:R009
-		panic(err)
+	if keyBlock.Type == pemBlockTypeRsaPrivateKey {
+		key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		if err != nil {
+			//lintignore:R009
+			panic(err)
+		}
+		return key
+	} else if keyBlock.Type == pemBlockTypeEcPrivateKey {
+		key, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+		if err != nil {
+			//lintignore:R009
+			panic(err)
+		}
+		return key
+	} else {
+		panic(fmt.Errorf("unsupported PEM block %s", keyBlock.Type))
 	}
+}
 
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+// TLSRSAPublicKeyPEM generates a RSA public key PEM string.
+// Replaced by TLSPublicKeyPEM
+
+// TLSPublicKeyPEM generates a public key PEM string from a RSA or ECDSA private key.
+// Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: public_key_pem = "%[1]s"
+func TLSPublicKeyPEM(keyPem string) string {
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	privateKey := TLSPrivateKey(keyPem)
+
+	var publicKeyBytes []byte
+	var err error
+
+	if keyBlock.Type == pemBlockTypeRsaPrivateKey {
+		publicKeyBytes, err = x509.MarshalPKIXPublicKey(&privateKey.(*rsa.PrivateKey).PublicKey)
+	} else if keyBlock.Type == pemBlockTypeEcPrivateKey {
+		publicKeyBytes, err = x509.MarshalPKIXPublicKey(&privateKey.(*ecdsa.PrivateKey).PublicKey)
+	} else {
+		panic(fmt.Errorf("unsupported PEM block %s", keyBlock.Type))
+	}
 
 	if err != nil {
 		//lintignore:R009
@@ -69,30 +104,16 @@ func TLSRSAPublicKeyPEM(keyPem string) string {
 }
 
 // TLSRSAX509LocallySignedCertificatePEM generates a local CA x509 certificate PEM string.
+// Replaced by TLSX509LocallySignedCertificatePEM
+
+// TLSX509LocallySignedCertificatePEM generates a local CA x509 certificate PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: certificate_pem = "%[1]s"
-func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, commonName string) string {
+func TLSX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, commonName string) string {
+	keyBlock, _ := pem.Decode([]byte(keyPem))
 	caCertificateBlock, _ := pem.Decode([]byte(caCertificatePem))
 
 	caCertificate, err := x509.ParseCertificate(caCertificateBlock.Bytes)
-
-	if err != nil {
-		//lintignore:R009
-		panic(err)
-	}
-
-	caKeyBlock, _ := pem.Decode([]byte(caKeyPem))
-
-	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
-
-	if err != nil {
-		//lintignore:R009
-		panic(err)
-	}
-
-	keyBlock, _ := pem.Decode([]byte(keyPem))
-
-	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 
 	if err != nil {
 		//lintignore:R009
@@ -119,11 +140,18 @@ func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, c
 		},
 	}
 
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, caCertificate, &key.PublicKey, caKey)
+	caKey := TLSPrivateKey(caKeyPem)
 
-	if err != nil {
-		//lintignore:R009
-		panic(err)
+	key := TLSPrivateKey(keyPem)
+
+	var certificateBytes []byte
+
+	if keyBlock.Type == pemBlockTypeRsaPrivateKey {
+		certificateBytes, err = x509.CreateCertificate(rand.Reader, certificate, caCertificate, &key.(*rsa.PrivateKey).PublicKey, caKey)
+	} else if keyBlock.Type == pemBlockTypeEcPrivateKey {
+		certificateBytes, err = x509.CreateCertificate(rand.Reader, certificate, caCertificate, &key.(*ecdsa.PrivateKey).PublicKey, caKey)
+	} else {
+		panic(fmt.Errorf("unsupported PEM block %s", keyBlock.Type))
 	}
 
 	certificateBlock := &pem.Block{
@@ -135,19 +163,25 @@ func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, c
 }
 
 // TLSRSAX509SelfSignedCACertificatePEM generates a x509 CA certificate PEM string.
+// Replaced by TLSX509SelfSignedCACertificatePEM
+
+// TLSX509SelfSignedCACertificatePEM generates a x509 CA certificate PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: root_certificate_pem = "%[1]s"
-func TLSRSAX509SelfSignedCACertificatePEM(keyPem string) string {
+func TLSX509SelfSignedCACertificatePEM(keyPem string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
-	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	key := TLSPrivateKey(keyPem)
+	var publicKeyBytes []byte
+	var err error
 
-	if err != nil {
-		//lintignore:R009
-		panic(err)
+	if keyBlock.Type == pemBlockTypeRsaPrivateKey {
+		publicKeyBytes, err = x509.MarshalPKIXPublicKey(&key.(*rsa.PrivateKey).PublicKey)
+	} else if keyBlock.Type == pemBlockTypeEcPrivateKey {
+		publicKeyBytes, err = x509.MarshalPKIXPublicKey(&key.(*ecdsa.PrivateKey).PublicKey)
+	} else {
+		panic(fmt.Errorf("unsupported PEM block %s", keyBlock.Type))
 	}
-
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 
 	if err != nil {
 		//lintignore:R009
@@ -178,7 +212,15 @@ func TLSRSAX509SelfSignedCACertificatePEM(keyPem string) string {
 		SubjectKeyId: publicKeyBytesSha1[:],
 	}
 
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
+	var certificateBytes []byte
+
+	if keyBlock.Type == pemBlockTypeRsaPrivateKey {
+		certificateBytes, err = x509.CreateCertificate(rand.Reader, certificate, certificate, &key.(*rsa.PrivateKey).PublicKey, key)
+	} else if keyBlock.Type == pemBlockTypeEcPrivateKey {
+		certificateBytes, err = x509.CreateCertificate(rand.Reader, certificate, certificate, &key.(*ecdsa.PrivateKey).PublicKey, key)
+	} else {
+		panic(fmt.Errorf("unsupported PEM block %s", keyBlock.Type))
+	}
 
 	if err != nil {
 		//lintignore:R009
@@ -194,17 +236,15 @@ func TLSRSAX509SelfSignedCACertificatePEM(keyPem string) string {
 }
 
 // TLSRSAX509SelfSignedCertificatePEM generates a x509 certificate PEM string.
+// Replaced by TLSX509SelfSignedCertificatePEM
+
+// TLSX509SelfSignedCertificatePEM generates a x509 certificate PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: private_key_pem = "%[1]s"
-func TLSRSAX509SelfSignedCertificatePEM(keyPem, commonName string) string {
+func TLSX509SelfSignedCertificatePEM(keyPem, commonName string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
-	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
-
-	if err != nil {
-		//lintignore:R009
-		panic(err)
-	}
+	key := TLSPrivateKey(keyPem)
 
 	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
 
@@ -226,7 +266,14 @@ func TLSRSAX509SelfSignedCertificatePEM(keyPem, commonName string) string {
 		},
 	}
 
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
+	var certificateBytes []byte
+	if keyBlock.Type == pemBlockTypeRsaPrivateKey {
+		certificateBytes, err = x509.CreateCertificate(rand.Reader, certificate, certificate, &key.(*rsa.PrivateKey).PublicKey, key)
+	} else if keyBlock.Type == pemBlockTypeEcPrivateKey {
+		certificateBytes, err = x509.CreateCertificate(rand.Reader, certificate, certificate, &key.(*ecdsa.PrivateKey).PublicKey, key)
+	} else {
+		panic(fmt.Errorf("unsupported PEM block %s", keyBlock.Type))
+	}
 
 	if err != nil {
 		//lintignore:R009
@@ -242,14 +289,47 @@ func TLSRSAX509SelfSignedCertificatePEM(keyPem, commonName string) string {
 }
 
 // TLSRSAX509CertificateRequestPEM generates a x509 certificate request PEM string
-// and a RSA private key PEM string.
+// Replaced by TLSX509CertificateRequestPEM
+
+// TLSX509CertificateRequestPEM generates a x509 certificate request PEM string
+// and a RSA or ECDSA private key PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: certificate_signing_request_pem = "%[1]s" private_key_pem = "%[2]s"
-func TLSRSAX509CertificateRequestPEM(keyBits int, commonName string) (string, string) {
-	keyBytes, err := rsa.GenerateKey(rand.Reader, keyBits)
-	if err != nil {
-		//lintignore:R009
-		panic(err)
+func TLSX509CertificateRequestPEM(publicKeyAlgorithm x509.PublicKeyAlgorithm, keyBits int, commonName string) (string, string) {
+	var keyBytes interface{}
+	keyBlock := &pem.Block{}
+	var signatureAlgorithm x509.SignatureAlgorithm
+	var err error
+
+	if publicKeyAlgorithm == x509.RSA {
+		keyBytes, err = rsa.GenerateKey(rand.Reader, keyBits)
+		if err != nil {
+			//lintignore:R009
+			panic(err)
+		}
+		keyBlock = &pem.Block{
+			Bytes: x509.MarshalPKCS1PrivateKey(keyBytes.(*rsa.PrivateKey)),
+			Type:  pemBlockTypeRsaPrivateKey,
+		}
+		signatureAlgorithm = x509.SHA256WithRSA
+	} else if publicKeyAlgorithm == x509.ECDSA {
+		keyBytes, err = ecdsa.GenerateKey(TLSECCurve(keyBits), rand.Reader)
+		if err != nil {
+			//lintignore:R009
+			panic(err)
+		}
+		privateKey, err := x509.MarshalECPrivateKey(keyBytes.(*ecdsa.PrivateKey))
+		if err != nil {
+			//lintignore:R009
+			panic(err)
+		}
+		keyBlock = &pem.Block{
+			Bytes: privateKey,
+			Type:  pemBlockTypeEcPrivateKey,
+		}
+		signatureAlgorithm = TLSECSignature(keyBits)
+	} else {
+		panic(fmt.Errorf("unsupported public key algorithm"))
 	}
 
 	csr := x509.CertificateRequest{
@@ -257,7 +337,8 @@ func TLSRSAX509CertificateRequestPEM(keyBits int, commonName string) (string, st
 			CommonName:   commonName,
 			Organization: []string{"ACME Examples, Inc"},
 		},
-		SignatureAlgorithm: x509.SHA256WithRSA,
+		SignatureAlgorithm: signatureAlgorithm,
+		PublicKeyAlgorithm: publicKeyAlgorithm,
 	}
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csr, keyBytes)
@@ -271,14 +352,126 @@ func TLSRSAX509CertificateRequestPEM(keyBits int, commonName string) (string, st
 		Type:  pemBlockTypeCertificateRequest,
 	}
 
-	keyBlock := &pem.Block{
-		Bytes: x509.MarshalPKCS1PrivateKey(keyBytes),
-		Type:  pemBlockTypeRsaPrivateKey,
+	return string(pem.EncodeToMemory(csrBlock)), string(pem.EncodeToMemory(keyBlock))
+}
+
+// TLSECPublicKeyPEM generates a ECDSA public key PEM string.
+// Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: public_key_pem = "%[1]s"
+func TLSECPublicKeyPEM(keyPem string) string {
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	key, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+
+	if err != nil {
+		//lintignore:R009
+		panic(err)
 	}
 
-	return string(pem.EncodeToMemory(csrBlock)), string(pem.EncodeToMemory(keyBlock))
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+
+	if err != nil {
+		//lintignore:R009
+		panic(err)
+	}
+
+	block := &pem.Block{
+		Bytes: publicKeyBytes,
+		Type:  pemBlockTypePublicKey,
+	}
+
+	return string(pem.EncodeToMemory(block))
 }
 
 func TLSPEMEscapeNewlines(pem string) string {
 	return strings.ReplaceAll(pem, "\n", "\\n")
+}
+
+// TLSPEMEncrypt encrypts a PEM block with a passphrase.
+// Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: private_key_pem = "%[1]s"
+func TLSPEMEncrypt(keyPem, passphrase string) string {
+	clearBlock, _ := pem.Decode([]byte(keyPem))
+
+	encryptedBlock, err := x509.EncryptPEMBlock(rand.Reader, clearBlock.Type, clearBlock.Bytes, []byte(passphrase), x509.PEMCipherAES256)
+	if err != nil {
+		panic(err)
+	}
+	return string(pem.EncodeToMemory(encryptedBlock))
+}
+
+// TLSECPrivateKeyPEM generates a ECDSA private key PEM string.
+// Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: private_key_pem = "%[1]s"
+func TLSECPrivateKeyPEM(bits int) string {
+	key, err := ecdsa.GenerateKey(TLSECCurve(bits), rand.Reader)
+	if err != nil {
+		//lintignore:R009
+		panic(err)
+	}
+
+	privateKey, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		//lintignore:R009
+		panic(err)
+	}
+
+	block := &pem.Block{
+		Bytes: privateKey,
+		Type:  pemBlockTypeEcPrivateKey,
+	}
+
+	return string(pem.EncodeToMemory(block))
+}
+
+// Select an appropriate EC curve for the number of bits
+func TLSECCurve(bits int) elliptic.Curve {
+	switch bits {
+	case 224:
+		return elliptic.P224()
+	case 256:
+		return elliptic.P256()
+	case 384:
+		return elliptic.P384()
+	case 512:
+		return elliptic.P521()
+	case 521:
+		return elliptic.P521()
+	default:
+		panic(fmt.Errorf("unsupported curve bits %d", bits))
+	}
+}
+
+// Select an appropriate EC signature for the number of bits
+func TLSECSignature(bits int) x509.SignatureAlgorithm {
+	switch {
+	case bits <= 256:
+		return x509.ECDSAWithSHA256
+	case bits <= 384:
+		return x509.ECDSAWithSHA384
+	case bits > 384:
+		return x509.ECDSAWithSHA512
+	}
+	return x509.ECDSAWithSHA256
+}
+
+// Aliases for compatibility wit existing RSA function names
+func TLSRSAPublicKeyPEM(keyPem string) string {
+	return TLSPublicKeyPEM(keyPem)
+}
+
+func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, commonName string) string {
+	return TLSX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, commonName)
+}
+
+func TLSRSAX509SelfSignedCACertificatePEM(keyPem string) string {
+	return TLSX509SelfSignedCACertificatePEM(keyPem)
+}
+
+func TLSRSAX509SelfSignedCertificatePEM(keyPem, commonName string) string {
+	return TLSX509SelfSignedCertificatePEM(keyPem, commonName)
+}
+
+func TLSRSAX509CertificateRequestPEM(keyBits int, commonName string) (string, string) {
+	return TLSX509CertificateRequestPEM(x509.RSA, keyBits, commonName)
 }

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -1,6 +1,7 @@
 package acctest
 
 import (
+	"crypto/x509"
 	"strings"
 	"testing"
 )
@@ -9,16 +10,55 @@ func TestTlsRsaPrivateKeyPem(t *testing.T) {
 	key := TLSRSAPrivateKeyPEM(2048)
 
 	if !strings.Contains(key, pemBlockTypeRsaPrivateKey) {
-		t.Errorf("key does not contain RSA PRIVATE KEY: %s", key)
+		t.Errorf("key does not contain %s:\n%s", pemBlockTypeRsaPrivateKey, key)
+	}
+}
+
+func TestTlsRsaPrivateKeyEncrypredPem(t *testing.T) {
+	key := TLSRSAPrivateKeyPEM(2048)
+	encryptedKey := TLSPEMEncrypt(key, "passphrase")
+	if !strings.Contains(encryptedKey, pemBlockTypeRsaPrivateKey) {
+		t.Errorf("key does not contain %s:\n%s", pemBlockTypeRsaPrivateKey, key)
+	}
+	if !strings.Contains(encryptedKey, pemBlockProcTypeEncrypted) {
+		t.Errorf("key does not contain %s:\n%s", pemBlockProcTypeEncrypted, key)
+	}
+}
+
+func TestTlsEcPrivateKeyPem(t *testing.T) {
+	key := TLSECPrivateKeyPEM(256)
+
+	if !strings.Contains(key, pemBlockTypeEcPrivateKey) {
+		t.Errorf("key does not contain %s:\n%s", pemBlockTypeEcPrivateKey, key)
+	}
+}
+
+func TestTlsEcPrivateKeyEncryptedPem(t *testing.T) {
+	key := TLSECPrivateKeyPEM(256)
+	encryptedKey := TLSPEMEncrypt(key, "passphrase")
+	if !strings.Contains(encryptedKey, pemBlockTypeEcPrivateKey) {
+		t.Errorf("key does not contain %s:\n%s", pemBlockTypeEcPrivateKey, key)
+	}
+	if !strings.Contains(encryptedKey, pemBlockProcTypeEncrypted) {
+		t.Errorf("key does not contain %s:\n%s", pemBlockProcTypeEncrypted, key)
 	}
 }
 
 func TestTlsRsaPublicKeyPem(t *testing.T) {
 	privateKey := TLSRSAPrivateKeyPEM(2048)
-	publicKey := TLSRSAPublicKeyPEM(privateKey)
+	publicKey := TLSPublicKeyPEM(privateKey)
 
 	if !strings.Contains(publicKey, pemBlockTypePublicKey) {
-		t.Errorf("key does not contain PUBLIC KEY: %s", publicKey)
+		t.Errorf("key does not contain %s:\n%s", pemBlockTypePublicKey, publicKey)
+	}
+}
+
+func TestTlsEcPublicKeyPem(t *testing.T) {
+	privateKey := TLSECPrivateKeyPEM(256)
+	publicKey := TLSPublicKeyPEM(privateKey)
+
+	if !strings.Contains(publicKey, pemBlockTypePublicKey) {
+		t.Errorf("key does not contain %s:\n%s", pemBlockTypePublicKey, publicKey)
 	}
 }
 
@@ -29,7 +69,18 @@ func TestTlsRsaX509LocallySignedCertificatePem(t *testing.T) {
 	certificate := TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, "example.com")
 
 	if !strings.Contains(certificate, pemBlockTypeCertificate) {
-		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeCertificate, certificate)
+	}
+}
+
+func TestTlsEcX509LocallySignedCertificatePem(t *testing.T) {
+	caKey := TLSECPrivateKeyPEM(384)
+	caCertificate := TLSX509SelfSignedCACertificatePEM(caKey)
+	key := TLSECPrivateKeyPEM(256)
+	certificate := TLSX509LocallySignedCertificatePEM(caKey, caCertificate, key, "example.com")
+
+	if !strings.Contains(certificate, pemBlockTypeCertificate) {
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeCertificate, certificate)
 	}
 }
 
@@ -38,7 +89,16 @@ func TestTlsRsaX509SelfSignedCaCertificatePem(t *testing.T) {
 	caCertificate := TLSRSAX509SelfSignedCACertificatePEM(caKey)
 
 	if !strings.Contains(caCertificate, pemBlockTypeCertificate) {
-		t.Errorf("CA certificate does not contain CERTIFICATE: %s", caCertificate)
+		t.Errorf("CA certificate does not contain %s:\n%s", pemBlockTypeCertificate, caCertificate)
+	}
+}
+
+func TestTlsEcX509SelfSignedCaCertificatePem(t *testing.T) {
+	caKey := TLSECPrivateKeyPEM(384)
+	caCertificate := TLSX509SelfSignedCACertificatePEM(caKey)
+
+	if !strings.Contains(caCertificate, pemBlockTypeCertificate) {
+		t.Errorf("CA certificate does not contain %s:\n%s", pemBlockTypeCertificate, caCertificate)
 	}
 }
 
@@ -47,7 +107,16 @@ func TestTlsRsaX509SelfSignedCertificatePem(t *testing.T) {
 	certificate := TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	if !strings.Contains(certificate, pemBlockTypeCertificate) {
-		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeCertificate, certificate)
+	}
+}
+
+func TestTlsEcX509SelfSignedCertificatePem(t *testing.T) {
+	key := TLSECPrivateKeyPEM(256)
+	certificate := TLSX509SelfSignedCertificatePEM(key, "example.com")
+
+	if !strings.Contains(certificate, pemBlockTypeCertificate) {
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeCertificate, certificate)
 	}
 }
 
@@ -55,10 +124,20 @@ func TestTlsRsaX509CertificateRequestPem(t *testing.T) {
 	csr, key := TLSRSAX509CertificateRequestPEM(2048, "example.com")
 
 	if !strings.Contains(csr, pemBlockTypeCertificateRequest) {
-		t.Errorf("certificate does not contain CERTIFICATE REQUEST: %s", csr)
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeCertificateRequest, csr)
 	}
-
 	if !strings.Contains(key, pemBlockTypeRsaPrivateKey) {
-		t.Errorf("certificate does not contain RSA PRIVATE KEY: %s", key)
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeRsaPrivateKey, key)
+	}
+}
+
+func TestTlsEcX509CertificateRequestPem(t *testing.T) {
+	csr, key := TLSX509CertificateRequestPEM(x509.ECDSA, 256, "example.com")
+
+	if !strings.Contains(csr, pemBlockTypeCertificateRequest) {
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeCertificateRequest, csr)
+	}
+	if !strings.Contains(key, pemBlockTypeEcPrivateKey) {
+		t.Errorf("certificate does not contain %s:\n%s", pemBlockTypeEcPrivateKey, key)
 	}
 }

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -309,6 +309,7 @@ import (
 
 type AWSClient struct {
 	AccountID                 string
+	ACMPrivateKeyPassphrase   string
 	DefaultTagsConfig         *tftags.DefaultConfig
 	DNSSuffix                 string
 	IgnoreTagsConfig          *tftags.IgnoreConfig

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -44,6 +44,7 @@ import (
 
 type Config struct {
 	AccessKey                      string
+	ACMPrivateKeyPassphrase        string
 	AllowedAccountIds              []string
 	AssumeRole                     *awsbase.AssumeRole
 	AssumeRoleWithWebIdentity      *awsbase.AssumeRoleWithWebIdentity
@@ -179,6 +180,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	client := c.clientConns(sess)
 
 	client.AccountID = accountID
+	client.ACMPrivateKeyPassphrase = c.ACMPrivateKeyPassphrase
 	client.DefaultTagsConfig = c.DefaultTagsConfig
 	client.DNSSuffix = DNSSuffix
 	client.IgnoreTagsConfig = c.IgnoreTagsConfig

--- a/internal/generate/awsclient/main.go
+++ b/internal/generate/awsclient/main.go
@@ -137,6 +137,7 @@ import (
 
 type AWSClient struct {
 	AccountID                 string
+	ACMPrivateKeyPassphrase   string
 	DefaultTagsConfig         *tftags.DefaultConfig
 	DNSSuffix                 string
 	IgnoreTagsConfig          *tftags.IgnoreConfig

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -198,8 +198,9 @@ func Provider() *schema.Provider {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "",
-				Description: "The passphrase used to decrypt PEM-encrypted private keys\n" +
-					"without storing them decrypted.",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_ACM_PRIVATE_KEY_PASSPHRASE", ""),
+				Description: "The passphrase used to decrypt PEM-encrypted private keys without storing them decrypted.\n" +
+					"Can also be configured using the `AWS_ACM_PRIVATE_KEY_PASSPHRASE` environment variable.",
 			},
 			"allowed_account_ids": {
 				Type:          schema.TypeSet,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -194,6 +194,13 @@ func Provider() *schema.Provider {
 				Description: "The access key for API operations. You can retrieve this\n" +
 					"from the 'Security & Credentials' section of the AWS console.",
 			},
+			"acm_private_key_passphrase": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The passphrase used to decrypt PEM-encrypted private keys\n" +
+					"without storing them decrypted.",
+			},
 			"allowed_account_ids": {
 				Type:          schema.TypeSet,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -2032,6 +2039,7 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVersion string) (interface{}, diag.Diagnostics) {
 	config := conns.Config{
 		AccessKey:                      d.Get("access_key").(string),
+		ACMPrivateKeyPassphrase:        d.Get("acm_private_key_passphrase").(string),
 		DefaultTagsConfig:              expandProviderDefaultTags(d.Get("default_tags").([]interface{})),
 		CustomCABundle:                 d.Get("custom_ca_bundle").(string),
 		EC2MetadataServiceEndpoint:     d.Get("ec2_metadata_service_endpoint").(string),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -282,6 +282,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
  `provider` block:
 
 * `access_key` - (Optional) AWS access key. Can also be set with the `AWS_ACCESS_KEY_ID` environment variable, or via a shared credentials file if `profile` is specified. See also `secret_key`.
+* `acm_private_key_passphrase` - (Optional) Private key passhrase for imported PEM-encrypted PKCS1 keys.
 * `allowed_account_ids` - (Optional) List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one (and potentially end up destroying a live environment). Conflicts with `forbidden_account_ids`.
 * `assume_role` - (Optional) Configuration block for assuming an IAM role. See the [`assume_role` Configuration Block](#assume_role-configuration-block) section below. Only one `assume_role` block may be in the configuration.
 * `assume_role_with_web_identity` - (Optional) Configuration block for assuming an IAM role using a web identity. See the [`assume_role_with_web_identity` Configuration Block](#assume_role_with_web_identity-configuration-block) section below. Only one `assume_role_with_web_identity` block may be in the configuration.

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
     * `options` - (Optional) Configuration block used to set certificate options. Detailed below.
     * `validation_option` - (Optional) Configuration block used to specify information about the initial validation of each domain name. Detailed below.
 * Importing an existing certificate
-    * `private_key` - (Required) The certificate's PEM-formatted private key
+    * `private_key` - (Required) The certificate's PEM-formatted private key (PKCS1/RSA or SEC1/ECDSA). PEM-encrypted private keys are supported by adding `acm_private_key_passphrase` to the provider
     * `certificate_body` - (Required) The certificate's PEM-formatted public key
     * `certificate_chain` - (Optional) The certificate's PEM-formatted chain
 * Creating a private CA issued certificate


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

We use imported keys for certificate types that ACM can't generate (OV/EV and ECDSA). Currently the recommendation is to manage imported keys outside Terraform to avoid private keys being stored in state, but PEM encryption can be leveraged to handle this.

While golang has marked DecryptPEMBlock as deprecated due to padding oracle attacks, that does not apply in this case (oracle attacks are chosen ciphertext). PKCS8 would be a better option, but golang does not natively support encrypted PKCS8 and it doesn't look like that will be added any time soon (golang/go/issues/8860). There are external options (youmark/pkcs8 and smallstep/crypto), but those probably shouldn't be pulled in. So for now this can only support PEM-level encryption.

Changes:
* Passphrase to decrypt PEM is set in the provider (acm_private_key_passphrase), so it won't be stored in state
* (Encrypted) PEM is stored in state, and decrypted in-memory just before the API call
* Certificate and chain are read back from API to avoid drift (FindCertificateByARN extended to return these)
  * Comments and non-PEM elements are masked during comparison because API does not store/return these
* ECDSA support added to acctest with generic function names (most parsing PEM to determine block type)
  * Wrapper functions created to maintain the existing 'RSA' function names being consumed by other tests
  * Aliased function comments retained just to keep the diff synced up for legible review
* ECDSA and encrypted PEM tests created for crypto and aws_acm_certificate
* Documentation updated for both PEM encryption and ECDSA options

Release note for CHANGELOG:
```
resource/aws_acm_certificate: Add ECDSA and PEM encryption support (acm_private_key_passphrase optional attribute added to the provider)
```

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccACMCertificate_Imported\|TestAccIoTCertificate_Keys_existing_certificate\|TestTls'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -count 1 -parallel 20  -run=TestAccACMCertificate_Imported\|TestAccIoTCertificate_Keys_existing_certificate\|TestTls -timeout 180m
=== RUN   TestTlsRsaPrivateKeyPem
--- PASS: TestTlsRsaPrivateKeyPem (0.36s)
=== RUN   TestTlsRsaPrivateKeyEncrypredPem
--- PASS: TestTlsRsaPrivateKeyEncrypredPem (0.10s)
=== RUN   TestTlsEcPrivateKeyPem
--- PASS: TestTlsEcPrivateKeyPem (0.00s)
=== RUN   TestTlsEcPrivateKeyEncryptedPem
--- PASS: TestTlsEcPrivateKeyEncryptedPem (0.00s)
=== RUN   TestTlsRsaPublicKeyPem
--- PASS: TestTlsRsaPublicKeyPem (0.10s)
=== RUN   TestTlsEcPublicKeyPem
--- PASS: TestTlsEcPublicKeyPem (0.00s)
=== RUN   TestTlsRsaX509LocallySignedCertificatePem
--- PASS: TestTlsRsaX509LocallySignedCertificatePem (0.43s)
=== RUN   TestTlsEcX509LocallySignedCertificatePem
--- PASS: TestTlsEcX509LocallySignedCertificatePem (0.06s)
=== RUN   TestTlsRsaX509SelfSignedCaCertificatePem
--- PASS: TestTlsRsaX509SelfSignedCaCertificatePem (0.12s)
=== RUN   TestTlsEcX509SelfSignedCaCertificatePem
--- PASS: TestTlsEcX509SelfSignedCaCertificatePem (0.02s)
=== RUN   TestTlsRsaX509SelfSignedCertificatePem
--- PASS: TestTlsRsaX509SelfSignedCertificatePem (0.19s)
=== RUN   TestTlsEcX509SelfSignedCertificatePem
--- PASS: TestTlsEcX509SelfSignedCertificatePem (0.00s)
=== RUN   TestTlsRsaX509CertificateRequestPem
--- PASS: TestTlsRsaX509CertificateRequestPem (0.31s)
=== RUN   TestTlsEcX509CertificateRequestPem
--- PASS: TestTlsEcX509CertificateRequestPem (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/acctest    1.860s
...
=== RUN   TestAccACMCertificate_Imported_domainName
=== PAUSE TestAccACMCertificate_Imported_domainName
=== RUN   TestAccACMCertificate_Imported_domainName_EC
=== PAUSE TestAccACMCertificate_Imported_domainName_EC
=== RUN   TestAccACMCertificate_Imported_ipAddress
=== PAUSE TestAccACMCertificate_Imported_ipAddress
=== RUN   TestAccACMCertificate_Imported_ipAddress_EC
=== PAUSE TestAccACMCertificate_Imported_ipAddress_EC
=== CONT  TestAccACMCertificate_Imported_domainName
=== CONT  TestAccACMCertificate_Imported_ipAddress
=== CONT  TestAccACMCertificate_Imported_domainName_EC
=== CONT  TestAccACMCertificate_Imported_ipAddress_EC
--- PASS: TestAccACMCertificate_Imported_ipAddress_EC (17.48s)
--- PASS: TestAccACMCertificate_Imported_ipAddress (22.73s)
--- PASS: TestAccACMCertificate_Imported_domainName_EC (47.81s)
--- PASS: TestAccACMCertificate_Imported_domainName (49.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        49.873s
...
=== RUN   TestAccIoTCertificate_Keys_existing_certificate
=== PAUSE TestAccIoTCertificate_Keys_existing_certificate
=== CONT  TestAccIoTCertificate_Keys_existing_certificate
--- PASS: TestAccIoTCertificate_Keys_existing_certificate (13.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        13.537s
```