### PR TITLE
Fixes aws_subnet on creation improperly handling IPv6 CIDR pending association state

### DIFF
--- a/.changelog/24685.txt
+++ b/.changelog/24685.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_subnet: Fixes aws_subnet on creation improperly handling IPv6 CIDR pending association state #24685
+```

--- a/.changelog/24685.txt
+++ b/.changelog/24685.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_subnet: Fix `InvalidSubnet.Conflict` errors when associating IPv6 CIDR blocks
 ```
+
+```release-note:bug
+resource/aws_default_subnet: Fix `InvalidSubnet.Conflict` errors when associating IPv6 CIDR blocks
+```

--- a/.changelog/24685.txt
+++ b/.changelog/24685.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_subnet: Fixes aws_subnet on creation improperly handling IPv6 CIDR pending association state #24685
+resource/aws_subnet: Fix `InvalidSubnet.Conflict` errors when associating IPv6 CIDR blocks
 ```

--- a/internal/service/ec2/vpc_default_subnet.go
+++ b/internal/service/ec2/vpc_default_subnet.go
@@ -200,15 +200,17 @@ func resourceDefaultSubnetCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		// Creating an IPv6-native default subnets associates an IPv6 CIDR block.
-		for _, v := range subnet.Ipv6CidrBlockAssociationSet {
+		for i, v := range subnet.Ipv6CidrBlockAssociationSet {
 			if aws.StringValue(v.Ipv6CidrBlockState.State) == ec2.SubnetCidrBlockStateCodeAssociating { //we can only ever have 1 IPv6 block associated at once
 				associationID := aws.StringValue(v.AssociationId)
 
-				_, err = WaitSubnetIPv6CIDRBlockAssociationCreated(conn, associationID)
+				subnetCidrBlockState, err := WaitSubnetIPv6CIDRBlockAssociationCreated(conn, associationID)
 
 				if err != nil {
 					return fmt.Errorf("error waiting for EC2 Default Subnet (%s) IPv6 CIDR block (%s) to become associated: %w", d.Id(), associationID, err)
 				}
+
+				subnet.Ipv6CidrBlockAssociationSet[i].Ipv6CidrBlockState = subnetCidrBlockState
 			}
 		}
 

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -200,7 +200,7 @@ func resourceSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error waiting for EC2 Subnet (%s) IPv6 CIDR block (%s) to become associated: %w", d.Id(), associationID, err)
 			}
 
-			subnet.Ipv6CidrBlockAssociationSet[i].SetIpv6CidrBlockState(subnetCidrBlockState)
+			subnet.Ipv6CidrBlockAssociationSet[i].Ipv6CidrBlockState = subnetCidrBlockState
 		}
 	}
 

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -190,15 +190,17 @@ func resourceSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error waiting for EC2 Subnet (%s) create: %w", d.Id(), err)
 	}
 
-	for _, v := range subnet.Ipv6CidrBlockAssociationSet {
+	for i, v := range subnet.Ipv6CidrBlockAssociationSet {
 		if aws.StringValue(v.Ipv6CidrBlockState.State) == ec2.SubnetCidrBlockStateCodeAssociating { //we can only ever have 1 IPv6 block associated at once
 			associationID := aws.StringValue(v.AssociationId)
 
-			_, err = WaitSubnetIPv6CIDRBlockAssociationCreated(conn, associationID)
+			subnetCidrBlockState, err := WaitSubnetIPv6CIDRBlockAssociationCreated(conn, associationID)
 
 			if err != nil {
 				return fmt.Errorf("error waiting for EC2 Subnet (%s) IPv6 CIDR block (%s) to become associated: %w", d.Id(), associationID, err)
 			}
+
+			subnet.Ipv6CidrBlockAssociationSet[i].SetIpv6CidrBlockState(subnetCidrBlockState)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24681

Output from acceptance testing:
```
$ TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2 -run=TestAccVPCSubnet -timeout 180m                                                                                                                                                                                                                   
=== RUN   TestAccVPCSubnetCIDRReservation_basic
=== PAUSE TestAccVPCSubnetCIDRReservation_basic
=== RUN   TestAccVPCSubnetCIDRReservation_ipv6
=== PAUSE TestAccVPCSubnetCIDRReservation_ipv6
=== RUN   TestAccVPCSubnetCIDRReservation_disappears
=== PAUSE TestAccVPCSubnetCIDRReservation_disappears
=== RUN   TestAccVPCSubnetDataSource_basic
=== PAUSE TestAccVPCSubnetDataSource_basic
=== RUN   TestAccVPCSubnetDataSource_ipv6ByIPv6Filter
=== PAUSE TestAccVPCSubnetDataSource_ipv6ByIPv6Filter
=== RUN   TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock
=== PAUSE TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock
=== RUN   TestAccVPCSubnetIDsDataSource_basic
=== PAUSE TestAccVPCSubnetIDsDataSource_basic
=== RUN   TestAccVPCSubnetIDsDataSource_filter
=== PAUSE TestAccVPCSubnetIDsDataSource_filter
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPCSubnet_tags
=== PAUSE TestAccVPCSubnet_tags
=== RUN   TestAccVPCSubnet_DefaultTags_providerOnly
=== PAUSE TestAccVPCSubnet_DefaultTags_providerOnly
=== RUN   TestAccVPCSubnet_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCSubnet_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCSubnet_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCSubnet_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag
=== PAUSE TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag
=== RUN   TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag
=== PAUSE TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag
=== RUN   TestAccVPCSubnet_DefaultTagsProviderAndResource_duplicateTag
=== PAUSE TestAccVPCSubnet_DefaultTagsProviderAndResource_duplicateTag
=== RUN   TestAccVPCSubnet_defaultAndIgnoreTags
=== PAUSE TestAccVPCSubnet_defaultAndIgnoreTags
=== RUN   TestAccVPCSubnet_updateTagsKnownAtApply
=== PAUSE TestAccVPCSubnet_updateTagsKnownAtApply
=== RUN   TestAccVPCSubnet_ignoreTags
=== PAUSE TestAccVPCSubnet_ignoreTags
=== RUN   TestAccVPCSubnet_ipv6
=== PAUSE TestAccVPCSubnet_ipv6
=== RUN   TestAccVPCSubnet_enableIPv6
=== PAUSE TestAccVPCSubnet_enableIPv6
=== RUN   TestAccVPCSubnet_availabilityZoneID
=== PAUSE TestAccVPCSubnet_availabilityZoneID
=== RUN   TestAccVPCSubnet_disappears
=== PAUSE TestAccVPCSubnet_disappears
=== RUN   TestAccVPCSubnet_customerOwnedIPv4Pool
=== PAUSE TestAccVPCSubnet_customerOwnedIPv4Pool
=== RUN   TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch
=== PAUSE TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch
=== RUN   TestAccVPCSubnet_mapPublicIPOnLaunch
=== PAUSE TestAccVPCSubnet_mapPublicIPOnLaunch
=== RUN   TestAccVPCSubnet_outpost
=== PAUSE TestAccVPCSubnet_outpost
=== RUN   TestAccVPCSubnet_enableDNS64
=== PAUSE TestAccVPCSubnet_enableDNS64
=== RUN   TestAccVPCSubnet_privateDnsNameOptionsOnLaunch
=== PAUSE TestAccVPCSubnet_privateDnsNameOptionsOnLaunch
=== RUN   TestAccVPCSubnet_ipv6Native
=== PAUSE TestAccVPCSubnet_ipv6Native
=== RUN   TestAccVPCSubnetsDataSource_basic
=== PAUSE TestAccVPCSubnetsDataSource_basic
=== RUN   TestAccVPCSubnetsDataSource_filter
=== PAUSE TestAccVPCSubnetsDataSource_filter
=== CONT  TestAccVPCSubnetCIDRReservation_basic
=== CONT  TestAccVPCSubnet_defaultAndIgnoreTags
--- PASS: TestAccVPCSubnetCIDRReservation_basic (21.81s)
=== CONT  TestAccVPCSubnet_basic
--- PASS: TestAccVPCSubnet_defaultAndIgnoreTags (40.66s)
=== CONT  TestAccVPCSubnet_DefaultTagsProviderAndResource_duplicateTag
--- PASS: TestAccVPCSubnet_basic (19.91s)
=== CONT  TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag
--- PASS: TestAccVPCSubnet_DefaultTagsProviderAndResource_duplicateTag (1.78s)
=== CONT  TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag
--- PASS: TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag (47.77s)
=== CONT  TestAccVPCSubnet_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag (47.18s)
=== CONT  TestAccVPCSubnet_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCSubnet_DefaultTags_updateToProviderOnly (31.59s)
=== CONT  TestAccVPCSubnet_DefaultTags_providerOnly
--- PASS: TestAccVPCSubnet_DefaultTags_updateToResourceOnly (32.71s)
=== CONT  TestAccVPCSubnet_tags
--- PASS: TestAccVPCSubnet_DefaultTags_providerOnly (39.08s)
=== CONT  TestAccVPCSubnetDataSource_ipv6ByIPv6Filter
--- PASS: TestAccVPCSubnet_tags (47.11s)
=== CONT  TestAccVPCSubnetIDsDataSource_filter
--- PASS: TestAccVPCSubnetIDsDataSource_filter (24.22s)
=== CONT  TestAccVPCSubnetIDsDataSource_basic
--- PASS: TestAccVPCSubnetDataSource_ipv6ByIPv6Filter (51.96s)
=== CONT  TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock
--- PASS: TestAccVPCSubnetIDsDataSource_basic (38.67s)
=== CONT  TestAccVPCSubnetCIDRReservation_disappears
--- PASS: TestAccVPCSubnetCIDRReservation_disappears (18.14s)
=== CONT  TestAccVPCSubnetDataSource_basic
--- PASS: TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock (41.87s)
=== CONT  TestAccVPCSubnetCIDRReservation_ipv6
--- PASS: TestAccVPCSubnetDataSource_basic (19.47s)
=== CONT  TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch
    acctest.go:1308: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch (0.39s)
