### PR TITLE
resource/aws_elasticache_replication_group: Fix perpetual diff for Global Replication Group members

### DIFF
--- a/.changelog/24688.txt
+++ b/.changelog/24688.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix perpetual diff on `auto_minor_version_upgrade`
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -62,7 +62,7 @@ func ResourceReplicationGroup() *schema.Resource {
 			"auto_minor_version_upgrade": {
 				Type:         nullable.TypeNullableBool,
 				Optional:     true,
-				Default:      "true",
+				Computed:     true,
 				ValidateFunc: nullable.ValidateTypeStringNullableBool,
 			},
 			"automatic_failover_enabled": {


### PR DESCRIPTION
Due to a recent change in the AWS API, `aws_elasticache_replication_group`s which were secondary members of a global replication group were returning a perpetual diff for `auto_minor_version_upgrade`.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=elasticache PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup

--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (60.27s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (766.53s)
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (888.84s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1287.60s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (1379.46s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1387.13s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1399.11s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (1461.84s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1462.86s)
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (2.51s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1484.48s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1525.60s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1562.78s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1583.11s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1804.79s)
--- PASS: TestAccElastiCacheReplicationGroup_tagWithOtherModification (1824.69s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1906.11s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (2.53s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (772.87s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (713.09s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (1326.09s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (774.37s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (872.98s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (964.08s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1674.35s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (2504.19s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (864.15s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2843.93s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1057.44s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (955.91s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (911.43s)
--- PASS: TestAccElastiCacheReplicationGroup_depecatedAvailabilityZones_vpc (782.57s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (1042.64s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (3173.55s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (1557.07s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (1058.00s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (911.83s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_nonExistent (3.45s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1966.80s)
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (978.25s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (573.73s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3721.67s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (881.03s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (767.97s)
--- PASS: TestAccElastiCacheReplicationGroup_basic_v5 (769.47s)
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1102.88s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (813.26s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3992.44s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2520.69s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (710.38s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2542.31s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzNotInVPC (2203.93s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (898.32s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (878.86s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2907.00s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2832.78s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1686.93s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (989.00s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (4751.95s)
```
