### PR TITLE
acmpca: Remove service from funcs

### DIFF
--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -115,7 +115,7 @@ func resourceCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 		IdempotencyToken:        aws.String(resource.UniqueId()),
 		SigningAlgorithm:        aws.String(d.Get("signing_algorithm").(string)),
 	}
-	validity, err := expandAcmpcaValidity(d.Get("validity").([]interface{}))
+	validity, err := expandValidity(d.Get("validity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("error issuing ACM PCA Certificate with Certificate Authority (%s): %w", certificateAuthorityArn, err)
 	}
@@ -255,7 +255,7 @@ func ValidTemplateARN(v interface{}, k string) (ws []string, errors []error) {
 	return ws, errors
 }
 
-func expandAcmpcaValidity(l []interface{}) (*acmpca.Validity, error) {
+func expandValidity(l []interface{}) (*acmpca.Validity, error) {
 	if len(l) == 0 {
 		return nil, nil
 	}

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -301,10 +301,10 @@ func resourceCertificateAuthorityCreate(d *schema.ResourceData, meta interface{}
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &acmpca.CreateCertificateAuthorityInput{
-		CertificateAuthorityConfiguration: expandAcmpcaCertificateAuthorityConfiguration(d.Get("certificate_authority_configuration").([]interface{})),
+		CertificateAuthorityConfiguration: expandCertificateAuthorityConfiguration(d.Get("certificate_authority_configuration").([]interface{})),
 		CertificateAuthorityType:          aws.String(d.Get("type").(string)),
 		IdempotencyToken:                  aws.String(resource.UniqueId()),
-		RevocationConfiguration:           expandAcmpcaRevocationConfiguration(d.Get("revocation_configuration").([]interface{})),
+		RevocationConfiguration:           expandRevocationConfiguration(d.Get("revocation_configuration").([]interface{})),
 	}
 
 	if len(tags) > 0 {
@@ -372,7 +372,7 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("arn", certificateAuthority.Arn)
 
-	if err := d.Set("certificate_authority_configuration", flattenAcmpcaCertificateAuthorityConfiguration(certificateAuthority.CertificateAuthorityConfiguration)); err != nil {
+	if err := d.Set("certificate_authority_configuration", flattenCertificateAuthorityConfiguration(certificateAuthority.CertificateAuthorityConfiguration)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -380,7 +380,7 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("not_after", aws.TimeValue(certificateAuthority.NotAfter).Format(time.RFC3339))
 	d.Set("not_before", aws.TimeValue(certificateAuthority.NotBefore).Format(time.RFC3339))
 
-	if err := d.Set("revocation_configuration", flattenAcmpcaRevocationConfiguration(certificateAuthority.RevocationConfiguration)); err != nil {
+	if err := d.Set("revocation_configuration", flattenRevocationConfiguration(certificateAuthority.RevocationConfiguration)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -477,7 +477,7 @@ func resourceCertificateAuthorityUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	if d.HasChange("revocation_configuration") {
-		input.RevocationConfiguration = expandAcmpcaRevocationConfiguration(d.Get("revocation_configuration").([]interface{}))
+		input.RevocationConfiguration = expandRevocationConfiguration(d.Get("revocation_configuration").([]interface{}))
 		updateCertificateAuthority = true
 	}
 
@@ -536,7 +536,7 @@ func resourceCertificateAuthorityDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func expandAcmpcaASN1Subject(l []interface{}) *acmpca.ASN1Subject {
+func expandASN1Subject(l []interface{}) *acmpca.ASN1Subject {
 	if len(l) == 0 {
 		return nil
 	}
@@ -587,7 +587,7 @@ func expandAcmpcaASN1Subject(l []interface{}) *acmpca.ASN1Subject {
 	return subject
 }
 
-func expandAcmpcaCertificateAuthorityConfiguration(l []interface{}) *acmpca.CertificateAuthorityConfiguration {
+func expandCertificateAuthorityConfiguration(l []interface{}) *acmpca.CertificateAuthorityConfiguration {
 	if len(l) == 0 {
 		return nil
 	}
@@ -597,13 +597,13 @@ func expandAcmpcaCertificateAuthorityConfiguration(l []interface{}) *acmpca.Cert
 	config := &acmpca.CertificateAuthorityConfiguration{
 		KeyAlgorithm:     aws.String(m["key_algorithm"].(string)),
 		SigningAlgorithm: aws.String(m["signing_algorithm"].(string)),
-		Subject:          expandAcmpcaASN1Subject(m["subject"].([]interface{})),
+		Subject:          expandASN1Subject(m["subject"].([]interface{})),
 	}
 
 	return config
 }
 
-func expandAcmpcaCrlConfiguration(l []interface{}) *acmpca.CrlConfiguration {
+func expandCrlConfiguration(l []interface{}) *acmpca.CrlConfiguration {
 	if len(l) == 0 {
 		return nil
 	}
@@ -630,7 +630,7 @@ func expandAcmpcaCrlConfiguration(l []interface{}) *acmpca.CrlConfiguration {
 	return config
 }
 
-func expandAcmpcaRevocationConfiguration(l []interface{}) *acmpca.RevocationConfiguration {
+func expandRevocationConfiguration(l []interface{}) *acmpca.RevocationConfiguration {
 	if len(l) == 0 {
 		return nil
 	}
@@ -638,13 +638,13 @@ func expandAcmpcaRevocationConfiguration(l []interface{}) *acmpca.RevocationConf
 	m := l[0].(map[string]interface{})
 
 	config := &acmpca.RevocationConfiguration{
-		CrlConfiguration: expandAcmpcaCrlConfiguration(m["crl_configuration"].([]interface{})),
+		CrlConfiguration: expandCrlConfiguration(m["crl_configuration"].([]interface{})),
 	}
 
 	return config
 }
 
-func flattenAcmpcaASN1Subject(subject *acmpca.ASN1Subject) []interface{} {
+func flattenASN1Subject(subject *acmpca.ASN1Subject) []interface{} {
 	if subject == nil {
 		return []interface{}{}
 	}
@@ -668,7 +668,7 @@ func flattenAcmpcaASN1Subject(subject *acmpca.ASN1Subject) []interface{} {
 	return []interface{}{m}
 }
 
-func flattenAcmpcaCertificateAuthorityConfiguration(config *acmpca.CertificateAuthorityConfiguration) []interface{} {
+func flattenCertificateAuthorityConfiguration(config *acmpca.CertificateAuthorityConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -676,13 +676,13 @@ func flattenAcmpcaCertificateAuthorityConfiguration(config *acmpca.CertificateAu
 	m := map[string]interface{}{
 		"key_algorithm":     aws.StringValue(config.KeyAlgorithm),
 		"signing_algorithm": aws.StringValue(config.SigningAlgorithm),
-		"subject":           flattenAcmpcaASN1Subject(config.Subject),
+		"subject":           flattenASN1Subject(config.Subject),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenAcmpcaCrlConfiguration(config *acmpca.CrlConfiguration) []interface{} {
+func flattenCrlConfiguration(config *acmpca.CrlConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -698,13 +698,13 @@ func flattenAcmpcaCrlConfiguration(config *acmpca.CrlConfiguration) []interface{
 	return []interface{}{m}
 }
 
-func flattenAcmpcaRevocationConfiguration(config *acmpca.RevocationConfiguration) []interface{} {
+func flattenRevocationConfiguration(config *acmpca.RevocationConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"crl_configuration": flattenAcmpcaCrlConfiguration(config.CrlConfiguration),
+		"crl_configuration": flattenCrlConfiguration(config.CrlConfiguration),
 	}
 
 	return []interface{}{m}

--- a/internal/service/acmpca/certificate_authority_data_source.go
+++ b/internal/service/acmpca/certificate_authority_data_source.go
@@ -124,7 +124,7 @@ func dataSourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}
 	d.Set("not_after", aws.TimeValue(certificateAuthority.NotAfter).Format(time.RFC3339))
 	d.Set("not_before", aws.TimeValue(certificateAuthority.NotBefore).Format(time.RFC3339))
 
-	if err := d.Set("revocation_configuration", flattenAcmpcaRevocationConfiguration(certificateAuthority.RevocationConfiguration)); err != nil {
+	if err := d.Set("revocation_configuration", flattenRevocationConfiguration(certificateAuthority.RevocationConfiguration)); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 

--- a/internal/service/acmpca/certificate_authority_migrate.go
+++ b/internal/service/acmpca/certificate_authority_migrate.go
@@ -11,13 +11,13 @@ func resourceCertificateAuthorityMigrateState(v int, is *terraform.InstanceState
 	switch v {
 	case 0:
 		log.Println("[INFO] Found ACM PCA Certificate Authority state v0; migrating to v1")
-		return migrateAcmpcaCertificateAuthorityStateV0toV1(is)
+		return migrateCertificateAuthorityStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
 }
 
-func migrateAcmpcaCertificateAuthorityStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+func migrateCertificateAuthorityStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
 	if is.Empty() || is.Attributes == nil {
 		log.Println("[DEBUG] Empty ACM PCA Certificate Authority state; nothing to migrate.")
 		return is, nil

--- a/internal/service/acmpca/certificate_test.go
+++ b/internal/service/acmpca/certificate_test.go
@@ -325,7 +325,7 @@ data "aws_partition" "current" {}
 
 func testAccCertificateConfig_SubordinateCertificate(domain string) string {
 	return acctest.ConfigCompose(
-		testAccAcmpcaCertificateBaseRootCAConfig(domain),
+		testAccCertificateBaseRootCAConfig(domain),
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate" "test" {
   certificate_authority_arn   = aws_acmpca_certificate_authority.root.arn
@@ -358,7 +358,7 @@ resource "aws_acmpca_certificate_authority" "test" {
 
 func testAccCertificateConfig_EndEntityCertificate(domain, csr string) string {
 	return acctest.ConfigCompose(
-		testAccAcmpcaCertificateBaseRootCAConfig(domain),
+		testAccCertificateBaseRootCAConfig(domain),
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate" "test" {
   certificate_authority_arn   = aws_acmpca_certificate_authority.root.arn
@@ -377,7 +377,7 @@ resource "aws_acmpca_certificate" "test" {
 
 func testAccCertificateConfig_Validity_EndDate(domain, csr, expiry string) string {
 	return acctest.ConfigCompose(
-		testAccAcmpcaCertificateBaseRootCAConfig(domain),
+		testAccCertificateBaseRootCAConfig(domain),
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate" "test" {
   certificate_authority_arn   = aws_acmpca_certificate_authority.root.arn
@@ -396,7 +396,7 @@ resource "aws_acmpca_certificate" "test" {
 
 func testAccCertificateConfig_Validity_Absolute(domain, csr string, expiry int64) string {
 	return acctest.ConfigCompose(
-		testAccAcmpcaCertificateBaseRootCAConfig(domain),
+		testAccCertificateBaseRootCAConfig(domain),
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate" "test" {
   certificate_authority_arn   = aws_acmpca_certificate_authority.root.arn
@@ -413,7 +413,7 @@ resource "aws_acmpca_certificate" "test" {
 `, csr, expiry))
 }
 
-func testAccAcmpcaCertificateBaseRootCAConfig(domain string) string {
+func testAccCertificateBaseRootCAConfig(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "root" {
   permanent_deletion_time_in_days = 7


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
