### PR TITLE
appconfig: Remove service from funcs

### DIFF
--- a/internal/service/appconfig/application_test.go
+++ b/internal/service/appconfig/application_test.go
@@ -24,7 +24,7 @@ func TestAccAppConfigApplication_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApplicationNameConfig(rName),
@@ -52,7 +52,7 @@ func TestAccAppConfigApplication_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApplicationNameConfig(rName),
@@ -75,7 +75,7 @@ func TestAccAppConfigApplication_updateName(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApplicationNameConfig(rName),
@@ -108,7 +108,7 @@ func TestAccAppConfigApplication_updateDescription(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApplicationDescriptionConfig(rName, rName),
@@ -153,7 +153,7 @@ func TestAccAppConfigApplication_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApplicationTags1(rName, "key1", "value1"),
@@ -189,7 +189,7 @@ func TestAccAppConfigApplication_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppConfigApplicationDestroy(s *terraform.State) error {
+func testAccCheckApplicationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/appconfig/configuration_profile.go
+++ b/internal/service/appconfig/configuration_profile.go
@@ -129,7 +129,7 @@ func resourceConfigurationProfileCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("validator"); ok && v.(*schema.Set).Len() > 0 {
-		input.Validators = expandAppconfigValidators(v.(*schema.Set).List())
+		input.Validators = expandValidators(v.(*schema.Set).List())
 	}
 
 	profile, err := conn.CreateConfigurationProfile(input)
@@ -248,7 +248,7 @@ func resourceConfigurationProfileUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		if d.HasChange("validator") {
-			updateInput.Validators = expandAppconfigValidators(d.Get("validator").(*schema.Set).List())
+			updateInput.Validators = expandValidators(d.Get("validator").(*schema.Set).List())
 		}
 
 		_, err = conn.UpdateConfigurationProfile(updateInput)
@@ -305,7 +305,7 @@ func ConfigurationProfileParseID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func expandAppconfigValidator(tfMap map[string]interface{}) *appconfig.Validator {
+func expandValidator(tfMap map[string]interface{}) *appconfig.Validator {
 	if tfMap == nil {
 		return nil
 	}
@@ -324,7 +324,7 @@ func expandAppconfigValidator(tfMap map[string]interface{}) *appconfig.Validator
 	return validator
 }
 
-func expandAppconfigValidators(tfList []interface{}) []*appconfig.Validator {
+func expandValidators(tfList []interface{}) []*appconfig.Validator {
 	// AppConfig API requires a 0 length slice instead of a nil value
 	// when updating from N validators to 0/nil validators
 	validators := make([]*appconfig.Validator, 0)
@@ -336,7 +336,7 @@ func expandAppconfigValidators(tfList []interface{}) []*appconfig.Validator {
 			continue
 		}
 
-		validator := expandAppconfigValidator(tfMap)
+		validator := expandValidator(tfMap)
 
 		if validator == nil {
 			continue

--- a/internal/service/appconfig/configuration_profile_test.go
+++ b/internal/service/appconfig/configuration_profile_test.go
@@ -25,7 +25,7 @@ func TestAccAppConfigConfigurationProfile_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileNameConfig(rName),
@@ -58,7 +58,7 @@ func TestAccAppConfigConfigurationProfile_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileNameConfig(rName),
@@ -80,7 +80,7 @@ func TestAccAppConfigConfigurationProfile_Validators_json(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileValidatorConfig_JSON(rName),
@@ -133,7 +133,7 @@ func TestAccAppConfigConfigurationProfile_Validators_lambda(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileValidatorConfig_Lambda(rName),
@@ -171,7 +171,7 @@ func TestAccAppConfigConfigurationProfile_Validators_multiple(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileValidatorConfig_Multiple(rName),
@@ -206,7 +206,7 @@ func TestAccAppConfigConfigurationProfile_updateName(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileNameConfig(rName),
@@ -240,7 +240,7 @@ func TestAccAppConfigConfigurationProfile_updateDescription(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileDescriptionConfig(rName, rName),
@@ -278,7 +278,7 @@ func TestAccAppConfigConfigurationProfile_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigConfigurationProfileDestroy,
+		CheckDestroy: testAccCheckConfigurationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationProfileTags1(rName, "key1", "value1"),
@@ -314,7 +314,7 @@ func TestAccAppConfigConfigurationProfile_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppConfigConfigurationProfileDestroy(s *terraform.State) error {
+func testAccCheckConfigurationProfileDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/appconfig/deployment_strategy_test.go
+++ b/internal/service/appconfig/deployment_strategy_test.go
@@ -24,7 +24,7 @@ func TestAccAppConfigDeploymentStrategy_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigDeploymentStrategyDestroy,
+		CheckDestroy: testAccCheckDeploymentStrategyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentStrategyNameConfig(rName),
@@ -56,7 +56,7 @@ func TestAccAppConfigDeploymentStrategy_updateDescription(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigDeploymentStrategyDestroy,
+		CheckDestroy: testAccCheckDeploymentStrategyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentStrategyDescriptionConfig(rName, rName),
@@ -89,7 +89,7 @@ func TestAccAppConfigDeploymentStrategy_updateFinalBakeTime(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigDeploymentStrategyDestroy,
+		CheckDestroy: testAccCheckDeploymentStrategyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentStrategyFinalBakeTimeConfig(rName, 60),
@@ -134,7 +134,7 @@ func TestAccAppConfigDeploymentStrategy_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigDeploymentStrategyDestroy,
+		CheckDestroy: testAccCheckDeploymentStrategyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentStrategyNameConfig(rName),
@@ -156,7 +156,7 @@ func TestAccAppConfigDeploymentStrategy_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigDeploymentStrategyDestroy,
+		CheckDestroy: testAccCheckDeploymentStrategyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentStrategyTags1(rName, "key1", "value1"),
@@ -192,7 +192,7 @@ func TestAccAppConfigDeploymentStrategy_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppConfigDeploymentStrategyDestroy(s *terraform.State) error {
+func testAccCheckDeploymentStrategyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/appconfig/deployment_test.go
+++ b/internal/service/appconfig/deployment_test.go
@@ -30,7 +30,7 @@ func TestAccAppConfigDeployment_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		// AppConfig Deployments cannot be destroyed, but we want to ensure
 		// the Application and its dependents are removed.
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentNameConfig(rName),
@@ -68,7 +68,7 @@ func TestAccAppConfigDeployment_predefinedStrategy(t *testing.T) {
 		Providers:  acctest.Providers,
 		// AppConfig Deployments cannot be destroyed, but we want to ensure
 		// the Application and its dependents are removed.
-		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		CheckDestroy: testAccCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_PredefinedStrategy(rName, strategy),

--- a/internal/service/appconfig/environment.go
+++ b/internal/service/appconfig/environment.go
@@ -103,7 +103,7 @@ func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("monitor"); ok && v.(*schema.Set).Len() > 0 {
-		input.Monitors = expandAppconfigEnvironmentMonitors(v.(*schema.Set).List())
+		input.Monitors = expandEnvironmentMonitors(v.(*schema.Set).List())
 	}
 
 	environment, err := conn.CreateEnvironment(input)
@@ -218,7 +218,7 @@ func resourceEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.HasChange("monitor") {
-			updateInput.Monitors = expandAppconfigEnvironmentMonitors(d.Get("monitor").(*schema.Set).List())
+			updateInput.Monitors = expandEnvironmentMonitors(d.Get("monitor").(*schema.Set).List())
 		}
 
 		_, err = conn.UpdateEnvironment(updateInput)
@@ -275,7 +275,7 @@ func EnvironmentParseID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func expandAppconfigEnvironmentMonitor(tfMap map[string]interface{}) *appconfig.Monitor {
+func expandEnvironmentMonitor(tfMap map[string]interface{}) *appconfig.Monitor {
 	if tfMap == nil {
 		return nil
 	}
@@ -293,7 +293,7 @@ func expandAppconfigEnvironmentMonitor(tfMap map[string]interface{}) *appconfig.
 	return monitor
 }
 
-func expandAppconfigEnvironmentMonitors(tfList []interface{}) []*appconfig.Monitor {
+func expandEnvironmentMonitors(tfList []interface{}) []*appconfig.Monitor {
 	// AppConfig API requires a 0 length slice instead of a nil value
 	// when updating from N monitors to 0/nil monitors
 	monitors := make([]*appconfig.Monitor, 0)
@@ -305,7 +305,7 @@ func expandAppconfigEnvironmentMonitors(tfList []interface{}) []*appconfig.Monit
 			continue
 		}
 
-		monitor := expandAppconfigEnvironmentMonitor(tfMap)
+		monitor := expandEnvironmentMonitor(tfMap)
 
 		if monitor == nil {
 			continue

--- a/internal/service/appconfig/environment_test.go
+++ b/internal/service/appconfig/environment_test.go
@@ -25,7 +25,7 @@ func TestAccAppConfigEnvironment_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentBasicConfig(rName),
@@ -56,7 +56,7 @@ func TestAccAppConfigEnvironment_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentBasicConfig(rName),
@@ -79,7 +79,7 @@ func TestAccAppConfigEnvironment_updateName(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentBasicConfig(rName),
@@ -112,7 +112,7 @@ func TestAccAppConfigEnvironment_updateDescription(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentDescriptionConfig(rName, rName),
@@ -157,7 +157,7 @@ func TestAccAppConfigEnvironment_monitors(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentWithMonitors(rName, 1),
@@ -214,7 +214,7 @@ func TestAccAppConfigEnvironment_multipleEnvironments(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentMultipleConfig(rName),
@@ -256,7 +256,7 @@ func TestAccAppConfigEnvironment_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigEnvironmentDestroy,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentTags1(rName, "key1", "value1"),
@@ -292,7 +292,7 @@ func TestAccAppConfigEnvironment_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppConfigEnvironmentDestroy(s *terraform.State) error {
+func testAccCheckEnvironmentDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/appconfig/hosted_configuration_version_test.go
+++ b/internal/service/appconfig/hosted_configuration_version_test.go
@@ -24,7 +24,7 @@ func TestAccAppConfigHostedConfigurationVersion_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigHostedConfigurationVersionDestroy,
+		CheckDestroy: testAccCheckHostedConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccHostedConfigurationVersion(rName),
@@ -56,7 +56,7 @@ func TestAccAppConfigHostedConfigurationVersion_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appconfig.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppConfigHostedConfigurationVersionDestroy,
+		CheckDestroy: testAccCheckHostedConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccHostedConfigurationVersion(rName),
@@ -70,7 +70,7 @@ func TestAccAppConfigHostedConfigurationVersion_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAppConfigHostedConfigurationVersionDestroy(s *terraform.State) error {
+func testAccCheckHostedConfigurationVersionDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
 
 	for _, rs := range s.RootModule().Resources {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
