### PR TITLE
Allow AWS Provider ACM Certificate Data Source to Return TLS Certificate Material

### DIFF
--- a/.changelog/24593.txt
+++ b/.changelog/24593.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_acm_certificate: Add `certificate` and `certificate_chain` attributes
+```

--- a/internal/service/acm/certificate_data_source.go
+++ b/internal/service/acm/certificate_data_source.go
@@ -25,11 +25,11 @@ func DataSourceCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tls_certificate": {
+			"certificate": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tls_certificate_full_chain": {
+			"certificate_chain": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -188,8 +188,8 @@ func dataSourceCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(aws.StringValue(matchedCertificate.CertificateArn))
 	d.Set("arn", matchedCertificate.CertificateArn)
 	d.Set("status", matchedCertificate.Status)
-	d.Set("tls_certificate", output.Certificate)
-	d.Set("tls_certificate_full_chain", output.CertificateChain)
+	d.Set("certificate", output.Certificate)
+	d.Set("certificate_chain", output.CertificateChain)
 	tags, err := ListTags(conn, aws.StringValue(matchedCertificate.CertificateArn))
 
 	if err != nil {

--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -47,6 +47,8 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
@@ -55,6 +57,8 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
@@ -62,6 +66,8 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
@@ -69,6 +75,8 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
@@ -76,6 +84,8 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
@@ -83,6 +93,8 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 		},

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -50,4 +50,6 @@ data "aws_acm_certificate" "rsa_4096" {
 * `arn` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
 * `id` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
 * `status` - Status of the found certificate.
+* `certificate` - The ACM-issued certificate.
+* `certificate_chain` - Certificates forming the requested ACM-issued certificate's chain of trust. The chain consists of the certificate of the issuing CA and the intermediate certificates of any other subordinate CAs.
 * `tags` - A mapping of tags for the resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
