### PR TITLE
Add retry on `MalformedPolicyDocumentException` to wait for IAM propagation on KMS policy update

### DIFF
--- a/.changelog/24697.txt
+++ b/.changelog/24697.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_key: Retry on `MalformedPolicyDocumentException` errors when updating key policy
+```

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -444,7 +444,7 @@ func updateKeyPolicy(conn *kms.KMS, keyID string, policy string, bypassPolicyLoc
 		return nil, err
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException)
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException, kms.ErrCodeMalformedPolicyDocumentException)
 
 	if err != nil {
 		return fmt.Errorf("error updating KMS Key (%s) policy: %w", keyID, err)

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -267,12 +267,6 @@ func TestAccKMSKey_Policy_iamRoleUpdate(t *testing.T) {
 					testAccCheckKeyExists(resourceName, &key),
 				),
 			},
-			//{
-			//	ResourceName:            resourceName,
-			//	ImportState:             true,
-			//	ImportStateVerify:       true,
-			//	ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
-			//},
 		},
 	})
 }

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -244,6 +244,39 @@ func TestAccKMSKey_Policy_iamRole(t *testing.T) {
 	})
 }
 
+func TestAccKMSKey_Policy_iamRoleUpdate(t *testing.T) {
+	var key kms.KeyMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, kms.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKey_policy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(resourceName, &key),
+				),
+			},
+			{
+				Config: testAccKeyPolicyIAMRoleConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(resourceName, &key),
+				),
+			},
+			//{
+			//	ResourceName:            resourceName,
+			//	ImportState:             true,
+			//	ImportStateVerify:       true,
+			//	ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
+			//},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11801
 func TestAccKMSKey_Policy_iamRoleOrder(t *testing.T) {
 	var key kms.KeyMetadata


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #24696 

This PR proposes to retry KMS policy updates when a `MalformedPolicyDocumentException` occurs. The intention is to avoid failing when a KMS policy reference IAM resources that get created at the same time.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccKMSKey_Policy PKG=kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20 -run='TestAccKMSKey_Policy'  -timeout 180m
--- PASS: TestAccKMSKey_Policy_booleanCondition (68.99s)
--- PASS: TestAccKMSKey_Policy_iamRole (92.13s)
--- PASS: TestAccKMSKey_Policy_bypassUpdate (111.73s)
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (111.79s)
--- PASS: TestAccKMSKey_Policy_basic (120.11s)
--- PASS: TestAccKMSKey_Policy_iamRoleUpdate (125.12s)
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (160.30s)
--- PASS: TestAccKMSKey_Policy_bypass (209.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        212.464s
```
