### PR TITLE
Tech debt: Prefer AWS Go SDK pointer conversion functions for dereferencing when converting int64 to int

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -721,3 +721,13 @@ rules:
         - "internal/**/*_test.go"
     pattern-regex: Providers:\s+(acctest\.)?Providers,
     severity: WARNING
+
+  - id: prefer-aws-go-sdk-pointer-conversion-int-conversion-int64-pointer
+    fix: $VALUE
+    languages: [go]
+    message: Prefer AWS Go SDK pointer conversion functions for dereferencing when converting int64 to int
+    paths:
+      include:
+        - internal/
+    pattern: int(*$VALUE)
+    severity: WARNING

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -38,25 +38,6 @@ func ResourceStack() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"template_body": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidStringIsJSONOrYAML,
-				StateFunc: func(v interface{}) string {
-					template, _ := verify.NormalizeJSONOrYAMLString(v)
-					return template
-				},
-			},
-			"template_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"capabilities": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -71,6 +52,15 @@ func ResourceStack() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"iam_role_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"notification_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -83,14 +73,14 @@ func ResourceStack() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(cloudformation.OnFailure_Values(), false),
 			},
-			"parameters": {
+			"outputs": {
 				Type:     schema.TypeMap,
-				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"outputs": {
+			"parameters": {
 				Type:     schema.TypeMap,
+				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -108,16 +98,26 @@ func ResourceStack() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"template_body": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidStringIsJSONOrYAML,
+				StateFunc: func(v interface{}) string {
+					template, _ := verify.NormalizeJSONOrYAMLString(v)
+					return template
+				},
+			},
+			"template_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"timeout_in_minutes": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
-			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
-			"iam_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
 			},
 		},
 

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -271,7 +271,6 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", stack.StackName)
 	d.Set("iam_role_arn", stack.RoleARN)
 	d.Set("timeout_in_minutes", stack.TimeoutInMinutes)
-	d.Set("description", stack.Description)
 
 	if stack.DisableRollback != nil {
 		d.Set("disable_rollback", stack.DisableRollback)

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -270,13 +270,9 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", stack.StackName)
 	d.Set("iam_role_arn", stack.RoleARN)
+	d.Set("timeout_in_minutes", stack.TimeoutInMinutes)
+	d.Set("description", stack.Description)
 
-	if stack.TimeoutInMinutes != nil {
-		d.Set("timeout_in_minutes", int(*stack.TimeoutInMinutes))
-	}
-	if stack.Description != nil {
-		d.Set("description", stack.Description)
-	}
 	if stack.DisableRollback != nil {
 		d.Set("disable_rollback", stack.DisableRollback)
 

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -384,13 +384,13 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 		m["function_association"] = FlattenFunctionAssociations(cb.FunctionAssociations)
 	}
 	if cb.MaxTTL != nil {
-		m["max_ttl"] = aws.Int64Value(cb.MaxTTL)
+		m["max_ttl"] = int(aws.Int64Value(cb.MaxTTL))
 	}
 	if cb.SmoothStreaming != nil {
 		m["smooth_streaming"] = aws.BoolValue(cb.SmoothStreaming)
 	}
 	if cb.DefaultTTL != nil {
-		m["default_ttl"] = aws.Int64Value(cb.DefaultTTL)
+		m["default_ttl"] = int(aws.Int64Value(cb.DefaultTTL))
 	}
 	if cb.AllowedMethods != nil {
 		m["allowed_methods"] = FlattenAllowedMethods(cb.AllowedMethods)
@@ -1149,7 +1149,7 @@ func FlattenCustomErrorResponse(er *cloudfront.CustomErrorResponse) map[string]i
 	m := make(map[string]interface{})
 	m["error_code"] = int(aws.Int64Value(er.ErrorCode))
 	if er.ErrorCachingMinTTL != nil {
-		m["error_caching_min_ttl"] = aws.Int64Value(er.ErrorCachingMinTTL)
+		m["error_caching_min_ttl"] = int(aws.Int64Value(er.ErrorCachingMinTTL))
 	}
 	if er.ResponseCode != nil {
 		m["response_code"], _ = strconv.Atoi(aws.StringValue(er.ResponseCode))

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -384,13 +384,13 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 		m["function_association"] = FlattenFunctionAssociations(cb.FunctionAssociations)
 	}
 	if cb.MaxTTL != nil {
-		m["max_ttl"] = int(*cb.MaxTTL)
+		m["max_ttl"] = aws.Int64Value(cb.MaxTTL)
 	}
 	if cb.SmoothStreaming != nil {
 		m["smooth_streaming"] = aws.BoolValue(cb.SmoothStreaming)
 	}
 	if cb.DefaultTTL != nil {
-		m["default_ttl"] = int(*cb.DefaultTTL)
+		m["default_ttl"] = aws.Int64Value(cb.DefaultTTL)
 	}
 	if cb.AllowedMethods != nil {
 		m["allowed_methods"] = FlattenAllowedMethods(cb.AllowedMethods)
@@ -1149,10 +1149,10 @@ func FlattenCustomErrorResponse(er *cloudfront.CustomErrorResponse) map[string]i
 	m := make(map[string]interface{})
 	m["error_code"] = int(aws.Int64Value(er.ErrorCode))
 	if er.ErrorCachingMinTTL != nil {
-		m["error_caching_min_ttl"] = int(*er.ErrorCachingMinTTL)
+		m["error_caching_min_ttl"] = aws.Int64Value(er.ErrorCachingMinTTL)
 	}
 	if er.ResponseCode != nil {
-		m["response_code"], _ = strconv.Atoi(*er.ResponseCode)
+		m["response_code"], _ = strconv.Atoi(aws.StringValue(er.ResponseCode))
 	}
 	if er.ResponsePagePath != nil {
 		m["response_page_path"] = aws.StringValue(er.ResponsePagePath)

--- a/internal/service/dax/cluster.go
+++ b/internal/service/dax/cluster.go
@@ -498,10 +498,10 @@ func setDaxClusterNodeData(d *schema.ResourceData, c *dax.Cluster) error {
 			return fmt.Errorf("Unexpected nil pointer in: %s", node)
 		}
 		nodeDate = append(nodeDate, map[string]interface{}{
-			"id":                *node.NodeId,
-			"address":           *node.Endpoint.Address,
-			"port":              int(*node.Endpoint.Port),
-			"availability_zone": *node.AvailabilityZone,
+			"id":                aws.StringValue(node.NodeId),
+			"address":           aws.StringValue(node.Endpoint.Address),
+			"port":              aws.Int64Value(node.Endpoint.Port),
+			"availability_zone": aws.StringValue(node.AvailabilityZone),
 		})
 	}
 

--- a/internal/service/directconnect/bgp_peer_test.go
+++ b/internal/service/directconnect/bgp_peer_test.go
@@ -56,9 +56,9 @@ func testAccCheckBGPPeerDestroy(s *terraform.State) error {
 			return err
 		}
 		for _, peer := range resp.VirtualInterfaces[0].BgpPeers {
-			if *peer.AddressFamily == rs.Primary.Attributes["address_family"] &&
-				strconv.Itoa(int(*peer.Asn)) == rs.Primary.Attributes["bgp_asn"] &&
-				*peer.BgpPeerState != directconnect.BGPPeerStateDeleted {
+			if aws.StringValue(peer.AddressFamily) == rs.Primary.Attributes["address_family"] &&
+				strconv.Itoa(int(aws.Int64Value(peer.Asn))) == rs.Primary.Attributes["bgp_asn"] &&
+				aws.StringValue(peer.BgpPeerState) != directconnect.BGPPeerStateDeleted {
 				return fmt.Errorf("[DESTROY ERROR] Dx BGP peer (%s) not deleted", rs.Primary.ID)
 			}
 		}

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -124,7 +124,7 @@ func TestAccVPCSecurityGroupRule_Ingress_vpc(t *testing.T) {
 		}
 
 		rule := group.IpPermissions[0]
-		if *rule.FromPort != int64(80) {
+		if aws.Int64Value(rule.FromPort) != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
 				80, int(*rule.FromPort))
 		}
@@ -205,7 +205,7 @@ func TestAccVPCSecurityGroupRule_Ingress_protocol(t *testing.T) {
 		rule := group.IpPermissions[0]
 		if *rule.FromPort != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
-				80, int(*rule.FromPort))
+				80, aws.Int64Value(rule.FromPort))
 		}
 
 		return nil
@@ -282,7 +282,7 @@ func TestAccVPCSecurityGroupRule_Ingress_ipv6(t *testing.T) {
 		rule := group.IpPermissions[0]
 		if *rule.FromPort != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
-				80, int(*rule.FromPort))
+				80, aws.Int64Value(rule.FromPort))
 		}
 
 		ipv6Address := rule.Ipv6Ranges[0]
