### PR TITLE
apigatewayv2: Remove service from funcs

### DIFF
--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -123,7 +123,7 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		req.RequestModels = flex.ExpandStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("request_parameter"); ok && v.(*schema.Set).Len() > 0 {
-		req.RequestParameters = expandApiGatewayV2RouteRequestParameters(v.(*schema.Set).List())
+		req.RequestParameters = expandRouteRequestParameters(v.(*schema.Set).List())
 	}
 	if v, ok := d.GetOk("route_response_selection_expression"); ok {
 		req.RouteResponseSelectionExpression = aws.String(v.(string))
@@ -172,7 +172,7 @@ func resourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("request_models", flex.PointersMapToStringList(resp.RequestModels)); err != nil {
 		return fmt.Errorf("error setting request_models: %w", err)
 	}
-	if err := d.Set("request_parameter", flattenApiGatewayV2RouteRequestParameters(resp.RequestParameters)); err != nil {
+	if err := d.Set("request_parameter", flattenRouteRequestParameters(resp.RequestParameters)); err != nil {
 		return fmt.Errorf("error setting request_parameter: %w", err)
 	}
 	d.Set("route_key", resp.RouteKey)
@@ -217,7 +217,7 @@ func resourceRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		requestParameters = expandApiGatewayV2RouteRequestParameters(ns.List())
+		requestParameters = expandRouteRequestParameters(ns.List())
 	}
 
 	if d.HasChangesExcept("request_parameter") || len(requestParameters) > 0 {
@@ -319,7 +319,7 @@ func resourceRouteImport(d *schema.ResourceData, meta interface{}) ([]*schema.Re
 	return []*schema.ResourceData{d}, nil
 }
 
-func expandApiGatewayV2RouteRequestParameters(tfList []interface{}) map[string]*apigatewayv2.ParameterConstraints {
+func expandRouteRequestParameters(tfList []interface{}) map[string]*apigatewayv2.ParameterConstraints {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -347,7 +347,7 @@ func expandApiGatewayV2RouteRequestParameters(tfList []interface{}) map[string]*
 	return apiObjects
 }
 
-func flattenApiGatewayV2RouteRequestParameters(apiObjects map[string]*apigatewayv2.ParameterConstraints) []interface{} {
+func flattenRouteRequestParameters(apiObjects map[string]*apigatewayv2.ParameterConstraints) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -209,13 +209,13 @@ func resourceStageCreate(d *schema.ResourceData, meta interface{}) error {
 		Tags:       Tags(tags.IgnoreAWS()),
 	}
 	if v, ok := d.GetOk("access_log_settings"); ok {
-		req.AccessLogSettings = expandApiGatewayV2AccessLogSettings(v.([]interface{}))
+		req.AccessLogSettings = expandAccessLogSettings(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("client_certificate_id"); ok {
 		req.ClientCertificateId = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("default_route_settings"); ok {
-		req.DefaultRouteSettings = expandApiGatewayV2DefaultRouteSettings(v.([]interface{}), protocolType)
+		req.DefaultRouteSettings = expandDefaultRouteSettings(v.([]interface{}), protocolType)
 	}
 	if v, ok := d.GetOk("deployment_id"); ok {
 		req.DeploymentId = aws.String(v.(string))
@@ -224,7 +224,7 @@ func resourceStageCreate(d *schema.ResourceData, meta interface{}) error {
 		req.Description = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("route_settings"); ok {
-		req.RouteSettings = expandApiGatewayV2RouteSettings(v.(*schema.Set).List(), protocolType)
+		req.RouteSettings = expandRouteSettings(v.(*schema.Set).List(), protocolType)
 	}
 	if v, ok := d.GetOk("stage_variables"); ok {
 		req.StageVariables = flex.ExpandStringMap(v.(map[string]interface{}))
@@ -261,7 +261,7 @@ func resourceStageRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stageName := aws.StringValue(resp.StageName)
-	err = d.Set("access_log_settings", flattenApiGatewayV2AccessLogSettings(resp.AccessLogSettings))
+	err = d.Set("access_log_settings", flattenAccessLogSettings(resp.AccessLogSettings))
 	if err != nil {
 		return fmt.Errorf("error setting access_log_settings: %s", err)
 	}
@@ -275,7 +275,7 @@ func resourceStageRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", resourceArn)
 	d.Set("auto_deploy", resp.AutoDeploy)
 	d.Set("client_certificate_id", resp.ClientCertificateId)
-	err = d.Set("default_route_settings", flattenApiGatewayV2DefaultRouteSettings(resp.DefaultRouteSettings))
+	err = d.Set("default_route_settings", flattenDefaultRouteSettings(resp.DefaultRouteSettings))
 	if err != nil {
 		return fmt.Errorf("error setting default_route_settings: %s", err)
 	}
@@ -290,7 +290,7 @@ func resourceStageRead(d *schema.ResourceData, meta interface{}) error {
 	}.String()
 	d.Set("execution_arn", executionArn)
 	d.Set("name", stageName)
-	err = d.Set("route_settings", flattenApiGatewayV2RouteSettings(resp.RouteSettings))
+	err = d.Set("route_settings", flattenRouteSettings(resp.RouteSettings))
 	if err != nil {
 		return fmt.Errorf("error setting route_settings: %s", err)
 	}
@@ -353,7 +353,7 @@ func resourceStageUpdate(d *schema.ResourceData, meta interface{}) error {
 			StageName: aws.String(d.Id()),
 		}
 		if d.HasChange("access_log_settings") {
-			req.AccessLogSettings = expandApiGatewayV2AccessLogSettings(d.Get("access_log_settings").([]interface{}))
+			req.AccessLogSettings = expandAccessLogSettings(d.Get("access_log_settings").([]interface{}))
 		}
 		if d.HasChange("auto_deploy") {
 			req.AutoDeploy = aws.Bool(d.Get("auto_deploy").(bool))
@@ -362,7 +362,7 @@ func resourceStageUpdate(d *schema.ResourceData, meta interface{}) error {
 			req.ClientCertificateId = aws.String(d.Get("client_certificate_id").(string))
 		}
 		if d.HasChange("default_route_settings") {
-			req.DefaultRouteSettings = expandApiGatewayV2DefaultRouteSettings(d.Get("default_route_settings").([]interface{}), protocolType)
+			req.DefaultRouteSettings = expandDefaultRouteSettings(d.Get("default_route_settings").([]interface{}), protocolType)
 		}
 		if d.HasChange("deployment_id") {
 			req.DeploymentId = aws.String(d.Get("deployment_id").(string))
@@ -392,7 +392,7 @@ func resourceStageUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 
-			req.RouteSettings = expandApiGatewayV2RouteSettings(ns.List(), protocolType)
+			req.RouteSettings = expandRouteSettings(ns.List(), protocolType)
 		}
 		if d.HasChange("stage_variables") {
 			o, n := d.GetChange("stage_variables")
@@ -472,7 +472,7 @@ func resourceStageImport(d *schema.ResourceData, meta interface{}) ([]*schema.Re
 	return []*schema.ResourceData{d}, nil
 }
 
-func expandApiGatewayV2AccessLogSettings(vSettings []interface{}) *apigatewayv2.AccessLogSettings {
+func expandAccessLogSettings(vSettings []interface{}) *apigatewayv2.AccessLogSettings {
 	settings := &apigatewayv2.AccessLogSettings{}
 
 	if len(vSettings) == 0 || vSettings[0] == nil {
@@ -490,7 +490,7 @@ func expandApiGatewayV2AccessLogSettings(vSettings []interface{}) *apigatewayv2.
 	return settings
 }
 
-func flattenApiGatewayV2AccessLogSettings(settings *apigatewayv2.AccessLogSettings) []interface{} {
+func flattenAccessLogSettings(settings *apigatewayv2.AccessLogSettings) []interface{} {
 	if settings == nil {
 		return []interface{}{}
 	}
@@ -501,7 +501,7 @@ func flattenApiGatewayV2AccessLogSettings(settings *apigatewayv2.AccessLogSettin
 	}}
 }
 
-func expandApiGatewayV2DefaultRouteSettings(vSettings []interface{}, protocolType string) *apigatewayv2.RouteSettings {
+func expandDefaultRouteSettings(vSettings []interface{}, protocolType string) *apigatewayv2.RouteSettings {
 	routeSettings := &apigatewayv2.RouteSettings{}
 
 	if len(vSettings) == 0 || vSettings[0] == nil {
@@ -528,7 +528,7 @@ func expandApiGatewayV2DefaultRouteSettings(vSettings []interface{}, protocolTyp
 	return routeSettings
 }
 
-func flattenApiGatewayV2DefaultRouteSettings(routeSettings *apigatewayv2.RouteSettings) []interface{} {
+func flattenDefaultRouteSettings(routeSettings *apigatewayv2.RouteSettings) []interface{} {
 	if routeSettings == nil {
 		return []interface{}{}
 	}
@@ -542,7 +542,7 @@ func flattenApiGatewayV2DefaultRouteSettings(routeSettings *apigatewayv2.RouteSe
 	}}
 }
 
-func expandApiGatewayV2RouteSettings(vSettings []interface{}, protocolType string) map[string]*apigatewayv2.RouteSettings {
+func expandRouteSettings(vSettings []interface{}, protocolType string) map[string]*apigatewayv2.RouteSettings {
 	settings := map[string]*apigatewayv2.RouteSettings{}
 
 	for _, v := range vSettings {
@@ -572,7 +572,7 @@ func expandApiGatewayV2RouteSettings(vSettings []interface{}, protocolType strin
 	return settings
 }
 
-func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings) []interface{} {
+func flattenRouteSettings(settings map[string]*apigatewayv2.RouteSettings) []interface{} {
 	vSettings := []interface{}{}
 
 	for k, routeSetting := range settings {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
