### PR TITLE
r/aws_imagebuilder_image_recipe: `ForceNew` resource on updates

### DIFF
--- a/.changelog/24708.txt
+++ b/.changelog/24708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ resource/aws_imagebuilder_image_recipe: Fix `ResourceDependencyException` errors when a dependency is modified
+ ```

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -132,6 +132,7 @@ func ResourceImageRecipe() *schema.Resource {
 						"component_arn": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"parameter": {
@@ -142,11 +143,13 @@ func ResourceImageRecipe() *schema.Resource {
 									"name": {
 										Type:         schema.TypeString,
 										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -161,6 +164,7 @@ func ResourceImageRecipe() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"name": {
@@ -194,6 +198,7 @@ func ResourceImageRecipe() *schema.Resource {
 						"uninstall_after_build": {
 							Type:     schema.TypeBool,
 							Required: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -53,7 +53,7 @@ func TestAccImageRecipe_basic(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_disappears(t *testing.T) {
+func TestAccImageRecipe_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -75,7 +75,7 @@ func TestAccImageBuilderImageRecipe_disappears(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMapping_deviceName(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -104,7 +104,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName(t *testing.T) 
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_deleteOnTermination(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -133,7 +133,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination(t 
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_encrypted(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -162,7 +162,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted(t *testing.T
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_iops(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -191,7 +191,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_kmsKeyID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_imagebuilder_image_recipe.test"
@@ -219,7 +219,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID(t *testing.T)
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_snapshotID(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	ebsSnapshotResourceName := "aws_ebs_snapshot.test"
 	resourceName := "aws_imagebuilder_image_recipe.test"
@@ -247,7 +247,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID(t *testing.
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_volumeSize(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -276,7 +276,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize(t *testing.
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -305,7 +305,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2(t *testi
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -334,7 +334,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3(t *testi
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMapping_noDevice(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -363,7 +363,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName(t *testing.T) {
+func TestAccImageRecipe_BlockDeviceMapping_virtualName(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -392,7 +392,7 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName(t *testing.T)
 	})
 }
 
-func TestAccImageBuilderImageRecipe_component(t *testing.T) {
+func TestAccImageRecipe_component(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -421,7 +421,7 @@ func TestAccImageBuilderImageRecipe_component(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_componentParameter(t *testing.T) {
+func TestAccImageRecipe_componentParameter(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -447,7 +447,7 @@ func TestAccImageBuilderImageRecipe_componentParameter(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_description(t *testing.T) {
+func TestAccImageRecipe_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -473,7 +473,7 @@ func TestAccImageBuilderImageRecipe_description(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_tags(t *testing.T) {
+func TestAccImageRecipe_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -517,7 +517,7 @@ func TestAccImageBuilderImageRecipe_tags(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_workingDirectory(t *testing.T) {
+func TestAccImageRecipe_workingDirectory(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -543,7 +543,7 @@ func TestAccImageBuilderImageRecipe_workingDirectory(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_pipelineUpdateDependency(t *testing.T) {
+func TestAccImageRecipe_pipelineUpdateDependency(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -569,7 +569,7 @@ func TestAccImageBuilderImageRecipe_pipelineUpdateDependency(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_systemsManagerAgent(t *testing.T) {
+func TestAccImageRecipe_systemsManagerAgent(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -596,7 +596,7 @@ func TestAccImageBuilderImageRecipe_systemsManagerAgent(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_updateDependency(t *testing.T) {
+func TestAccImageRecipe_updateDependency(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -631,7 +631,7 @@ func TestAccImageBuilderImageRecipe_updateDependency(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_userDataBase64(t *testing.T) {
+func TestAccImageRecipe_userDataBase64(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -657,7 +657,7 @@ func TestAccImageBuilderImageRecipe_userDataBase64(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageRecipe_WindowsBaseImage(t *testing.T) {
+func TestAccImageRecipe_WindowsBaseImage(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22127

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccImageRecipe_ PKG=imagebuilder

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageRecipe_'  -timeout 180m
=== RUN   TestAccImageRecipe_basic
=== PAUSE TestAccImageRecipe_basic
=== RUN   TestAccImageRecipe_disappears
=== PAUSE TestAccImageRecipe_disappears
=== RUN   TestAccImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageRecipe_component
=== PAUSE TestAccImageRecipe_component
=== RUN   TestAccImageRecipe_componentParameter
=== PAUSE TestAccImageRecipe_componentParameter
=== RUN   TestAccImageRecipe_description
=== PAUSE TestAccImageRecipe_description
=== RUN   TestAccImageRecipe_tags
=== PAUSE TestAccImageRecipe_tags
=== RUN   TestAccImageRecipe_workingDirectory
=== PAUSE TestAccImageRecipe_workingDirectory
=== RUN   TestAccImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageRecipe_systemsManagerAgent
=== PAUSE TestAccImageRecipe_systemsManagerAgent
=== RUN   TestAccImageRecipe_componentUpdateDependency
=== PAUSE TestAccImageRecipe_componentUpdateDependency
=== RUN   TestAccImageRecipe_userDataBase64
=== PAUSE TestAccImageRecipe_userDataBase64
=== RUN   TestAccImageRecipe_WindowsBaseImage
=== PAUSE TestAccImageRecipe_WindowsBaseImage
=== CONT  TestAccImageRecipe_basic
=== CONT  TestAccImageRecipe_BlockDeviceMapping_virtualName
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageRecipe_pipelineUpdateDependency
=== CONT  TestAccImageRecipe_workingDirectory
=== CONT  TestAccImageRecipe_tags
=== CONT  TestAccImageRecipe_WindowsBaseImage
=== CONT  TestAccImageRecipe_description
=== CONT  TestAccImageRecipe_userDataBase64
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageRecipe_componentParameter
=== CONT  TestAccImageRecipe_systemsManagerAgent
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_iops
=== CONT  TestAccImageRecipe_component
=== CONT  TestAccImageRecipe_componentUpdateDependency
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageRecipe_BlockDeviceMapping_noDevice
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_snapshotID
--- PASS: TestAccImageRecipe_componentParameter (26.94s)
=== CONT  TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
--- PASS: TestAccImageRecipe_systemsManagerAgent (27.29s)
=== CONT  TestAccImageRecipe_disappears
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (27.35s)
=== CONT  TestAccImageRecipe_BlockDeviceMapping_deviceName
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_iops (27.66s)
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (27.69s)
--- PASS: TestAccImageRecipe_workingDirectory (29.05s)
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_encrypted (29.67s)
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_kmsKeyID (29.71s)
--- PASS: TestAccImageRecipe_WindowsBaseImage (29.95s)
--- PASS: TestAccImageRecipe_BlockDeviceMapping_noDevice (30.11s)
--- PASS: TestAccImageRecipe_description (34.81s)
--- PASS: TestAccImageRecipe_BlockDeviceMapping_virtualName (35.09s)
--- PASS: TestAccImageRecipe_basic (35.19s)
--- PASS: TestAccImageRecipe_userDataBase64 (35.25s)
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_volumeSize (41.12s)
--- PASS: TestAccImageRecipe_BlockDeviceMapping_deviceName (16.92s)
--- PASS: TestAccImageRecipe_disappears (17.50s)
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (17.89s)
--- PASS: TestAccImageRecipe_component (48.02s)
--- PASS: TestAccImageRecipe_pipelineUpdateDependency (48.69s)
--- PASS: TestAccImageRecipe_BlockDeviceMappingEBS_snapshotID (48.70s)
--- PASS: TestAccImageRecipe_componentUpdateDependency (49.64s)
--- PASS: TestAccImageRecipe_tags (50.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	53.302s
...
```
