### PR TITLE
[Docs] Add additional services to grafana_workspace.data_sources

### DIFF
--- a/website/docs/r/grafana_workspace.html.markdown
+++ b/website/docs/r/grafana_workspace.html.markdown
@@ -50,7 +50,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `data_sources` - (Optional) The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `CLOUDWATCH`, `PROMETHEUS`, `XRAY`, `TIMESTREAM`, `SITEWISE`.
+* `data_sources` - (Optional) The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY`
 * `description` - (Optional) The workspace description.
 * `name` - (Optional) The Grafana workspace name.
 * `notification_destinations` - (Optional) The notification destinations. If a data source is specified here, Amazon Managed Grafana will create IAM roles and permissions needed to use these destinations. Must be set to `SNS`.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #24753

Output from acceptance testing: n/a, docs

### Information

The list of supported values for `aws_grafana_dashboard.data_sources` was out of date. This PR aims to bring it back to reality. Also alphabetized the list while I was at it.

- [`data_source` validation](https://github.com/hashicorp/terraform-provider-aws/blob/f83ba5a0f32717879115a45f3ea78544686803f8/internal/service/grafana/workspace.go#L62)
- [`func DataSourceType_Values()`](https://docs.aws.amazon.com/sdk-for-go/api/service/managedgrafana/#DataSourceType_Values)
- [enum definition](https://docs.aws.amazon.com/sdk-for-go/api/service/managedgrafana/) (apologies, can't link directly to it, but a quick page search for `DataSourceTypeAmazonOpensearchService` will get you there)