### PR TITLE
Fix Elastic Beanstalk semgrep `prefer-aws-go-sdk-pointer-conversion-conditional` errors

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -61,7 +61,6 @@ rules:
       exclude:
         - internal/service/ecs
         - internal/service/elasticache
-        - internal/service/elasticbeanstalk
         - internal/service/elb
         - internal/service/rds
         - internal/service/redshift

--- a/internal/service/elasticbeanstalk/configuration_template.go
+++ b/internal/service/elasticbeanstalk/configuration_template.go
@@ -192,7 +192,8 @@ func resourceConfigurationTemplateOptionSettingsUpdate(conn *elasticbeanstalk.El
 		var remove []*elasticbeanstalk.ConfigurationOptionSetting
 		for _, r := range rm {
 			for _, a := range add {
-				if *r.Namespace == *a.Namespace && *r.OptionName == *a.OptionName {
+				if aws.StringValue(r.Namespace) == aws.StringValue(a.Namespace) &&
+					aws.StringValue(r.OptionName) == aws.StringValue(a.OptionName) {
 					continue
 				}
 				remove = append(remove, r)

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -380,11 +380,12 @@ func resourceEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
 						if r.ResourceName == nil {
 							continue
 						}
-						if *r.ResourceName != *a.ResourceName {
+						if aws.StringValue(r.ResourceName) != aws.StringValue(a.ResourceName) {
 							continue
 						}
 					}
-					if *r.Namespace == *a.Namespace && *r.OptionName == *a.OptionName {
+					if aws.StringValue(r.Namespace) == aws.StringValue(a.Namespace) &&
+						aws.StringValue(r.OptionName) == aws.StringValue(a.OptionName) {
 						log.Printf("[DEBUG] Updating Beanstalk setting (%s::%s) \"%s\" => \"%s\"", *a.Namespace, *a.OptionName, *r.Value, *a.Value)
 						update = true
 						break
@@ -528,7 +529,7 @@ func resourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 
 	env := resp.Environments[0]
 
-	if *env.Status == "Terminated" {
+	if aws.StringValue(env.Status) == elasticbeanstalk.EnvironmentStatusTerminated {
 		log.Printf("[DEBUG] Elastic Beanstalk environment %s was terminated", d.Id())
 
 		d.SetId("")
@@ -951,7 +952,7 @@ func extractOptionSettings(s *schema.Set) []*elasticbeanstalk.ConfigurationOptio
 				OptionName: aws.String(setting.(map[string]interface{})["name"].(string)),
 				Value:      aws.String(setting.(map[string]interface{})["value"].(string)),
 			}
-			if *optionSetting.Namespace == "aws:autoscaling:scheduledaction" {
+			if aws.StringValue(optionSetting.Namespace) == "aws:autoscaling:scheduledaction" {
 				if v, ok := setting.(map[string]interface{})["resource"].(string); ok && v != "" {
 					optionSetting.ResourceName = aws.String(v)
 				}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: https://github.com/hashicorp/terraform-provider-aws/issues/12992.

Fixes:

```
Findings:

  internal/service/elasticbeanstalk/configuration_template.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        195┆ if *r.Namespace == *a.Namespace && *r.OptionName == *a.OptionName {
          ⋮┆----------------------------------------
        195┆ if *r.Namespace == *a.Namespace && *r.OptionName == *a.OptionName {


  internal/service/elasticbeanstalk/environment.go 
     prefer-aws-go-sdk-pointer-conversion-conditional
        Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g.
        aws.StringValue()

        383┆ if *r.ResourceName != *a.ResourceName {
          ⋮┆----------------------------------------
        387┆ if *r.Namespace == *a.Namespace && *r.OptionName == *a.OptionName {
          ⋮┆----------------------------------------
        387┆ if *r.Namespace == *a.Namespace && *r.OptionName == *a.OptionName {
          ⋮┆----------------------------------------
        531┆ if *env.Status == "Terminated" {
          ⋮┆----------------------------------------
        954┆ if *optionSetting.Namespace == "aws:autoscaling:scheduledaction" {
```