### PR TITLE
aws_db_parameter_group: add note to docs about perpetual diff/drift

### DIFF
--- a/website/docs/r/db_parameter_group.html.markdown
+++ b/website/docs/r/db_parameter_group.html.markdown
@@ -18,6 +18,12 @@ Provides an RDS DB parameter group resource .Documentation of the available para
 
 > **Hands-on:** For an example of the `aws_db_parameter_group` in use, follow the [Manage AWS RDS Instances](https://learn.hashicorp.com/tutorials/terraform/aws-rds?in=terraform/aws&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
+~> **NOTE:** After applying your changes, you may encounter a perpetual diff in your Terraform plan
+output for a `parameter` whose `value` remains unchanged but whose `apply_method` is changing
+(e.g. from `immediate` to `pending-reboot`, or `pending-reboot` to `immediate`).  If only the
+apply method of a parameter is changing, the AWS API will not register this change.  To change
+the `apply_method` of a parameter, its value must also change.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
This PR adds the following note to the `aws_db_parameter_group` resource documentation page, to explain why some people might encounter a perpetual diff in their Terraform code.  I encountered this recently and it took me some time to understand what was happening.  I'm hoping this might help others understand their issue more quickly.

![image](https://user-images.githubusercontent.com/6306623/167755675-8e059c22-b6ef-4c28-acc1-9eab9fe480e3.png)

I had initially created an RDS Parameter Group with the `max_heap_table_size` parameter set with an apply method of `pending-reboot`.  I subsequently changed only the apply method to `immediate`.  After a successful `terraform apply` of this change (i.e. no errors), a subsequent `terraform plan` showed the same diff to be applied, perpetually.

```
  # module.database.aws_db_parameter_group.db_alt[0] will be updated in-place
  ~ resource "aws_db_parameter_group" "db_alt" {
        id          = "prd-us-east-1-artifactory-db-alt"
        name        = "prd-us-east-1-artifactory-db-alt"
        tags        = {}
        # (4 unchanged attributes hidden)

      + parameter {
          + apply_method = "immediate"
          + name         = "max_heap_table_size"
          + value        = "536870912"
        }
      - parameter {
          - apply_method = "pending-reboot" -> null
          - name         = "max_heap_table_size" -> null
          - value        = "536870912" -> null
        }
        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The problem does not appear to be with Terraform.  Instead, it appears to be a behavior of the AWS API.  I was able to confirm this with the `aws` CLI.

Here, I obtain the parameter, showing the `ApplyMethod` set to `pending-reboot`.

```
$ aws rds describe-db-parameters --db-parameter-group-name prd-us-east-1-artifactory-db-alt \
    | jq '.Parameters[] | select(.ParameterName == "max_heap_table_size")'

{
  "ParameterName": "max_heap_table_size",
  "ParameterValue": "536870912",
  "Description": "Maximum size to which MEMORY tables are allowed to grow.",
  "Source": "user",
  "ApplyType": "dynamic",
  "DataType": "integer",
  "AllowedValues": "16384-1844674407370954752",
  "IsModifiable": true,
  "ApplyMethod": "pending-reboot"
}
```

Next, I modify the parameter with the `aws` CLI, changing only the `ApplyMethod` to `immediate`.  (Same as what Terraform attempted to do.)  No errors.

```
$ aws rds modify-db-parameter-group --db-parameter-group-name prd-us-east-1-artifactory-db-alt \
    --parameters "ParameterName='max_heap_table_size',ParameterValue='536870912',ApplyMethod='immediate'"

{
    "DBParameterGroupName": "prd-us-east-1-artifactory-db-alt"
}
```

And once more, I fetch the parameter using the `aws` CLI.  The `ApplyMethod` remains unchanged.

```
$ aws rds describe-db-parameters --db-parameter-group-name prd-us-east-1-artifactory-db-alt \
    | jq '.Parameters[] | select(.ParameterName == "max_heap_table_size")'
{
  "ParameterName": "max_heap_table_size",
  "ParameterValue": "536870912",
  "Description": "Maximum size to which MEMORY tables are allowed to grow.",
  "Source": "user",
  "ApplyType": "dynamic",
  "DataType": "integer",
  "AllowedValues": "16384-1844674407370954752",
  "IsModifiable": true,
  "ApplyMethod": "pending-reboot"
}
```

The only way I have found to change the `ApplyMethod` is to also change the `ParameterValue`, which I do in the following example, by incrementing the value by 1 (from `536870912` to `536870913`).

```
$ aws rds modify-db-parameter-group --db-parameter-group-name prd-us-east-1-artifactory-db-alt \
    --parameters "ParameterName='max_heap_table_size',ParameterValue='536870913',ApplyMethod='immediate'"

{
    "DBParameterGroupName": "prd-us-east-1-artifactory-db-alt"
}
```

The `aws` CLI confirms the `ApplyMethod` (along with the `ParameterValue`) is changed.

```
$ aws rds describe-db-parameters --db-parameter-group-name prd-us-east-1-artifactory-db-alt \
    | jq '.Parameters[] | select(.ParameterName == "max_heap_table_size")'

{
  "ParameterName": "max_heap_table_size",
  "ParameterValue": "536870913",
  "Description": "Maximum size to which MEMORY tables are allowed to grow.",
  "Source": "user",
  "ApplyType": "dynamic",
  "DataType": "integer",
  "AllowedValues": "16384-1844674407370954752",
  "IsModifiable": true,
  "ApplyMethod": "immediate"
}
```

The same thing can be done with Terraform to resolve the perpetual drift.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20660
Relates #22028
