### PR TITLE
efs: Remove service from funcs

### DIFF
--- a/internal/service/efs/access_point.go
+++ b/internal/service/efs/access_point.go
@@ -135,11 +135,11 @@ func resourceAccessPointCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("posix_user"); ok {
-		input.PosixUser = expandEfsAccessPointPosixUser(v.([]interface{}))
+		input.PosixUser = expandAccessPointPOSIXUser(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("root_directory"); ok {
-		input.RootDirectory = expandEfsAccessPointRootDirectory(v.([]interface{}))
+		input.RootDirectory = expandAccessPointRootDirectory(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating EFS Access Point: %#v", input)
@@ -210,11 +210,11 @@ func resourceAccessPointRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", ap.AccessPointArn)
 	d.Set("owner_id", ap.OwnerId)
 
-	if err := d.Set("posix_user", flattenEfsAccessPointPosixUser(ap.PosixUser)); err != nil {
+	if err := d.Set("posix_user", flattenAccessPointPOSIXUser(ap.PosixUser)); err != nil {
 		return fmt.Errorf("error setting posix user: %w", err)
 	}
 
-	if err := d.Set("root_directory", flattenEfsAccessPointRootDirectory(ap.RootDirectory)); err != nil {
+	if err := d.Set("root_directory", flattenAccessPointRootDirectory(ap.RootDirectory)); err != nil {
 		return fmt.Errorf("error setting root directory: %w", err)
 	}
 
@@ -265,7 +265,7 @@ func hasEmptyAccessPoints(aps *efs.DescribeAccessPointsOutput) bool {
 	return true
 }
 
-func expandEfsAccessPointPosixUser(pUser []interface{}) *efs.PosixUser {
+func expandAccessPointPOSIXUser(pUser []interface{}) *efs.PosixUser {
 	if len(pUser) < 1 || pUser[0] == nil {
 		return nil
 	}
@@ -284,7 +284,7 @@ func expandEfsAccessPointPosixUser(pUser []interface{}) *efs.PosixUser {
 	return posixUser
 }
 
-func expandEfsAccessPointRootDirectory(rDir []interface{}) *efs.RootDirectory {
+func expandAccessPointRootDirectory(rDir []interface{}) *efs.RootDirectory {
 	if len(rDir) < 1 || rDir[0] == nil {
 		return nil
 	}
@@ -298,13 +298,13 @@ func expandEfsAccessPointRootDirectory(rDir []interface{}) *efs.RootDirectory {
 	}
 
 	if v, ok := m["creation_info"]; ok {
-		rootDir.CreationInfo = expandEfsAccessPointRootDirectoryCreationInfo(v.([]interface{}))
+		rootDir.CreationInfo = expandAccessPointRootDirectoryCreationInfo(v.([]interface{}))
 	}
 
 	return rootDir
 }
 
-func expandEfsAccessPointRootDirectoryCreationInfo(cInfo []interface{}) *efs.CreationInfo {
+func expandAccessPointRootDirectoryCreationInfo(cInfo []interface{}) *efs.CreationInfo {
 	if len(cInfo) < 1 || cInfo[0] == nil {
 		return nil
 	}
@@ -320,7 +320,7 @@ func expandEfsAccessPointRootDirectoryCreationInfo(cInfo []interface{}) *efs.Cre
 	return creationInfo
 }
 
-func flattenEfsAccessPointPosixUser(posixUser *efs.PosixUser) []interface{} {
+func flattenAccessPointPOSIXUser(posixUser *efs.PosixUser) []interface{} {
 	if posixUser == nil {
 		return []interface{}{}
 	}
@@ -334,20 +334,20 @@ func flattenEfsAccessPointPosixUser(posixUser *efs.PosixUser) []interface{} {
 	return []interface{}{m}
 }
 
-func flattenEfsAccessPointRootDirectory(rDir *efs.RootDirectory) []interface{} {
+func flattenAccessPointRootDirectory(rDir *efs.RootDirectory) []interface{} {
 	if rDir == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
 		"path":          aws.StringValue(rDir.Path),
-		"creation_info": flattenEfsAccessPointRootDirectoryCreationInfo(rDir.CreationInfo),
+		"creation_info": flattenAccessPointRootDirectoryCreationInfo(rDir.CreationInfo),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenEfsAccessPointRootDirectoryCreationInfo(cInfo *efs.CreationInfo) []interface{} {
+func flattenAccessPointRootDirectoryCreationInfo(cInfo *efs.CreationInfo) []interface{} {
 	if cInfo == nil {
 		return []interface{}{}
 	}

--- a/internal/service/efs/access_point_data_source.go
+++ b/internal/service/efs/access_point_data_source.go
@@ -129,11 +129,11 @@ func dataSourceAccessPointRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", ap.AccessPointArn)
 	d.Set("owner_id", ap.OwnerId)
 
-	if err := d.Set("posix_user", flattenEfsAccessPointPosixUser(ap.PosixUser)); err != nil {
+	if err := d.Set("posix_user", flattenAccessPointPOSIXUser(ap.PosixUser)); err != nil {
 		return fmt.Errorf("error setting posix user: %w", err)
 	}
 
-	if err := d.Set("root_directory", flattenEfsAccessPointRootDirectory(ap.RootDirectory)); err != nil {
+	if err := d.Set("root_directory", flattenAccessPointRootDirectory(ap.RootDirectory)); err != nil {
 		return fmt.Errorf("error setting root directory: %w", err)
 	}
 

--- a/internal/service/efs/access_point_data_source_test.go
+++ b/internal/service/efs/access_point_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccEFSAccessPointDataSource_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointDataSourceConfig(rName),

--- a/internal/service/efs/access_point_test.go
+++ b/internal/service/efs/access_point_test.go
@@ -26,12 +26,12 @@ func TestAccEFSAccessPoint_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttrPair(resourceName, "file_system_arn", fsResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "file_system_id", fsResourceName, "id"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticfilesystem", regexp.MustCompile(`access-point/fsap-.+`)),
@@ -60,12 +60,12 @@ func TestAccEFSAccessPoint_Root_directory(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointRootDirectoryConfig(rName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.0.path", "/home/test"),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.0.creation_info.#", "0"),
@@ -89,12 +89,12 @@ func TestAccEFSAccessPoint_RootDirectoryCreation_info(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointRootDirectoryCreationInfoConfig(rName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.0.path", "/home/test"),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.0.creation_info.#", "1"),
@@ -121,12 +121,12 @@ func TestAccEFSAccessPoint_POSIX_user(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointPOSIXUserConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.0.gid", "1001"),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.0.uid", "1001"),
@@ -151,12 +151,12 @@ func TestAccEFSAccessPoint_POSIXUserSecondary_gids(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointPOSIXUserSecondaryGidsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.0.gid", "1001"),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.0.uid", "1001"),
@@ -180,12 +180,12 @@ func TestAccEFSAccessPoint_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -198,7 +198,7 @@ func TestAccEFSAccessPoint_tags(t *testing.T) {
 			{
 				Config: testAccAccessPointTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -207,7 +207,7 @@ func TestAccEFSAccessPoint_tags(t *testing.T) {
 			{
 				Config: testAccAccessPointTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -225,12 +225,12 @@ func TestAccEFSAccessPoint_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccCheckAccessPointExists(resourceName, &ap),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceAccessPoint(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -239,7 +239,7 @@ func TestAccEFSAccessPoint_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckEfsAccessPointDestroy(s *terraform.State) error {
+func testAccCheckAccessPointDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EFSConn
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_efs_access_point" {
@@ -263,7 +263,7 @@ func testAccCheckEfsAccessPointDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckEfsAccessPointExists(resourceID string, mount *efs.AccessPointDescription) resource.TestCheckFunc {
+func testAccCheckAccessPointExists(resourceID string, mount *efs.AccessPointDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceID]
 		if !ok {

--- a/internal/service/efs/access_points_data_source_test.go
+++ b/internal/service/efs/access_points_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccEFSAccessPointsDataSource_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointsDataSourceConfig(),
@@ -35,7 +35,7 @@ func TestAccEFSAccessPointsDataSource_empty(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		CheckDestroy: testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessPointsEmptyDataSourceConfig(),

--- a/internal/service/efs/backup_policy.go
+++ b/internal/service/efs/backup_policy.go
@@ -56,7 +56,7 @@ func resourceBackupPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 
 	fsID := d.Get("file_system_id").(string)
 
-	if err := efsBackupPolicyPut(conn, fsID, d.Get("backup_policy").([]interface{})[0].(map[string]interface{})); err != nil {
+	if err := backupPolicyPut(conn, fsID, d.Get("backup_policy").([]interface{})[0].(map[string]interface{})); err != nil {
 		return err
 	}
 
@@ -80,7 +80,7 @@ func resourceBackupPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading EFS Backup Policy (%s): %w", d.Id(), err)
 	}
 
-	if err := d.Set("backup_policy", []interface{}{flattenEfsBackupPolicy(output)}); err != nil {
+	if err := d.Set("backup_policy", []interface{}{flattenBackupPolicy(output)}); err != nil {
 		return fmt.Errorf("error setting backup_policy: %w", err)
 	}
 
@@ -92,7 +92,7 @@ func resourceBackupPolicyRead(d *schema.ResourceData, meta interface{}) error {
 func resourceBackupPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EFSConn
 
-	if err := efsBackupPolicyPut(conn, d.Id(), d.Get("backup_policy").([]interface{})[0].(map[string]interface{})); err != nil {
+	if err := backupPolicyPut(conn, d.Id(), d.Get("backup_policy").([]interface{})[0].(map[string]interface{})); err != nil {
 		return err
 	}
 
@@ -102,7 +102,7 @@ func resourceBackupPolicyUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceBackupPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EFSConn
 
-	err := efsBackupPolicyPut(conn, d.Id(), map[string]interface{}{
+	err := backupPolicyPut(conn, d.Id(), map[string]interface{}{
 		"status": efs.StatusDisabled,
 	})
 
@@ -117,11 +117,11 @@ func resourceBackupPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-// efsBackupPolicyPut attempts to update the file system's backup policy.
+// backupPolicyPut attempts to update the file system's backup policy.
 // Any error is returned.
-func efsBackupPolicyPut(conn *efs.EFS, fsID string, tfMap map[string]interface{}) error {
+func backupPolicyPut(conn *efs.EFS, fsID string, tfMap map[string]interface{}) error {
 	input := &efs.PutBackupPolicyInput{
-		BackupPolicy: expandEfsBackupPolicy(tfMap),
+		BackupPolicy: expandBackupPolicy(tfMap),
 		FileSystemId: aws.String(fsID),
 	}
 
@@ -145,7 +145,7 @@ func efsBackupPolicyPut(conn *efs.EFS, fsID string, tfMap map[string]interface{}
 	return nil
 }
 
-func expandEfsBackupPolicy(tfMap map[string]interface{}) *efs.BackupPolicy {
+func expandBackupPolicy(tfMap map[string]interface{}) *efs.BackupPolicy {
 	if tfMap == nil {
 		return nil
 	}
@@ -159,7 +159,7 @@ func expandEfsBackupPolicy(tfMap map[string]interface{}) *efs.BackupPolicy {
 	return apiObject
 }
 
-func flattenEfsBackupPolicy(apiObject *efs.BackupPolicy) map[string]interface{} {
+func flattenBackupPolicy(apiObject *efs.BackupPolicy) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/efs/backup_policy_test.go
+++ b/internal/service/efs/backup_policy_test.go
@@ -24,12 +24,12 @@ func TestAccEFSBackupPolicy_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsBackupPolicyDestroy,
+		CheckDestroy: testAccCheckBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackupPolicyConfig(rName, "ENABLED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEFSBackupPolicyExists(resourceName, &v),
+					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.status", "ENABLED"),
 				),
@@ -53,12 +53,12 @@ func TestAccEFSBackupPolicy_Disappears_fs(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsBackupPolicyDestroy,
+		CheckDestroy: testAccCheckBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackupPolicyConfig(rName, "ENABLED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEFSBackupPolicyExists(resourceName, &v),
+					testAccCheckBackupPolicyExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystem(), fsResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -76,12 +76,12 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsBackupPolicyDestroy,
+		CheckDestroy: testAccCheckBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackupPolicyConfig(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEFSBackupPolicyExists(resourceName, &v),
+					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.status", "DISABLED"),
 				),
@@ -94,7 +94,7 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 			{
 				Config: testAccBackupPolicyConfig(rName, "ENABLED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEFSBackupPolicyExists(resourceName, &v),
+					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.status", "ENABLED"),
 				),
@@ -102,7 +102,7 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 			{
 				Config: testAccBackupPolicyConfig(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEFSBackupPolicyExists(resourceName, &v),
+					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.status", "DISABLED"),
 				),
@@ -111,7 +111,7 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckEFSBackupPolicyExists(name string, v *efs.BackupPolicy) resource.TestCheckFunc {
+func testAccCheckBackupPolicyExists(name string, v *efs.BackupPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -136,7 +136,7 @@ func testAccCheckEFSBackupPolicyExists(name string, v *efs.BackupPolicy) resourc
 	}
 }
 
-func testAccCheckEfsBackupPolicyDestroy(s *terraform.State) error {
+func testAccCheckBackupPolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EFSConn
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/efs/file_system.go
+++ b/internal/service/efs/file_system.go
@@ -213,7 +213,7 @@ func resourceFileSystemCreate(d *schema.ResourceData, meta interface{}) error {
 	if hasLifecyclePolicy {
 		_, err := conn.PutLifecycleConfiguration(&efs.PutLifecycleConfigurationInput{
 			FileSystemId:      aws.String(d.Id()),
-			LifecyclePolicies: expandEfsFileSystemLifecyclePolicies(d.Get("lifecycle_policy").([]interface{})),
+			LifecyclePolicies: expandFileSystemLifecyclePolicies(d.Get("lifecycle_policy").([]interface{})),
 		})
 
 		if err != nil {
@@ -253,7 +253,7 @@ func resourceFileSystemUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("lifecycle_policy") {
 		input := &efs.PutLifecycleConfigurationInput{
 			FileSystemId:      aws.String(d.Id()),
-			LifecyclePolicies: expandEfsFileSystemLifecyclePolicies(d.Get("lifecycle_policy").([]interface{})),
+			LifecyclePolicies: expandFileSystemLifecyclePolicies(d.Get("lifecycle_policy").([]interface{})),
 		}
 
 		// Prevent the following error during removal:
@@ -321,7 +321,7 @@ func resourceFileSystemRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
-	if err := d.Set("size_in_bytes", flattenEfsFileSystemSizeInBytes(fs.SizeInBytes)); err != nil {
+	if err := d.Set("size_in_bytes", flattenFileSystemSizeInBytes(fs.SizeInBytes)); err != nil {
 		return fmt.Errorf("error setting size_in_bytes: %w", err)
 	}
 
@@ -335,7 +335,7 @@ func resourceFileSystemRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading EFS file system (%s) lifecycle configuration: %w", d.Id(), err)
 	}
 
-	if err := d.Set("lifecycle_policy", flattenEfsFileSystemLifecyclePolicies(res.LifecyclePolicies)); err != nil {
+	if err := d.Set("lifecycle_policy", flattenFileSystemLifecyclePolicies(res.LifecyclePolicies)); err != nil {
 		return fmt.Errorf("error setting lifecycle_policy: %w", err)
 	}
 
@@ -368,7 +368,7 @@ func resourceFileSystemDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func flattenEfsFileSystemLifecyclePolicies(apiObjects []*efs.LifecyclePolicy) []interface{} {
+func flattenFileSystemLifecyclePolicies(apiObjects []*efs.LifecyclePolicy) []interface{} {
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
@@ -392,7 +392,7 @@ func flattenEfsFileSystemLifecyclePolicies(apiObjects []*efs.LifecyclePolicy) []
 	return tfList
 }
 
-func expandEfsFileSystemLifecyclePolicies(tfList []interface{}) []*efs.LifecyclePolicy {
+func expandFileSystemLifecyclePolicies(tfList []interface{}) []*efs.LifecyclePolicy {
 	var apiObjects []*efs.LifecyclePolicy
 
 	for _, tfMapRaw := range tfList {
@@ -418,7 +418,7 @@ func expandEfsFileSystemLifecyclePolicies(tfList []interface{}) []*efs.Lifecycle
 	return apiObjects
 }
 
-func flattenEfsFileSystemSizeInBytes(sizeInBytes *efs.FileSystemSize) []interface{} {
+func flattenFileSystemSizeInBytes(sizeInBytes *efs.FileSystemSize) []interface{} {
 	if sizeInBytes == nil {
 		return []interface{}{}
 	}

--- a/internal/service/efs/file_system_data_source.go
+++ b/internal/service/efs/file_system_data_source.go
@@ -169,7 +169,7 @@ func dataSourceFileSystemRead(d *schema.ResourceData, meta interface{}) error {
 			aws.StringValue(fs.FileSystemId), err)
 	}
 
-	if err := d.Set("lifecycle_policy", flattenEfsFileSystemLifecyclePolicies(res.LifecyclePolicies)); err != nil {
+	if err := d.Set("lifecycle_policy", flattenFileSystemLifecyclePolicies(res.LifecyclePolicies)); err != nil {
 		return fmt.Errorf("error setting lifecycle_policy: %w", err)
 	}
 

--- a/internal/service/efs/file_system_data_source_test.go
+++ b/internal/service/efs/file_system_data_source_test.go
@@ -150,7 +150,7 @@ func TestAccEFSFileSystemDataSource_nonExistent_tags(t *testing.T) {
 			{
 				Config: testAccFileSystemConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 				),
 			},
 			{

--- a/internal/service/efs/file_system_policy_test.go
+++ b/internal/service/efs/file_system_policy_test.go
@@ -23,12 +23,12 @@ func TestAccEFSFileSystemPolicy_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
+		CheckDestroy: testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
@@ -41,7 +41,7 @@ func TestAccEFSFileSystemPolicy_basic(t *testing.T) {
 			{
 				Config: testAccFileSystemPolicyUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
@@ -58,12 +58,12 @@ func TestAccEFSFileSystemPolicy_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
+		CheckDestroy: testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystemPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -81,12 +81,12 @@ func TestAccEFSFileSystemPolicy_policyBypass(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
+		CheckDestroy: testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
 				),
 			},
@@ -99,7 +99,7 @@ func TestAccEFSFileSystemPolicy_policyBypass(t *testing.T) {
 			{
 				Config: testAccFileSystemPolicyBypassConfig(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
 				),
 			},
@@ -117,12 +117,12 @@ func TestAccEFSFileSystemPolicy_equivalentPolicies(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
+		CheckDestroy: testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemPolicyFirstEquivalentConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
@@ -144,12 +144,12 @@ func TestAccEFSFileSystemPolicy_equivalentPoliciesIAMPolicyDoc(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
+		CheckDestroy: testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemPolicyEquivalentIAMPolicyDocConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
@@ -161,7 +161,7 @@ func TestAccEFSFileSystemPolicy_equivalentPoliciesIAMPolicyDoc(t *testing.T) {
 	})
 }
 
-func testAccCheckEfsFileSystemPolicyDestroy(s *terraform.State) error {
+func testAccCheckFileSystemPolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EFSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -185,7 +185,7 @@ func testAccCheckEfsFileSystemPolicyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckEfsFileSystemPolicyExists(n string, v *efs.DescribeFileSystemPolicyOutput) resource.TestCheckFunc {
+func testAccCheckFileSystemPolicyExists(n string, v *efs.DescribeFileSystemPolicyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -24,12 +24,12 @@ func TestAccEFSFileSystem_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
 					acctest.MatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
 					resource.TestCheckResourceAttr(resourceName, "performance_mode", "generalPurpose"),
@@ -54,7 +54,7 @@ func TestAccEFSFileSystem_basic(t *testing.T) {
 			{
 				Config: testAccFileSystemWithPerformanceModeConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem("aws_efs_file_system.test2", &desc),
+					testAccCheckFileSystem("aws_efs_file_system.test2", &desc),
 					resource.TestCheckResourceAttr("aws_efs_file_system.test2", "creation_token", "supercalifragilisticexpialidocious"),
 					resource.TestCheckResourceAttr("aws_efs_file_system.test2", "performance_mode", "maxIO"),
 				),
@@ -72,12 +72,12 @@ func TestAccEFSFileSystem_availabilityZoneName(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemAvailabilityZoneNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone_id", "data.aws_availability_zones.available", "zone_ids.0"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone_name", "data.aws_availability_zones.available", "names.0"),
 				),
@@ -100,12 +100,12 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -118,7 +118,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 			{
 				Config: testAccFileSystemTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -127,7 +127,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 			{
 				Config: testAccFileSystemTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -135,7 +135,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 			{
 				Config: testAccFileSystemWithMaxTagsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "50"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.Another", "tag"),
@@ -155,12 +155,12 @@ func TestAccEFSFileSystem_pagedTags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemPagedTagsConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "10"),
 				),
 			},
@@ -183,12 +183,12 @@ func TestAccEFSFileSystem_kmsKey(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemWithKMSKeyConfig(rInt, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "encrypted", "true"),
 				),
@@ -209,7 +209,7 @@ func TestAccEFSFileSystem_kmsWithoutEncryption(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccFileSystemWithKMSKeyConfig(rInt, false),
@@ -227,12 +227,12 @@ func TestAccEFSFileSystem_provisionedThroughputInMibps(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemConfig_ProvisionedThroughputInMibps(1.0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "1"),
 					resource.TestCheckResourceAttr(resourceName, "throughput_mode", efs.ThroughputModeProvisioned),
 				),
@@ -240,7 +240,7 @@ func TestAccEFSFileSystem_provisionedThroughputInMibps(t *testing.T) {
 			{
 				Config: testAccFileSystemConfig_ProvisionedThroughputInMibps(2.0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "2"),
 					resource.TestCheckResourceAttr(resourceName, "throughput_mode", efs.ThroughputModeProvisioned),
 				),
@@ -262,12 +262,12 @@ func TestAccEFSFileSystem_throughputMode(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemConfig_ProvisionedThroughputInMibps(1.0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "1"),
 					resource.TestCheckResourceAttr(resourceName, "throughput_mode", efs.ThroughputModeProvisioned),
 				),
@@ -275,7 +275,7 @@ func TestAccEFSFileSystem_throughputMode(t *testing.T) {
 			{
 				Config: testAccFileSystemConfig_ThroughputMode(efs.ThroughputModeBursting),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "0"),
 					resource.TestCheckResourceAttr(resourceName, "throughput_mode", efs.ThroughputModeBursting),
 				),
@@ -297,7 +297,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemWithLifecyclePolicyConfig(
@@ -312,7 +312,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 					efs.TransitionToIARulesAfter30Days,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", efs.TransitionToIARulesAfter30Days),
 				),
@@ -328,7 +328,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 					efs.TransitionToPrimaryStorageClassRulesAfter1Access,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", efs.TransitionToPrimaryStorageClassRulesAfter1Access),
 				),
@@ -336,7 +336,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 			{
 				Config: testAccFileSystemRemovedLifecyclePolicyConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "0"),
 				),
 			},
@@ -348,7 +348,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 					efs.TransitionToIARulesAfter30Days,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", efs.TransitionToPrimaryStorageClassRulesAfter1Access),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_ia", efs.TransitionToIARulesAfter30Days),
@@ -367,12 +367,12 @@ func TestAccEFSFileSystem_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFileSystemConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
+					testAccCheckFileSystem(resourceName, &desc),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystem(), resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystem(), resourceName),
 				),
@@ -382,7 +382,7 @@ func TestAccEFSFileSystem_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckEfsFileSystemDestroy(s *terraform.State) error {
+func testAccCheckFileSystemDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EFSConn
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_efs_file_system" {
@@ -405,7 +405,7 @@ func testAccCheckEfsFileSystemDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckEfsFileSystem(resourceID string, fDesc *efs.FileSystemDescription) resource.TestCheckFunc {
+func testAccCheckFileSystem(resourceID string, fDesc *efs.FileSystemDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceID]
 		if !ok {

--- a/internal/service/efs/mount_target_test.go
+++ b/internal/service/efs/mount_target_test.go
@@ -28,12 +28,12 @@ func TestAccEFSMountTarget_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsMountTargetDestroy,
+		CheckDestroy: testAccCheckMountTargetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMountTargetConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsMountTarget(resourceName, &mount),
+					testAccCheckMountTarget(resourceName, &mount),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_name"),
 					acctest.MatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
@@ -52,8 +52,8 @@ func TestAccEFSMountTarget_basic(t *testing.T) {
 			{
 				Config: testAccMountTargetModifiedConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsMountTarget(resourceName, &mount),
-					testAccCheckEfsMountTarget(resourceName2, &mount),
+					testAccCheckMountTarget(resourceName, &mount),
+					testAccCheckMountTarget(resourceName2, &mount),
 					acctest.MatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
 					acctest.MatchResourceAttrRegionalHostname(resourceName2, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
 				),
@@ -76,7 +76,7 @@ func TestAccEFSMountTarget_disappears(t *testing.T) {
 			{
 				Config: testAccMountTargetConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsMountTarget(resourceName, &mount),
+					testAccCheckMountTarget(resourceName, &mount),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceMountTarget(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -94,12 +94,12 @@ func TestAccEFSMountTarget_ipAddress(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsMountTargetDestroy,
+		CheckDestroy: testAccCheckMountTargetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMountTargetIPAddressConfig(rName, "10.0.0.100"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsMountTarget(resourceName, &mount),
+					testAccCheckMountTarget(resourceName, &mount),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "10.0.0.100"),
 				),
 			},
@@ -122,12 +122,12 @@ func TestAccEFSMountTarget_IPAddress_emptyString(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, efs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckEfsMountTargetDestroy,
+		CheckDestroy: testAccCheckMountTargetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMountTargetIPAddressConfigNullIP(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsMountTarget(resourceName, &mount),
+					testAccCheckMountTarget(resourceName, &mount),
 					resource.TestMatchResourceAttr(resourceName, "ip_address", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
 				),
 			},
@@ -159,7 +159,7 @@ func TestMountTarget_hasEmptyMountTargets(t *testing.T) {
 	}
 }
 
-func testAccCheckEfsMountTargetDestroy(s *terraform.State) error {
+func testAccCheckMountTargetDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EFSConn
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_efs_mount_target" {
@@ -184,7 +184,7 @@ func testAccCheckEfsMountTargetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckEfsMountTarget(resourceID string, mount *efs.MountTargetDescription) resource.TestCheckFunc {
+func testAccCheckMountTarget(resourceID string, mount *efs.MountTargetDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceID]
 		if !ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
