### PR TITLE
d/aws_route53_resolver_rules: add new name_regex filter argument

### DIFF
--- a/.changelog/24582.txt
+++ b/.changelog/24582.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/aws_route53_resolver_rules: add `name_regex` argument
+```

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -2,6 +2,7 @@ package route53resolver_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/route53resolver"
@@ -47,6 +48,44 @@ func TestAccRoute53ResolverRulesDataSource_resolverEndpointID(t *testing.T) {
 					resource.TestCheckResourceAttr(ds1ResourceName, "resolver_rule_ids.#", "1"),
 					resource.TestCheckResourceAttr(ds2ResourceName, "resolver_rule_ids.#", "1"),
 					resource.TestCheckResourceAttr(ds3ResourceName, "resolver_rule_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53ResolverRulesDataSource_nameRegex(t *testing.T) {
+	dsResourceName := "data.aws_route53_resolver_rules.test"
+	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, route53resolver.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRulesDataSource_nameRegex(rCount, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", rCount),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex(t *testing.T) {
+	dsResourceName := "data.aws_route53_resolver_rules.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, route53resolver.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRulesDataSource_nonExistentNameRegex,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", "0"),
 				),
 			},
 		},
@@ -100,3 +139,26 @@ data "aws_route53_resolver_rules" "by_invalid_owner_id" {
 }
 `, rName1, rName2)
 }
+
+func testAccRulesDataSource_nameRegex(rCount, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "test" {
+  count       = %[1]q
+  domain_name = "%[2]s.example.org"
+  name        = "%[2]s-${count.index}-rule"
+  rule_type   = "SYSTEM"
+}
+
+data "aws_route53_resolver_rules" "test" {
+  name_regex = "%[2]s-.*-rule"
+
+  depends_on = [aws_route53_resolver_rule.test]
+}
+`, rCount, rName)
+}
+
+const testAccRulesDataSource_nonExistentNameRegex = `
+data "aws_route53_resolver_rules" "test" {
+  name_regex = "dne-regex"
+}
+`

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -143,7 +143,7 @@ data "aws_route53_resolver_rules" "by_invalid_owner_id" {
 func testAccRulesDataSource_nameRegex(rCount, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "test" {
-  count       = %[1]q
+  count       = %[1]s
   domain_name = "%[2]s.example.org"
   name        = "%[2]s-${count.index}-rule"
   rule_type   = "SYSTEM"

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -56,7 +56,7 @@ func TestAccRoute53ResolverRulesDataSource_resolverEndpointID(t *testing.T) {
 
 func TestAccRoute53ResolverRulesDataSource_nameRegex(t *testing.T) {
 	dsResourceName := "data.aws_route53_resolver_rules.test"
-	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
+	rCount := 3
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,7 +67,7 @@ func TestAccRoute53ResolverRulesDataSource_nameRegex(t *testing.T) {
 			{
 				Config: testAccRulesDataSource_nameRegex(rCount, rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", rCount),
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", strconv.Itoa(rCount)),
 				),
 			},
 		},
@@ -140,10 +140,10 @@ data "aws_route53_resolver_rules" "by_invalid_owner_id" {
 `, rName1, rName2)
 }
 
