### PR TITLE
autoscaling: Remove service from funcs

### DIFF
--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -563,7 +563,7 @@ func ResourceGroup() *schema.Resource {
 							Set:      schema.HashString,
 							Elem: &schema.Schema{
 								Type:             schema.TypeString,
-								ValidateDiagFunc: validateAutoScalingGroupInstanceRefreshTriggerFields,
+								ValidateDiagFunc: validateGroupInstanceRefreshTriggerFields,
 							},
 						},
 					},
@@ -676,7 +676,7 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	createOpts := autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName:             aws.String(asgName),
-		MixedInstancesPolicy:             expandAutoScalingMixedInstancesPolicy(d.Get("mixed_instances_policy").([]interface{})),
+		MixedInstancesPolicy:             expandMixedInstancesPolicy(d.Get("mixed_instances_policy").([]interface{})),
 		NewInstancesProtectedFromScaleIn: aws.Bool(d.Get("protect_from_scale_in").(bool)),
 	}
 	updateOpts := autoscaling.UpdateAutoScalingGroupInput{
@@ -887,14 +887,14 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("launch_configuration", g.LaunchConfigurationName)
 
-	if err := d.Set("launch_template", flattenLaunchTemplateSpecification(g.LaunchTemplate)); err != nil {
+	if err := d.Set("launch_template", flattenLaunchTemplateSpecificationMap(g.LaunchTemplate)); err != nil {
 		return fmt.Errorf("error setting launch_template: %s", err)
 	}
 
 	d.Set("max_size", g.MaxSize)
 	d.Set("min_size", g.MinSize)
 
-	if err := d.Set("mixed_instances_policy", flattenAutoScalingMixedInstancesPolicy(g.MixedInstancesPolicy)); err != nil {
+	if err := d.Set("mixed_instances_policy", flattenMixedInstancesPolicy(g.MixedInstancesPolicy)); err != nil {
 		return fmt.Errorf("error setting mixed_instances_policy: %s", err)
 	}
 
@@ -966,7 +966,7 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func waitUntilAutoscalingGroupLoadBalancerTargetGroupsRemoved(conn *autoscaling.AutoScaling, asgName string) error {
+func waitUntilGroupLoadBalancerTargetGroupsRemoved(conn *autoscaling.AutoScaling, asgName string) error {
 	input := &autoscaling.DescribeLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: aws.String(asgName),
 	}
@@ -1002,7 +1002,7 @@ func waitUntilAutoscalingGroupLoadBalancerTargetGroupsRemoved(conn *autoscaling.
 	return nil
 }
 
-func waitUntilAutoscalingGroupLoadBalancerTargetGroupsAdded(conn *autoscaling.AutoScaling, asgName string) error {
+func waitUntilGroupLoadBalancerTargetGroupsAdded(conn *autoscaling.AutoScaling, asgName string) error {
 	input := &autoscaling.DescribeLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: aws.String(asgName),
 	}
@@ -1083,7 +1083,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("mixed_instances_policy") {
-		opts.MixedInstancesPolicy = expandAutoScalingMixedInstancesPolicy(d.Get("mixed_instances_policy").([]interface{}))
+		opts.MixedInstancesPolicy = expandMixedInstancesPolicy(d.Get("mixed_instances_policy").([]interface{}))
 		shouldRefreshInstances = true
 	}
 
@@ -1197,7 +1197,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 					return fmt.Errorf("error detaching Auto Scaling Group (%s) Load Balancers: %s", d.Id(), err)
 				}
 
-				if err := waitUntilAutoscalingGroupLoadBalancersRemoved(conn, d.Id()); err != nil {
+				if err := waitUntilGroupLoadBalancersRemoved(conn, d.Id()); err != nil {
 					return fmt.Errorf("error describing Auto Scaling Group (%s) Load Balancers being removed: %s", d.Id(), err)
 				}
 			}
@@ -1224,7 +1224,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 					return fmt.Errorf("error attaching Auto Scaling Group (%s) Load Balancers: %s", d.Id(), err)
 				}
 
-				if err := waitUntilAutoscalingGroupLoadBalancersAdded(conn, d.Id()); err != nil {
+				if err := waitUntilGroupLoadBalancersAdded(conn, d.Id()); err != nil {
 					return fmt.Errorf("error describing Auto Scaling Group (%s) Load Balancers being added: %s", d.Id(), err)
 				}
 			}
@@ -1266,7 +1266,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 					return fmt.Errorf("Error updating Load Balancers Target Groups for Auto Scaling Group (%s), error: %s", d.Id(), err)
 				}
 
-				if err := waitUntilAutoscalingGroupLoadBalancerTargetGroupsRemoved(conn, d.Id()); err != nil {
+				if err := waitUntilGroupLoadBalancerTargetGroupsRemoved(conn, d.Id()); err != nil {
 					return fmt.Errorf("error describing Auto Scaling Group (%s) Load Balancer Target Groups being removed: %s", d.Id(), err)
 				}
 			}
@@ -1293,7 +1293,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 					return fmt.Errorf("Error updating Load Balancers Target Groups for Auto Scaling Group (%s), error: %s", d.Id(), err)
 				}
 
-				if err := waitUntilAutoscalingGroupLoadBalancerTargetGroupsAdded(conn, d.Id()); err != nil {
+				if err := waitUntilGroupLoadBalancerTargetGroupsAdded(conn, d.Id()); err != nil {
 					return fmt.Errorf("error describing Auto Scaling Group (%s) Load Balancer Target Groups being added: %s", d.Id(), err)
 				}
 			}
@@ -1320,7 +1320,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		if shouldRefreshInstances {
-			if err := autoScalingGroupRefreshInstances(conn, d.Id(), instanceRefresh); err != nil {
+			if err := GroupRefreshInstances(conn, d.Id(), instanceRefresh); err != nil {
 				return fmt.Errorf("failed to start instance refresh of Auto Scaling Group %s: %w", d.Id(), err)
 			}
 		}
@@ -1336,7 +1336,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 
-			if err := resourceAutoScalingGroupWarmPoolDelete(g, d, meta); err != nil {
+			if err := resourceGroupWarmPoolDelete(g, d, meta); err != nil {
 				return fmt.Errorf("error deleting Warm pool for Auto Scaling Group %s: %s", d.Id(), err)
 			}
 
@@ -1389,7 +1389,7 @@ func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Try deleting Warm pool first.
-	if err := resourceAutoScalingGroupWarmPoolDelete(g, d, meta); err != nil {
+	if err := resourceGroupWarmPoolDelete(g, d, meta); err != nil {
 		return fmt.Errorf("error deleting Warm pool for Auto Scaling Group %s: %s", d.Id(), err)
 	}
 
@@ -1457,7 +1457,7 @@ func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAutoScalingGroupWarmPoolDelete(g *autoscaling.Group, d *schema.ResourceData, meta interface{}) error {
+func resourceGroupWarmPoolDelete(g *autoscaling.Group, d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).AutoScalingConn
 
 	if g.WarmPoolConfiguration == nil {
@@ -1888,7 +1888,7 @@ func expandVpcZoneIdentifiers(list []interface{}) *string {
 	return aws.String(strings.Join(strs, ","))
 }
 
-func expandAutoScalingInstancesDistribution(l []interface{}) *autoscaling.InstancesDistribution {
+func expandInstancesDistribution(l []interface{}) *autoscaling.InstancesDistribution {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -1936,13 +1936,13 @@ func expandMixedInstancesLaunchTemplate(l []interface{}) *autoscaling.LaunchTemp
 	}
 
 	if v, ok := m["override"]; ok {
-		launchTemplate.Overrides = expandAutoScalingLaunchTemplateOverrides(v.([]interface{}))
+		launchTemplate.Overrides = expandLaunchTemplateOverrides(v.([]interface{}))
 	}
 
 	return launchTemplate
 }
 
-func expandAutoScalingLaunchTemplateOverrides(l []interface{}) []*autoscaling.LaunchTemplateOverrides {
+func expandLaunchTemplateOverrides(l []interface{}) []*autoscaling.LaunchTemplateOverrides {
 	if len(l) == 0 {
 		return nil
 	}
@@ -1954,12 +1954,12 @@ func expandAutoScalingLaunchTemplateOverrides(l []interface{}) []*autoscaling.La
 			continue
 		}
 
-		launchTemplateOverrides[i] = expandAutoScalingLaunchTemplateOverride(m.(map[string]interface{}))
+		launchTemplateOverrides[i] = expandLaunchTemplateOverride(m.(map[string]interface{}))
 	}
 	return launchTemplateOverrides
 }
 
-func expandAutoScalingLaunchTemplateOverride(m map[string]interface{}) *autoscaling.LaunchTemplateOverrides {
+func expandLaunchTemplateOverride(m map[string]interface{}) *autoscaling.LaunchTemplateOverrides {
 	launchTemplateOverrides := &autoscaling.LaunchTemplateOverrides{}
 
 	if v, ok := m["instance_type"]; ok && v.(string) != "" {
@@ -2004,7 +2004,7 @@ func expandMixedInstancesLaunchTemplateSpecification(l []interface{}) *autoscali
 	return launchTemplateSpecification
 }
 
-func expandAutoScalingMixedInstancesPolicy(l []interface{}) *autoscaling.MixedInstancesPolicy {
+func expandMixedInstancesPolicy(l []interface{}) *autoscaling.MixedInstancesPolicy {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -2016,13 +2016,13 @@ func expandAutoScalingMixedInstancesPolicy(l []interface{}) *autoscaling.MixedIn
 	}
 
 	if v, ok := m["instances_distribution"]; ok {
-		mixedInstancesPolicy.InstancesDistribution = expandAutoScalingInstancesDistribution(v.([]interface{}))
+		mixedInstancesPolicy.InstancesDistribution = expandInstancesDistribution(v.([]interface{}))
 	}
 
 	return mixedInstancesPolicy
 }
 
-func flattenAutoScalingInstancesDistribution(instancesDistribution *autoscaling.InstancesDistribution) []interface{} {
+func flattenInstancesDistribution(instancesDistribution *autoscaling.InstancesDistribution) []interface{} {
 	if instancesDistribution == nil {
 		return []interface{}{}
 	}
@@ -2039,20 +2039,20 @@ func flattenAutoScalingInstancesDistribution(instancesDistribution *autoscaling.
 	return []interface{}{m}
 }
 
-func flattenAutoScalingLaunchTemplate(launchTemplate *autoscaling.LaunchTemplate) []interface{} {
+func flattenLaunchTemplate(launchTemplate *autoscaling.LaunchTemplate) []interface{} {
 	if launchTemplate == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"launch_template_specification": flattenAutoScalingLaunchTemplateSpecification(launchTemplate.LaunchTemplateSpecification),
-		"override":                      flattenAutoScalingLaunchTemplateOverrides(launchTemplate.Overrides),
+		"launch_template_specification": flattenLaunchTemplateSpecification(launchTemplate.LaunchTemplateSpecification),
+		"override":                      flattenLaunchTemplateOverrides(launchTemplate.Overrides),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenAutoScalingLaunchTemplateOverrides(launchTemplateOverrides []*autoscaling.LaunchTemplateOverrides) []interface{} {
+func flattenLaunchTemplateOverrides(launchTemplateOverrides []*autoscaling.LaunchTemplateOverrides) []interface{} {
 	l := make([]interface{}, len(launchTemplateOverrides))
 
 	for i, launchTemplateOverride := range launchTemplateOverrides {
@@ -2062,7 +2062,7 @@ func flattenAutoScalingLaunchTemplateOverrides(launchTemplateOverrides []*autosc
 		}
 		m := map[string]interface{}{
 			"instance_type":                 aws.StringValue(launchTemplateOverride.InstanceType),
-			"launch_template_specification": flattenAutoScalingLaunchTemplateSpecification(launchTemplateOverride.LaunchTemplateSpecification),
+			"launch_template_specification": flattenLaunchTemplateSpecification(launchTemplateOverride.LaunchTemplateSpecification),
 			"weighted_capacity":             aws.StringValue(launchTemplateOverride.WeightedCapacity),
 		}
 		l[i] = m
@@ -2071,7 +2071,7 @@ func flattenAutoScalingLaunchTemplateOverrides(launchTemplateOverrides []*autosc
 	return l
 }
 
-func flattenAutoScalingLaunchTemplateSpecification(launchTemplateSpecification *autoscaling.LaunchTemplateSpecification) []interface{} {
+func flattenLaunchTemplateSpecification(launchTemplateSpecification *autoscaling.LaunchTemplateSpecification) []interface{} {
 	if launchTemplateSpecification == nil {
 		return []interface{}{}
 	}
@@ -2085,14 +2085,14 @@ func flattenAutoScalingLaunchTemplateSpecification(launchTemplateSpecification *
 	return []interface{}{m}
 }
 
-func flattenAutoScalingMixedInstancesPolicy(mixedInstancesPolicy *autoscaling.MixedInstancesPolicy) []interface{} {
+func flattenMixedInstancesPolicy(mixedInstancesPolicy *autoscaling.MixedInstancesPolicy) []interface{} {
 	if mixedInstancesPolicy == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"instances_distribution": flattenAutoScalingInstancesDistribution(mixedInstancesPolicy.InstancesDistribution),
-		"launch_template":        flattenAutoScalingLaunchTemplate(mixedInstancesPolicy.LaunchTemplate),
+		"instances_distribution": flattenInstancesDistribution(mixedInstancesPolicy.InstancesDistribution),
+		"launch_template":        flattenLaunchTemplate(mixedInstancesPolicy.LaunchTemplate),
 	}
 
 	return []interface{}{m}
@@ -2133,7 +2133,7 @@ func flattenWarmPoolInstanceReusePolicy(instanceReusePolicy *autoscaling.Instanc
 	return []interface{}{m}
 }
 
-func waitUntilAutoscalingGroupLoadBalancersAdded(conn *autoscaling.AutoScaling, asgName string) error {
+func waitUntilGroupLoadBalancersAdded(conn *autoscaling.AutoScaling, asgName string) error {
 	input := &autoscaling.DescribeLoadBalancersInput{
 		AutoScalingGroupName: aws.String(asgName),
 	}
@@ -2169,7 +2169,7 @@ func waitUntilAutoscalingGroupLoadBalancersAdded(conn *autoscaling.AutoScaling, 
 	return nil
 }
 
-func waitUntilAutoscalingGroupLoadBalancersRemoved(conn *autoscaling.AutoScaling, asgName string) error {
+func waitUntilGroupLoadBalancersRemoved(conn *autoscaling.AutoScaling, asgName string) error {
 	input := &autoscaling.DescribeLoadBalancersInput{
 		AutoScalingGroupName: aws.String(asgName),
 	}
@@ -2245,11 +2245,11 @@ func CreateGroupInstanceRefreshInput(asgName string, l []interface{}) *autoscali
 	return &autoscaling.StartInstanceRefreshInput{
 		AutoScalingGroupName: aws.String(asgName),
 		Strategy:             aws.String(m["strategy"].(string)),
-		Preferences:          expandAutoScalingGroupInstanceRefreshPreferences(m["preferences"].([]interface{})),
+		Preferences:          expandGroupInstanceRefreshPreferences(m["preferences"].([]interface{})),
 	}
 }
 
-func expandAutoScalingGroupInstanceRefreshPreferences(l []interface{}) *autoscaling.RefreshPreferences {
+func expandGroupInstanceRefreshPreferences(l []interface{}) *autoscaling.RefreshPreferences {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -2301,12 +2301,12 @@ func expandWarmPoolInstanceReusePolicy(l []interface{}) *autoscaling.InstanceReu
 	return instanceReusePolicy
 }
 
-func autoScalingGroupRefreshInstances(conn *autoscaling.AutoScaling, asgName string, refreshConfig []interface{}) error {
+func GroupRefreshInstances(conn *autoscaling.AutoScaling, asgName string, refreshConfig []interface{}) error {
 	input := CreateGroupInstanceRefreshInput(asgName, refreshConfig)
 	err := resource.Retry(instanceRefreshStartedTimeout, func() *resource.RetryError {
 		_, err := conn.StartInstanceRefresh(input)
 		if tfawserr.ErrCodeEquals(err, autoscaling.ErrCodeInstanceRefreshInProgressFault) {
-			cancelErr := cancelAutoscalingInstanceRefresh(conn, asgName)
+			cancelErr := cancelInstanceRefresh(conn, asgName)
 			if cancelErr != nil {
 				return resource.NonRetryableError(cancelErr)
 			}
@@ -2327,7 +2327,7 @@ func autoScalingGroupRefreshInstances(conn *autoscaling.AutoScaling, asgName str
 	return nil
 }
 
-func cancelAutoscalingInstanceRefresh(conn *autoscaling.AutoScaling, asgName string) error {
+func cancelInstanceRefresh(conn *autoscaling.AutoScaling, asgName string) error {
 	input := autoscaling.CancelInstanceRefreshInput{
 		AutoScalingGroupName: aws.String(asgName),
 	}
@@ -2350,7 +2350,7 @@ func cancelAutoscalingInstanceRefresh(conn *autoscaling.AutoScaling, asgName str
 	return nil
 }
 
-func validateAutoScalingGroupInstanceRefreshTriggerFields(i interface{}, path cty.Path) diag.Diagnostics {
+func validateGroupInstanceRefreshTriggerFields(i interface{}, path cty.Path) diag.Diagnostics {
 	v, ok := i.(string)
 	if !ok {
 		return diag.Errorf("expected type to be string")
@@ -2405,7 +2405,7 @@ func expandLaunchTemplateSpecification(specs []interface{}) *autoscaling.LaunchT
 	return result
 }
 
-func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecification) []map[string]interface{} {
+func flattenLaunchTemplateSpecificationMap(lt *autoscaling.LaunchTemplateSpecification) []map[string]interface{} {
 	if lt == nil {
 		return []map[string]interface{}{}
 	}

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -172,7 +172,7 @@ func dataSourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("health_check_grace_period", group.HealthCheckGracePeriod)
 	d.Set("health_check_type", group.HealthCheckType)
 	d.Set("launch_configuration", group.LaunchConfigurationName)
-	if err := d.Set("launch_template", flattenLaunchTemplateSpecification(group.LaunchTemplate)); err != nil {
+	if err := d.Set("launch_template", flattenLaunchTemplateSpecificationMap(group.LaunchTemplate)); err != nil {
 		return fmt.Errorf("error setting launch_template: %w", err)
 	}
 	if err := d.Set("load_balancers", aws.StringValueSlice(group.LoadBalancerNames)); err != nil {

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupDataSourceConfig_groupDataResource(rName),
+				Config: testAccGroupDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
@@ -54,7 +54,7 @@ func TestAccAutoScalingGroupDataSource_launchTemplate(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupDataSourceConfig_groupDataResourcelaunchTemplate(),
+				Config: testAccGroupDataSourceConfig_launchTemplate(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
@@ -81,7 +81,7 @@ func TestAccAutoScalingGroupDataSource_launchTemplate(t *testing.T) {
 }
 
 // Lookup based on AutoScalingGroupName
-func testAccGroupDataSourceConfig_groupDataResource(rName string) string {
+func testAccGroupDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -123,7 +123,7 @@ resource "aws_launch_configuration" "data_source_aws_autoscaling_group_test" {
 `, rName))
 }
 
-func testAccGroupDataSourceConfig_groupDataResourcelaunchTemplate() string {
+func testAccGroupDataSourceConfig_launchTemplate() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAutoScalingGroupDataResourceConfig(rName),
+				Config: testAccGroupDataSourceConfig_groupDataResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
@@ -54,7 +54,7 @@ func TestAccAutoScalingGroupDataSource_launchTemplate(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAutoScalingGroupDataResourceConfig_launchTemplate(),
+				Config: testAccGroupDataSourceConfig_groupDataResourcelaunchTemplate(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
@@ -81,7 +81,7 @@ func TestAccAutoScalingGroupDataSource_launchTemplate(t *testing.T) {
 }
 
 // Lookup based on AutoScalingGroupName
-func testAccAutoScalingGroupDataResourceConfig(rName string) string {
+func testAccGroupDataSourceConfig_groupDataResource(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -123,7 +123,7 @@ resource "aws_launch_configuration" "data_source_aws_autoscaling_group_test" {
 `, rName))
 }
 
-func testAccAutoScalingGroupDataResourceConfig_launchTemplate() string {
+func testAccGroupDataSourceConfig_groupDataResourcelaunchTemplate() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),

--- a/internal/service/autoscaling/group_tag_test.go
+++ b/internal/service/autoscaling/group_tag_test.go
@@ -21,12 +21,12 @@ func TestAccAutoScalingGroupTag_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, autoscaling.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAutoscalingGroupTagDestroy,
+		CheckDestroy: testAccCheckGroupTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAutoscalingGroupTagConfig("key1", "value1"),
+				Config: testAccGroupTagConfig_basic("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAutoscalingGroupTagExists(resourceName),
+					testAccCheckGroupTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tag.0.key", "key1"),
 					resource.TestCheckResourceAttr(resourceName, "tag.0.value", "value1"),
 				),
@@ -47,12 +47,12 @@ func TestAccAutoScalingGroupTag_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, autoscaling.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAutoscalingGroupTagDestroy,
+		CheckDestroy: testAccCheckGroupTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAutoscalingGroupTagConfig("key1", "value1"),
+				Config: testAccGroupTagConfig_basic("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAutoscalingGroupTagExists(resourceName),
+					testAccCheckGroupTagExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfautoscaling.ResourceGroupTag(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -68,12 +68,12 @@ func TestAccAutoScalingGroupTag_value(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, autoscaling.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAutoscalingGroupTagDestroy,
+		CheckDestroy: testAccCheckGroupTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAutoscalingGroupTagConfig("key1", "value1"),
+				Config: testAccGroupTagConfig_basic("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAutoscalingGroupTagExists(resourceName),
+					testAccCheckGroupTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tag.0.key", "key1"),
 					resource.TestCheckResourceAttr(resourceName, "tag.0.value", "value1"),
 				),
@@ -84,9 +84,9 @@ func TestAccAutoScalingGroupTag_value(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAutoscalingGroupTagConfig("key1", "value1updated"),
+				Config: testAccGroupTagConfig_basic("key1", "value1updated"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAutoscalingGroupTagExists(resourceName),
+					testAccCheckGroupTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tag.0.key", "key1"),
 					resource.TestCheckResourceAttr(resourceName, "tag.0.value", "value1updated"),
 				),
@@ -95,7 +95,7 @@ func TestAccAutoScalingGroupTag_value(t *testing.T) {
 	})
 }
 
-func testAccCheckAutoscalingGroupTagDestroy(s *terraform.State) error {
+func testAccCheckGroupTagDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -125,7 +125,7 @@ func testAccCheckAutoscalingGroupTagDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAutoscalingGroupTagExists(n string) resource.TestCheckFunc {
+func testAccCheckGroupTagExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -154,7 +154,7 @@ func testAccCheckAutoscalingGroupTagExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAutoscalingGroupTagConfig(key string, value string) string {
+func testAccGroupTagConfig_basic(key string, value string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 func init() {
-	acctest.RegisterServiceErrorCheckFunc(autoscaling.EndpointsID, testAccErrorCheckSkipAutoScaling)
+	acctest.RegisterServiceErrorCheckFunc(autoscaling.EndpointsID, testAccErrorCheckSkip)
 
 }
 
-func testAccErrorCheckSkipAutoScaling(t *testing.T) resource.ErrorCheckFunc {
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"gp3 is invalid",
 	)
@@ -54,7 +54,7 @@ func TestAccAutoScalingGroup_basic(t *testing.T) {
 					testAccCheckGroupAttributes(&group, randName),
 					acctest.MatchResourceAttrRegionalARN("aws_autoscaling_group.bar", "arn", "autoscaling", regexp.MustCompile(`autoScalingGroup:.+`)),
 					resource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
-					testAccCheckAutoScalingInstanceRefreshCount(&group, 0),
+					testAccCheckInstanceRefreshCount(&group, 0),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "default_cooldown", "300"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "desired_capacity", "4"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "enabled_metrics.#", "0"),
@@ -103,20 +103,20 @@ func TestAccAutoScalingGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckLaunchConfigurationExists("aws_launch_configuration.new", &lc),
-					testAccCheckAutoScalingInstanceRefreshCount(&group, 0),
+					testAccCheckInstanceRefreshCount(&group, 0),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "desired_capacity", "5"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "termination_policies.0", "ClosestToNextInstanceHour"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "protect_from_scale_in", "true"),
 					testLaunchConfigurationName("aws_autoscaling_group.bar", &lc),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags1Changed", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags1Changed", map[string]interface{}{
 						"value":               "value1changed",
 						"propagate_at_launch": true,
 					}),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags2", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags2", map[string]interface{}{
 						"value":               "value2changed",
 						"propagate_at_launch": true,
 					}),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags3", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags3", map[string]interface{}{
 						"value":               "value3",
 						"propagate_at_launch": true,
 					}),
@@ -280,15 +280,15 @@ func TestAccAutoScalingGroup_tags(t *testing.T) {
 				Config: testAccGroupConfig(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists("aws_autoscaling_group.bar", &group),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags1", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags1", map[string]interface{}{
 						"value":               "value1",
 						"propagate_at_launch": true,
 					}),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags2", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags2", map[string]interface{}{
 						"value":               "value2",
 						"propagate_at_launch": true,
 					}),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags3", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags3", map[string]interface{}{
 						"value":               "value3",
 						"propagate_at_launch": true,
 					}),
@@ -311,16 +311,16 @@ func TestAccAutoScalingGroup_tags(t *testing.T) {
 				Config: testAccGroupUpdateConfig(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists("aws_autoscaling_group.bar", &group),
-					testAccCheckAutoscalingTagNotExists(&group.Tags, "Foo"),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags1Changed", map[string]interface{}{
+					testAccCheckTagNotExists(&group.Tags, "Foo"),
+					testAccCheckTags(&group.Tags, "FromTags1Changed", map[string]interface{}{
 						"value":               "value1changed",
 						"propagate_at_launch": true,
 					}),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags2", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags2", map[string]interface{}{
 						"value":               "value2changed",
 						"propagate_at_launch": true,
 					}),
-					testAccCheckAutoscalingTags(&group.Tags, "FromTags3", map[string]interface{}{
+					testAccCheckTags(&group.Tags, "FromTags3", map[string]interface{}{
 						"value":               "value3",
 						"propagate_at_launch": true,
 					}),
@@ -1032,7 +1032,7 @@ func TestAccAutoScalingGroup_InstanceRefresh_start(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_configuration", launchConfigurationName, "name"),
-					testAccCheckAutoScalingInstanceRefreshCount(&group, 0),
+					testAccCheckInstanceRefreshCount(&group, 0),
 				),
 			},
 			{
@@ -1040,8 +1040,8 @@ func TestAccAutoScalingGroup_InstanceRefresh_start(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_configuration", launchConfigurationName, "name"),
-					testAccCheckAutoScalingInstanceRefreshCount(&group, 1),
-					testAccCheckAutoScalingInstanceRefreshStatus(&group, 0, autoscaling.InstanceRefreshStatusPending, autoscaling.InstanceRefreshStatusInProgress),
+					testAccCheckInstanceRefreshCount(&group, 1),
+					testAccCheckInstanceRefreshStatus(&group, 0, autoscaling.InstanceRefreshStatusPending, autoscaling.InstanceRefreshStatusInProgress),
 				),
 			},
 			{
@@ -1049,9 +1049,9 @@ func TestAccAutoScalingGroup_InstanceRefresh_start(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_configuration", launchConfigurationName, "name"),
-					testAccCheckAutoScalingInstanceRefreshCount(&group, 2),
-					testAccCheckAutoScalingInstanceRefreshStatus(&group, 0, autoscaling.InstanceRefreshStatusPending, autoscaling.InstanceRefreshStatusInProgress),
-					testAccCheckAutoScalingInstanceRefreshStatus(&group, 1, autoscaling.InstanceRefreshStatusCancelled),
+					testAccCheckInstanceRefreshCount(&group, 2),
+					testAccCheckInstanceRefreshStatus(&group, 0, autoscaling.InstanceRefreshStatusPending, autoscaling.InstanceRefreshStatusInProgress),
+					testAccCheckInstanceRefreshStatus(&group, 1, autoscaling.InstanceRefreshStatusCancelled),
 				),
 			},
 		},
@@ -1083,8 +1083,8 @@ func TestAccAutoScalingGroup_InstanceRefresh_triggers(t *testing.T) {
 					testAccCheckGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.triggers.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "instance_refresh.0.triggers.*", "tags"),
-					testAccCheckAutoScalingInstanceRefreshCount(&group, 1),
-					testAccCheckAutoScalingInstanceRefreshStatus(&group, 0, autoscaling.InstanceRefreshStatusPending, autoscaling.InstanceRefreshStatusInProgress),
+					testAccCheckInstanceRefreshCount(&group, 1),
+					testAccCheckInstanceRefreshStatus(&group, 0, autoscaling.InstanceRefreshStatusPending, autoscaling.InstanceRefreshStatusInProgress),
 				),
 			},
 		},
@@ -1336,10 +1336,10 @@ func testAccCheckGroupAttributesVPCZoneIdentifier(group *autoscaling.Group) reso
 }
 
 // testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckAutoscalingTags(
+func testAccCheckTags(
 	ts *[]*autoscaling.TagDescription, key string, expected map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := autoscalingTagDescriptionsToMap(ts)
+		m := TagDescriptionsToMap(ts)
 		v, ok := m[key]
 		if !ok {
 			return fmt.Errorf("Missing tag: %s", key)
@@ -1354,9 +1354,9 @@ func testAccCheckAutoscalingTags(
 	}
 }
 
-func testAccCheckAutoscalingTagNotExists(ts *[]*autoscaling.TagDescription, key string) resource.TestCheckFunc {
+func testAccCheckTagNotExists(ts *[]*autoscaling.TagDescription, key string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := autoscalingTagDescriptionsToMap(ts)
+		m := TagDescriptionsToMap(ts)
 		if _, ok := m[key]; ok {
 			return fmt.Errorf("Tag exists when it should not: %s", key)
 		}
@@ -1365,8 +1365,8 @@ func testAccCheckAutoscalingTagNotExists(ts *[]*autoscaling.TagDescription, key 
 	}
 }
 
-// autoscalingTagDescriptionsToMap turns the list of tags into a map.
-func autoscalingTagDescriptionsToMap(ts *[]*autoscaling.TagDescription) map[string]map[string]interface{} {
+// TagDescriptionsToMap turns the list of tags into a map.
+func TagDescriptionsToMap(ts *[]*autoscaling.TagDescription) map[string]map[string]interface{} {
 	tags := make(map[string]map[string]interface{})
 	for _, t := range *ts {
 		tag := map[string]interface{}{
@@ -4862,7 +4862,7 @@ resource "aws_launch_configuration" "test" {
 `
 }
 
-func testAccCheckAutoScalingInstanceRefreshCount(group *autoscaling.Group, expected int) resource.TestCheckFunc {
+func testAccCheckInstanceRefreshCount(group *autoscaling.Group, expected int) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingConn
 
@@ -4881,7 +4881,7 @@ func testAccCheckAutoScalingInstanceRefreshCount(group *autoscaling.Group, expec
 	}
 }
 
-func testAccCheckAutoScalingInstanceRefreshStatus(group *autoscaling.Group, offset int, expected ...string) resource.TestCheckFunc {
+func testAccCheckInstanceRefreshStatus(group *autoscaling.Group, offset int, expected ...string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingConn
 

--- a/internal/service/autoscaling/groups_data_source_test.go
+++ b/internal/service/autoscaling/groups_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccAutoScalingGroupsDataSource_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAutoScalingGroupsDataSourceConfig(rName),
+				Config: testAccGroupsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasource1Name, "names.#", "3"),
 					resource.TestCheckResourceAttr(datasource1Name, "arns.#", "3"),
@@ -39,7 +39,7 @@ func TestAccAutoScalingGroupsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccAutoScalingGroupsDataSourceConfig(rName string) string {
+func testAccGroupsDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),

--- a/internal/service/autoscaling/policy_test.go
+++ b/internal/service/autoscaling/policy_test.go
@@ -259,7 +259,7 @@ func TestAccAutoScalingPolicy_predictiveScalingUpdated(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAutoScalingPolicyConfigPredictiveScalingUpdated(name),
+				Config: testAccPolicyConfig_predictiveScalingUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists(resourceSimpleName, &policy),
 					resource.TestCheckResourceAttr(resourceSimpleName, "predictive_scaling_configuration.0.mode", "ForecastOnly"),
@@ -723,7 +723,7 @@ resource "aws_autoscaling_policy" "test" {
 `, name))
 }
 
-func testAccAutoScalingPolicyConfigPredictiveScalingUpdated(name string) string {
+func testAccPolicyConfig_predictiveScalingUpdated(name string) string {
 	return testAccPolicyConfigBase(name) + fmt.Sprintf(`
 resource "aws_autoscaling_policy" "test" {
   name                   = "%[1]s-policy_predictive"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
