### PR TITLE
Fix `golangci-lint` errors

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -612,7 +612,7 @@ func PreCheckAlternateAccount(t *testing.T) {
 func PreCheckPartitionHasService(serviceId string, t *testing.T) {
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), Region()); ok {
 		if _, ok := partition.Services()[serviceId]; !ok {
-			t.Skip(fmt.Sprintf("skipping tests; partition %s does not support %s service", partition.ID(), serviceId))
+			t.Skipf("skipping tests; partition %s does not support %s service", partition.ID(), serviceId)
 		}
 	}
 }

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -1029,11 +1029,6 @@ func flattenCustomizedCapacityMetricSpecification(customizedCapacityMetricSpecif
 }
 
 func flattenMetricDataQueries(metricDataQueries []*autoscaling.MetricDataQuery) []interface{} {
-	metricDataQueriesFlat := map[string]interface{}{}
-	if metricDataQueriesFlat == nil {
-		return []interface{}{}
-	}
-
 	metricDataQueriesSpec := make([]interface{}, len(metricDataQueries))
 	for i := range metricDataQueriesSpec {
 		metricDataQuery := map[string]interface{}{}

--- a/internal/service/sagemaker/app_image_config.go
+++ b/internal/service/sagemaker/app_image_config.go
@@ -283,10 +283,6 @@ func expandAppImageConfigKernelGatewayImageConfigKernelSpecs(tfList []interface{
 			kernelSpec.DisplayName = aws.String(v)
 		}
 
-		if kernelSpec == nil {
-			continue
-		}
-
 		kernelSpecs = append(kernelSpecs, kernelSpec)
 	}
 

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -846,10 +846,6 @@ func expandWorkflowDetail(tfList []interface{}) []*transfer.WorkflowDetail {
 			apiObject.WorkflowId = aws.String(v)
 		}
 
-		if apiObject == nil {
-			continue
-		}
-
 		apiObjects = append(apiObjects, apiObject)
 	}
 

--- a/internal/service/transfer/workflow.go
+++ b/internal/service/transfer/workflow.go
@@ -576,10 +576,6 @@ func expandWorkflows(tfList []interface{}) []*transfer.WorkflowStep {
 			apiObject.TagStepDetails = expandTagStepDetails(v)
 		}
 
-		if apiObject == nil {
-			continue
-		}
-
 		apiObjects = append(apiObjects, apiObject)
 	}
 
@@ -948,10 +944,6 @@ func expandS3Tags(tfList []interface{}) []*transfer.S3Tag {
 
 		if v, ok := tfMap["value"].(string); ok && v != "" {
 			apiObject.Value = aws.String(v)
-		}
-
-		if apiObject == nil {
-			continue
 		}
 
 		apiObjects = append(apiObjects, apiObject)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/24718.

Fixes:

```console
% make golangci-lint 
==> Checking source code with golangci-lint...
internal/acctest/acctest.go:615:4: S1038: should use t.Skipf(...) instead of t.Skip(fmt.Sprintf(...)) (gosimple)
			t.Skip(fmt.Sprintf("skipping tests; partition %s does not support %s service", partition.ID(), serviceId))
			^
internal/service/transfer/server.go:849:6: SA4031: this nil check is never true (staticcheck)
		if apiObject == nil {
		   ^
internal/service/transfer/server.go:839:17: SA4031(related information): this is the value of apiObject (staticcheck)
		apiObject := &transfer.WorkflowDetail{}
		              ^
internal/service/transfer/workflow.go:579:6: SA4031: this nil check is never true (staticcheck)
		if apiObject == nil {
		   ^
internal/service/transfer/workflow.go:559:17: SA4031(related information): this is the value of apiObject (staticcheck)
		apiObject := &transfer.WorkflowStep{
		              ^
internal/service/transfer/workflow.go:953:6: SA4031: this nil check is never true (staticcheck)
		if apiObject == nil {
		   ^
internal/service/transfer/workflow.go:943:17: SA4031(related information): this is the value of apiObject (staticcheck)
		apiObject := &transfer.S3Tag{}
		              ^
internal/service/autoscaling/policy.go:1033:5: SA4031: this nil check is never true (staticcheck)
	if metricDataQueriesFlat == nil {
	   ^
internal/service/autoscaling/policy.go:1032:27: SA4031(related information): this is the value of metricDataQueriesFlat (staticcheck)
	metricDataQueriesFlat := map[string]interface{}{}
	                         ^
internal/service/sagemaker/app_image_config.go:286:6: SA4031: this nil check is never true (staticcheck)
		if kernelSpec == nil {
		   ^
internal/service/sagemaker/app_image_config.go:278:18: SA4031(related information): this is the value of kernelSpec (staticcheck)
		kernelSpec := &sagemaker.KernelSpec{
		               ^
make: *** [golangci-lint] Error 1
```