### PR TITLE
Fix Redshift semgrep `prefer-aws-go-sdk-pointer-conversion-conditional` errors

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -64,7 +64,6 @@ rules:
         - internal/service/elasticbeanstalk
         - internal/service/elb
         - internal/service/rds
-        - internal/service/redshift
     patterns:
       - pattern-either:
         - pattern: '$LHS == *$RHS'

--- a/internal/service/redshift/security_group.go
+++ b/internal/service/redshift/security_group.go
@@ -241,7 +241,7 @@ func resourceSecurityGroupRetrieve(d *schema.ResourceData, meta interface{}) (*r
 	}
 
 	if len(resp.ClusterSecurityGroups) != 1 ||
-		*resp.ClusterSecurityGroups[0].ClusterSecurityGroupName != d.Id() {
+		aws.StringValue(resp.ClusterSecurityGroups[0].ClusterSecurityGroupName) != d.Id() {
 		return nil, fmt.Errorf("Unable to find Redshift Security Group: %#v", resp.ClusterSecurityGroups)
 	}
 

--- a/internal/service/redshift/snapshot_schedule_association.go
+++ b/internal/service/redshift/snapshot_schedule_association.go
@@ -105,7 +105,7 @@ func resourceSnapshotScheduleAssociationRead(d *schema.ResourceData, meta interf
 
 	var associatedCluster *redshift.ClusterAssociatedToSchedule
 	for _, cluster := range snapshotSchedule.AssociatedClusters {
-		if *cluster.ClusterIdentifier == clusterIdentifier {
+		if aws.StringValue(cluster.ClusterIdentifier) == clusterIdentifier {
 			associatedCluster = cluster
 			break
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: https://github.com/hashicorp/terraform-provider-aws/issues/12992.

Fixes:

```
Findings:

  internal/service/redshift/security_group.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        244┆ *resp.ClusterSecurityGroups[0].ClusterSecurityGroupName != d.Id() {


  internal/service/redshift/snapshot_schedule_association.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        108┆ if *cluster.ClusterIdentifier == clusterIdentifier {
```

```console
% make testacc TESTARGS='-run=TestAccRedshiftSnapshotScheduleAssociation_basic\|TestAccRedshiftSecurityGroup_basic' PKG=redshift
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 20  -run=TestAccRedshiftSnapshotScheduleAssociation_basic\|TestAccRedshiftSecurityGroup_basic -timeout 180m
=== RUN   TestAccRedshiftSecurityGroup_basic
=== PAUSE TestAccRedshiftSecurityGroup_basic
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_basic
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_basic
=== CONT  TestAccRedshiftSecurityGroup_basic
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_basic
--- PASS: TestAccRedshiftSecurityGroup_basic (15.14s)
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_basic (279.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	286.719s
```