-func testAccRulesDataSource_nameRegex(rCount, rName string) string {
+func testAccRulesDataSource_nameRegex(rCount int, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "test" {
-  count       = %[1]s
+  count       = %[1]d
   domain_name = "%[2]s.example.org"
   name        = "%[2]s-${count.index}-rule"
   rule_type   = "SYSTEM"

--- a/website/docs/d/route53_resolver_rules.html.markdown
+++ b/website/docs/d/route53_resolver_rules.html.markdown
@@ -22,7 +22,7 @@ data "aws_route53_resolver_rules" "example" {
 }
 ```
 
-### Retrieving forward rule(s) shared with me
+### Retrieving forward rules shared with me
 
 ```terraform
 data "aws_route53_resolver_rules" "example" {
@@ -31,7 +31,7 @@ data "aws_route53_resolver_rules" "example" {
 }
 ```
 
-### Retrieving rule(s) by name regex
+### Retrieving rules by name regex
 
 Resolver rules whose name contains `abc`.
 
@@ -45,9 +45,9 @@ data "aws_route53_resolver_rules" "example" {
 
 The arguments of this data source act as filters for querying the available resolver rules in the current region.
 
-* `name_regex` - (Optional) A regex string to apply to the resolver rules list returned by AWS. This allows more advanced filtering not supported from the AWS API.
-  This filtering is done locally on what AWS returns, and could have a performance impact if the result is large. It is recommended to combine this with other
-  options to narrow down the list AWS returns.
+* `name_regex` - (Optional) A regex string to filter resolver rule names.
+  The filtering is done locally, so could have a performance impact if the result is large.
+  This argument should be used along with other arguments to limit the number of results returned.
 * `owner_id` (Optional) When the desired resolver rules are shared with another AWS account, the account ID of the account that the rules are shared with.
 * `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint for the desired resolver rules.
 * `rule_type` (Optional) The rule type of the desired resolver rules. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.

--- a/website/docs/d/route53_resolver_rules.html.markdown
+++ b/website/docs/d/route53_resolver_rules.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-Retrieving the default resolver rule.
+### Retrieving the default resolver rule
 
 ```terraform
 data "aws_route53_resolver_rules" "example" {
@@ -22,6 +22,8 @@ data "aws_route53_resolver_rules" "example" {
 }
 ```
 
+### Retrieving forward rule(s) shared with me
+
 ```terraform
 data "aws_route53_resolver_rules" "example" {
   rule_type    = "FORWARD"
@@ -29,10 +31,23 @@ data "aws_route53_resolver_rules" "example" {
 }
 ```
 
+### Retrieving rule(s) by name regex
+
+Resolver rules whose name contains `abc`.
+
+```terraform
+data "aws_route53_resolver_rules" "example" {
+  name_regex = ".*abc.*"
+}
+```
+
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available resolver rules in the current region.
 
+* `name_regex` - (Optional) A regex string to apply to the resolver rules list returned by AWS. This allows more advanced filtering not supported from the AWS API.
+  This filtering is done locally on what AWS returns, and could have a performance impact if the result is large. It is recommended to combine this with other
+  options to narrow down the list AWS returns.
 * `owner_id` (Optional) When the desired resolver rules are shared with another AWS account, the account ID of the account that the rules are shared with.
 * `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint for the desired resolver rules.
 * `rule_type` (Optional) The rule type of the desired resolver rules. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Add new `name_regex` filter argument for `aws_route53_resolver_rules` datasource. Given this isn't supported natively by [AWS API](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_Filter.html), filtering is performed locally after retrieving results from the API.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTS=TestAccRoute53ResolverRulesDataSource PKG=route53resolver
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53resolver/... -v -count 1 -parallel 20 -run='TestAccRoute53ResolverRulesDataSource'  -timeout 180m
=== RUN   TestAccRoute53ResolverRulesDataSource_basic
=== PAUSE TestAccRoute53ResolverRulesDataSource_basic
=== RUN   TestAccRoute53ResolverRulesDataSource_resolverEndpointID
=== PAUSE TestAccRoute53ResolverRulesDataSource_resolverEndpointID
=== RUN   TestAccRoute53ResolverRulesDataSource_nameRegex
=== PAUSE TestAccRoute53ResolverRulesDataSource_nameRegex
=== RUN   TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex
=== PAUSE TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex
=== CONT  TestAccRoute53ResolverRulesDataSource_basic
=== CONT  TestAccRoute53ResolverRulesDataSource_nameRegex
=== CONT  TestAccRoute53ResolverRulesDataSource_resolverEndpointID
=== CONT  TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex
--- PASS: TestAccRoute53ResolverRulesDataSource_basic (6.72s)
--- PASS: TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex (7.97s)
--- PASS: TestAccRoute53ResolverRulesDataSource_nameRegex (29.14s)
--- PASS: TestAccRoute53ResolverRulesDataSource_resolverEndpointID (205.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    206.737s

...
```
