### PR TITLE
Add XNotEmplemented error handling in resourceBucketRead

### DIFF
--- a/.changelog/24764.txt
+++ b/.changelog/24764.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add error handling for `ErrCodeNotImplemented` and `ErrCodeXNotImplemented` errors when ready bucket information.
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1006,7 +1006,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchCORSConfiguration) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchCORSConfiguration, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
 		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The following patch takes into account third party S3 who does not support CORS.
Example of error message:
```
 Error: error getting S3 Bucket CORS configuration: NotImplemented: The requested resource is not implemented status code: 501, request id: [redacted], host id: [redacted] 
````