### PR TITLE
d/aws_location_map - new data source

### DIFF
--- a/.changelog/24693.txt
+++ b/.changelog/24693.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_location_map
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -726,6 +726,8 @@ func Provider() *schema.Provider {
 			"aws_lex_intent":    lexmodels.DataSourceIntent(),
 			"aws_lex_slot_type": lexmodels.DataSourceSlotType(),
 
+			"aws_location_map": location.DataSourceMap(),
+
 			"aws_arn":                     meta.DataSourceARN(),
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),
 			"aws_default_tags":            meta.DataSourceDefaultTags(),

--- a/internal/service/location/map.go
+++ b/internal/service/location/map.go
@@ -60,12 +60,12 @@ func ResourceMap() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
 			"update_time": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}

--- a/internal/service/location/map_data_source.go
+++ b/internal/service/location/map_data_source.go
@@ -1,0 +1,92 @@
+package location
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceMap() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMapRead,
+		Schema: map[string]*schema.Schema{
+			"configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"style": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"map_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"map_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceMapRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.DescribeMapInput{}
+
+	if v, ok := d.GetOk("map_name"); ok {
+		input.MapName = aws.String(v.(string))
+	}
+
+	output, err := conn.DescribeMap(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Location Service Map: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Location Service Map: empty response")
+	}
+
+	d.SetId(aws.StringValue(output.MapName))
+
+	if output.Configuration != nil {
+		d.Set("configuration", []interface{}{flattenConfiguration(output.Configuration)})
+	} else {
+		d.Set("configuration", nil)
+	}
+
+	d.Set("create_time", aws.TimeValue(output.CreateTime).Format(time.RFC3339))
+	d.Set("description", output.Description)
+	d.Set("map_arn", output.MapArn)
+	d.Set("map_name", output.MapName)
+	d.Set("update_time", aws.TimeValue(output.UpdateTime).Format(time.RFC3339))
+	d.Set("tags", KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(meta.(*conns.AWSClient).IgnoreTagsConfig).Map())
+
+	return nil
+}

--- a/internal/service/location/map_data_source.go
+++ b/internal/service/location/map_data_source.go
@@ -45,11 +45,11 @@ func DataSourceMap() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
+			"tags": tftags.TagsSchemaComputed(),
 			"update_time": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
 }

--- a/internal/service/location/map_data_source_test.go
+++ b/internal/service/location/map_data_source_test.go
@@ -1,0 +1,55 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationMapDataSource_mapName(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_map.test"
+	resourceName := "aws_location_map.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigMapDataSource_mapName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "configuration.#", resourceName, "configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "configuration.0.style", resourceName, "configuration.0.style"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_time", resourceName, "create_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "map_arn", resourceName, "map_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "map_name", resourceName, "map_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "update_time", resourceName, "update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigMapDataSource_mapName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_map" "test" {
+  configuration {
+    style = "VectorHereBerlin"
+  }
+
+  map_name = %[1]q
+}
+
+data "aws_location_map" "test" {
+  map_name = aws_location_map.test.map_name
+}
+`, rName)
+}

--- a/website/docs/d/location_map.html.markdown
+++ b/website/docs/d/location_map.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_map"
+description: |-
+    Retrieve information about a Location Service Map.
+---
+
+# Data Source: aws_location_map
+
+Retrieve information about a Location Service Map.
+
+## Example Usage
+
+```terraform
+data "aws_location_map" "example" {
+  map_name = "example"
+}
+```
+
+## Argument Reference
+
+* `map_name` - (Required) The name of the map resource.
+
+## Attribute Reference
+
+* `configuration` - List of configurations that specify the map tile style selected from a partner data provider.
+    * `style` - The map style selected from an available data provider.
+* `create_time` - The timestamp for when the map resource was created in ISO 8601 format.
+* `description` - The optional description for the map resource.
+* `map_arn` - The Amazon Resource Name (ARN) for the map resource.
+* `tags` - Key-value map of resource tags for the map.
+* `update_time` - The timestamp for when the map resource was last updated in ISO 8601.

--- a/website/docs/r/location_map.html.markdown
+++ b/website/docs/r/location_map.html.markdown
@@ -41,7 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `map_arn` - The Amazon Resource Name (ARN) for the map resource. Used to specify a resource across all AWS.
 * `create_time` - The timestamp for when the map resource was created in ISO 8601 format.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
-* `update_time` - The timestamp for when the map resource was last update in ISO 8601.
+* `update_time` - The timestamp for when the map resource was last updated in ISO 8601.
 
 ## configuration
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationMap_|TestAccLocationMapDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationMap_|TestAccLocationMapDataSource_'  -timeout 180m
=== RUN   TestAccLocationMapDataSource_mapName
=== PAUSE TestAccLocationMapDataSource_mapName
=== RUN   TestAccLocationMap_basic
=== PAUSE TestAccLocationMap_basic
=== RUN   TestAccLocationMap_disappears
=== PAUSE TestAccLocationMap_disappears
=== RUN   TestAccLocationMap_description
=== PAUSE TestAccLocationMap_description
=== RUN   TestAccLocationMap_tags
=== PAUSE TestAccLocationMap_tags
=== CONT  TestAccLocationMapDataSource_mapName
=== CONT  TestAccLocationMap_description
=== CONT  TestAccLocationMap_disappears
=== CONT  TestAccLocationMap_tags
=== CONT  TestAccLocationMap_basic
--- PASS: TestAccLocationMap_disappears (20.06s)
--- PASS: TestAccLocationMapDataSource_mapName (24.50s)
--- PASS: TestAccLocationMap_basic (26.84s)
--- PASS: TestAccLocationMap_description (43.26s)
--- PASS: TestAccLocationMap_tags (60.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   62.538s
```
