### PR TITLE
Fix ElastiCache semgrep `prefer-aws-go-sdk-pointer-conversion-conditional` errors

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -60,7 +60,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/ecs
-        - internal/service/elasticache
         - internal/service/elasticbeanstalk
         - internal/service/elb
         - internal/service/rds

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -488,7 +488,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if c.NotificationConfiguration != nil {
-		if *c.NotificationConfiguration.TopicStatus == "active" {
+		if aws.StringValue(c.NotificationConfiguration.TopicStatus) == "active" {
 			d.Set("notification_topic_arn", c.NotificationConfiguration.TopicArn)
 		}
 	}
@@ -775,7 +775,7 @@ func (b byCacheNodeId) Len() int      { return len(b) }
 func (b byCacheNodeId) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b byCacheNodeId) Less(i, j int) bool {
 	return b[i].CacheNodeId != nil && b[j].CacheNodeId != nil &&
-		*b[i].CacheNodeId < *b[j].CacheNodeId
+		aws.StringValue(b[i].CacheNodeId) < aws.StringValue(b[j].CacheNodeId)
 }
 
 func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {

--- a/internal/service/elasticache/security_group.go
+++ b/internal/service/elasticache/security_group.go
@@ -105,7 +105,7 @@ func resourceSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
 	var group *elasticache.CacheSecurityGroup
 	for _, g := range res.CacheSecurityGroups {
 		log.Printf("[DEBUG] CacheSecurityGroupName: %v, id: %v", g.CacheSecurityGroupName, d.Id())
-		if *g.CacheSecurityGroupName == d.Id() {
+		if aws.StringValue(g.CacheSecurityGroupName) == d.Id() {
 			group = g
 		}
 	}

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -163,7 +163,7 @@ func resourceSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
 	var group *elasticache.CacheSubnetGroup
 	for _, g := range res.CacheSubnetGroups {
 		log.Printf("[DEBUG] %v %v", g.CacheSubnetGroupName, d.Id())
-		if *g.CacheSubnetGroupName == d.Id() {
+		if aws.StringValue(g.CacheSubnetGroupName) == d.Id() {
 			group = g
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: https://github.com/hashicorp/terraform-provider-aws/issues/12992.

Fixes:

```
Findings:

  internal/service/elasticache/cluster.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        491┆ if *c.NotificationConfiguration.TopicStatus == "active" {
          ⋮┆----------------------------------------
        778┆ *b[i].CacheNodeId < *b[j].CacheNodeId


  internal/service/elasticache/security_group.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        108┆ if *g.CacheSecurityGroupName == d.Id() {


  internal/service/elasticache/subnet_group.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        166┆ if *g.CacheSubnetGroupName == d.Id() {
```

```console
% make testacc TESTARGS='-run=TestAccElastiCacheSubnetGroup_basic\|TestAccElastiCacheSecurityGroup_basic\|TestAccElastiCacheCluster_Engine_memcached' PKG=elasticache ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 2  -run=TestAccElastiCacheSubnetGroup_basic\|TestAccElastiCacheSecurityGroup_basic\|TestAccElastiCacheCluster_Engine_memcached -timeout 180m
=== RUN   TestAccElastiCacheCluster_Engine_memcached
=== PAUSE TestAccElastiCacheCluster_Engine_memcached
=== RUN   TestAccElastiCacheSecurityGroup_basic
=== PAUSE TestAccElastiCacheSecurityGroup_basic
=== RUN   TestAccElastiCacheSubnetGroup_basic
=== PAUSE TestAccElastiCacheSubnetGroup_basic
=== CONT  TestAccElastiCacheCluster_Engine_memcached
=== CONT  TestAccElastiCacheSubnetGroup_basic
--- PASS: TestAccElastiCacheSubnetGroup_basic (24.63s)
=== CONT  TestAccElastiCacheSecurityGroup_basic
--- PASS: TestAccElastiCacheSecurityGroup_basic (12.82s)
--- PASS: TestAccElastiCacheCluster_Engine_memcached (490.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	494.925s
```