### PR TITLE
Add enabled_metrics to aws_autoscaling_group data source

### DIFF
--- a/.changelog/24691.txt
+++ b/.changelog/24691.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `enabled_metrics` attribute
+```

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -38,6 +38,13 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"enabled_metrics": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"health_check_grace_period": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -169,6 +176,9 @@ func dataSourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("default_cooldown", group.DefaultCooldown)
 	d.Set("desired_capacity", group.DesiredCapacity)
+	if err := d.Set("enabled_metrics", flattenASGEnabledMetrics(group.EnabledMetrics)); err != nil {
+		return fmt.Errorf("error setting enabled_metrics: %w", err)
+	}
 	d.Set("health_check_grace_period", group.HealthCheckGracePeriod)
 	d.Set("health_check_type", group.HealthCheckType)
 	d.Set("launch_configuration", group.LaunchConfigurationName)

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -15,10 +15,6 @@ func DataSourceGroup() *schema.Resource {
 		Read: dataSourceGroupRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -83,6 +79,10 @@ func DataSourceGroup() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"new_instances_protected_from_scale_in": {
 				Type:     schema.TypeBool,

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "availability_zones.#", resourceName, "availability_zones.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "default_cooldown", resourceName, "default_cooldown"),
 					resource.TestCheckResourceAttrPair(datasourceName, "desired_capacity", resourceName, "desired_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enabled_metrics.#", resourceName, "enabled_metrics.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "health_check_grace_period", resourceName, "health_check_grace_period"),
 					resource.TestCheckResourceAttrPair(datasourceName, "health_check_type", resourceName, "health_check_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "launch_configuration", resourceName, "launch_configuration"),
@@ -61,6 +62,7 @@ func TestAccAutoScalingGroupDataSource_launchTemplate(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "availability_zones.#", resourceName, "availability_zones.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "default_cooldown", resourceName, "default_cooldown"),
 					resource.TestCheckResourceAttrPair(datasourceName, "desired_capacity", resourceName, "desired_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enabled_metrics.#", resourceName, "enabled_metrics.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "health_check_grace_period", resourceName, "health_check_grace_period"),
 					resource.TestCheckResourceAttrPair(datasourceName, "health_check_type", resourceName, "health_check_type"),
 					resource.TestCheckResourceAttr(datasourceName, "launch_configuration", ""),
@@ -98,6 +100,7 @@ resource "aws_autoscaling_group" "match" {
   health_check_grace_period = 300
   health_check_type         = "ELB"
   desired_capacity          = 0
+  enabled_metrics           = ["GroupDesiredCapacity"]
   force_delete              = true
   launch_configuration      = aws_launch_configuration.data_source_aws_autoscaling_group_test.name
   availability_zones        = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
@@ -110,6 +113,7 @@ resource "aws_autoscaling_group" "no_match" {
   health_check_grace_period = 300
   health_check_type         = "ELB"
   desired_capacity          = 0
+  enabled_metrics           = ["GroupDesiredCapacity", "GroupStandbyInstances"]
   force_delete              = true
   launch_configuration      = aws_launch_configuration.data_source_aws_autoscaling_group_test.name
   availability_zones        = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -31,6 +31,7 @@ interpolation.
 * `availability_zones` - One or more Availability Zones for the group.
 * `default_cool_down` - The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
 * `desired_capacity` - The desired size of the group.
+* `enabled_metrics` - The list of metrics enabled for collection.
 * `health_check_grace_period` - The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before checking the health status of an EC2 instance that has come into service.
 * `health_check_type` - The service to use for the health checks. The valid values are EC2 and ELB.
 * `id` - Name of the Auto Scaling Group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--- Relates OR Closes #0000 --->

### Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAutoScalingGroupDataSource_ PKG=autoscaling

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingGroupDataSource_'  -timeout 180m
=== RUN   TestAccAutoScalingGroupDataSource_basic
=== PAUSE TestAccAutoScalingGroupDataSource_basic
=== RUN   TestAccAutoScalingGroupDataSource_launchTemplate
=== PAUSE TestAccAutoScalingGroupDataSource_launchTemplate
=== CONT  TestAccAutoScalingGroupDataSource_basic
=== CONT  TestAccAutoScalingGroupDataSource_launchTemplate
--- PASS: TestAccAutoScalingGroupDataSource_basic (50.70s)
--- PASS: TestAccAutoScalingGroupDataSource_launchTemplate (51.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	52.232s
```

---

👋 This is my first contribution to this provider. These changes are largely cargo-culted from existing values.
Tried my best to follow the guidelines from [Enhancement/Bugfix to a Resource](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#enhancementbugfix-to-a-resource) & [Basic Acceptance Tests](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#basic-acceptance-tests).

More than happy to make any changes/fixes to make things up-to-snuff.