### PR TITLE
Tech debt: Prefer `(*awserr.Error)` instead of `(*awserr.Error).Code()` / `(*awserr.Error).Message()` in `fmt.Errorf()`

### DIFF
--- a/.changelog/24745.txt
+++ b/.changelog/24745.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ resource/aws_ebs_volume: Add configurable timeouts
+ ```

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -746,3 +746,15 @@ rules:
               if $AWSERR.Code() == $CODE { $BODY }
             }
     severity: WARNING
+
+  - id: fmt-Errorf-awserr-Error-Code
+    languages: [go]
+    message: Prefer `err` with `%w` format verb instead of `err.Code()` or `err.Message()`
+    paths:
+      include:
+        - internal/
+    patterns:
+      - pattern-either:
+        - pattern: fmt.Errorf(..., $ERR.Code(), ...)
+        - pattern: fmt.Errorf(..., $ERR.Message(), ...)
+    severity: WARNING

--- a/internal/service/autoscaling/notification.go
+++ b/internal/service/autoscaling/notification.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -169,13 +168,12 @@ func addNotificationConfigToGroupsWithTopic(conn *autoscaling.AutoScaling, group
 		}
 
 		_, err := conn.PutNotificationConfiguration(opts)
+
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				return fmt.Errorf("Error creating Autoscaling Group Notification for Group %s, error: \"%s\", code: \"%s\"", *a, awsErr.Message(), awsErr.Code())
-			}
-			return err
+			return fmt.Errorf("Error creating Autoscaling Group Notification for Group (%s): %w", aws.StringValue(a), err)
 		}
 	}
+
 	return nil
 }
 

--- a/internal/service/autoscaling/notification.go
+++ b/internal/service/autoscaling/notification.go
@@ -19,24 +19,20 @@ func ResourceNotification() *schema.Resource {
 		Delete: resourceNotificationDelete,
 
 		Schema: map[string]*schema.Schema{
-			"topic_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"group_names": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
-
 			"notifications": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+			},
+			"topic_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -69,6 +69,12 @@ func ResourceEBSVolume() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"outpost_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -82,17 +88,6 @@ func ResourceEBSVolume() *schema.Resource {
 				ForceNew:     true,
 				AtLeastOneOf: []string{"size", "snapshot_id"},
 			},
-			"outpost_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"throughput": {
@@ -100,6 +95,11 @@ func ResourceEBSVolume() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.IntBetween(125, 1000),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/internal/service/ec2/ebs_volume_attachment.go
+++ b/internal/service/ec2/ebs_volume_attachment.go
@@ -22,6 +22,7 @@ func ResourceVolumeAttachment() *schema.Resource {
 		Read:   resourceVolumeAttachmentRead,
 		Update: resourceVolumeAttachmentUpdate,
 		Delete: resourceVolumeAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), ":")
@@ -45,22 +46,14 @@ func ResourceVolumeAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
+			"force_detach": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"instance_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-
-			"volume_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"force_detach": {
-				Type:     schema.TypeBool,
-				Optional: true,
 			},
 			"skip_destroy": {
 				Type:     schema.TypeBool,
@@ -69,6 +62,11 @@ func ResourceVolumeAttachment() *schema.Resource {
 			"stop_instance_before_detaching": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/internal/service/ec2/ebs_volume_attachment_test.go
+++ b/internal/service/ec2/ebs_volume_attachment_test.go
@@ -7,18 +7,16 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccEC2EBSVolumeAttachment_basic(t *testing.T) {
-	var i ec2.Instance
-	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -31,10 +29,8 @@ func TestAccEC2EBSVolumeAttachment_basic(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists("aws_instance.test", &i),
-					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
-					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -48,8 +44,6 @@ func TestAccEC2EBSVolumeAttachment_basic(t *testing.T) {
 }
 
 func TestAccEC2EBSVolumeAttachment_skipDestroy(t *testing.T) {
-	var i ec2.Instance
-	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -62,10 +56,8 @@ func TestAccEC2EBSVolumeAttachment_skipDestroy(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfigSkipDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists("aws_instance.test", &i),
-					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
-					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -83,7 +75,6 @@ func TestAccEC2EBSVolumeAttachment_skipDestroy(t *testing.T) {
 
 func TestAccEC2EBSVolumeAttachment_attachStopped(t *testing.T) {
 	var i ec2.Instance
-	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -113,10 +104,8 @@ func TestAccEC2EBSVolumeAttachment_attachStopped(t *testing.T) {
 				PreConfig: stopInstance,
 				Config:    testAccVolumeAttachmentConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists("aws_instance.test", &i),
-					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
-					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -194,7 +183,7 @@ func TestAccEC2EBSVolumeAttachment_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.test", &i),
 					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
-					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
+					testAccCheckVolumeAttachmentExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVolumeAttachment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -204,8 +193,6 @@ func TestAccEC2EBSVolumeAttachment_disappears(t *testing.T) {
 }
 
 func TestAccEC2EBSVolumeAttachment_stopInstance(t *testing.T) {
-	var i ec2.Instance
-	var v ec2.Volume
 	resourceName := "aws_volume_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -218,10 +205,8 @@ func TestAccEC2EBSVolumeAttachment_stopInstance(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentStopInstanceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists("aws_instance.test", &i),
-					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
-					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -237,7 +222,7 @@ func TestAccEC2EBSVolumeAttachment_stopInstance(t *testing.T) {
 	})
 }
 
-func testAccCheckVolumeAttachmentExists(n string, i *ec2.Instance, v *ec2.Volume) resource.TestCheckFunc {
+func testAccCheckVolumeAttachmentExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -245,21 +230,18 @@ func testAccCheckVolumeAttachmentExists(n string, i *ec2.Instance, v *ec2.Volume
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("No EBS Volume Attachment ID is set")
 		}
 
-		for _, b := range i.BlockDeviceMappings {
-			if rs.Primary.Attributes["device_name"] == aws.StringValue(b.DeviceName) {
-				if b.Ebs.VolumeId != nil &&
-					rs.Primary.Attributes["volume_id"] == aws.StringValue(b.Ebs.VolumeId) &&
-					rs.Primary.Attributes["volume_id"] == aws.StringValue(v.VolumeId) {
-					// pass
-					return nil
-				}
-			}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+		_, err := tfec2.FindEBSVolumeAttachment(conn, rs.Primary.Attributes["volume_id"], rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["device_name"])
+
+		if err != nil {
+			return err
 		}
 
-		return fmt.Errorf("Error finding instance/volume")
+		return nil
 	}
 }
 
@@ -271,28 +253,19 @@ func testAccCheckVolumeAttachmentDestroy(s *terraform.State) error {
 			continue
 		}
 
-		request := &ec2.DescribeVolumesInput{
-			VolumeIds: []*string{aws.String(rs.Primary.Attributes["volume_id"])},
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("attachment.device"),
-					Values: []*string{aws.String(rs.Primary.Attributes["device_name"])},
-				},
-				{
-					Name:   aws.String("attachment.instance-id"),
-					Values: []*string{aws.String(rs.Primary.Attributes["instance_id"])},
-				},
-			},
+		_, err := tfec2.FindEBSVolumeAttachment(conn, rs.Primary.Attributes["volume_id"], rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["device_name"])
+
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		_, err := conn.DescribeVolumes(request)
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, "InvalidVolume.NotFound") {
-				return nil
-			}
-			return fmt.Errorf("error describing volumes (%s): %s", rs.Primary.ID, err)
+			return err
 		}
+
+		return fmt.Errorf("EBS Volume Attachment %s still exists", rs.Primary.ID)
 	}
+
 	return nil
 }
 

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -85,6 +85,7 @@ const (
 	ErrCodeInvalidVpnGatewayIDNotFound                    = "InvalidVpnGatewayID.NotFound"
 	ErrCodeNatGatewayNotFound                             = "NatGatewayNotFound"
 	ErrCodeUnsupportedOperation                           = "UnsupportedOperation"
+	ErrCodeVolumeInUse                                    = "VolumeInUse"
 )
 
 func CancelSpotFleetRequestError(apiObject *ec2.CancelSpotFleetRequestsErrorItem) error {

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -573,6 +573,48 @@ func FindEBSVolume(conn *ec2.EC2, input *ec2.DescribeVolumesInput) (*ec2.Volume,
 	return output[0], nil
 }
 
+func FindEBSVolumeAttachment(conn *ec2.EC2, volumeID, instanceID, deviceName string) (*ec2.VolumeAttachment, error) {
+	input := &ec2.DescribeVolumesInput{
+		Filters: BuildAttributeFilterList(map[string]string{
+			"attachment.device":      deviceName,
+			"attachment.instance-id": instanceID,
+		}),
+		VolumeIds: aws.StringSlice([]string{volumeID}),
+	}
+
+	output, err := FindEBSVolume(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if state := aws.StringValue(output.State); state == ec2.VolumeStateAvailable {
+		return nil, &resource.NotFoundError{
+			Message:     state,
+			LastRequest: input,
+		}
+	}
+
+	// Eventual consistency check.
+	if aws.StringValue(output.VolumeId) != volumeID {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	for _, v := range output.Attachments {
+		if aws.StringValue(v.State) == ec2.VolumeAttachmentStateDetached {
+			continue
+		}
+
+		if aws.StringValue(v.Device) == deviceName && aws.StringValue(v.InstanceId) == instanceID {
+			return v, nil
+		}
+	}
+
+	return nil, &resource.NotFoundError{}
+}
+
 func FindEIPs(conn *ec2.EC2, input *ec2.DescribeAddressesInput) ([]*ec2.Address, error) {
 	var addresses []*ec2.Address
 

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -761,6 +761,22 @@ func StatusTransitGatewayRouteTablePropagationState(conn *ec2.EC2, transitGatewa
 	}
 }
 
+func StatusVolumeAttachmentState(conn *ec2.EC2, volumeID, instanceID, deviceName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindEBSVolumeAttachment(conn, volumeID, instanceID, deviceName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.State), nil
+	}
+}
+
 func StatusVolumeModificationState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindVolumeModificationByID(conn, id)

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -761,6 +761,22 @@ func StatusTransitGatewayRouteTablePropagationState(conn *ec2.EC2, transitGatewa
 	}
 }
 
+func StatusVolumeState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindEBSVolumeByID(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.State), nil
+	}
+}
+
 func StatusVolumeAttachmentState(conn *ec2.EC2, volumeID, instanceID, deviceName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindEBSVolumeAttachment(conn, volumeID, instanceID, deviceName)

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1318,6 +1318,25 @@ func WaitTransitGatewayRouteTablePropagationStateDisabled(conn *ec2.EC2, transit
 	return nil, err
 }
 
+func WaitVolumeAttachmentDeleted(conn *ec2.EC2, volumeID, instanceID, deviceName string, timeout time.Duration) (*ec2.VolumeAttachment, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ec2.VolumeAttachmentStateDetaching},
+		Target:     []string{},
+		Refresh:    StatusVolumeAttachmentState(conn, volumeID, instanceID, deviceName),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.VolumeAttachment); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func WaitVolumeModificationComplete(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.VolumeModification, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.VolumeModificationStateModifying},

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1318,6 +1318,25 @@ func WaitTransitGatewayRouteTablePropagationStateDisabled(conn *ec2.EC2, transit
 	return nil, err
 }
 
+func WaitVolumeCreated(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.Volume, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ec2.VolumeStateCreating},
+		Target:     []string{ec2.VolumeStateAvailable},
+		Refresh:    StatusVolumeState(conn, id),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.Volume); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func WaitVolumeDeleted(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.Volume, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{ec2.VolumeStateDeleting},

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1318,6 +1318,25 @@ func WaitTransitGatewayRouteTablePropagationStateDisabled(conn *ec2.EC2, transit
 	return nil, err
 }
 
+func WaitVolumeAttachmentCreated(conn *ec2.EC2, volumeID, instanceID, deviceName string, timeout time.Duration) (*ec2.VolumeAttachment, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ec2.VolumeAttachmentStateAttaching},
+		Target:     []string{ec2.VolumeAttachmentStateAttached},
+		Refresh:    StatusVolumeAttachmentState(conn, volumeID, instanceID, deviceName),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.VolumeAttachment); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func WaitVolumeAttachmentDeleted(conn *ec2.EC2, volumeID, instanceID, deviceName string, timeout time.Duration) (*ec2.VolumeAttachment, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{ec2.VolumeAttachmentStateDetaching},

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1318,6 +1318,25 @@ func WaitTransitGatewayRouteTablePropagationStateDisabled(conn *ec2.EC2, transit
 	return nil, err
 }
 
+func WaitVolumeDeleted(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.Volume, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ec2.VolumeStateDeleting},
+		Target:     []string{},
+		Refresh:    StatusVolumeState(conn, id),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.Volume); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func WaitVolumeAttachmentCreated(conn *ec2.EC2, volumeID, instanceID, deviceName string, timeout time.Duration) (*ec2.VolumeAttachment, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{ec2.VolumeAttachmentStateAttaching},

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -51,6 +51,14 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The volume ARN (e.g., arn:aws:ec2:us-east-1:0123456789012:volume/vol-59fcb34e).
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
+## Timeouts
+
+`aws_ebs_volume` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+- `create` - (Default `5 minutes`) Used for creating volumes. This includes the time required for the volume to become available
+- `update` - (Default `5 minutes`) Used for `size`, `type`, or `iops` volume changes
+- `delete` - (Default `5 minutes`) Used for destroying volumes
+
 ## Import
 
 EBS Volumes can be imported using the `id`, e.g.,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/12987.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/8349.

Fixes:

```console
% semgrep --config .semgrep.yml 
Scanning 3906 files.
  100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|3906/3906 tasks

Findings:

  internal/service/autoscaling/notification.go 
     fmt-Errorf-awserr-Error-Code
        Prefer `err` with `%w` format verb instead of `err.Code()` or `err.Message()`

        174┆ return fmt.Errorf("Error creating Autoscaling Group Notification for Group %s, error: \"%s\", code: \"%s\"", *a, awsErr.Message(), awsErr.Code())


  internal/service/ec2/ebs_volume_attachment.go 
     fmt-Errorf-awserr-Error-Code
        Prefer `err` with `%w` format verb instead of `err.Code()` or `err.Message()`

        120┆ return fmt.Errorf("Error attaching volume (%s) to instance (%s), message: \"%s\", code: \"%s\"",
        121┆ 	vID, iID, awsErr.Message(), awsErr.Code())
          ⋮┆----------------------------------------
        253┆ return nil, "failed", fmt.Errorf("code: %s, message: %s", awsErr.Code(), awsErr.Message())

Some files were skipped.
  Scan was limited to files tracked by git.
  Scan skipped: 1593 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 1 rule on 3906 files: 3 findings.
```