### PR TITLE
appmesh: Remove service from funcs

### DIFF
--- a/internal/service/appmesh/flex.go
+++ b/internal/service/appmesh/flex.go
@@ -1084,7 +1084,7 @@ func expandVirtualServiceSpec(vSpec []interface{}) *appmesh.VirtualServiceSpec {
 	return spec
 }
 
-func flattenAppMeshClientPolicy(clientPolicy *appmesh.ClientPolicy) []interface{} {
+func flattenClientPolicy(clientPolicy *appmesh.ClientPolicy) []interface{} {
 	if clientPolicy == nil {
 		return []interface{}{}
 	}
@@ -1176,7 +1176,7 @@ func flattenAppMeshClientPolicy(clientPolicy *appmesh.ClientPolicy) []interface{
 	return []interface{}{mClientPolicy}
 }
 
-func flattenAppMeshDuration(duration *appmesh.Duration) []interface{} {
+func flattenDuration(duration *appmesh.Duration) []interface{} {
 	if duration == nil {
 		return []interface{}{}
 	}
@@ -1189,7 +1189,7 @@ func flattenAppMeshDuration(duration *appmesh.Duration) []interface{} {
 	return []interface{}{mDuration}
 }
 
-func flattenAppMeshGRPCRoute(grpcRoute *appmesh.GrpcRoute) []interface{} {
+func flattenGRPCRoute(grpcRoute *appmesh.GrpcRoute) []interface{} {
 	if grpcRoute == nil {
 		return []interface{}{}
 	}
@@ -1263,32 +1263,32 @@ func flattenAppMeshGRPCRoute(grpcRoute *appmesh.GrpcRoute) []interface{} {
 			"grpc_retry_events": flex.FlattenStringSet(grpcRetryPolicy.GrpcRetryEvents),
 			"http_retry_events": flex.FlattenStringSet(grpcRetryPolicy.HttpRetryEvents),
 			"max_retries":       int(aws.Int64Value(grpcRetryPolicy.MaxRetries)),
-			"per_retry_timeout": flattenAppMeshDuration(grpcRetryPolicy.PerRetryTimeout),
+			"per_retry_timeout": flattenDuration(grpcRetryPolicy.PerRetryTimeout),
 			"tcp_retry_events":  flex.FlattenStringSet(grpcRetryPolicy.TcpRetryEvents),
 		}
 
 		mGrpcRoute["retry_policy"] = []interface{}{mGrpcRetryPolicy}
 	}
 
-	mGrpcRoute["timeout"] = flattenAppMeshGRPCTimeout(grpcRoute.Timeout)
+	mGrpcRoute["timeout"] = flattenGRPCTimeout(grpcRoute.Timeout)
 
 	return []interface{}{mGrpcRoute}
 }
 
-func flattenAppMeshGRPCTimeout(grpcTimeout *appmesh.GrpcTimeout) []interface{} {
+func flattenGRPCTimeout(grpcTimeout *appmesh.GrpcTimeout) []interface{} {
 	if grpcTimeout == nil {
 		return []interface{}{}
 	}
 
 	mGrpcTimeout := map[string]interface{}{
-		"idle":        flattenAppMeshDuration(grpcTimeout.Idle),
-		"per_request": flattenAppMeshDuration(grpcTimeout.PerRequest),
+		"idle":        flattenDuration(grpcTimeout.Idle),
+		"per_request": flattenDuration(grpcTimeout.PerRequest),
 	}
 
 	return []interface{}{mGrpcTimeout}
 }
 
-func flattenAppMeshHTTPRoute(httpRoute *appmesh.HttpRoute) []interface{} {
+func flattenHTTPRoute(httpRoute *appmesh.HttpRoute) []interface{} {
 	if httpRoute == nil {
 		return []interface{}{}
 	}
@@ -1362,32 +1362,32 @@ func flattenAppMeshHTTPRoute(httpRoute *appmesh.HttpRoute) []interface{} {
 		mHttpRetryPolicy := map[string]interface{}{
 			"http_retry_events": flex.FlattenStringSet(httpRetryPolicy.HttpRetryEvents),
 			"max_retries":       int(aws.Int64Value(httpRetryPolicy.MaxRetries)),
-			"per_retry_timeout": flattenAppMeshDuration(httpRetryPolicy.PerRetryTimeout),
+			"per_retry_timeout": flattenDuration(httpRetryPolicy.PerRetryTimeout),
 			"tcp_retry_events":  flex.FlattenStringSet(httpRetryPolicy.TcpRetryEvents),
 		}
 
 		mHttpRoute["retry_policy"] = []interface{}{mHttpRetryPolicy}
 	}
 
-	mHttpRoute["timeout"] = flattenAppMeshHTTPTimeout(httpRoute.Timeout)
+	mHttpRoute["timeout"] = flattenHTTPTimeout(httpRoute.Timeout)
 
 	return []interface{}{mHttpRoute}
 }
 
-func flattenAppMeshHTTPTimeout(httpTimeout *appmesh.HttpTimeout) []interface{} {
+func flattenHTTPTimeout(httpTimeout *appmesh.HttpTimeout) []interface{} {
 	if httpTimeout == nil {
 		return []interface{}{}
 	}
 
 	mHttpTimeout := map[string]interface{}{
-		"idle":        flattenAppMeshDuration(httpTimeout.Idle),
-		"per_request": flattenAppMeshDuration(httpTimeout.PerRequest),
+		"idle":        flattenDuration(httpTimeout.Idle),
+		"per_request": flattenDuration(httpTimeout.PerRequest),
 	}
 
 	return []interface{}{mHttpTimeout}
 }
 
-func flattenAppMeshMeshSpec(spec *appmesh.MeshSpec) []interface{} {
+func flattenMeshSpec(spec *appmesh.MeshSpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}
@@ -1405,23 +1405,23 @@ func flattenAppMeshMeshSpec(spec *appmesh.MeshSpec) []interface{} {
 	return []interface{}{mSpec}
 }
 
-func flattenAppMeshRouteSpec(spec *appmesh.RouteSpec) []interface{} {
+func flattenRouteSpec(spec *appmesh.RouteSpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}
 
 	mSpec := map[string]interface{}{
-		"grpc_route":  flattenAppMeshGRPCRoute(spec.GrpcRoute),
-		"http2_route": flattenAppMeshHTTPRoute(spec.Http2Route),
-		"http_route":  flattenAppMeshHTTPRoute(spec.HttpRoute),
+		"grpc_route":  flattenGRPCRoute(spec.GrpcRoute),
+		"http2_route": flattenHTTPRoute(spec.Http2Route),
+		"http_route":  flattenHTTPRoute(spec.HttpRoute),
 		"priority":    int(aws.Int64Value(spec.Priority)),
-		"tcp_route":   flattenAppMeshTCPRoute(spec.TcpRoute),
+		"tcp_route":   flattenTCPRoute(spec.TcpRoute),
 	}
 
 	return []interface{}{mSpec}
 }
 
-func flattenAppMeshTCPRoute(tcpRoute *appmesh.TcpRoute) []interface{} {
+func flattenTCPRoute(tcpRoute *appmesh.TcpRoute) []interface{} {
 	if tcpRoute == nil {
 		return []interface{}{}
 	}
@@ -1449,24 +1449,24 @@ func flattenAppMeshTCPRoute(tcpRoute *appmesh.TcpRoute) []interface{} {
 		}
 	}
 
-	mTcpRoute["timeout"] = flattenAppMeshTCPTimeout(tcpRoute.Timeout)
+	mTcpRoute["timeout"] = flattenTCPTimeout(tcpRoute.Timeout)
 
 	return []interface{}{mTcpRoute}
 }
 
-func flattenAppMeshTCPTimeout(tcpTimeout *appmesh.TcpTimeout) []interface{} {
+func flattenTCPTimeout(tcpTimeout *appmesh.TcpTimeout) []interface{} {
 	if tcpTimeout == nil {
 		return []interface{}{}
 	}
 
 	mTcpTimeout := map[string]interface{}{
-		"idle": flattenAppMeshDuration(tcpTimeout.Idle),
+		"idle": flattenDuration(tcpTimeout.Idle),
 	}
 
 	return []interface{}{mTcpTimeout}
 }
 
-func flattenAppMeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} {
+func flattenVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}
@@ -1481,7 +1481,7 @@ func flattenAppMeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} 
 
 			if virtualService := backend.VirtualService; virtualService != nil {
 				mVirtualService := map[string]interface{}{
-					"client_policy":        flattenAppMeshClientPolicy(virtualService.ClientPolicy),
+					"client_policy":        flattenClientPolicy(virtualService.ClientPolicy),
 					"virtual_service_name": aws.StringValue(virtualService.VirtualServiceName),
 				}
 
@@ -1496,7 +1496,7 @@ func flattenAppMeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} 
 
 	if backendDefaults := spec.BackendDefaults; backendDefaults != nil {
 		mBackendDefaults := map[string]interface{}{
-			"client_policy": flattenAppMeshClientPolicy(backendDefaults.ClientPolicy),
+			"client_policy": flattenClientPolicy(backendDefaults.ClientPolicy),
 		}
 
 		mSpec["backend_defaults"] = []interface{}{mBackendDefaults}
@@ -1557,8 +1557,8 @@ func flattenAppMeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} 
 
 		if outlierDetection := listener.OutlierDetection; outlierDetection != nil {
 			mOutlierDetection := map[string]interface{}{
-				"base_ejection_duration": flattenAppMeshDuration(outlierDetection.BaseEjectionDuration),
-				"interval":               flattenAppMeshDuration(outlierDetection.Interval),
+				"base_ejection_duration": flattenDuration(outlierDetection.BaseEjectionDuration),
+				"interval":               flattenDuration(outlierDetection.Interval),
 				"max_ejection_percent":   int(aws.Int64Value(outlierDetection.MaxEjectionPercent)),
 				"max_server_errors":      int(aws.Int64Value(outlierDetection.MaxServerErrors)),
 			}
@@ -1575,10 +1575,10 @@ func flattenAppMeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} 
 
 		if listenerTimeout := listener.Timeout; listenerTimeout != nil {
 			mListenerTimeout := map[string]interface{}{
-				"grpc":  flattenAppMeshGRPCTimeout(listenerTimeout.Grpc),
-				"http":  flattenAppMeshHTTPTimeout(listenerTimeout.Http),
-				"http2": flattenAppMeshHTTPTimeout(listenerTimeout.Http2),
-				"tcp":   flattenAppMeshTCPTimeout(listenerTimeout.Tcp),
+				"grpc":  flattenGRPCTimeout(listenerTimeout.Grpc),
+				"http":  flattenHTTPTimeout(listenerTimeout.Http),
+				"http2": flattenHTTPTimeout(listenerTimeout.Http2),
+				"tcp":   flattenTCPTimeout(listenerTimeout.Tcp),
 			}
 			mListener["timeout"] = []interface{}{mListenerTimeout}
 		}
@@ -1720,7 +1720,7 @@ func flattenAppMeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} 
 	return []interface{}{mSpec}
 }
 
-func flattenAppMeshVirtualRouterSpec(spec *appmesh.VirtualRouterSpec) []interface{} {
+func flattenVirtualRouterSpec(spec *appmesh.VirtualRouterSpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}
@@ -1742,7 +1742,7 @@ func flattenAppMeshVirtualRouterSpec(spec *appmesh.VirtualRouterSpec) []interfac
 	return []interface{}{mSpec}
 }
 
-func flattenAppMeshVirtualServiceSpec(spec *appmesh.VirtualServiceSpec) []interface{} {
+func flattenVirtualServiceSpec(spec *appmesh.VirtualServiceSpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}

--- a/internal/service/appmesh/gateway_route.go
+++ b/internal/service/appmesh/gateway_route.go
@@ -306,7 +306,7 @@ func resourceGatewayRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	input := &appmesh.CreateGatewayRouteInput{
 		GatewayRouteName:   aws.String(d.Get("name").(string)),
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
-		Spec:               expandAppmeshGatewayRouteSpec(d.Get("spec").([]interface{})),
+		Spec:               expandGatewayRouteSpec(d.Get("spec").([]interface{})),
 		Tags:               Tags(tags.IgnoreAWS()),
 		VirtualGatewayName: aws.String(d.Get("virtual_gateway_name").(string)),
 	}
@@ -391,7 +391,7 @@ func resourceGatewayRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("mesh_owner", gatewayRoute.Metadata.MeshOwner)
 	d.Set("name", gatewayRoute.GatewayRouteName)
 	d.Set("resource_owner", gatewayRoute.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppmeshGatewayRouteSpec(gatewayRoute.Spec))
+	err = d.Set("spec", flattenGatewayRouteSpec(gatewayRoute.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %w", err)
 	}
@@ -424,7 +424,7 @@ func resourceGatewayRouteUpdate(d *schema.ResourceData, meta interface{}) error 
 		input := &appmesh.UpdateGatewayRouteInput{
 			GatewayRouteName:   aws.String(d.Get("name").(string)),
 			MeshName:           aws.String(d.Get("mesh_name").(string)),
-			Spec:               expandAppmeshGatewayRouteSpec(d.Get("spec").([]interface{})),
+			Spec:               expandGatewayRouteSpec(d.Get("spec").([]interface{})),
 			VirtualGatewayName: aws.String(d.Get("virtual_gateway_name").(string)),
 		}
 		if v, ok := d.GetOk("mesh_owner"); ok {
@@ -499,7 +499,7 @@ func resourceGatewayRouteImport(d *schema.ResourceData, meta interface{}) ([]*sc
 	return []*schema.ResourceData{d}, nil
 }
 
-func expandAppmeshGatewayRouteSpec(vSpec []interface{}) *appmesh.GatewayRouteSpec {
+func expandGatewayRouteSpec(vSpec []interface{}) *appmesh.GatewayRouteSpec {
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		return nil
 	}
@@ -509,21 +509,21 @@ func expandAppmeshGatewayRouteSpec(vSpec []interface{}) *appmesh.GatewayRouteSpe
 	mSpec := vSpec[0].(map[string]interface{})
 
 	if vGrpcRoute, ok := mSpec["grpc_route"].([]interface{}); ok {
-		spec.GrpcRoute = expandAppmeshGrpcGatewayRoute(vGrpcRoute)
+		spec.GrpcRoute = expandGrpcGatewayRoute(vGrpcRoute)
 	}
 
 	if vHttp2Route, ok := mSpec["http2_route"].([]interface{}); ok {
-		spec.Http2Route = expandAppmeshHttpGatewayRoute(vHttp2Route)
+		spec.Http2Route = expandHttpGatewayRoute(vHttp2Route)
 	}
 
 	if vHttpRoute, ok := mSpec["http_route"].([]interface{}); ok {
-		spec.HttpRoute = expandAppmeshHttpGatewayRoute(vHttpRoute)
+		spec.HttpRoute = expandHttpGatewayRoute(vHttpRoute)
 	}
 
 	return spec
 }
 
-func expandAppmeshGatewayRouteTarget(vRouteTarget []interface{}) *appmesh.GatewayRouteTarget {
+func expandGatewayRouteTarget(vRouteTarget []interface{}) *appmesh.GatewayRouteTarget {
 	if len(vRouteTarget) == 0 || vRouteTarget[0] == nil {
 		return nil
 	}
@@ -547,7 +547,7 @@ func expandAppmeshGatewayRouteTarget(vRouteTarget []interface{}) *appmesh.Gatewa
 	return routeTarget
 }
 
-func expandAppmeshGrpcGatewayRoute(vGrpcRoute []interface{}) *appmesh.GrpcGatewayRoute {
+func expandGrpcGatewayRoute(vGrpcRoute []interface{}) *appmesh.GrpcGatewayRoute {
 	if len(vGrpcRoute) == 0 || vGrpcRoute[0] == nil {
 		return nil
 	}
@@ -562,7 +562,7 @@ func expandAppmeshGrpcGatewayRoute(vGrpcRoute []interface{}) *appmesh.GrpcGatewa
 		mRouteAction := vRouteAction[0].(map[string]interface{})
 
 		if vRouteTarget, ok := mRouteAction["target"].([]interface{}); ok {
-			routeAction.Target = expandAppmeshGatewayRouteTarget(vRouteTarget)
+			routeAction.Target = expandGatewayRouteTarget(vRouteTarget)
 		}
 
 		route.Action = routeAction
@@ -583,7 +583,7 @@ func expandAppmeshGrpcGatewayRoute(vGrpcRoute []interface{}) *appmesh.GrpcGatewa
 	return route
 }
 
-func expandAppmeshHttpGatewayRoute(vHttpRoute []interface{}) *appmesh.HttpGatewayRoute {
+func expandHttpGatewayRoute(vHttpRoute []interface{}) *appmesh.HttpGatewayRoute {
 	if len(vHttpRoute) == 0 || vHttpRoute[0] == nil {
 		return nil
 	}
@@ -598,7 +598,7 @@ func expandAppmeshHttpGatewayRoute(vHttpRoute []interface{}) *appmesh.HttpGatewa
 		mRouteAction := vRouteAction[0].(map[string]interface{})
 
 		if vRouteTarget, ok := mRouteAction["target"].([]interface{}); ok {
-			routeAction.Target = expandAppmeshGatewayRouteTarget(vRouteTarget)
+			routeAction.Target = expandGatewayRouteTarget(vRouteTarget)
 		}
 
 		route.Action = routeAction
@@ -619,21 +619,21 @@ func expandAppmeshHttpGatewayRoute(vHttpRoute []interface{}) *appmesh.HttpGatewa
 	return route
 }
 
-func flattenAppmeshGatewayRouteSpec(spec *appmesh.GatewayRouteSpec) []interface{} {
+func flattenGatewayRouteSpec(spec *appmesh.GatewayRouteSpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}
 
 	mSpec := map[string]interface{}{
-		"grpc_route":  flattenAppmeshGrpcGatewayRoute(spec.GrpcRoute),
-		"http2_route": flattenAppmeshHttpGatewayRoute(spec.Http2Route),
-		"http_route":  flattenAppmeshHttpGatewayRoute(spec.HttpRoute),
+		"grpc_route":  flattenGrpcGatewayRoute(spec.GrpcRoute),
+		"http2_route": flattenHttpGatewayRoute(spec.Http2Route),
+		"http_route":  flattenHttpGatewayRoute(spec.HttpRoute),
 	}
 
 	return []interface{}{mSpec}
 }
 
-func flattenAppmeshGatewayRouteTarget(routeTarget *appmesh.GatewayRouteTarget) []interface{} {
+func flattenGatewayRouteTarget(routeTarget *appmesh.GatewayRouteTarget) []interface{} {
 	if routeTarget == nil {
 		return []interface{}{}
 	}
@@ -651,7 +651,7 @@ func flattenAppmeshGatewayRouteTarget(routeTarget *appmesh.GatewayRouteTarget) [
 	return []interface{}{mRouteTarget}
 }
 
-func flattenAppmeshGrpcGatewayRoute(grpcRoute *appmesh.GrpcGatewayRoute) []interface{} {
+func flattenGrpcGatewayRoute(grpcRoute *appmesh.GrpcGatewayRoute) []interface{} {
 	if grpcRoute == nil {
 		return []interface{}{}
 	}
@@ -660,7 +660,7 @@ func flattenAppmeshGrpcGatewayRoute(grpcRoute *appmesh.GrpcGatewayRoute) []inter
 
 	if routeAction := grpcRoute.Action; routeAction != nil {
 		mRouteAction := map[string]interface{}{
-			"target": flattenAppmeshGatewayRouteTarget(routeAction.Target),
+			"target": flattenGatewayRouteTarget(routeAction.Target),
 		}
 
 		mGrpcRoute["action"] = []interface{}{mRouteAction}
@@ -677,7 +677,7 @@ func flattenAppmeshGrpcGatewayRoute(grpcRoute *appmesh.GrpcGatewayRoute) []inter
 	return []interface{}{mGrpcRoute}
 }
 
-func flattenAppmeshHttpGatewayRoute(httpRoute *appmesh.HttpGatewayRoute) []interface{} {
+func flattenHttpGatewayRoute(httpRoute *appmesh.HttpGatewayRoute) []interface{} {
 	if httpRoute == nil {
 		return []interface{}{}
 	}
@@ -686,7 +686,7 @@ func flattenAppmeshHttpGatewayRoute(httpRoute *appmesh.HttpGatewayRoute) []inter
 
 	if routeAction := httpRoute.Action; routeAction != nil {
 		mRouteAction := map[string]interface{}{
-			"target": flattenAppmeshGatewayRouteTarget(routeAction.Target),
+			"target": flattenGatewayRouteTarget(routeAction.Target),
 		}
 
 		mHttpRoute["action"] = []interface{}{mRouteAction}

--- a/internal/service/appmesh/gateway_route_test.go
+++ b/internal/service/appmesh/gateway_route_test.go
@@ -26,12 +26,12 @@ func testAccGatewayRoute_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshGatewayRouteDestroy,
+		CheckDestroy: testAccCheckGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshGatewayRouteConfigHttpRoute(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigHttpRoute(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -73,12 +73,12 @@ func testAccGatewayRoute_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshGatewayRouteDestroy,
+		CheckDestroy: testAccCheckGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshGatewayRouteConfigHttpRoute(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigHttpRoute(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappmesh.ResourceGatewayRoute(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -100,12 +100,12 @@ func testAccGatewayRoute_GRPCRoute(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshGatewayRouteDestroy,
+		CheckDestroy: testAccCheckGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshGatewayRouteConfigGrpcRoute(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigGrpcRoute(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -127,9 +127,9 @@ func testAccGatewayRoute_GRPCRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshGatewayRouteConfigGrpcRouteUpdated(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigGrpcRouteUpdated(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -173,12 +173,12 @@ func testAccGatewayRoute_HTTPRoute(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshGatewayRouteDestroy,
+		CheckDestroy: testAccCheckGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshGatewayRouteConfigHttpRoute(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigHttpRoute(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -200,9 +200,9 @@ func testAccGatewayRoute_HTTPRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshGatewayRouteConfigHttpRouteUpdated(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigHttpRouteUpdated(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -246,12 +246,12 @@ func testAccGatewayRoute_HTTP2Route(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshGatewayRouteDestroy,
+		CheckDestroy: testAccCheckGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshGatewayRouteConfigHttp2Route(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigHttp2Route(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -273,9 +273,9 @@ func testAccGatewayRoute_HTTP2Route(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshGatewayRouteConfigHttp2RouteUpdated(meshName, vgName, grName),
+				Config: testAccGatewayRouteConfigHttp2RouteUpdated(meshName, vgName, grName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", grName),
@@ -317,12 +317,12 @@ func testAccGatewayRoute_Tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshGatewayRouteDestroy,
+		CheckDestroy: testAccCheckGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshGatewayRouteConfigTags1(meshName, vgName, grName, "key1", "value1"),
+				Config: testAccGatewayRouteConfigTags1(meshName, vgName, grName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -334,18 +334,18 @@ func testAccGatewayRoute_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshGatewayRouteConfigTags2(meshName, vgName, grName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccGatewayRouteConfigTags2(meshName, vgName, grName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccAppmeshGatewayRouteConfigTags1(meshName, vgName, grName, "key2", "value2"),
+				Config: testAccGatewayRouteConfigTags1(meshName, vgName, grName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshGatewayRouteExists(resourceName, &v),
+					testAccCheckGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -365,7 +365,7 @@ func testAccGatewayRouteImportStateIdFunc(resourceName string) resource.ImportSt
 	}
 }
 
-func testAccCheckAppmeshGatewayRouteDestroy(s *terraform.State) error {
+func testAccCheckGatewayRouteDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -386,7 +386,7 @@ func testAccCheckAppmeshGatewayRouteDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshGatewayRouteExists(name string, v *appmesh.GatewayRouteData) resource.TestCheckFunc {
+func testAccCheckGatewayRouteExists(name string, v *appmesh.GatewayRouteData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -410,7 +410,7 @@ func testAccCheckAppmeshGatewayRouteExists(name string, v *appmesh.GatewayRouteD
 	}
 }
 
-func testAccAppmeshGatewayRouteConfigBase(meshName, vgName string) string {
+func testAccGatewayRouteConfigBase(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -441,8 +441,8 @@ resource "aws_appmesh_virtual_service" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshGatewayRouteConfigGrpcRoute(meshName, vgName, grName string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigGrpcRoute(meshName, vgName, grName string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -467,8 +467,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName))
 }
 
-func testAccAppmeshGatewayRouteConfigGrpcRouteUpdated(meshName, vgName, grName string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigGrpcRouteUpdated(meshName, vgName, grName string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -493,8 +493,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName))
 }
 
-func testAccAppmeshGatewayRouteConfigHttpRoute(meshName, vgName, grName string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigHttpRoute(meshName, vgName, grName string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -519,8 +519,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName))
 }
 
-func testAccAppmeshGatewayRouteConfigHttpRouteUpdated(meshName, vgName, grName string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigHttpRouteUpdated(meshName, vgName, grName string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -545,8 +545,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName))
 }
 
-func testAccAppmeshGatewayRouteConfigHttp2Route(meshName, vgName, grName string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigHttp2Route(meshName, vgName, grName string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -571,8 +571,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName))
 }
 
-func testAccAppmeshGatewayRouteConfigHttp2RouteUpdated(meshName, vgName, grName string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigHttp2RouteUpdated(meshName, vgName, grName string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -597,8 +597,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName))
 }
 
-func testAccAppmeshGatewayRouteConfigTags1(meshName, vgName, grName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigTags1(meshName, vgName, grName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name
@@ -627,8 +627,8 @@ resource "aws_appmesh_gateway_route" "test" {
 `, grName, tagKey1, tagValue1))
 }
 
-func testAccAppmeshGatewayRouteConfigTags2(meshName, vgName, grName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccAppmeshGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
+func testAccGatewayRouteConfigTags2(meshName, vgName, grName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccGatewayRouteConfigBase(meshName, vgName), fmt.Sprintf(`
 resource "aws_appmesh_gateway_route" "test" {
   name                 = %[1]q
   mesh_name            = aws_appmesh_mesh.test.name

--- a/internal/service/appmesh/mesh.go
+++ b/internal/service/appmesh/mesh.go
@@ -188,7 +188,7 @@ func resourceMeshRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("last_updated_date", resp.Mesh.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("mesh_owner", resp.Mesh.Metadata.MeshOwner)
 	d.Set("resource_owner", resp.Mesh.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppMeshMeshSpec(resp.Mesh.Spec))
+	err = d.Set("spec", flattenMeshSpec(resp.Mesh.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %s", err)
 	}

--- a/internal/service/appmesh/mesh_data_source.go
+++ b/internal/service/appmesh/mesh_data_source.go
@@ -102,7 +102,7 @@ func dataSourceMeshRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("last_updated_date", resp.Mesh.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("mesh_owner", resp.Mesh.Metadata.MeshOwner)
 	d.Set("resource_owner", resp.Mesh.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppMeshMeshSpec(resp.Mesh.Spec))
+	err = d.Set("spec", flattenMeshSpec(resp.Mesh.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %s", err)
 	}

--- a/internal/service/appmesh/mesh_data_source_test.go
+++ b/internal/service/appmesh/mesh_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccAppMeshMeshDataSource_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		CheckDestroy: testAccCheckMeshDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckMeshDataSourceConfig(rName),
@@ -47,7 +47,7 @@ func TestAccAppMeshMeshDataSource_meshOwner(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		CheckDestroy: testAccCheckMeshDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckMeshDataSourceConfig_meshOwner(rName),
@@ -75,7 +75,7 @@ func TestAccAppMeshMeshDataSource_specAndTagsSet(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		CheckDestroy: testAccCheckMeshDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckMeshDataSourceConfig_specAndTagsSet(rName),

--- a/internal/service/appmesh/mesh_test.go
+++ b/internal/service/appmesh/mesh_test.go
@@ -24,12 +24,12 @@ func testAccMesh_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		CheckDestroy: testAccCheckMeshDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshMeshConfig_basic(rName),
+				Config: testAccMeshConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshMeshExists(resourceName, &mesh),
+					testAccCheckMeshExists(resourceName, &mesh),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
@@ -56,12 +56,12 @@ func testAccMesh_egressFilter(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		CheckDestroy: testAccCheckMeshDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshMeshConfig_egressFilter(rName, "ALLOW_ALL"),
+				Config: testAccMeshConfig_egressFilter(rName, "ALLOW_ALL"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshMeshExists(resourceName, &mesh),
+					testAccCheckMeshExists(resourceName, &mesh),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.egress_filter.0.type", "ALLOW_ALL"),
 				),
@@ -72,16 +72,16 @@ func testAccMesh_egressFilter(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshMeshConfig_egressFilter(rName, "DROP_ALL"),
+				Config: testAccMeshConfig_egressFilter(rName, "DROP_ALL"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshMeshExists(resourceName, &mesh),
+					testAccCheckMeshExists(resourceName, &mesh),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.egress_filter.0.type", "DROP_ALL"),
 				),
 			},
 			{
 				PlanOnly: true,
-				Config:   testAccAppmeshMeshConfig_basic(rName),
+				Config:   testAccMeshConfig_basic(rName),
 			},
 		},
 	})
@@ -96,12 +96,12 @@ func testAccMesh_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		CheckDestroy: testAccCheckMeshDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshMeshConfigWithTags(rName),
+				Config: testAccMeshConfigWithTags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshMeshExists(resourceName, &mesh),
+					testAccCheckMeshExists(resourceName, &mesh),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
@@ -113,18 +113,18 @@ func testAccMesh_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshMeshConfigWithUpdateTags(rName),
+				Config: testAccMeshConfigWithUpdateTags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshMeshExists(resourceName, &mesh),
+					testAccCheckMeshExists(resourceName, &mesh),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
 				),
 			},
 			{
-				Config: testAccAppmeshMeshConfigWithRemoveTags(rName),
+				Config: testAccMeshConfigWithRemoveTags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshMeshExists(resourceName, &mesh),
+					testAccCheckMeshExists(resourceName, &mesh),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
@@ -132,7 +132,7 @@ func testAccMesh_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppmeshMeshDestroy(s *terraform.State) error {
+func testAccCheckMeshDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -155,7 +155,7 @@ func testAccCheckAppmeshMeshDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshMeshExists(name string, v *appmesh.MeshData) resource.TestCheckFunc {
+func testAccCheckMeshExists(name string, v *appmesh.MeshData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -180,7 +180,7 @@ func testAccCheckAppmeshMeshExists(name string, v *appmesh.MeshData) resource.Te
 	}
 }
 
-func testAccAppmeshMeshConfig_basic(rName string) string {
+func testAccMeshConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -188,7 +188,7 @@ resource "aws_appmesh_mesh" "test" {
 `, rName)
 }
 
-func testAccAppmeshMeshConfig_egressFilter(rName, egressFilterType string) string {
+func testAccMeshConfig_egressFilter(rName, egressFilterType string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -202,7 +202,7 @@ resource "aws_appmesh_mesh" "test" {
 `, rName, egressFilterType)
 }
 
-func testAccAppmeshMeshConfigWithTags(rName string) string {
+func testAccMeshConfigWithTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -215,7 +215,7 @@ resource "aws_appmesh_mesh" "test" {
 `, rName)
 }
 
-func testAccAppmeshMeshConfigWithUpdateTags(rName string) string {
+func testAccMeshConfigWithUpdateTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -229,7 +229,7 @@ resource "aws_appmesh_mesh" "test" {
 `, rName)
 }
 
-func testAccAppmeshMeshConfigWithRemoveTags(rName string) string {
+func testAccMeshConfigWithRemoveTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q

--- a/internal/service/appmesh/route.go
+++ b/internal/service/appmesh/route.go
@@ -325,13 +325,13 @@ func ResourceRoute() *schema.Resource {
 						},
 
 						"http2_route": func() *schema.Schema {
-							schema := appmeshRouteHttpRouteSchema()
+							schema := RouteHttpRouteSchema()
 							schema.ConflictsWith = []string{"spec.0.grpc_route", "spec.0.http_route", "spec.0.tcp_route"}
 							return schema
 						}(),
 
 						"http_route": func() *schema.Schema {
-							schema := appmeshRouteHttpRouteSchema()
+							schema := RouteHttpRouteSchema()
 							schema.ConflictsWith = []string{"spec.0.grpc_route", "spec.0.http2_route", "spec.0.tcp_route"}
 							return schema
 						}(),
@@ -448,8 +448,8 @@ func ResourceRoute() *schema.Resource {
 	}
 }
 
-// appmeshRouteHttpRouteSchema returns the schema for `http2_route` and `http_route` attributes.
-func appmeshRouteHttpRouteSchema() *schema.Schema {
+// RouteHttpRouteSchema returns the schema for `http2_route` and `http_route` attributes.
+func RouteHttpRouteSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -797,7 +797,7 @@ func resourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("created_date", resp.Route.Metadata.CreatedAt.Format(time.RFC3339))
 	d.Set("last_updated_date", resp.Route.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("resource_owner", resp.Route.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppMeshRouteSpec(resp.Route.Spec))
+	err = d.Set("spec", flattenRouteSpec(resp.Route.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %s", err)
 	}

--- a/internal/service/appmesh/route_test.go
+++ b/internal/service/appmesh/route_test.go
@@ -27,12 +27,12 @@ func testAccRoute_grpcRoute(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_grpcRoute(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -75,7 +75,7 @@ func testAccRoute_grpcRoute(t *testing.T) {
 			{
 				Config: testAccRouteConfig_grpcRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -127,7 +127,7 @@ func testAccRoute_grpcRoute(t *testing.T) {
 			{
 				Config: testAccRouteConfig_grpcRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -179,7 +179,7 @@ func testAccRoute_grpcRoute(t *testing.T) {
 			{
 				Config: testAccRouteConfig_grpcRouteWithMaxRetriesZero(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -242,12 +242,12 @@ func testAccRoute_grpcRouteTimeout(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_grpcRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -283,7 +283,7 @@ func testAccRoute_grpcRouteTimeout(t *testing.T) {
 			{
 				Config: testAccRouteConfig_grpcRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -341,12 +341,12 @@ func testAccRoute_grpcRouteEmptyMatch(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_grpcRouteWithEmptyMatch(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -394,12 +394,12 @@ func testAccRoute_http2Route(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_http2Route(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -440,7 +440,7 @@ func testAccRoute_http2Route(t *testing.T) {
 			{
 				Config: testAccRouteConfig_http2RouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -511,12 +511,12 @@ func testAccRoute_http2RouteTimeout(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_http2RouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -554,7 +554,7 @@ func testAccRoute_http2RouteTimeout(t *testing.T) {
 			{
 				Config: testAccRouteConfig_http2RouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -614,12 +614,12 @@ func testAccRoute_httpRoute(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -647,9 +647,9 @@ func testAccRoute_httpRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -677,9 +677,9 @@ func testAccRoute_httpRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -725,12 +725,12 @@ func testAccRoute_httpRouteTimeout(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshRouteConfig_httpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_httpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -762,9 +762,9 @@ func testAccRoute_httpRouteTimeout(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_httpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_httpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -820,12 +820,12 @@ func testAccRoute_tcpRoute(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -847,9 +847,9 @@ func testAccRoute_tcpRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -871,9 +871,9 @@ func testAccRoute_tcpRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -914,12 +914,12 @@ func testAccRoute_tcpRouteTimeout(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshRouteConfig_tcpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_tcpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -944,9 +944,9 @@ func testAccRoute_tcpRouteTimeout(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_tcpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_tcpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -993,30 +993,30 @@ func testAccRoute_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, "foo", "bar", "good", "bad"),
+				Config: testAccRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, "foo", "bar", "good", "bad"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, "foo2", "bar", "good", "bad2"),
+				Config: testAccRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, "foo2", "bar", "good", "bad2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo2", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad2"),
 				),
 			},
 			{
-				Config: testAccAppmeshRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName),
+				Config: testAccRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -1043,12 +1043,12 @@ func testAccRoute_httpHeader(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_httpHeader(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1081,7 +1081,7 @@ func testAccRoute_httpHeader(t *testing.T) {
 			{
 				Config: testAccRouteConfig_httpHeaderUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1142,12 +1142,12 @@ func testAccRoute_routePriority(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Name, rName, 42),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1176,7 +1176,7 @@ func testAccRoute_routePriority(t *testing.T) {
 			{
 				Config: testAccRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Name, rName, 1000),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1225,12 +1225,12 @@ func testAccRoute_httpRetryPolicy(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteConfig_httpRetryPolicy(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1265,7 +1265,7 @@ func testAccRoute_httpRetryPolicy(t *testing.T) {
 			{
 				Config: testAccRouteConfig_httpMaxRetriesZero(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1300,7 +1300,7 @@ func testAccRoute_httpRetryPolicy(t *testing.T) {
 			{
 				Config: testAccRouteConfig_httpRetryPolicyUpdated(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshRouteExists(resourceName, &r),
+					testAccCheckRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1355,7 +1355,7 @@ func testAccRouteImportStateIdFunc(resourceName string) resource.ImportStateIdFu
 	}
 }
 
-func testAccCheckAppmeshRouteDestroy(s *terraform.State) error {
+func testAccCheckRouteDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -1380,7 +1380,7 @@ func testAccCheckAppmeshRouteDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshRouteExists(name string, v *appmesh.RouteData) resource.TestCheckFunc {
+func testAccCheckRouteExists(name string, v *appmesh.RouteData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -1407,7 +1407,7 @@ func testAccCheckAppmeshRouteExists(name string, v *appmesh.RouteData) resource.
 	}
 }
 
-func testAccAppmeshRouteConfigBase(meshName, vrName, vrProtocol, vn1Name, vn2Name string) string {
+func testAccRouteConfigBase(meshName, vrName, vrProtocol, vn1Name, vn2Name string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1444,7 +1444,7 @@ resource "aws_appmesh_virtual_node" "bar" {
 }
 
 func testAccRouteConfig_grpcRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1489,7 +1489,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_grpcRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1559,7 +1559,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_grpcRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1629,7 +1629,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_grpcRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1663,7 +1663,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_grpcRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1702,7 +1702,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_grpcRouteWithEmptyMatch(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1725,7 +1725,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_grpcRouteWithMaxRetriesZero(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "grpc", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1770,7 +1770,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_http2Route(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1814,7 +1814,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_http2RouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1876,7 +1876,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_http2RouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1914,7 +1914,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_http2RouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http2", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1956,8 +1956,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -1981,8 +1981,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2011,8 +2011,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2041,8 +2041,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_httpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_httpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2073,8 +2073,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_httpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_httpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2110,8 +2110,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2131,8 +2131,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2157,8 +2157,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2183,8 +2183,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_tcpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_tcpRouteWithTimeout(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2211,8 +2211,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfig_tcpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfig_tcpRouteWithTimeoutUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "tcp", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2239,8 +2239,8 @@ resource "aws_appmesh_route" "test" {
 `, rName))
 }
 
-func testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+func testAccRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2270,7 +2270,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_httpHeader(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2300,7 +2300,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_httpHeaderUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2343,7 +2343,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Name, rName string, priority int) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2370,7 +2370,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_httpRetryPolicy(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2408,7 +2408,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_httpMaxRetriesZero(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id
@@ -2446,7 +2446,7 @@ resource "aws_appmesh_route" "test" {
 }
 
 func testAccRouteConfig_httpRetryPolicyUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
-	return acctest.ConfigCompose(testAccAppmeshRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccRouteConfigBase(meshName, vrName, "http", vn1Name, vn2Name), fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = aws_appmesh_mesh.test.id

--- a/internal/service/appmesh/virtual_gateway.go
+++ b/internal/service/appmesh/virtual_gateway.go
@@ -693,7 +693,7 @@ func resourceVirtualGatewayCreate(d *schema.ResourceData, meta interface{}) erro
 
 	input := &appmesh.CreateVirtualGatewayInput{
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
-		Spec:               expandAppmeshVirtualGatewaySpec(d.Get("spec").([]interface{})),
+		Spec:               expandVirtualGatewaySpec(d.Get("spec").([]interface{})),
 		Tags:               Tags(tags.IgnoreAWS()),
 		VirtualGatewayName: aws.String(d.Get("name").(string)),
 	}
@@ -778,7 +778,7 @@ func resourceVirtualGatewayRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("mesh_owner", virtualGateway.Metadata.MeshOwner)
 	d.Set("name", virtualGateway.VirtualGatewayName)
 	d.Set("resource_owner", virtualGateway.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppmeshVirtualGatewaySpec(virtualGateway.Spec))
+	err = d.Set("spec", flattenVirtualGatewaySpec(virtualGateway.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %w", err)
 	}
@@ -809,7 +809,7 @@ func resourceVirtualGatewayUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("spec") {
 		input := &appmesh.UpdateVirtualGatewayInput{
 			MeshName:           aws.String(d.Get("mesh_name").(string)),
-			Spec:               expandAppmeshVirtualGatewaySpec(d.Get("spec").([]interface{})),
+			Spec:               expandVirtualGatewaySpec(d.Get("spec").([]interface{})),
 			VirtualGatewayName: aws.String(d.Get("name").(string)),
 		}
 		if v, ok := d.GetOk("mesh_owner"); ok {
@@ -881,7 +881,7 @@ func resourceVirtualGatewayImport(d *schema.ResourceData, meta interface{}) ([]*
 	return []*schema.ResourceData{d}, nil
 }
 
-func expandAppmeshVirtualGatewaySpec(vSpec []interface{}) *appmesh.VirtualGatewaySpec {
+func expandVirtualGatewaySpec(vSpec []interface{}) *appmesh.VirtualGatewaySpec {
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		return nil
 	}
@@ -896,7 +896,7 @@ func expandAppmeshVirtualGatewaySpec(vSpec []interface{}) *appmesh.VirtualGatewa
 		mBackendDefaults := vBackendDefaults[0].(map[string]interface{})
 
 		if vClientPolicy, ok := mBackendDefaults["client_policy"].([]interface{}); ok {
-			backendDefaults.ClientPolicy = expandAppmeshVirtualGatewayClientPolicy(vClientPolicy)
+			backendDefaults.ClientPolicy = expandVirtualGatewayClientPolicy(vClientPolicy)
 		}
 
 		spec.BackendDefaults = backendDefaults
@@ -1158,7 +1158,7 @@ func expandAppmeshVirtualGatewaySpec(vSpec []interface{}) *appmesh.VirtualGatewa
 	return spec
 }
 
-func expandAppmeshVirtualGatewayClientPolicy(vClientPolicy []interface{}) *appmesh.VirtualGatewayClientPolicy {
+func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *appmesh.VirtualGatewayClientPolicy {
 	if len(vClientPolicy) == 0 || vClientPolicy[0] == nil {
 		return nil
 	}
@@ -1293,7 +1293,7 @@ func expandAppmeshVirtualGatewayClientPolicy(vClientPolicy []interface{}) *appme
 	return clientPolicy
 }
 
-func flattenAppmeshVirtualGatewaySpec(spec *appmesh.VirtualGatewaySpec) []interface{} {
+func flattenVirtualGatewaySpec(spec *appmesh.VirtualGatewaySpec) []interface{} {
 	if spec == nil {
 		return []interface{}{}
 	}
@@ -1302,7 +1302,7 @@ func flattenAppmeshVirtualGatewaySpec(spec *appmesh.VirtualGatewaySpec) []interf
 
 	if backendDefaults := spec.BackendDefaults; backendDefaults != nil {
 		mBackendDefaults := map[string]interface{}{
-			"client_policy": flattenAppmeshVirtualGatewayClientPolicy(backendDefaults.ClientPolicy),
+			"client_policy": flattenVirtualGatewayClientPolicy(backendDefaults.ClientPolicy),
 		}
 
 		mSpec["backend_defaults"] = []interface{}{mBackendDefaults}
@@ -1469,7 +1469,7 @@ func flattenAppmeshVirtualGatewaySpec(spec *appmesh.VirtualGatewaySpec) []interf
 	return []interface{}{mSpec}
 }
 
-func flattenAppmeshVirtualGatewayClientPolicy(clientPolicy *appmesh.VirtualGatewayClientPolicy) []interface{} {
+func flattenVirtualGatewayClientPolicy(clientPolicy *appmesh.VirtualGatewayClientPolicy) []interface{} {
 	if clientPolicy == nil {
 		return []interface{}{}
 	}

--- a/internal/service/appmesh/virtual_gateway_test.go
+++ b/internal/service/appmesh/virtual_gateway_test.go
@@ -25,12 +25,12 @@ func testAccVirtualGateway_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfig(meshName, vgName),
+				Config: testAccVirtualGatewayConfig(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -70,12 +70,12 @@ func testAccVirtualGateway_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfig(meshName, vgName),
+				Config: testAccVirtualGatewayConfig(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappmesh.ResourceVirtualGateway(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -94,12 +94,12 @@ func testAccVirtualGateway_BackendDefaults(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigBackendDefaults(meshName, vgName),
+				Config: testAccVirtualGatewayConfigBackendDefaults(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -132,9 +132,9 @@ func testAccVirtualGateway_BackendDefaults(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigBackendDefaultsUpdated(meshName, vgName),
+				Config: testAccVirtualGatewayConfigBackendDefaultsUpdated(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -187,12 +187,12 @@ func testAccVirtualGateway_BackendDefaultsCertificate(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigBackendDefaultsCertificate(meshName, vgName),
+				Config: testAccVirtualGatewayConfigBackendDefaultsCertificate(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -251,12 +251,12 @@ func testAccVirtualGateway_ListenerConnectionPool(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerConnectionPool(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerConnectionPool(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -281,9 +281,9 @@ func testAccVirtualGateway_ListenerConnectionPool(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerConnectionPoolUpdated(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerConnectionPoolUpdated(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -328,12 +328,12 @@ func testAccVirtualGateway_ListenerHealthChecks(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerHealthChecks(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerHealthChecks(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -361,9 +361,9 @@ func testAccVirtualGateway_ListenerHealthChecks(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerHealthChecksUpdated(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerHealthChecksUpdated(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -415,12 +415,12 @@ func testAccVirtualGateway_ListenerTLS(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerTlsFile(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerTlsFile(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -456,16 +456,16 @@ func testAccVirtualGateway_ListenerTLS(t *testing.T) {
 			},
 			// We need to create and activate the CA before issuing a certificate.
 			{
-				Config: testAccAppmeshVirtualGatewayConfigRootCA(domain),
+				Config: testAccVirtualGatewayConfigRootCA(domain),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckACMPCACertificateAuthorityExists(acmCAResourceName, &ca),
 					acctest.CheckACMPCACertificateAuthorityActivateRootCA(&ca),
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerTlsAcm(meshName, vgName, domain),
+				Config: testAccVirtualGatewayConfigListenerTlsAcm(meshName, vgName, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -498,7 +498,7 @@ func testAccVirtualGateway_ListenerTLS(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerTlsAcm(meshName, vgName, domain),
+				Config: testAccVirtualGatewayConfigListenerTlsAcm(meshName, vgName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					// CA must be DISABLED for deletion.
 					acctest.CheckACMPCACertificateAuthorityDisableCA(&ca),
@@ -519,12 +519,12 @@ func testAccVirtualGateway_ListenerValidation(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerValidation(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerValidation(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -568,9 +568,9 @@ func testAccVirtualGateway_ListenerValidation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigListenerValidationUpdated(meshName, vgName),
+				Config: testAccVirtualGatewayConfigListenerValidationUpdated(meshName, vgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -617,12 +617,12 @@ func testAccVirtualGateway_Logging(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigLogging(meshName, vgName, "/dev/stdout"),
+				Config: testAccVirtualGatewayConfigLogging(meshName, vgName, "/dev/stdout"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -646,9 +646,9 @@ func testAccVirtualGateway_Logging(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigLogging(meshName, vgName, "/tmp/access.log"),
+				Config: testAccVirtualGatewayConfigLogging(meshName, vgName, "/tmp/access.log"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
 					resource.TestCheckResourceAttr(resourceName, "name", vgName),
@@ -689,12 +689,12 @@ func testAccVirtualGateway_Tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualGatewayDestroy,
+		CheckDestroy: testAccCheckVirtualGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualGatewayConfigTags1(meshName, vgName, "key1", "value1"),
+				Config: testAccVirtualGatewayConfigTags1(meshName, vgName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -706,18 +706,18 @@ func testAccVirtualGateway_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigTags2(meshName, vgName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVirtualGatewayConfigTags2(meshName, vgName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualGatewayConfigTags1(meshName, vgName, "key2", "value2"),
+				Config: testAccVirtualGatewayConfigTags1(meshName, vgName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualGatewayExists(resourceName, &v),
+					testAccCheckVirtualGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -726,7 +726,7 @@ func testAccVirtualGateway_Tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppmeshVirtualGatewayDestroy(s *terraform.State) error {
+func testAccCheckVirtualGatewayDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -747,7 +747,7 @@ func testAccCheckAppmeshVirtualGatewayDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshVirtualGatewayExists(name string, v *appmesh.VirtualGatewayData) resource.TestCheckFunc {
+func testAccCheckVirtualGatewayExists(name string, v *appmesh.VirtualGatewayData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -771,7 +771,7 @@ func testAccCheckAppmeshVirtualGatewayExists(name string, v *appmesh.VirtualGate
 	}
 }
 
-func testAccAppmeshVirtualGatewayConfig(meshName, vgName string) string {
+func testAccVirtualGatewayConfig(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -793,7 +793,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigBackendDefaults(meshName, vgName string) string {
+func testAccVirtualGatewayConfigBackendDefaults(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -831,7 +831,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigBackendDefaultsUpdated(meshName, vgName string) string {
+func testAccVirtualGatewayConfigBackendDefaultsUpdated(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -869,7 +869,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigBackendDefaultsCertificate(meshName, vgName string) string {
+func testAccVirtualGatewayConfigBackendDefaultsCertificate(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -918,7 +918,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerConnectionPool(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerConnectionPool(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -946,7 +946,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerConnectionPoolUpdated(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerConnectionPoolUpdated(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -975,7 +975,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerHealthChecks(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerHealthChecks(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1006,7 +1006,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerHealthChecksUpdated(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerHealthChecksUpdated(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1037,7 +1037,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigRootCA(domain string) string {
+func testAccVirtualGatewayConfigRootCA(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
@@ -1055,9 +1055,9 @@ resource "aws_acmpca_certificate_authority" "test" {
 `, domain)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerTlsAcm(meshName, vgName, domain string) string {
+func testAccVirtualGatewayConfigListenerTlsAcm(meshName, vgName, domain string) string {
 	return acctest.ConfigCompose(
-		testAccAppmeshVirtualGatewayConfigRootCA(domain),
+		testAccVirtualGatewayConfigRootCA(domain),
 		fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1094,7 +1094,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName, domain))
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerTlsFile(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerTlsFile(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1127,7 +1127,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerValidation(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerValidation(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1173,7 +1173,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigListenerValidationUpdated(meshName, vgName string) string {
+func testAccVirtualGatewayConfigListenerValidationUpdated(meshName, vgName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1213,7 +1213,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName)
 }
 
-func testAccAppmeshVirtualGatewayConfigLogging(meshName, vgName, path string) string {
+func testAccVirtualGatewayConfigLogging(meshName, vgName, path string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1243,7 +1243,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName, path)
 }
 
-func testAccAppmeshVirtualGatewayConfigTags1(meshName, vgName, tagKey1, tagValue1 string) string {
+func testAccVirtualGatewayConfigTags1(meshName, vgName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1269,7 +1269,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
 `, meshName, vgName, tagKey1, tagValue1)
 }
 
-func testAccAppmeshVirtualGatewayConfigTags2(meshName, vgName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVirtualGatewayConfigTags2(meshName, vgName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q

--- a/internal/service/appmesh/virtual_node.go
+++ b/internal/service/appmesh/virtual_node.go
@@ -81,7 +81,7 @@ func ResourceVirtualNode() *schema.Resource {
 													ValidateFunc: validation.StringLenBetween(1, 255),
 												},
 
-												"client_policy": appmeshVirtualNodeClientPolicySchema(),
+												"client_policy": VirtualNodeClientPolicySchema(),
 											},
 										},
 									},
@@ -96,7 +96,7 @@ func ResourceVirtualNode() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"client_policy": appmeshVirtualNodeClientPolicySchema(),
+									"client_policy": VirtualNodeClientPolicySchema(),
 								},
 							},
 						},
@@ -879,8 +879,8 @@ func ResourceVirtualNode() *schema.Resource {
 	}
 }
 
-// appmeshVirtualNodeClientPolicySchema returns the schema for `client_policy` attributes.
-func appmeshVirtualNodeClientPolicySchema() *schema.Schema {
+// VirtualNodeClientPolicySchema returns the schema for `client_policy` attributes.
+func VirtualNodeClientPolicySchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -1152,7 +1152,7 @@ func resourceVirtualNodeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("created_date", resp.VirtualNode.Metadata.CreatedAt.Format(time.RFC3339))
 	d.Set("last_updated_date", resp.VirtualNode.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("resource_owner", resp.VirtualNode.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppMeshVirtualNodeSpec(resp.VirtualNode.Spec))
+	err = d.Set("spec", flattenVirtualNodeSpec(resp.VirtualNode.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %w", err)
 	}

--- a/internal/service/appmesh/virtual_node_migrate.go
+++ b/internal/service/appmesh/virtual_node_migrate.go
@@ -12,13 +12,13 @@ func resourceVirtualNodeMigrateState(v int, is *terraform.InstanceState, meta in
 	switch v {
 	case 0:
 		log.Println("[INFO] Found App Mesh virtual node state v0; migrating to v1")
-		return migrateAppmeshVirtualNodeStateV0toV1(is)
+		return migrateVirtualNodeStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
 }
 
-func migrateAppmeshVirtualNodeStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+func migrateVirtualNodeStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
 	if is.Empty() || is.Attributes == nil {
 		log.Println("[DEBUG] Empty App Mesh virtual node state; nothing to migrate.")
 		return is, nil

--- a/internal/service/appmesh/virtual_node_test.go
+++ b/internal/service/appmesh/virtual_node_test.go
@@ -26,12 +26,12 @@ func testAccVirtualNode_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_basic(meshName, vnName),
+				Config: testAccVirtualNodeConfig_basic(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -67,12 +67,12 @@ func testAccVirtualNode_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_basic(meshName, vnName),
+				Config: testAccVirtualNodeConfig_basic(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappmesh.ResourceVirtualNode(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -95,20 +95,20 @@ func testAccVirtualNode_backendClientPolicyACM(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			// We need to create and activate the CA before issuing a certificate.
 			{
-				Config: testAccAppmeshVirtualNodeConfigRootCA(domain),
+				Config: testAccVirtualNodeConfigRootCA(domain),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckACMPCACertificateAuthorityExists(acmCAResourceName, &ca),
 					acctest.CheckACMPCACertificateAuthorityActivateRootCA(&ca),
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendClientPolicyAcm(meshName, vnName, domain),
+				Config: testAccVirtualNodeConfig_backendClientPolicyAcm(meshName, vnName, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -157,7 +157,7 @@ func testAccVirtualNode_backendClientPolicyACM(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendClientPolicyAcm(meshName, vnName, domain),
+				Config: testAccVirtualNodeConfig_backendClientPolicyAcm(meshName, vnName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					// CA must be DISABLED for deletion.
 					acctest.CheckACMPCACertificateAuthorityDisableCA(&ca),
@@ -178,12 +178,12 @@ func testAccVirtualNode_backendClientPolicyFile(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendClientPolicyFile(meshName, vnName),
+				Config: testAccVirtualNodeConfig_backendClientPolicyFile(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -226,9 +226,9 @@ func testAccVirtualNode_backendClientPolicyFile(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendClientPolicyFileUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_backendClientPolicyFileUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -292,12 +292,12 @@ func testAccVirtualNode_backendDefaults(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendDefaults(meshName, vnName),
+				Config: testAccVirtualNodeConfig_backendDefaults(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -327,9 +327,9 @@ func testAccVirtualNode_backendDefaults(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendDefaultsUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_backendDefaultsUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -379,12 +379,12 @@ func testAccVirtualNode_backendDefaultsCertificate(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_backendDefaultsCertificate(meshName, vnName),
+				Config: testAccVirtualNodeConfig_backendDefaultsCertificate(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -443,12 +443,12 @@ func testAccVirtualNode_cloudMapServiceDiscovery(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_cloudMapServiceDiscovery(meshName, vnName, rName, "Key1", "Value1"),
+				Config: testAccVirtualNodeConfig_cloudMapServiceDiscovery(meshName, vnName, rName, "Key1", "Value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
@@ -461,9 +461,9 @@ func testAccVirtualNode_cloudMapServiceDiscovery(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_cloudMapServiceDiscovery(meshName, vnName, rName, "Key1", "Value2"),
+				Config: testAccVirtualNodeConfig_cloudMapServiceDiscovery(meshName, vnName, rName, "Key1", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
@@ -495,12 +495,12 @@ func testAccVirtualNode_listenerConnectionPool(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerConnectionPool(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerConnectionPool(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -531,9 +531,9 @@ func testAccVirtualNode_listenerConnectionPool(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerConnectionPoolUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerConnectionPoolUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -584,12 +584,12 @@ func testAccVirtualNode_listenerHealthChecks(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerHealthChecks(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerHealthChecks(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -628,9 +628,9 @@ func testAccVirtualNode_listenerHealthChecks(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerHealthChecksUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerHealthChecksUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -692,12 +692,12 @@ func testAccVirtualNode_listenerOutlierDetection(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerOutlierDetection(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerOutlierDetection(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -731,9 +731,9 @@ func testAccVirtualNode_listenerOutlierDetection(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerOutlierDetectionUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerOutlierDetectionUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -786,12 +786,12 @@ func testAccVirtualNode_listenerTimeout(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerTimeout(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerTimeout(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -824,9 +824,9 @@ func testAccVirtualNode_listenerTimeout(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerTimeoutUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerTimeoutUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -886,12 +886,12 @@ func testAccVirtualNode_listenerTLS(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerTlsFile(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerTlsFile(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -937,16 +937,16 @@ func testAccVirtualNode_listenerTLS(t *testing.T) {
 			},
 			// We need to create and activate the CA before issuing a certificate.
 			{
-				Config: testAccAppmeshVirtualNodeConfigRootCA(domain),
+				Config: testAccVirtualNodeConfigRootCA(domain),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckACMPCACertificateAuthorityExists(acmCAResourceName, &ca),
 					acctest.CheckACMPCACertificateAuthorityActivateRootCA(&ca),
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerTlsAcm(meshName, vnName, domain),
+				Config: testAccVirtualNodeConfig_listenerTlsAcm(meshName, vnName, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -990,7 +990,7 @@ func testAccVirtualNode_listenerTLS(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerTlsAcm(meshName, vnName, domain),
+				Config: testAccVirtualNodeConfig_listenerTlsAcm(meshName, vnName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					// CA must be DISABLED for deletion.
 					acctest.CheckACMPCACertificateAuthorityDisableCA(&ca),
@@ -1011,12 +1011,12 @@ func testAccVirtualNode_listenerValidation(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerValidation(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerValidation(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1070,9 +1070,9 @@ func testAccVirtualNode_listenerValidation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_listenerValidationUpdated(meshName, vnName),
+				Config: testAccVirtualNodeConfig_listenerValidationUpdated(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1129,12 +1129,12 @@ func testAccVirtualNode_logging(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_logging(meshName, vnName, "/dev/stdout"),
+				Config: testAccVirtualNodeConfig_logging(meshName, vnName, "/dev/stdout"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1146,9 +1146,9 @@ func testAccVirtualNode_logging(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_logging(meshName, vnName, "/tmp/access.log"),
+				Config: testAccVirtualNodeConfig_logging(meshName, vnName, "/tmp/access.log"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "name", vnName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -1178,30 +1178,30 @@ func testAccVirtualNode_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		CheckDestroy: testAccCheckVirtualNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, "foo", "bar", "good", "bad"),
+				Config: testAccVirtualNodeConfig_tags(meshName, vnName, "foo", "bar", "good", "bad"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, "foo2", "bar", "good", "bad2"),
+				Config: testAccVirtualNodeConfig_tags(meshName, vnName, "foo2", "bar", "good", "bad2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo2", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad2"),
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualNodeConfig_basic(meshName, vnName),
+				Config: testAccVirtualNodeConfig_basic(meshName, vnName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					testAccCheckVirtualNodeExists(resourceName, &vn),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -1215,7 +1215,7 @@ func testAccVirtualNode_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppmeshVirtualNodeDestroy(s *terraform.State) error {
+func testAccCheckVirtualNodeDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -1239,7 +1239,7 @@ func testAccCheckAppmeshVirtualNodeDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshVirtualNodeExists(name string, v *appmesh.VirtualNodeData) resource.TestCheckFunc {
+func testAccCheckVirtualNodeExists(name string, v *appmesh.VirtualNodeData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -1265,7 +1265,7 @@ func testAccCheckAppmeshVirtualNodeExists(name string, v *appmesh.VirtualNodeDat
 	}
 }
 
-func testAccAppmeshVirtualNodeConfig_mesh(rName string) string {
+func testAccVirtualNodeConfig_mesh(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -1273,7 +1273,7 @@ resource "aws_appmesh_mesh" "test" {
 `, rName)
 }
 
-func testAccAppmeshVirtualNodeConfigRootCA(domain string) string {
+func testAccVirtualNodeConfigRootCA(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
@@ -1291,7 +1291,7 @@ resource "aws_acmpca_certificate_authority" "test" {
 `, domain)
 }
 
-func testAccAppmeshVirtualNodeConfigPrivateCert(domain string) string {
+func testAccVirtualNodeConfigPrivateCert(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   domain_name               = "test.%[1]s"
@@ -1300,8 +1300,8 @@ resource "aws_acm_certificate" "test" {
 `, domain)
 }
 
-func testAccAppmeshVirtualNodeConfig_basic(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_basic(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1311,8 +1311,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_backendDefaults(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_backendDefaults(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1338,8 +1338,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_backendDefaultsUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_backendDefaultsUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1365,8 +1365,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_backendDefaultsCertificate(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_backendDefaultsCertificate(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1405,11 +1405,11 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_backendClientPolicyAcm(meshName, vnName, domain string) string {
+func testAccVirtualNodeConfig_backendClientPolicyAcm(meshName, vnName, domain string) string {
 	return acctest.ConfigCompose(
-		testAccAppmeshVirtualNodeConfigRootCA(domain),
-		testAccAppmeshVirtualNodeConfigPrivateCert(domain),
-		testAccAppmeshVirtualNodeConfig_mesh(meshName),
+		testAccVirtualNodeConfigRootCA(domain),
+		testAccVirtualNodeConfigPrivateCert(domain),
+		testAccVirtualNodeConfig_mesh(meshName),
 		fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
@@ -1453,8 +1453,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_backendClientPolicyFile(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_backendClientPolicyFile(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1497,8 +1497,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_backendClientPolicyFileUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_backendClientPolicyFileUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1547,8 +1547,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_cloudMapServiceDiscovery(meshName, vnName, rName, attrKey, attrValue string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_cloudMapServiceDiscovery(meshName, vnName, rName, attrKey, attrValue string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_service_discovery_http_namespace" "test" {
   name = %[2]q
 }
@@ -1586,8 +1586,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName, rName, attrKey, attrValue))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerConnectionPool(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerConnectionPool(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1622,8 +1622,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerConnectionPoolUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerConnectionPoolUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1659,8 +1659,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerHealthChecks(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerHealthChecks(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1698,8 +1698,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerHealthChecksUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerHealthChecksUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1743,8 +1743,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerOutlierDetection(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerOutlierDetection(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1788,8 +1788,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerOutlierDetectionUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerOutlierDetectionUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1833,8 +1833,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerTimeout(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerTimeout(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1872,8 +1872,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerTimeoutUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerTimeoutUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1916,8 +1916,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerTlsFile(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerTlsFile(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -1957,11 +1957,11 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerTlsAcm(meshName, vnName, domain string) string {
+func testAccVirtualNodeConfig_listenerTlsAcm(meshName, vnName, domain string) string {
 	return acctest.ConfigCompose(
-		testAccAppmeshVirtualNodeConfigRootCA(domain),
-		testAccAppmeshVirtualNodeConfigPrivateCert(domain),
-		testAccAppmeshVirtualNodeConfig_mesh(meshName),
+		testAccVirtualNodeConfigRootCA(domain),
+		testAccVirtualNodeConfigPrivateCert(domain),
+		testAccVirtualNodeConfig_mesh(meshName),
 		fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
@@ -2001,8 +2001,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerValidation(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerValidation(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -2055,8 +2055,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_listenerValidationUpdated(meshName, vnName string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_listenerValidationUpdated(meshName, vnName string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -2103,8 +2103,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName))
 }
 
-func testAccAppmeshVirtualNodeConfig_logging(meshName, vnName, path string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_logging(meshName, vnName, path string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id
@@ -2141,8 +2141,8 @@ resource "aws_appmesh_virtual_node" "test" {
 `, vnName, path))
 }
 
-func testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccAppmeshVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
+func testAccVirtualNodeConfig_tags(meshName, vnName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccVirtualNodeConfig_mesh(meshName), fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
   mesh_name = aws_appmesh_mesh.test.id

--- a/internal/service/appmesh/virtual_router.go
+++ b/internal/service/appmesh/virtual_router.go
@@ -219,7 +219,7 @@ func resourceVirtualRouterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("created_date", resp.VirtualRouter.Metadata.CreatedAt.Format(time.RFC3339))
 	d.Set("last_updated_date", resp.VirtualRouter.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("resource_owner", resp.VirtualRouter.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppMeshVirtualRouterSpec(resp.VirtualRouter.Spec))
+	err = d.Set("spec", flattenVirtualRouterSpec(resp.VirtualRouter.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %s", err)
 	}

--- a/internal/service/appmesh/virtual_router_migrate.go
+++ b/internal/service/appmesh/virtual_router_migrate.go
@@ -12,13 +12,13 @@ func resourceVirtualRouterMigrateState(v int, is *terraform.InstanceState, meta 
 	switch v {
 	case 0:
 		log.Println("[INFO] Found App Mesh virtual router state v0; migrating to v1")
-		return migrateAppmeshVirtualRouterStateV0toV1(is)
+		return migrateVirtualRouterStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
 }
 
-func migrateAppmeshVirtualRouterStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+func migrateVirtualRouterStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
 	if is.Empty() || is.Attributes == nil {
 		log.Println("[DEBUG] Empty App Mesh virtual router state; nothing to migrate.")
 		return is, nil

--- a/internal/service/appmesh/virtual_router_test.go
+++ b/internal/service/appmesh/virtual_router_test.go
@@ -24,12 +24,12 @@ func testAccVirtualRouter_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualRouterDestroy,
+		CheckDestroy: testAccCheckVirtualRouterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualRouterConfig_basic(meshName, vrName),
+				Config: testAccVirtualRouterConfig_basic(meshName, vrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualRouterExists(resourceName, &vr),
+					testAccCheckVirtualRouterExists(resourceName, &vr),
 					resource.TestCheckResourceAttr(resourceName, "name", vrName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -45,9 +45,9 @@ func testAccVirtualRouter_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualRouterConfig_updated(meshName, vrName),
+				Config: testAccVirtualRouterConfig_updated(meshName, vrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualRouterExists(resourceName, &vr),
+					testAccCheckVirtualRouterExists(resourceName, &vr),
 					resource.TestCheckResourceAttr(resourceName, "name", vrName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -78,12 +78,12 @@ func testAccVirtualRouter_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualRouterDestroy,
+		CheckDestroy: testAccCheckVirtualRouterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualRouterConfig_tags(meshName, vrName, "foo", "bar", "good", "bad"),
+				Config: testAccVirtualRouterConfig_tags(meshName, vrName, "foo", "bar", "good", "bad"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualRouterExists(
+					testAccCheckVirtualRouterExists(
 						resourceName, &vr),
 					resource.TestCheckResourceAttr(
 						resourceName, "tags.%", "2"),
@@ -94,9 +94,9 @@ func testAccVirtualRouter_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualRouterConfig_tags(meshName, vrName, "foo2", "bar", "good", "bad2"),
+				Config: testAccVirtualRouterConfig_tags(meshName, vrName, "foo2", "bar", "good", "bad2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualRouterExists(
+					testAccCheckVirtualRouterExists(
 						resourceName, &vr),
 					resource.TestCheckResourceAttr(
 						resourceName, "tags.%", "2"),
@@ -107,9 +107,9 @@ func testAccVirtualRouter_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualRouterConfig_basic(meshName, vrName),
+				Config: testAccVirtualRouterConfig_basic(meshName, vrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualRouterExists(
+					testAccCheckVirtualRouterExists(
 						resourceName, &vr),
 					resource.TestCheckResourceAttr(
 						resourceName, "tags.%", "0"),
@@ -125,7 +125,7 @@ func testAccVirtualRouter_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppmeshVirtualRouterDestroy(s *terraform.State) error {
+func testAccCheckVirtualRouterDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -149,7 +149,7 @@ func testAccCheckAppmeshVirtualRouterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshVirtualRouterExists(name string, v *appmesh.VirtualRouterData) resource.TestCheckFunc {
+func testAccCheckVirtualRouterExists(name string, v *appmesh.VirtualRouterData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -175,7 +175,7 @@ func testAccCheckAppmeshVirtualRouterExists(name string, v *appmesh.VirtualRoute
 	}
 }
 
-func testAccAppmeshVirtualRouterConfig_basic(meshName, vrName string) string {
+func testAccVirtualRouterConfig_basic(meshName, vrName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -197,7 +197,7 @@ resource "aws_appmesh_virtual_router" "test" {
 `, meshName, vrName)
 }
 
-func testAccAppmeshVirtualRouterConfig_updated(meshName, vrName string) string {
+func testAccVirtualRouterConfig_updated(meshName, vrName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -219,7 +219,7 @@ resource "aws_appmesh_virtual_router" "test" {
 `, meshName, vrName)
 }
 
-func testAccAppmeshVirtualRouterConfig_tags(meshName, vrName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVirtualRouterConfig_tags(meshName, vrName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q

--- a/internal/service/appmesh/virtual_service.go
+++ b/internal/service/appmesh/virtual_service.go
@@ -227,7 +227,7 @@ func resourceVirtualServiceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("created_date", resp.VirtualService.Metadata.CreatedAt.Format(time.RFC3339))
 	d.Set("last_updated_date", resp.VirtualService.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("resource_owner", resp.VirtualService.Metadata.ResourceOwner)
-	err = d.Set("spec", flattenAppMeshVirtualServiceSpec(resp.VirtualService.Spec))
+	err = d.Set("spec", flattenVirtualServiceSpec(resp.VirtualService.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %s", err)
 	}

--- a/internal/service/appmesh/virtual_service_data_source.go
+++ b/internal/service/appmesh/virtual_service_data_source.go
@@ -129,7 +129,7 @@ func dataSourceVirtualServiceRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("last_updated_date", resp.VirtualService.Metadata.LastUpdatedAt.Format(time.RFC3339))
 	d.Set("resource_owner", resp.VirtualService.Metadata.ResourceOwner)
 
-	err = d.Set("spec", flattenAppMeshVirtualServiceSpec(resp.VirtualService.Spec))
+	err = d.Set("spec", flattenVirtualServiceSpec(resp.VirtualService.Spec))
 	if err != nil {
 		return fmt.Errorf("error setting spec: %s", err)
 	}

--- a/internal/service/appmesh/virtual_service_data_source_test.go
+++ b/internal/service/appmesh/virtual_service_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccAppMeshVirtualServiceDataSource_virtualNode(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualServiceDestroy,
+		CheckDestroy: testAccCheckVirtualServiceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckVirtualServiceDataSourceConfig_virtualNode(rName, vsName),
@@ -50,7 +50,7 @@ func TestAccAppMeshVirtualServiceDataSource_virtualRouter(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualServiceDestroy,
+		CheckDestroy: testAccCheckVirtualServiceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckVirtualServiceDataSourceConfig_virtualRouter(rName, vsName),

--- a/internal/service/appmesh/virtual_service_test.go
+++ b/internal/service/appmesh/virtual_service_test.go
@@ -26,12 +26,12 @@ func testAccVirtualService_virtualNode(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualServiceDestroy,
+		CheckDestroy: testAccCheckVirtualServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo"),
+				Config: testAccVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(resourceName, "name", vsName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -46,9 +46,9 @@ func testAccVirtualService_virtualNode(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.bar"),
+				Config: testAccVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.bar"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(resourceName, "name", vsName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -80,12 +80,12 @@ func testAccVirtualService_virtualRouter(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualServiceDestroy,
+		CheckDestroy: testAccCheckVirtualServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualServiceConfig_virtualRouter(meshName, vrName1, vrName2, vsName, "aws_appmesh_virtual_router.foo"),
+				Config: testAccVirtualServiceConfig_virtualRouter(meshName, vrName1, vrName2, vsName, "aws_appmesh_virtual_router.foo"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(resourceName, "name", vsName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -99,9 +99,9 @@ func testAccVirtualService_virtualRouter(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualService/%s", meshName, vsName))),
 			},
 			{
-				Config: testAccAppmeshVirtualServiceConfig_virtualRouter(meshName, vrName1, vrName2, vsName, "aws_appmesh_virtual_router.bar"),
+				Config: testAccVirtualServiceConfig_virtualRouter(meshName, vrName1, vrName2, vsName, "aws_appmesh_virtual_router.bar"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(resourceName, "name", vsName),
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					acctest.CheckResourceAttrAccountID(resourceName, "mesh_owner"),
@@ -127,12 +127,12 @@ func testAccVirtualService_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appmesh.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appmesh.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAppmeshVirtualServiceDestroy,
+		CheckDestroy: testAccCheckVirtualServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppmeshVirtualServiceConfig_tags(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo", "foo", "bar", "good", "bad"),
+				Config: testAccVirtualServiceConfig_tags(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo", "foo", "bar", "good", "bad"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(
 						resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(
@@ -142,9 +142,9 @@ func testAccVirtualService_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualServiceConfig_tags(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo", "foo2", "bar", "good", "bad2"),
+				Config: testAccVirtualServiceConfig_tags(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo", "foo2", "bar", "good", "bad2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(
 						resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(
@@ -154,9 +154,9 @@ func testAccVirtualService_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppmeshVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo"),
+				Config: testAccVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, "aws_appmesh_virtual_node.foo"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppmeshVirtualServiceExists(resourceName, &vs),
+					testAccCheckVirtualServiceExists(resourceName, &vs),
 					resource.TestCheckResourceAttr(
 						resourceName, "tags.%", "0"),
 				),
@@ -171,7 +171,7 @@ func testAccVirtualService_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAppmeshVirtualServiceDestroy(s *terraform.State) error {
+func testAccCheckVirtualServiceDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -195,7 +195,7 @@ func testAccCheckAppmeshVirtualServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAppmeshVirtualServiceExists(name string, v *appmesh.VirtualServiceData) resource.TestCheckFunc {
+func testAccCheckVirtualServiceExists(name string, v *appmesh.VirtualServiceData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppMeshConn
 
@@ -221,7 +221,7 @@ func testAccCheckAppmeshVirtualServiceExists(name string, v *appmesh.VirtualServ
 	}
 }
 
-func testAccAppmeshVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, rName string) string {
+func testAccVirtualServiceConfig_virtualNode(meshName, vnName1, vnName2, vsName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -256,7 +256,7 @@ resource "aws_appmesh_virtual_service" "test" {
 `, meshName, vnName1, vnName2, vsName, rName)
 }
 
-func testAccAppmeshVirtualServiceConfig_virtualRouter(meshName, vrName1, vrName2, vsName, rName string) string {
+func testAccVirtualServiceConfig_virtualRouter(meshName, vrName1, vrName2, vsName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q
@@ -305,7 +305,7 @@ resource "aws_appmesh_virtual_service" "test" {
 `, meshName, vrName1, vrName2, vsName, rName)
 }
 
-func testAccAppmeshVirtualServiceConfig_tags(meshName, vnName1, vnName2, vsName, rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVirtualServiceConfig_tags(meshName, vnName1, vnName2, vsName, rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
   name = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
