### PR TITLE
b/fix PreconditionFailed errors on aws_cloudfront_distribution

### DIFF
--- a/.changelog/24537.txt
+++ b/.changelog/24537.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution: Fix PreconditionFailed errors when other CloudFront resources are changed before the distribution
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -962,6 +962,29 @@ func resourceDistributionUpdate(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	})
 
+	// Refresh our ETag if it is out of date and attempt update again
+	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodePreconditionFailed) {
+		getDistributionInput := &cloudfront.GetDistributionInput{
+			Id: aws.String(d.Id()),
+		}
+		var getDistributionOutput *cloudfront.GetDistributionOutput
+
+		log.Printf("[DEBUG] Refreshing CloudFront Distribution (%s) ETag", d.Id())
+		getDistributionOutput, err = conn.GetDistribution(getDistributionInput)
+
+		if err != nil {
+			return fmt.Errorf("error refreshing CloudFront Distribution (%s) ETag: %s", d.Id(), err)
+		}
+
+		if getDistributionOutput == nil {
+			return fmt.Errorf("error refreshing CloudFront Distribution (%s) ETag: empty response", d.Id())
+		}
+
+		params.IfMatch = getDistributionOutput.ETag
+
+		_, err = conn.UpdateDistribution(params)
+	}
+
 	// Propagate AWS Go SDK retried error, if any
 	if tfresource.TimedOut(err) {
 		_, err = conn.UpdateDistribution(params)


### PR DESCRIPTION
Amazon's docs say to fetch the ETag immediately before updating to ensure it is up to date. This fix only updates it if the PreconditonFailed error occurs and tries again, since it seems AWS fails fast if the ETag is incorrect.

https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateDistribution.html

From my findings, CloudFront redeploys the distribution automatically when something it depends on (like a Response Header Policy) changes, creating a new ETag variable. Fair enough, but not really conducive to having a state file with a value that can be modified by an external resource. IMO the ETag shouldn't be stored in the state at all because of this, but for simple distributions that have no external resources having the ETag can in theory speed things up, as long as all changes are made in Terraform.

Since adding this fix locally, I haven't encountered a PreconditonFailed error once, in quite a complicated distribution, however if this fix isn't an ideal solution I'm happy to be included in discussions for better ideas.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24033
Closes #22816

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCloudFrontDistribution_preconditionFailed PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_preconditionFailed'  -timeout 180m
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (584.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 586.349s
...
```
