### PR TITLE
appstream: Remove service from funcs

### DIFF
--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 func init() {
-	acctest.RegisterServiceErrorCheckFunc(appstream.EndpointsID, testAccErrorCheckSkipAppStream)
+	acctest.RegisterServiceErrorCheckFunc(appstream.EndpointsID, testAccErrorCheckSkip)
 
 }
 
-// testAccErrorCheckSkipAppStream skips AppStream tests that have error messages indicating unsupported features
-func testAccErrorCheckSkipAppStream(t *testing.T) resource.ErrorCheckFunc {
+// testAccErrorCheckSkip skips AppStream tests that have error messages indicating unsupported features
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"ResourceNotFoundException: The image",
 		"InvalidParameterValueException: The AppStream 2.0 user pool feature",

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -218,7 +218,7 @@ func resourceImageBuilderCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if v, ok := d.GetOk("vpc_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.VpcConfig = expandAppStreamImageBuilderVpcConfig(v.([]interface{}))
+		input.VpcConfig = expandImageBuilderVpcConfig(v.([]interface{}))
 	}
 
 	if len(tags) > 0 {
@@ -347,7 +347,7 @@ func resourceImageBuilderDelete(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func expandAppStreamImageBuilderVpcConfig(tfList []interface{}) *appstream.VpcConfig {
+func expandImageBuilderVpcConfig(tfList []interface{}) *appstream.VpcConfig {
 	if len(tfList) == 0 {
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