=== CONT  TestAccVPCSubnetsDataSource_filter
--- PASS: TestAccVPCSubnetCIDRReservation_ipv6 (32.06s)
=== CONT  TestAccVPCSubnetsDataSource_basic
--- PASS: TestAccVPCSubnetsDataSource_filter (20.67s)
=== CONT  TestAccVPCSubnet_ipv6Native
--- PASS: TestAccVPCSubnetsDataSource_basic (35.72s)
=== CONT  TestAccVPCSubnet_privateDnsNameOptionsOnLaunch
--- PASS: TestAccVPCSubnet_ipv6Native (32.42s)
=== CONT  TestAccVPCSubnet_enableDNS64
--- PASS: TestAccVPCSubnet_enableDNS64 (101.69s)
=== CONT  TestAccVPCSubnet_outpost
    acctest.go:1308: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_outpost (0.36s)
=== CONT  TestAccVPCSubnet_mapPublicIPOnLaunch
--- PASS: TestAccVPCSubnet_privateDnsNameOptionsOnLaunch (154.24s)
=== CONT  TestAccVPCSubnet_enableIPv6
--- PASS: TestAccVPCSubnet_mapPublicIPOnLaunch (80.72s)
=== CONT  TestAccVPCSubnet_customerOwnedIPv4Pool
    acctest.go:1308: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_customerOwnedIPv4Pool (0.42s)
=== CONT  TestAccVPCSubnet_disappears
--- PASS: TestAccVPCSubnet_disappears (18.49s)
=== CONT  TestAccVPCSubnet_availabilityZoneID
--- PASS: TestAccVPCSubnet_availabilityZoneID (21.09s)
=== CONT  TestAccVPCSubnet_ignoreTags
--- PASS: TestAccVPCSubnet_enableIPv6 (83.05s)
=== CONT  TestAccVPCSubnet_ipv6
--- PASS: TestAccVPCSubnet_ignoreTags (40.29s)
=== CONT  TestAccVPCSubnet_updateTagsKnownAtApply
--- PASS: TestAccVPCSubnet_updateTagsKnownAtApply (41.18s)
--- PASS: TestAccVPCSubnet_ipv6 (80.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        640.409s
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCSubnet PKG=ec2

...
```
