### PR TITLE
r/ecs_service: retry `WaitUntilServicesStable` up to 3 times within resource instead of client connection

### DIFF
--- a/.changelog/24541.txt
+++ b/.changelog/24541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Fix retry when using the `wait_for_steady_state` parameter
+```

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -400,26 +400,6 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 		}
 	})
 
-	client.ECSConn.Handlers.Retry.PushBack(func(r *request.Request) {
-		// By design the "WaitUntilServicesStable" method will poll every 15 seconds until a successful state
-		// has been reached. This will exit with a return code of 255 (ResourceNotReady) after 40 failed checks.
-		// Thus, here we retry the operation a set number of times as
-		// described in https://github.com/hashicorp/terraform-provider-aws/pull/23747.
-		if r.Operation.Name == "WaitUntilServicesStable" {
-			if tfawserr.ErrCodeEquals(r.Error, "ResourceNotReady") {
-				// We only want to retry briefly as the default max retry count would
-				// excessively retry when the error could be legitimate.
-				// We currently depend on the DefaultRetryer exponential backoff here.
-				// ~10 retries gives a fair backoff of a few seconds.
-				if r.RetryCount < 9 {
-					r.Retryable = aws.Bool(true)
-				} else {
-					r.Retryable = aws.Bool(false)
-				}
-			}
-		}
-	})
-
 	client.FMSConn.Handlers.Retry.PushBack(func(r *request.Request) {
 		// Acceptance testing creates and deletes resources in quick succession.
 		// The FMS onboarding process into Organizations is opaque to consumers.

--- a/internal/service/ecs/wait.go
+++ b/internal/service/ecs/wait.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -26,6 +27,8 @@ const (
 
 	taskSetCreateTimeout = 10 * time.Minute
 	taskSetDeleteTimeout = 10 * time.Minute
+
+	serviceStableRetryCount = 3
 )
 
 func waitCapacityProviderDeleted(conn *ecs.ECS, arn string) (*ecs.CapacityProvider, error) {
@@ -63,6 +66,7 @@ func waitCapacityProviderUpdated(conn *ecs.ECS, arn string) (*ecs.CapacityProvid
 }
 
 func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
+	var err error
 	input := &ecs.DescribeServicesInput{
 		Services: aws.StringSlice([]string{id}),
 	}
@@ -71,10 +75,25 @@ func waitServiceStable(conn *ecs.ECS, id, cluster string) error {
 		input.Cluster = aws.String(cluster)
 	}
 
-	if err := conn.WaitUntilServicesStable(input); err != nil {
-		return err
+	// Here we retry the following operation a set number of times as
+	// described in https://github.com/hashicorp/terraform-provider-aws/pull/23747.
+	// Previously, handling was attempted in the ECSConn.Handlers in conns/config.go, but did not work as expected.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/pull/24223.
+	// The waiter within the "WaitUntilServicesStable" request will poll until the service is either
+	// in a failure state ('MISSING', 'DRAINING', or 'INACTIVE') or reaches the successful stable state.
+	// Reference: https://github.com/aws/aws-sdk-go/blob/f377248cbb3037d1989004ba26f6d73f620461df/service/ecs/waiters.go#L79-L105
+	// Thus, since the waiter will return an error when one of the 'MISSING', 'DRAINING', 'INACTIVE' states is met,
+	// we make up to 3 repetitive calls, hoping the service reaches a stable state by the end.
+	for i := 1; i <= serviceStableRetryCount; i++ {
+		log.Printf("[DEBUG] WaitUntilServicesStable attempt %d/%d", i, serviceStableRetryCount)
+		err = conn.WaitUntilServicesStable(input)
+		if err == nil {
+			return nil
+		}
+		log.Printf("[DEBUG] error received from WaitUntilServicesStable: %s", err)
 	}
-	return nil
+
+	return err
 }
 
 func waitServiceInactive(conn *ecs.ECS, id, cluster string) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20452#issuecomment-1117386281

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccECSService_' PKG=ecs ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 5  -run=TestAccECSService_ -timeout 180m
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_basicImport
=== PAUSE TestAccECSService_basicImport
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_CapacityProviderStrategy_multiple
=== PAUSE TestAccECSService_CapacityProviderStrategy_multiple
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_renamedCluster
=== PAUSE TestAccECSService_renamedCluster
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSService_multipleTargetGroups
=== CONT  TestAccECSService_iamRole
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== CONT  TestAccECSService_executeCommand
--- PASS: TestAccECSService_iamRole (67.52s)
=== CONT  TestAccECSService_Tags_propagate
--- PASS: TestAccECSService_executeCommand (68.95s)
=== CONT  TestAccECSService_Tags_managed
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (73.00s)
=== CONT  TestAccECSService_Tags_basic
--- PASS: TestAccECSService_basic (84.46s)
=== CONT  TestAccECSService_ServiceRegistries_changes
--- PASS: TestAccECSService_Tags_managed (70.99s)
=== CONT  TestAccECSService_ServiceRegistries_container
--- PASS: TestAccECSService_Tags_basic (67.16s)
=== CONT  TestAccECSService_ServiceRegistries_basic
--- PASS: TestAccECSService_Tags_propagate (110.13s)
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_replicaSchedulingStrategy (86.25s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
--- PASS: TestAccECSService_ServiceRegistries_basic (137.68s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (39.21s)
=== CONT  TestAccECSService_LaunchTypeEC2_network
--- PASS: TestAccECSService_multipleTargetGroups (303.31s)
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
--- PASS: TestAccECSService_ServiceRegistries_container (168.68s)
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (39.49s)
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
--- PASS: TestAccECSService_ServiceRegistries_changes (256.80s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_LaunchTypeEC2_network (87.67s)
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (117.39s)
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (164.37s)
=== CONT  TestAccECSService_forceNewDeployment
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (167.71s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (85.73s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_PlacementStrategy_basic (87.19s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_PlacementConstraints_basic (50.98s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSService_DeploymentControllerType_external (57.26s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_forceNewDeployment (81.83s)
=== CONT  TestAccECSService_loadBalancerChanges
--- PASS: TestAccECSService_DeploymentValues_basic (70.57s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
--- PASS: TestAccECSService_clusterName (86.05s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_loadBalancerChanges (261.84s)
=== CONT  TestAccECSService_renamedCluster
--- PASS: TestAccECSService_alb (286.20s)
=== CONT  TestAccECSService_familyAndRevision
--- PASS: TestAccECSService_CapacityProviderStrategy_update (250.31s)
=== CONT  TestAccECSService_CapacityProviderStrategy_multiple
--- PASS: TestAccECSService_renamedCluster (81.57s)
=== CONT  TestAccECSService_PlacementStrategy_missing
--- PASS: TestAccECSService_PlacementStrategy_missing (0.72s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
--- PASS: TestAccECSService_familyAndRevision (82.48s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (63.74s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (312.86s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (87.14s)
=== CONT  TestAccECSService_basicImport
--- PASS: TestAccECSService_disappears (71.83s)
=== CONT  TestAccECSService_deploymentCircuitBreaker
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (130.51s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_deploymentCircuitBreaker (87.44s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_basicImport (92.01s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (191.35s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (875.77s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (304.26s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (386.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	1413.941s
```
