### PR TITLE
r/aws_launch_template: Fix crash in `TestAccEC2LaunchTemplate_licenseSpecification`

### DIFF
--- a/.changelog/24579.txt
+++ b/.changelog/24579.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_luanch_template: Fix crash when reading `license_specification`
+```

--- a/.changelog/24579.txt
+++ b/.changelog/24579.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_luanch_template: Fix crash when reading `license_specification`
+resource/aws_launch_template: Fix crash when reading `license_specification`
 ```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -980,8 +980,8 @@ func expandRequestLaunchTemplateData(d *schema.ResourceData) *ec2.RequestLaunchT
 		apiObject.KeyName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("license_specification"); ok && len(v.([]interface{})) > 0 {
-		apiObject.LicenseSpecifications = expandLaunchTemplateLicenseConfigurationRequests(v.([]interface{}))
+	if v, ok := d.GetOk("license_specification"); ok && v.(*schema.Set).Len() > 0 {
+		apiObject.LicenseSpecifications = expandLaunchTemplateLicenseConfigurationRequests(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("maintenance_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -1300,7 +1300,10 @@ func TestAccEC2LaunchTemplate_licenseSpecification(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckIAMServiceLinkedRole(t, "/aws-service-role/license-manager.amazonaws.com")
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckLaunchTemplateDestroy,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24575.

```console
% make testacc TESTS=TestAccEC2LaunchTemplate_licenseSpecification PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_licenseSpecification'  -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_licenseSpecification
=== PAUSE TestAccEC2LaunchTemplate_licenseSpecification
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
--- PASS: TestAccEC2LaunchTemplate_licenseSpecification (18.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	24.055s
```