### PR TITLE
r/servicecatalog_provisioned_product: remove waiter from read CRUD op to prevent irreversible state

### DIFF
--- a/.changelog/24758.txt
+++ b/.changelog/24758.txt
@@ -1,0 +1,10 @@
+```release-note:bug
+resource/aws_servicecatalog_provisioned_product: Prevent error when retrieving a provisioned product in a non-available state
+```
+
+```release-note:enhancement
+resource/aws_servicecatalog_provisioned_product: Wait for provisioning to finish
+```
+
+```release-note:enhancement
+resource/aws_servicecatalog_provisioned_product: Wait for update to finish

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -30,7 +30,72 @@ func TestAccServiceCatalogProvisionedProduct_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckProvisionedProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress),
+				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", servicecatalog.ServiceName, regexp.MustCompile(fmt.Sprintf(`stack/%s/pp-.*`, rName))),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_provisioning_record_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_record_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_successful_provisioning_record_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					// One output will default to the launched CloudFormation Stack (provisioned outside terraform).
+					// While another output will describe the output parameter configured in the S3 object resource,
+					// which we can check as follows.
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"description": "VPC ID",
+						"key":         "VpcID",
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]*regexp.Regexp{
+						"value": regexp.MustCompile(`vpc-.+`),
+					}),
+					resource.TestCheckResourceAttrPair(resourceName, "path_id", "data.aws_servicecatalog_launch_paths.test", "summaries.0.path_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "provisioning_artifact_name", "aws_servicecatalog_product.test", "provisioning_artifact_parameters.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "status", servicecatalog.StatusAvailable),
+					resource.TestCheckResourceAttr(resourceName, "type", "CFN_STACK"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"ignore_errors",
+					"provisioning_artifact_name",
+					"provisioning_parameters",
+					"retain_physical_resources",
+				},
+			},
+		},
+	})
+}
+
+// TestAccServiceCatalogProvisionedProduct_update verifies the resource update
+// of only a change in provisioning_parameters
+func TestAccServiceCatalogProvisionedProduct_update(t *testing.T) {
+	resourceName := "aws_servicecatalog_provisioned_product.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, servicecatalog.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckProvisionedProductDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(resourceName),
+				),
+			},
+			{
+				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress, "10.10.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProvisionedProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
@@ -87,7 +152,7 @@ func TestAccServiceCatalogProvisionedProduct_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckProvisionedProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress),
+				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProvisionedProductExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfservicecatalog.ResourceProvisionedProduct(), resourceName),
@@ -298,7 +363,7 @@ data "aws_servicecatalog_launch_paths" "test" {
 `, rName, domain, email)
 }
 
-func testAccProvisionedProductConfig_basic(rName, domain, email string) string {
+func testAccProvisionedProductConfig_basic(rName, domain, email, vpcCidr string) string {
 	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(rName, domain, email),
 		fmt.Sprintf(`
 resource "aws_servicecatalog_provisioned_product" "test" {
@@ -309,7 +374,7 @@ resource "aws_servicecatalog_provisioned_product" "test" {
 
   provisioning_parameters {
     key   = "VPCPrimaryCIDR"
-    value = "10.1.0.0/16"
+    value = %[2]q
   }
 
   provisioning_parameters {
@@ -317,7 +382,7 @@ resource "aws_servicecatalog_provisioned_product" "test" {
     value = ""
   }
 }
-`, rName))
+`, rName, vpcCidr))
 }
 
 func testAccProvisionedProductConfig_tags(rName, tagKey, tagValue, domain, email string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24574

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TESTARGS='-run=TestAccServiceCatalogProvisionedProduct_' PKG=servicecatalog
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20  -run=TestAccServiceCatalogProvisionedProduct_ -timeout 180m
=== RUN   TestAccServiceCatalogProvisionedProduct_basic
=== PAUSE TestAccServiceCatalogProvisionedProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_update
=== PAUSE TestAccServiceCatalogProvisionedProduct_update
=== RUN   TestAccServiceCatalogProvisionedProduct_disappears
=== PAUSE TestAccServiceCatalogProvisionedProduct_disappears
=== RUN   TestAccServiceCatalogProvisionedProduct_tags
=== PAUSE TestAccServiceCatalogProvisionedProduct_tags
=== CONT  TestAccServiceCatalogProvisionedProduct_basic
=== CONT  TestAccServiceCatalogProvisionedProduct_disappears
=== CONT  TestAccServiceCatalogProvisionedProduct_tags
=== CONT  TestAccServiceCatalogProvisionedProduct_update
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (137.02s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (145.85s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (238.49s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (242.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	246.290s
```
