### PR TITLE
apprunner: Remove service from funcs

### DIFF
--- a/internal/service/apprunner/auto_scaling_configuration_version_test.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version_test.go
@@ -22,13 +22,13 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_basic(t *testing.T) {
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_basic(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`autoscalingconfiguration/%s/1/.+`, rName))),
@@ -55,13 +55,13 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_complex(t *testing.T) {
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_withNonDefaults(rName, 50, 10, 2),
+				Config: testAccAutoScalingConfigurationVersionConfig_nonDefaults(rName, 50, 10, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`autoscalingconfiguration/%s/1/.+`, rName))),
@@ -81,7 +81,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_complex(t *testing.T) {
 			},
 			{
 				// Test resource recreation such that the revision number is still 1
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_withNonDefaults(rName, 150, 20, 5),
+				Config: testAccAutoScalingConfigurationVersionConfig_nonDefaults(rName, 150, 20, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`autoscalingconfiguration/%s/1/.+`, rName))),
@@ -101,7 +101,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_complex(t *testing.T) {
 			},
 			{
 				// Test resource recreation such that the revision number is still 1
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_basic(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`autoscalingconfiguration/%s/1/.+`, rName))),
@@ -124,13 +124,13 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_multipleVersions(t *testing
 	otherResourceName := "aws_apprunner_auto_scaling_configuration_version.other"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_multipleVersions(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_multipleVersions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					testAccCheckAutoScalingConfigurationVersionExists(otherResourceName),
@@ -154,7 +154,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_multipleVersions(t *testing
 			},
 			{
 				// Test update of "latest" computed attribute after apply
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_multipleVersions(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_multipleVersions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					testAccCheckAutoScalingConfigurationVersionExists(otherResourceName),
@@ -182,20 +182,20 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_updateMultipleVersions(t *t
 	otherResourceName := "aws_apprunner_auto_scaling_configuration_version.other"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_multipleVersions(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_multipleVersions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					testAccCheckAutoScalingConfigurationVersionExists(otherResourceName),
 				),
 			},
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_updateMultipleVersions(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_updateMultipleVersions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					testAccCheckAutoScalingConfigurationVersionExists(otherResourceName),
@@ -236,13 +236,13 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_disappears(t *testing.T) {
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfig_basic(rName),
+				Config: testAccAutoScalingConfigurationVersionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfapprunner.ResourceAutoScalingConfigurationVersion(), resourceName),
@@ -258,13 +258,13 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags(t *testing.T) {
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfigTags1(rName, "key1", "value1"),
+				Config: testAccAutoScalingConfigurationVersionConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -277,7 +277,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAutoScalingConfigurationVersionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -286,7 +286,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppRunnerAutoScalingConfigurationVersionConfigTags1(rName, "key2", "value2"),
+				Config: testAccAutoScalingConfigurationVersionConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAutoScalingConfigurationVersionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -358,7 +358,7 @@ func testAccCheckAutoScalingConfigurationVersionExists(n string) resource.TestCh
 	}
 }
 
-func testAccAppRunnerAutoScalingConfigurationVersionConfig_basic(rName string) string {
+func testAccAutoScalingConfigurationVersionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q
@@ -366,7 +366,7 @@ resource "aws_apprunner_auto_scaling_configuration_version" "test" {
 `, rName)
 }
 
-func testAccAppRunnerAutoScalingConfigurationVersionConfig_withNonDefaults(rName string, maxConcurrency, maxSize, minSize int) string {
+func testAccAutoScalingConfigurationVersionConfig_nonDefaults(rName string, maxConcurrency, maxSize, minSize int) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q
@@ -378,7 +378,7 @@ resource "aws_apprunner_auto_scaling_configuration_version" "test" {
 `, rName, maxConcurrency, maxSize, minSize)
 }
 
-func testAccAppRunnerAutoScalingConfigurationVersionConfig_multipleVersions(rName string) string {
+func testAccAutoScalingConfigurationVersionConfig_multipleVersions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q
@@ -390,7 +390,7 @@ resource "aws_apprunner_auto_scaling_configuration_version" "other" {
 `, rName)
 }
 
-func testAccAppRunnerAutoScalingConfigurationVersionConfig_updateMultipleVersions(rName string) string {
+func testAccAutoScalingConfigurationVersionConfig_updateMultipleVersions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q
@@ -405,7 +405,7 @@ resource "aws_apprunner_auto_scaling_configuration_version" "other" {
 `, rName)
 }
 
-func testAccAppRunnerAutoScalingConfigurationVersionConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccAutoScalingConfigurationVersionConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q
@@ -417,7 +417,7 @@ resource "aws_apprunner_auto_scaling_configuration_version" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAppRunnerAutoScalingConfigurationVersionConfigTags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccAutoScalingConfigurationVersionConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q

--- a/internal/service/apprunner/connection_test.go
+++ b/internal/service/apprunner/connection_test.go
@@ -21,13 +21,13 @@ func TestAccAppRunnerConnection_basic(t *testing.T) {
 	resourceName := "aws_apprunner_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerConnection_basic(rName),
+				Config: testAccConnectionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`connection/%s/.+`, rName))),
@@ -51,13 +51,13 @@ func TestAccAppRunnerConnection_disappears(t *testing.T) {
 	resourceName := "aws_apprunner_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerConnection_basic(rName),
+				Config: testAccConnectionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfapprunner.ResourceConnection(), resourceName),
@@ -73,13 +73,13 @@ func TestAccAppRunnerConnection_tags(t *testing.T) {
 	resourceName := "aws_apprunner_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerConnectionConfigTags1(rName, "key1", "value1"),
+				Config: testAccConnectionConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -94,7 +94,7 @@ func TestAccAppRunnerConnection_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppRunnerConnectionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccConnectionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -106,7 +106,7 @@ func TestAccAppRunnerConnection_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppRunnerConnectionConfigTags1(rName, "key2", "value2"),
+				Config: testAccConnectionConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -172,7 +172,7 @@ func testAccCheckConnectionExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAppRunnerConnection_basic(rName string) string {
+func testAccConnectionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_connection" "test" {
   connection_name = %q
@@ -181,7 +181,7 @@ resource "aws_apprunner_connection" "test" {
 `, rName)
 }
 
-func testAccAppRunnerConnectionConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccConnectionConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_connection" "test" {
   connection_name = %[1]q
@@ -194,7 +194,7 @@ resource "aws_apprunner_connection" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAppRunnerConnectionConfigTags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccConnectionConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_connection" "test" {
   connection_name = %[1]q

--- a/internal/service/apprunner/custom_domain_association.go
+++ b/internal/service/apprunner/custom_domain_association.go
@@ -138,7 +138,7 @@ func resourceCustomDomainAssociationRead(ctx context.Context, d *schema.Resource
 		return nil
 	}
 
-	if err := d.Set("certificate_validation_records", flattenAppRunnerCustomDomainCertificateValidationRecords(customDomain.CertificateValidationRecords)); err != nil {
+	if err := d.Set("certificate_validation_records", flattenCustomDomainCertificateValidationRecords(customDomain.CertificateValidationRecords)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting certificate_validation_records: %w", err))
 	}
 
@@ -185,7 +185,7 @@ func resourceCustomDomainAssociationDelete(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func flattenAppRunnerCustomDomainCertificateValidationRecords(records []*apprunner.CertificateValidationRecord) []interface{} {
+func flattenCustomDomainCertificateValidationRecords(records []*apprunner.CertificateValidationRecord) []interface{} {
 	var results []interface{}
 
 	for _, record := range records {

--- a/internal/service/apprunner/custom_domain_association_test.go
+++ b/internal/service/apprunner/custom_domain_association_test.go
@@ -27,13 +27,13 @@ func TestAccAppRunnerCustomDomainAssociation_basic(t *testing.T) {
 	serviceResourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckCustomDomainAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerCustomDomainAssociation_basic(rName, domain),
+				Config: testAccCustomDomainAssociationConfig_basic(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomDomainAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "certificate_validation_records.#", "3"),
@@ -64,13 +64,13 @@ func TestAccAppRunnerCustomDomainAssociation_disappears(t *testing.T) {
 	resourceName := "aws_apprunner_custom_domain_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckCustomDomainAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerCustomDomainAssociation_basic(rName, domain),
+				Config: testAccCustomDomainAssociationConfig_basic(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomDomainAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfapprunner.ResourceCustomDomainAssociation(), resourceName),
@@ -146,7 +146,7 @@ func testAccCheckCustomDomainAssociationExists(n string) resource.TestCheckFunc 
 	}
 }
 
-func testAccAppRunnerCustomDomainAssociation_basic(rName, domain string) string {
+func testAccCustomDomainAssociationConfig_basic(rName, domain string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -390,7 +390,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	input := &apprunner.CreateServiceInput{
 		ServiceName:         aws.String(serviceName),
-		SourceConfiguration: expandAppRunnerServiceSourceConfiguration(d.Get("source_configuration").([]interface{})),
+		SourceConfiguration: expandServiceSourceConfiguration(d.Get("source_configuration").([]interface{})),
 		Tags:                Tags(tags.IgnoreAWS()),
 	}
 
@@ -399,19 +399,19 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("encryption_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.EncryptionConfiguration = expandAppRunnerServiceEncryptionConfiguration(v.([]interface{}))
+		input.EncryptionConfiguration = expandServiceEncryptionConfiguration(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("health_check_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.HealthCheckConfiguration = expandAppRunnerServiceHealthCheckConfiguration(v.([]interface{}))
+		input.HealthCheckConfiguration = expandServiceHealthCheckConfiguration(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("instance_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.InstanceConfiguration = expandAppRunnerServiceInstanceConfiguration(v.([]interface{}))
+		input.InstanceConfiguration = expandServiceInstanceConfiguration(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("network_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.NetworkConfiguration = expandAppRunnerNetworkConfiguration(v.([]interface{}))
+		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{}))
 	}
 
 	var output *apprunner.CreateServiceOutput
@@ -500,23 +500,23 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("service_name", service.ServiceName)
 	d.Set("service_url", service.ServiceUrl)
 	d.Set("status", service.Status)
-	if err := d.Set("encryption_configuration", flattenAppRunnerServiceEncryptionConfiguration(service.EncryptionConfiguration)); err != nil {
+	if err := d.Set("encryption_configuration", flattenServiceEncryptionConfiguration(service.EncryptionConfiguration)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting encryption_configuration: %w", err))
 	}
 
-	if err := d.Set("health_check_configuration", flattenAppRunnerServiceHealthCheckConfiguration(service.HealthCheckConfiguration)); err != nil {
+	if err := d.Set("health_check_configuration", flattenServiceHealthCheckConfiguration(service.HealthCheckConfiguration)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting health_check_configuration: %w", err))
 	}
 
-	if err := d.Set("instance_configuration", flattenAppRunnerServiceInstanceConfiguration(service.InstanceConfiguration)); err != nil {
+	if err := d.Set("instance_configuration", flattenServiceInstanceConfiguration(service.InstanceConfiguration)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting instance_configuration: %w", err))
 	}
 
-	if err := d.Set("network_configuration", flattenAppRunnerNetworkConfiguration(service.NetworkConfiguration)); err != nil {
+	if err := d.Set("network_configuration", flattenNetworkConfiguration(service.NetworkConfiguration)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting network_configuration: %w", err))
 	}
 
-	if err := d.Set("source_configuration", flattenAppRunnerServiceSourceConfiguration(service.SourceConfiguration)); err != nil {
+	if err := d.Set("source_configuration", flattenServiceSourceConfiguration(service.SourceConfiguration)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting source_configuration: %w", err))
 	}
 
@@ -558,15 +558,15 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if d.HasChange("instance_configuration") {
-			input.InstanceConfiguration = expandAppRunnerServiceInstanceConfiguration(d.Get("instance_configuration").([]interface{}))
+			input.InstanceConfiguration = expandServiceInstanceConfiguration(d.Get("instance_configuration").([]interface{}))
 		}
 
 		if d.HasChange("network_configuration") {
-			input.NetworkConfiguration = expandAppRunnerNetworkConfiguration(d.Get("network_configuration").([]interface{}))
+			input.NetworkConfiguration = expandNetworkConfiguration(d.Get("network_configuration").([]interface{}))
 		}
 
 		if d.HasChange("source_configuration") {
-			input.SourceConfiguration = expandAppRunnerServiceSourceConfiguration(d.Get("source_configuration").([]interface{}))
+			input.SourceConfiguration = expandServiceSourceConfiguration(d.Get("source_configuration").([]interface{}))
 		}
 
 		_, err := conn.UpdateServiceWithContext(ctx, input)
@@ -619,7 +619,7 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return nil
 }
 
-func expandAppRunnerServiceEncryptionConfiguration(l []interface{}) *apprunner.EncryptionConfiguration {
+func expandServiceEncryptionConfiguration(l []interface{}) *apprunner.EncryptionConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -639,7 +639,7 @@ func expandAppRunnerServiceEncryptionConfiguration(l []interface{}) *apprunner.E
 	return result
 }
 
-func expandAppRunnerServiceHealthCheckConfiguration(l []interface{}) *apprunner.HealthCheckConfiguration {
+func expandServiceHealthCheckConfiguration(l []interface{}) *apprunner.HealthCheckConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -679,7 +679,7 @@ func expandAppRunnerServiceHealthCheckConfiguration(l []interface{}) *apprunner.
 	return result
 }
 
-func expandAppRunnerServiceInstanceConfiguration(l []interface{}) *apprunner.InstanceConfiguration {
+func expandServiceInstanceConfiguration(l []interface{}) *apprunner.InstanceConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -707,7 +707,7 @@ func expandAppRunnerServiceInstanceConfiguration(l []interface{}) *apprunner.Ins
 	return result
 }
 
-func expandAppRunnerNetworkConfiguration(l []interface{}) *apprunner.NetworkConfiguration {
+func expandNetworkConfiguration(l []interface{}) *apprunner.NetworkConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -721,13 +721,13 @@ func expandAppRunnerNetworkConfiguration(l []interface{}) *apprunner.NetworkConf
 	result := &apprunner.NetworkConfiguration{}
 
 	if v, ok := tfMap["egress_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.EgressConfiguration = expandAppRunnerNetworkEgressConfiguration(v)
+		result.EgressConfiguration = expandNetworkEgressConfiguration(v)
 	}
 
 	return result
 }
 
-func expandAppRunnerServiceSourceConfiguration(l []interface{}) *apprunner.SourceConfiguration {
+func expandServiceSourceConfiguration(l []interface{}) *apprunner.SourceConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -741,7 +741,7 @@ func expandAppRunnerServiceSourceConfiguration(l []interface{}) *apprunner.Sourc
 	result := &apprunner.SourceConfiguration{}
 
 	if v, ok := tfMap["authentication_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.AuthenticationConfiguration = expandAppRunnerServiceAuthenticationConfiguration(v)
+		result.AuthenticationConfiguration = expandServiceAuthenticationConfiguration(v)
 	}
 
 	if v, ok := tfMap["auto_deployments_enabled"].(bool); ok {
@@ -749,17 +749,17 @@ func expandAppRunnerServiceSourceConfiguration(l []interface{}) *apprunner.Sourc
 	}
 
 	if v, ok := tfMap["code_repository"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.CodeRepository = expandAppRunnerServiceCodeRepository(v)
+		result.CodeRepository = expandServiceCodeRepository(v)
 	}
 
 	if v, ok := tfMap["image_repository"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.ImageRepository = expandAppRunnerServiceImageRepository(v)
+		result.ImageRepository = expandServiceImageRepository(v)
 	}
 
 	return result
 }
 
-func expandAppRunnerServiceAuthenticationConfiguration(l []interface{}) *apprunner.AuthenticationConfiguration {
+func expandServiceAuthenticationConfiguration(l []interface{}) *apprunner.AuthenticationConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -783,7 +783,7 @@ func expandAppRunnerServiceAuthenticationConfiguration(l []interface{}) *apprunn
 	return result
 }
 
-func expandAppRunnerNetworkEgressConfiguration(l []interface{}) *apprunner.EgressConfiguration {
+func expandNetworkEgressConfiguration(l []interface{}) *apprunner.EgressConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -807,7 +807,7 @@ func expandAppRunnerNetworkEgressConfiguration(l []interface{}) *apprunner.Egres
 	return result
 }
 
-func expandAppRunnerServiceImageConfiguration(l []interface{}) *apprunner.ImageConfiguration {
+func expandServiceImageConfiguration(l []interface{}) *apprunner.ImageConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -835,7 +835,7 @@ func expandAppRunnerServiceImageConfiguration(l []interface{}) *apprunner.ImageC
 	return result
 }
 
-func expandAppRunnerServiceCodeRepository(l []interface{}) *apprunner.CodeRepository {
+func expandServiceCodeRepository(l []interface{}) *apprunner.CodeRepository {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -849,11 +849,11 @@ func expandAppRunnerServiceCodeRepository(l []interface{}) *apprunner.CodeReposi
 	result := &apprunner.CodeRepository{}
 
 	if v, ok := tfMap["source_code_version"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.SourceCodeVersion = expandAppRunnerServiceSourceCodeVersion(v)
+		result.SourceCodeVersion = expandServiceSourceCodeVersion(v)
 	}
 
 	if v, ok := tfMap["code_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.CodeConfiguration = expandAppRunnerServiceCodeConfiguration(v)
+		result.CodeConfiguration = expandServiceCodeConfiguration(v)
 	}
 
 	if v, ok := tfMap["repository_url"].(string); ok && v != "" {
@@ -863,7 +863,7 @@ func expandAppRunnerServiceCodeRepository(l []interface{}) *apprunner.CodeReposi
 	return result
 }
 
-func expandAppRunnerServiceImageRepository(l []interface{}) *apprunner.ImageRepository {
+func expandServiceImageRepository(l []interface{}) *apprunner.ImageRepository {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -877,7 +877,7 @@ func expandAppRunnerServiceImageRepository(l []interface{}) *apprunner.ImageRepo
 	result := &apprunner.ImageRepository{}
 
 	if v, ok := tfMap["image_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.ImageConfiguration = expandAppRunnerServiceImageConfiguration(v)
+		result.ImageConfiguration = expandServiceImageConfiguration(v)
 	}
 
 	if v, ok := tfMap["image_identifier"].(string); ok && v != "" {
@@ -891,7 +891,7 @@ func expandAppRunnerServiceImageRepository(l []interface{}) *apprunner.ImageRepo
 	return result
 }
 
-func expandAppRunnerServiceCodeConfiguration(l []interface{}) *apprunner.CodeConfiguration {
+func expandServiceCodeConfiguration(l []interface{}) *apprunner.CodeConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -909,13 +909,13 @@ func expandAppRunnerServiceCodeConfiguration(l []interface{}) *apprunner.CodeCon
 	}
 
 	if v, ok := tfMap["code_configuration_values"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		result.CodeConfigurationValues = expandAppRunnerServiceCodeConfigurationValues(v)
+		result.CodeConfigurationValues = expandServiceCodeConfigurationValues(v)
 	}
 
 	return result
 }
 
-func expandAppRunnerServiceCodeConfigurationValues(l []interface{}) *apprunner.CodeConfigurationValues {
+func expandServiceCodeConfigurationValues(l []interface{}) *apprunner.CodeConfigurationValues {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -951,7 +951,7 @@ func expandAppRunnerServiceCodeConfigurationValues(l []interface{}) *apprunner.C
 	return result
 }
 
-func expandAppRunnerServiceSourceCodeVersion(l []interface{}) *apprunner.SourceCodeVersion {
+func expandServiceSourceCodeVersion(l []interface{}) *apprunner.SourceCodeVersion {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -975,7 +975,7 @@ func expandAppRunnerServiceSourceCodeVersion(l []interface{}) *apprunner.SourceC
 	return result
 }
 
-func flattenAppRunnerServiceEncryptionConfiguration(config *apprunner.EncryptionConfiguration) []interface{} {
+func flattenServiceEncryptionConfiguration(config *apprunner.EncryptionConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -987,7 +987,7 @@ func flattenAppRunnerServiceEncryptionConfiguration(config *apprunner.Encryption
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceHealthCheckConfiguration(config *apprunner.HealthCheckConfiguration) []interface{} {
+func flattenServiceHealthCheckConfiguration(config *apprunner.HealthCheckConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -1004,7 +1004,7 @@ func flattenAppRunnerServiceHealthCheckConfiguration(config *apprunner.HealthChe
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceInstanceConfiguration(config *apprunner.InstanceConfiguration) []interface{} {
+func flattenServiceInstanceConfiguration(config *apprunner.InstanceConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -1018,19 +1018,19 @@ func flattenAppRunnerServiceInstanceConfiguration(config *apprunner.InstanceConf
 	return []interface{}{m}
 }
 
-func flattenAppRunnerNetworkConfiguration(config *apprunner.NetworkConfiguration) []interface{} {
+func flattenNetworkConfiguration(config *apprunner.NetworkConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"egress_configuration": flattenAppRunnerNetworkEgressConfiguration(config.EgressConfiguration),
+		"egress_configuration": flattenNetworkEgressConfiguration(config.EgressConfiguration),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenAppRunnerNetworkEgressConfiguration(config *apprunner.EgressConfiguration) []interface{} {
+func flattenNetworkEgressConfiguration(config *apprunner.EgressConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -1043,34 +1043,34 @@ func flattenAppRunnerNetworkEgressConfiguration(config *apprunner.EgressConfigur
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceCodeRepository(r *apprunner.CodeRepository) []interface{} {
+func flattenServiceCodeRepository(r *apprunner.CodeRepository) []interface{} {
 	if r == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"code_configuration":  flattenAppRunnerServiceCodeConfiguration(r.CodeConfiguration),
+		"code_configuration":  flattenServiceCodeConfiguration(r.CodeConfiguration),
 		"repository_url":      aws.StringValue(r.RepositoryUrl),
-		"source_code_version": flattenAppRunnerServiceSourceCodeVersion(r.SourceCodeVersion),
+		"source_code_version": flattenServiceSourceCodeVersion(r.SourceCodeVersion),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceCodeConfiguration(config *apprunner.CodeConfiguration) []interface{} {
+func flattenServiceCodeConfiguration(config *apprunner.CodeConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"code_configuration_values": flattenAppRunnerServiceCodeConfigurationValues(config.CodeConfigurationValues),
+		"code_configuration_values": flattenServiceCodeConfigurationValues(config.CodeConfigurationValues),
 		"configuration_source":      aws.StringValue(config.ConfigurationSource),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceCodeConfigurationValues(values *apprunner.CodeConfigurationValues) []interface{} {
+func flattenServiceCodeConfigurationValues(values *apprunner.CodeConfigurationValues) []interface{} {
 	if values == nil {
 		return []interface{}{}
 	}
@@ -1086,7 +1086,7 @@ func flattenAppRunnerServiceCodeConfigurationValues(values *apprunner.CodeConfig
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceSourceCodeVersion(v *apprunner.SourceCodeVersion) []interface{} {
+func flattenServiceSourceCodeVersion(v *apprunner.SourceCodeVersion) []interface{} {
 	if v == nil {
 		return []interface{}{}
 	}
@@ -1099,22 +1099,22 @@ func flattenAppRunnerServiceSourceCodeVersion(v *apprunner.SourceCodeVersion) []
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceSourceConfiguration(config *apprunner.SourceConfiguration) []interface{} {
+func flattenServiceSourceConfiguration(config *apprunner.SourceConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"authentication_configuration": flattenAppRunnerServiceAuthenticationConfiguration(config.AuthenticationConfiguration),
+		"authentication_configuration": flattenServiceAuthenticationConfiguration(config.AuthenticationConfiguration),
 		"auto_deployments_enabled":     aws.BoolValue(config.AutoDeploymentsEnabled),
-		"code_repository":              flattenAppRunnerServiceCodeRepository(config.CodeRepository),
-		"image_repository":             flattenAppRunnerServiceImageRepository(config.ImageRepository),
+		"code_repository":              flattenServiceCodeRepository(config.CodeRepository),
+		"image_repository":             flattenServiceImageRepository(config.ImageRepository),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceAuthenticationConfiguration(config *apprunner.AuthenticationConfiguration) []interface{} {
+func flattenServiceAuthenticationConfiguration(config *apprunner.AuthenticationConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -1127,7 +1127,7 @@ func flattenAppRunnerServiceAuthenticationConfiguration(config *apprunner.Authen
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceImageConfiguration(config *apprunner.ImageConfiguration) []interface{} {
+func flattenServiceImageConfiguration(config *apprunner.ImageConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -1141,13 +1141,13 @@ func flattenAppRunnerServiceImageConfiguration(config *apprunner.ImageConfigurat
 	return []interface{}{m}
 }
 
-func flattenAppRunnerServiceImageRepository(r *apprunner.ImageRepository) []interface{} {
+func flattenServiceImageRepository(r *apprunner.ImageRepository) []interface{} {
 	if r == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"image_configuration":   flattenAppRunnerServiceImageConfiguration(r.ImageConfiguration),
+		"image_configuration":   flattenServiceImageConfiguration(r.ImageConfiguration),
 		"image_identifier":      aws.StringValue(r.ImageIdentifier),
 		"image_repository_type": aws.StringValue(r.ImageRepositoryType),
 	}

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -22,13 +22,13 @@ func TestAccAppRunnerService_ImageRepository_basic(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository(rName),
+				Config: testAccServiceConfig_imageRepository(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_name", rName),
@@ -79,19 +79,19 @@ func TestAccAppRunnerService_ImageRepository_autoScaling(t *testing.T) {
 	autoScalingResourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository(rName),
+				Config: testAccServiceConfig_imageRepository(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 				),
 			},
 			{
-				Config: testAccAppRunnerService_imageRepository_autoScalingConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_autoScalingConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "auto_scaling_configuration_arn", autoScalingResourceName, "arn"),
@@ -112,13 +112,13 @@ func TestAccAppRunnerService_ImageRepository_encryption(t *testing.T) {
 	kmsResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository_encryptionConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_encryptionConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -132,7 +132,7 @@ func TestAccAppRunnerService_ImageRepository_encryption(t *testing.T) {
 			},
 			{
 				// Test resource recreation; EncryptionConfiguration (or lack thereof) Forces New resource
-				Config: testAccAppRunnerService_imageRepository(rName),
+				Config: testAccServiceConfig_imageRepository(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "0"),
@@ -147,13 +147,13 @@ func TestAccAppRunnerService_ImageRepository_healthCheck(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository_healthCheckConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_healthCheckConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "health_check_configuration.#", "1"),
@@ -171,7 +171,7 @@ func TestAccAppRunnerService_ImageRepository_healthCheck(t *testing.T) {
 			},
 			{
 				// Test resource recreation; HealthConfiguration Forces New resource
-				Config: testAccAppRunnerService_imageRepository_updateHealthCheckConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_updateHealthCheckConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "health_check_configuration.#", "1"),
@@ -196,13 +196,13 @@ func TestAccAppRunnerService_ImageRepository_instance_NoInstanceRole(t *testing.
 	resourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository_instanceConfiguration_NoInstanceRole(rName),
+				Config: testAccServiceConfig_ImageRepository_InstanceConfiguration_noInstanceRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
@@ -226,13 +226,13 @@ func TestAccAppRunnerService_ImageRepository_instance_Update(t *testing.T) {
 	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository_instanceConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_instanceConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
@@ -247,7 +247,7 @@ func TestAccAppRunnerService_ImageRepository_instance_Update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppRunnerService_imageRepository_updateInstanceConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_updateInstanceConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
@@ -262,7 +262,7 @@ func TestAccAppRunnerService_ImageRepository_instance_Update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppRunnerService_imageRepository(rName),
+				Config: testAccServiceConfig_imageRepository(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
@@ -281,13 +281,13 @@ func TestAccAppRunnerService_ImageRepository_networkConfiguration(t *testing.T) 
 	vpcConnectorResourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository_networkConfiguration(rName),
+				Config: testAccServiceConfig_ImageRepository_networkConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "network_configuration.#", "1"),
@@ -311,13 +311,13 @@ func TestAccAppRunnerService_ImageRepository_runtimeEnvironmentVars(t *testing.T
 	resourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository_runtimeEnvVars(rName),
+				Config: testAccServiceConfig_ImageRepository_runtimeEnvVars(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.#", "1"),
@@ -341,13 +341,13 @@ func TestAccAppRunnerService_disappears(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerService_imageRepository(rName),
+				Config: testAccServiceConfig_imageRepository(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfapprunner.ResourceService(), resourceName),
@@ -363,13 +363,13 @@ func TestAccAppRunnerService_tags(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerServiceConfigTags1(rName, "key1", "value1"),
+				Config: testAccServiceConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -382,7 +382,7 @@ func TestAccAppRunnerService_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppRunnerServiceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccServiceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -391,7 +391,7 @@ func TestAccAppRunnerService_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppRunnerServiceConfigTags1(rName, "key2", "value2"),
+				Config: testAccServiceConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -463,7 +463,7 @@ func testAccCheckServiceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccPreCheckAppRunner(t *testing.T) {
+func testAccPreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppRunnerConn
 	ctx := context.Background()
 
@@ -480,7 +480,7 @@ func testAccPreCheckAppRunner(t *testing.T) {
 	}
 }
 
-func testAccAppRunnerService_imageRepository(rName string) string {
+func testAccServiceConfig_imageRepository(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -498,7 +498,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_runtimeEnvVars(rName string) string {
+func testAccServiceConfig_ImageRepository_runtimeEnvVars(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -519,7 +519,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_autoScalingConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_autoScalingConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_auto_scaling_configuration_version" "test" {
   auto_scaling_configuration_name = %[1]q
@@ -544,7 +544,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_encryptionConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_encryptionConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -572,7 +572,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_healthCheckConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_healthCheckConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -596,7 +596,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_updateHealthCheckConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_updateHealthCheckConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -621,7 +621,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_networkConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_networkConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -679,7 +679,7 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerIAMRole(rName string) string {
+func testAccIAMRole(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -705,9 +705,9 @@ EOF
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_instanceConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_instanceConfiguration(rName string) string {
 	return acctest.ConfigCompose(
-		testAccAppRunnerIAMRole(rName),
+		testAccIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -732,7 +732,7 @@ resource "aws_apprunner_service" "test" {
 `, rName))
 }
 
-func testAccAppRunnerService_imageRepository_instanceConfiguration_NoInstanceRole(rName string) string {
+func testAccServiceConfig_ImageRepository_InstanceConfiguration_noInstanceRole(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -756,9 +756,9 @@ resource "aws_apprunner_service" "test" {
 `, rName)
 }
 
-func testAccAppRunnerService_imageRepository_updateInstanceConfiguration(rName string) string {
+func testAccServiceConfig_ImageRepository_updateInstanceConfiguration(rName string) string {
 	return acctest.ConfigCompose(
-		testAccAppRunnerIAMRole(rName),
+		testAccIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -783,7 +783,7 @@ resource "aws_apprunner_service" "test" {
 `, rName))
 }
 
-func testAccAppRunnerServiceConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccServiceConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q
@@ -805,7 +805,7 @@ resource "aws_apprunner_service" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAppRunnerServiceConfigTags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccServiceConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_apprunner_service" "test" {
   service_name = %[1]q

--- a/internal/service/apprunner/vpc_connector_test.go
+++ b/internal/service/apprunner/vpc_connector_test.go
@@ -22,13 +22,13 @@ func TestAccAppRunnerVpcConnector_basic(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunnerVpcConnector(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckVPCConnector(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVpcConnectorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerVpcConnector_basic(rName),
+				Config: testAccVPCConnectorConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcConnectorExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`vpcconnector/%s/1/.+`, rName))),
@@ -52,13 +52,13 @@ func TestAccAppRunnerVpcConnector_disappears(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunnerVpcConnector(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckVPCConnector(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVpcConnectorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerVpcConnector_basic(rName),
+				Config: testAccVPCConnectorConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcConnectorExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfapprunner.ResourceVpcConnector(), resourceName),
@@ -74,13 +74,13 @@ func TestAccAppRunnerVpcConnector_tags(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunnerVpcConnector(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckVPCConnector(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVpcConnectorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppRunnerVpcConnectorConfigTags1(rName, "key1", "value1"),
+				Config: testAccVPCConnectorConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcConnectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -157,7 +157,7 @@ func testAccCheckVpcConnectorExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAppRunnerVpcConnector_basic(rName string) string {
+func testAccVPCConnectorConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -193,7 +193,7 @@ resource "aws_apprunner_vpc_connector" "test" {
 `, rName)
 }
 
-func testAccAppRunnerVpcConnectorConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccVPCConnectorConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -233,7 +233,7 @@ resource "aws_apprunner_vpc_connector" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccPreCheckAppRunnerVpcConnector(t *testing.T) {
+func testAccPreCheckVPCConnector(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppRunnerConn
 	ctx := context.Background()
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
