### PR TITLE
Correct aws_synthetics_canary encryption_mode argument documentation

### DIFF
--- a/website/docs/r/synthetics_canary.html.markdown
+++ b/website/docs/r/synthetics_canary.html.markdown
@@ -60,8 +60,8 @@ The following arguments are optional:
 
 ### s3_encryption
 
-* `encryption_mode` - (Optional) The encryption method to use for artifacts created by this canary. Valid values are: `SSE-S3` and `SSE-KMS`.
-* `kms_key_arn` - (Optional) The ARN of the customer-managed KMS key to use, if you specify `SSE-KMS` for `encryption_mode`.
+* `encryption_mode` - (Optional) The encryption method to use for artifacts created by this canary. Valid values are: `SSE_S3` and `SSE_KMS`.
+* `kms_key_arn` - (Optional) The ARN of the customer-managed KMS key to use, if you specify `SSE_KMS` for `encryption_mode`.
 
 ### schedule
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #24744

Output from acceptance testing: n/a, docs

### Information

The docs incorrectly state the accepted values for `aws_synthetics_canary.artifact_config.s3_encryption.encryption_mode` were `SSE-S3` and `SSE-KMS`, when they are indeed `SSE_S3` and `SSE_KMS`. 

- [argument validation](https://github.com/hashicorp/terraform-provider-aws/blob/f83ba5a0f32717879115a45f3ea78544686803f8/internal/service/synthetics/canary.go#L57)
- [`func EncryptionMode_Values()`](https://docs.aws.amazon.com/sdk-for-go/api/service/synthetics/#EncryptionMode_Values)
- [const definition](https://docs.aws.amazon.com/sdk-for-go/api/service/synthetics/) (apologies, can't link directly to it, but a quick page search for `EncryptionModeSseS3` will get you there)