@@ -330,7 +330,7 @@ func TestAccVPCSecurityGroupRule_Ingress_classic(t *testing.T) {
 		rule := group.IpPermissions[0]
 		if *rule.FromPort != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
-				80, int(*rule.FromPort))
+				80, aws.Int64Value(rule.FromPort))
 		}
 
 		return nil
@@ -380,7 +380,7 @@ func TestAccVPCSecurityGroupRule_multiIngress(t *testing.T) {
 
 		if *rule.ToPort != int64(8000) {
 			return fmt.Errorf("Wrong Security Group port 2 setting, expected %d, got %d",
-				8000, int(*rule.ToPort))
+				8000, aws.Int64Value(rule.ToPort))
 		}
 
 		return nil

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -126,7 +126,7 @@ func TestAccVPCSecurityGroupRule_Ingress_vpc(t *testing.T) {
 		rule := group.IpPermissions[0]
 		if aws.Int64Value(rule.FromPort) != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
-				80, int(*rule.FromPort))
+				80, aws.Int64Value(rule.FromPort))
 		}
 
 		return nil

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -759,10 +759,10 @@ func setCacheNodeData(d *schema.ResourceData, c *elasticache.CacheCluster) error
 			return fmt.Errorf("Unexpected nil pointer in: %s", node)
 		}
 		cacheNodeData = append(cacheNodeData, map[string]interface{}{
-			"id":                *node.CacheNodeId,
-			"address":           *node.Endpoint.Address,
-			"port":              int(*node.Endpoint.Port),
-			"availability_zone": *node.CustomerAvailabilityZone,
+			"id":                aws.StringValue(node.CacheNodeId),
+			"address":           aws.StringValue(node.Endpoint.Address),
+			"port":              aws.Int64Value(node.Endpoint.Port),
+			"availability_zone": aws.StringValue(node.CustomerAvailabilityZone),
 		})
 	}
 

