### PR TITLE
Always include AttachmentsSources when updating SSM documents

### DIFF
--- a/.changelog/24530.txt
+++ b/.changelog/24530.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ssm_document: Always include AttachmentsSources when updating SSM documents (fixes #21725)
+resource/aws_ssm_document: Always include `attachment_sources` when updating SSM documents
 ```

--- a/.changelog/24530.txt
+++ b/.changelog/24530.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_document: Always include AttachmentsSources when updating SSM documents (fixes #21725)
+```

--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -673,8 +673,8 @@ func updateDocument(d *schema.ResourceData, meta interface{}) error {
 		updateDocInput.VersionName = aws.String(v.(string))
 	}
 
-	if d.HasChange("attachments_source") {
-		updateDocInput.Attachments = expandSsmAttachmentsSources(d.Get("attachments_source").([]interface{}))
+	if v, ok := d.GetOk("attachments_source"); ok {
+		updateDocInput.Attachments = expandSsmAttachmentsSources(v.([]interface{}))
 	}
 
 	newDefaultVersion := d.Get("default_version").(string)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #21725

Output from acceptance testing:
```
make testacc TESTS=TestAccSSMDocument_package PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocument_package'  -timeout 180m
=== RUN   TestAccSSMDocument_package
=== PAUSE TestAccSSMDocument_package
=== CONT  TestAccSSMDocument_package
--- PASS: TestAccSSMDocument_package (48.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	59.888s
```

```
make testacc TESTS=TestAccSSMDocument_update PKG=ssm                                                                                                                                                              
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocument_update'  -timeout 180m
=== RUN   TestAccSSMDocument_update
=== PAUSE TestAccSSMDocument_update
=== CONT  TestAccSSMDocument_update
--- PASS: TestAccSSMDocument_update (24.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	33.752s
```
