### PR TITLE
Updated lambda environment.variables docs with non empty requirement

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -293,7 +293,7 @@ Dead letter queue configuration that specifies the queue or topic where Lambda s
 
 ### environment
 
-* `variables` - (Optional) Map of environment variables that are accessible from the function code during execution.
+* `variables` - (Optional) Map of environment variables that are accessible from the function code during execution. If provided at least one key must be present.
 
 ### ephemeral_storage
 


### PR DESCRIPTION
The documentation did not reflect the requirement that an `aws_lambda_function.environment.variables` argument cannot be an empty map. This PR adds a quick sentence to reflect the reality of the API.

Pictured below is the error message I got when I had the following terraform:

```hcl
resource "aws_lambda_function" "lambda" {
  # ...
  environment {
    variables = {}
  }
}
```

![image](https://user-images.githubusercontent.com/86365960/167667098-46d7b3dc-a019-4fa7-b5c4-33ea4027713a.png)


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->