--- a/internal/service/elb/backend_server_policy.go
+++ b/internal/service/elb/backend_server_policy.go
@@ -94,7 +94,7 @@ func resourceBackendServerPolicyRead(d *schema.ResourceData, meta interface{}) e
 
 	policyNames := []*string{}
 	for _, backendServer := range lb.BackendServerDescriptions {
-		if instancePort != strconv.Itoa(int(*backendServer.InstancePort)) {
+		if instancePort != strconv.Itoa(int(aws.Int64Value(backendServer.InstancePort))) {
 			continue
 		}
 

--- a/internal/service/elb/listener_policy.go
+++ b/internal/service/elb/listener_policy.go
@@ -94,7 +94,7 @@ func resourceListenerPolicyRead(d *schema.ResourceData, meta interface{}) error 
 
 	policyNames := []*string{}
 	for _, listener := range lb.ListenerDescriptions {
-		if loadBalancerPort != strconv.Itoa(int(*listener.Listener.LoadBalancerPort)) {
+		if loadBalancerPort != strconv.Itoa(int(aws.Int64Value(listener.Listener.LoadBalancerPort))) {
 			continue
 		}
 

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -850,7 +850,7 @@ func (lt *opsworksLayerType) SetVolumeConfigurations(d *schema.ResourceData, v [
 			data["number_of_disks"] = aws.Int64Value(config.NumberOfDisks)
 		}
 		if config.RaidLevel != nil {
-			data["raid_level"] = strconv.Itoa(int(*config.RaidLevel))
+			data["raid_level"] = strconv.Itoa(int(aws.Int64Value(config.RaidLevel)))
 		}
 		if config.Size != nil {
 			data["size"] = aws.Int64Value(config.Size)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12992.

```console
% make testacc TESTARGS='-run=TestAccCloudFormationStack_allAttributes\|TestAccCloudFormationStack_basic' PKG=cloudformation
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 20  -run=TestAccCloudFormationStack_allAttributes\|TestAccCloudFormationStack_basic -timeout 180m
=== RUN   TestAccCloudFormationStack_basic
=== PAUSE TestAccCloudFormationStack_basic
=== RUN   TestAccCloudFormationStack_allAttributes
=== PAUSE TestAccCloudFormationStack_allAttributes
=== CONT  TestAccCloudFormationStack_basic
=== CONT  TestAccCloudFormationStack_allAttributes
--- PASS: TestAccCloudFormationStack_basic (53.94s)
--- PASS: TestAccCloudFormationStack_allAttributes (67.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	71.327s
% go test -v -run=TestCloudFrontStructure_ ./internal/service/cloudfront
=== RUN   TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior
--- PASS: TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior (0.00s)
=== RUN   TestCloudFrontStructure_expandTrustedSigners
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.00s)
=== RUN   TestCloudFrontStructure_flattenTrustedSigners
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.00s)
=== RUN   TestCloudFrontStructure_expandTrustedSigners_empty
--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandLambdaFunctionAssociations
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_flattenlambdaFunctionAssociations
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_expandlambdaFunctionAssociations_empty
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandFunctionAssociations
--- PASS: TestCloudFrontStructure_expandFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_flattenFunctionAssociations
--- PASS: TestCloudFrontStructure_flattenFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_expandFunctionAssociations_empty
--- PASS: TestCloudFrontStructure_expandFunctionAssociations_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandForwardedValues
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.00s)
=== RUN   TestCloudFrontStructure_flattenForwardedValues
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.00s)
=== RUN   TestCloudFrontStructure_expandHeaders
--- PASS: TestCloudFrontStructure_expandHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenHeaders
--- PASS: TestCloudFrontStructure_flattenHeaders (0.00s)
=== RUN   TestCloudFrontStructure_expandQueryStringCacheKeys
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.00s)
=== RUN   TestCloudFrontStructure_flattenQueryStringCacheKeys
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.00s)
=== RUN   TestCloudFrontStructure_expandCookiePreference
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.00s)
=== RUN   TestCloudFrontStructure_flattenCookiePreference
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.00s)
=== RUN   TestCloudFrontStructure_expandCookieNames
--- PASS: TestCloudFrontStructure_expandCookieNames (0.00s)
=== RUN   TestCloudFrontStructure_flattenCookieNames
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.00s)
=== RUN   TestCloudFrontStructure_expandAllowedMethods
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.00s)
=== RUN   TestCloudFrontStructure_flattenAllowedMethods
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.00s)
=== RUN   TestCloudFrontStructure_expandCachedMethods
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.00s)
=== RUN   TestCloudFrontStructure_flattenCachedMethods
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.00s)
=== RUN   TestCloudFrontStructure_expandOrigins
--- PASS: TestCloudFrontStructure_expandOrigins (0.00s)
=== RUN   TestCloudFrontStructure_flattenOrigins
--- PASS: TestCloudFrontStructure_flattenOrigins (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginGroups
--- PASS: TestCloudFrontStructure_expandOriginGroups (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginGroups
--- PASS: TestCloudFrontStructure_flattenOriginGroups (0.00s)
=== RUN   TestCloudFrontStructure_expandOrigin
--- PASS: TestCloudFrontStructure_expandOrigin (0.00s)
=== RUN   TestCloudFrontStructure_flattenOrigin
--- PASS: TestCloudFrontStructure_flattenOrigin (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomHeaders
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomHeaders
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginCustomHeader
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginCustomHeader
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomOriginConfig
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomOriginConfig
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomOriginConfigSSL
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomOriginConfigSSL
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginShield
--- PASS: TestCloudFrontStructure_expandOriginShield (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginShield
--- PASS: TestCloudFrontStructure_flattenOriginShield (0.00s)
=== RUN   TestCloudFrontStructure_expandS3OriginConfig
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_flattenS3OriginConfig
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponses
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomErrorResponses
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponse
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomErrorResponse
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.00s)
=== RUN   TestCloudFrontStructure_expandLoggingConfig
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandLoggingConfig_nilValue
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.00s)
=== RUN   TestCloudFrontStructure_expandAliases
--- PASS: TestCloudFrontStructure_expandAliases (0.00s)
=== RUN   TestCloudFrontStructure_flattenAliases
--- PASS: TestCloudFrontStructure_flattenAliases (0.00s)
=== RUN   TestCloudFrontStructure_expandRestrictions
--- PASS: TestCloudFrontStructure_expandRestrictions (0.00s)
=== RUN   TestCloudFrontStructure_expandGeoRestriction_whitelist
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.00s)
=== RUN   TestCloudFrontStructure_flattenGeoRestriction_whitelist
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.00s)
=== RUN   TestCloudFrontStructure_expandGeoRestriction_no_items
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.00s)
=== RUN   TestCloudFrontStructure_flattenGeoRestriction_no_items
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	4.388s
% make testacc TESTS=TestAccDAXCluster_basic PKG=dax
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dax/... -v -count 1 -parallel 20 -run='TestAccDAXCluster_basic'  -timeout 180m
=== RUN   TestAccDAXCluster_basic
=== PAUSE TestAccDAXCluster_basic
=== CONT  TestAccDAXCluster_basic
--- PASS: TestAccDAXCluster_basic (635.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	639.032s
% make testacc TESTS=TestAccElastiCacheCluster_Engine_redis PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_Engine_redis'  -timeout 180m
=== RUN   TestAccElastiCacheCluster_Engine_redis
=== PAUSE TestAccElastiCacheCluster_Engine_redis
=== RUN   TestAccElastiCacheCluster_Engine_redis_v5
=== PAUSE TestAccElastiCacheCluster_Engine_redis_v5
=== CONT  TestAccElastiCacheCluster_Engine_redis
=== CONT  TestAccElastiCacheCluster_Engine_redis_v5
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (500.55s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (521.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	525.285s
% make testacc TESTARGS='-run=TestAccELBListenerPolicy_basic\|TestAccELBBackendServerPolicy_basic' PKG=elb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elb/... -v -count 1 -parallel 20  -run=TestAccELBListenerPolicy_basic\|TestAccELBBackendServerPolicy_basic -timeout 180m
=== RUN   TestAccELBBackendServerPolicy_basic
=== PAUSE TestAccELBBackendServerPolicy_basic
=== RUN   TestAccELBListenerPolicy_basic
=== PAUSE TestAccELBListenerPolicy_basic
=== CONT  TestAccELBBackendServerPolicy_basic
=== CONT  TestAccELBListenerPolicy_basic
--- PASS: TestAccELBListenerPolicy_basic (46.50s)
--- PASS: TestAccELBBackendServerPolicy_basic (57.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	61.699s
% make testacc TESTARGS='-run=TestAccOpsWorksCustomLayer_noVPC' PKG=opsworks
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 20  -run=TestAccOpsWorksCustomLayer_noVPC -timeout 180m
=== RUN   TestAccOpsWorksCustomLayer_noVPC
=== PAUSE TestAccOpsWorksCustomLayer_noVPC
=== CONT  TestAccOpsWorksCustomLayer_noVPC
--- PASS: TestAccOpsWorksCustomLayer_noVPC (51.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	55.671s
```