### PR TITLE
rds: Import `name_prefix` for `aws_rds_cluster_parameter_group`

### DIFF
--- a/.changelog/24687.txt
+++ b/.changelog/24687.txt
@@ -1,0 +1,2 @@
+```release-note:enhancement
+resource/aws_rds_cluster_parameter_group: Support import of `name_prefix` argument

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -97,14 +98,7 @@ func resourceClusterParameterGroupCreate(d *schema.ResourceData, meta interface{
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	var groupName string
-	if v, ok := d.GetOk("name"); ok {
-		groupName = v.(string)
-	} else if v, ok := d.GetOk("name_prefix"); ok {
-		groupName = resource.PrefixedUniqueId(v.(string))
-	} else {
-		groupName = resource.UniqueId()
-	}
+	groupName := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 
 	createOpts := rds.CreateDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String(groupName),
@@ -158,6 +152,7 @@ func resourceClusterParameterGroupRead(d *schema.ResourceData, meta interface{})
 	d.Set("description", describeResp.DBClusterParameterGroups[0].Description)
 	d.Set("family", describeResp.DBClusterParameterGroups[0].DBParameterGroupFamily)
 	d.Set("name", describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName)
+	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName)))
 
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := rds.DescribeDBClusterParametersInput{

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -35,6 +35,17 @@ func ResourceClusterParameterGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "Managed by Terraform",
+			},
+			"family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -51,22 +62,16 @@ func ResourceClusterParameterGroup() *schema.Resource {
 				ConflictsWith: []string{"name"},
 				ValidateFunc:  validParamGroupNamePrefix,
 			},
-			"family": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "Managed by Terraform",
-			},
 			"parameter": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"apply_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "immediate",
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -75,16 +80,10 @@ func ResourceClusterParameterGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"apply_method": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "immediate",
-						},
 					},
 				},
 				Set: resourceParameterHash,
 			},
-
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},


### PR DESCRIPTION
Reference: #9574
Reference: #12052

Use the shared naming module to match the name and the
prefix. Acceptance tests were updated to test the import.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Output from acceptance testing:


```
make testacc TESTS=TestAccRDSClusterParameterGroup_ PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterParameterGroup_'  -timeout 180m
=== RUN   TestAccRDSClusterParameterGroup_basic
=== PAUSE TestAccRDSClusterParameterGroup_basic
=== RUN   TestAccRDSClusterParameterGroup_withApplyMethod
=== PAUSE TestAccRDSClusterParameterGroup_withApplyMethod
=== RUN   TestAccRDSClusterParameterGroup_namePrefix
=== PAUSE TestAccRDSClusterParameterGroup_namePrefix
=== RUN   TestAccRDSClusterParameterGroup_NamePrefix_parameter
=== PAUSE TestAccRDSClusterParameterGroup_NamePrefix_parameter
=== RUN   TestAccRDSClusterParameterGroup_generatedName
=== PAUSE TestAccRDSClusterParameterGroup_generatedName
=== RUN   TestAccRDSClusterParameterGroup_GeneratedName_parameter
=== PAUSE TestAccRDSClusterParameterGroup_GeneratedName_parameter
=== RUN   TestAccRDSClusterParameterGroup_disappears
=== PAUSE TestAccRDSClusterParameterGroup_disappears
=== RUN   TestAccRDSClusterParameterGroup_only
=== PAUSE TestAccRDSClusterParameterGroup_only
=== RUN   TestAccRDSClusterParameterGroup_updateParameters
=== PAUSE TestAccRDSClusterParameterGroup_updateParameters
=== RUN   TestAccRDSClusterParameterGroup_caseParameters
=== PAUSE TestAccRDSClusterParameterGroup_caseParameters
=== CONT  TestAccRDSClusterParameterGroup_basic
=== CONT  TestAccRDSClusterParameterGroup_GeneratedName_parameter
=== CONT  TestAccRDSClusterParameterGroup_updateParameters
=== CONT  TestAccRDSClusterParameterGroup_NamePrefix_parameter
=== CONT  TestAccRDSClusterParameterGroup_generatedName
=== CONT  TestAccRDSClusterParameterGroup_namePrefix
=== CONT  TestAccRDSClusterParameterGroup_withApplyMethod
=== CONT  TestAccRDSClusterParameterGroup_caseParameters
=== CONT  TestAccRDSClusterParameterGroup_disappears
=== CONT  TestAccRDSClusterParameterGroup_only
--- PASS: TestAccRDSClusterParameterGroup_disappears (25.83s)
--- PASS: TestAccRDSClusterParameterGroup_withApplyMethod (32.37s)
--- PASS: TestAccRDSClusterParameterGroup_generatedName (32.56s)
--- PASS: TestAccRDSClusterParameterGroup_NamePrefix_parameter (36.23s)
--- PASS: TestAccRDSClusterParameterGroup_namePrefix (36.91s)
--- PASS: TestAccRDSClusterParameterGroup_GeneratedName_parameter (37.19s)
--- PASS: TestAccRDSClusterParameterGroup_only (37.45s)
--- PASS: TestAccRDSClusterParameterGroup_caseParameters (50.40s)
--- PASS: TestAccRDSClusterParameterGroup_updateParameters (51.58s)
--- PASS: TestAccRDSClusterParameterGroup_basic (67.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	69.537s
```
