### PR TITLE
r/aws_msk_cluster - new storage_info arg

### DIFF
--- a/.changelog/24767.txt
+++ b/.changelog/24767.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_msk_cluster: The `ebs_volume_size` argument is deprecated in favor of the `storage_info` block. The `storage_info` block can set `volume_size` and `provisioned_throughput`
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -125,9 +125,12 @@ func ResourceCluster() *schema.Resource {
 							},
 						},
 						"ebs_volume_size": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 16384),
+							Type:          schema.TypeInt,
+							Optional:      true,
+							Computed:      true,
+							Deprecated:    "use 'storage_info' argument instead",
+							ValidateFunc:  validation.IntBetween(1, 16384),
+							ConflictsWith: []string{"broker_node_group_info.0.storage_info"},
 						},
 						"instance_type": {
 							Type:     schema.TypeString,
@@ -139,6 +142,55 @@ func ResourceCluster() *schema.Resource {
 							ForceNew: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
+							},
+						},
+						"storage_info": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							Computed:      true,
+							MaxItems:      1,
+							ConflictsWith: []string{"broker_node_group_info.0.ebs_volume_size"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ebs_storage_info": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"provisioned_throughput": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															// This feature is available for
+															// storage volume larger than 10 GiB and
+															// broker types kafka.m5.4xlarge and larger.
+															"enabled": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+															// Minimum and maximum for this varies between broker type
+															// https://docs.aws.amazon.com/msk/latest/developerguide/msk-provision-throughput.html
+															"volume_throughput": {
+																Type:         schema.TypeInt,
+																Optional:     true,
+																ValidateFunc: validation.IntBetween(250, 2375),
+															},
+														},
+													},
+												},
+												"volume_size": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													// https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-ebsstorageinfo
+													ValidateFunc: validation.IntBetween(1, 16384),
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -40,6 +40,12 @@ func ResourceCluster() *schema.Resource {
 			customdiff.ForceNewIfChange("kafka_version", func(_ context.Context, old, new, meta interface{}) bool {
 				return verify.SemVerLessThan(new.(string), old.(string))
 			}),
+			customdiff.ComputedIf("broker_node_group_info.0.storage_info", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("broker_node_group_info.0.ebs_volume_size")
+			}),
+			customdiff.ComputedIf("broker_node_group_info.0.ebs_volume_size", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("broker_node_group_info.0.storage_info")
+			}),
 			verify.SetTagsDiff,
 		),
 

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -648,24 +648,14 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 		// case: deprecated ebs_volume_size replaced with storage_info
 		if d.HasChange("broker_node_group_info.0.storage_info") {
-			if v, ok := d.GetOk("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.provisioned_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
-					{
-						KafkaBrokerNodeId:     aws.String("All"),
-						ProvisionedThroughput: expandProvisionedThroughput(v.([]interface{})[0].(map[string]interface{})),
-						VolumeSizeGB:          aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
-					},
-				}
-
-			} else {
-				// ProvisionedThroughput not specified when ebs_volume_size replaced with storage_info
-				input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
-					{
-						KafkaBrokerNodeId: aws.String("All"),
-						VolumeSizeGB:      aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
-					},
-				}
+			ebsVolumeInfo := &kafka.BrokerEBSVolumeInfo{
+				KafkaBrokerNodeId: aws.String("All"),
+				VolumeSizeGB:      aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
 			}
+			if v, ok := d.GetOk("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.provisioned_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+				ebsVolumeInfo.ProvisionedThroughput = expandProvisionedThroughput(v.([]interface{})[0].(map[string]interface{}))
+			}
+			input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{ebsVolumeInfo}
 		} else {
 			// case: regular update of deprecated ebs_volume_size
 			input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
@@ -704,23 +694,14 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			ClusterArn:     aws.String(d.Id()),
 			CurrentVersion: aws.String(d.Get("current_version").(string)),
 		}
-		if v, ok := d.GetOk("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.provisioned_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
-				{
-					KafkaBrokerNodeId:     aws.String("All"),
-					ProvisionedThroughput: expandProvisionedThroughput(v.([]interface{})[0].(map[string]interface{})),
-					VolumeSizeGB:          aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
-				},
-			}
-
-		} else {
-			input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
-				{
-					KafkaBrokerNodeId: aws.String("All"),
-					VolumeSizeGB:      aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
-				},
-			}
+		ebsVolumeInfo := &kafka.BrokerEBSVolumeInfo{
+			KafkaBrokerNodeId: aws.String("All"),
+			VolumeSizeGB:      aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
 		}
+		if v, ok := d.GetOk("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.provisioned_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			ebsVolumeInfo.ProvisionedThroughput = expandProvisionedThroughput(v.([]interface{})[0].(map[string]interface{}))
+		}
+		input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{ebsVolumeInfo}
 
 		output, err := conn.UpdateBrokerStorageWithContext(ctx, input)
 

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -668,6 +668,52 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
+	if d.HasChange("broker_node_group_info.0.storage_info") {
+		input := &kafka.UpdateBrokerStorageInput{
+			ClusterArn:     aws.String(d.Id()),
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
+		}
+		if v, ok := d.GetOk("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.provisioned_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
+				{
+					KafkaBrokerNodeId:     aws.String("All"),
+					ProvisionedThroughput: expandProvisionedThroughput(v.([]interface{})[0].(map[string]interface{})),
+					VolumeSizeGB:          aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
+				},
+			}
+
+		} else {
+			input.TargetBrokerEBSVolumeInfo = []*kafka.BrokerEBSVolumeInfo{
+				{
+					KafkaBrokerNodeId: aws.String("All"),
+					VolumeSizeGB:      aws.Int64(int64(d.Get("broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size").(int))),
+				},
+			}
+		}
+
+		output, err := conn.UpdateBrokerStorageWithContext(ctx, input)
+
+		// the following error is thrown if previous ebs_volume_size and new storage_info.ebs_storage_info.volume_size have the same value:
+		// BadRequestException: The request does not include any updates to the EBS volumes of the cluster. Verify the request, then try again
+		// ignore this error to allow users to replace deprecated ebs_volume_size with storage_info
+		if err != nil && !tfawserr.ErrMessageContains(err, kafka.ErrCodeBadRequestException, "The request does not include any updates to the EBS volumes of the cluster") {
+			return diag.Errorf("updating MSK Cluster (%s) broker storage: %s", d.Id(), err)
+		}
+
+		clusterOperationARN := aws.StringValue(output.ClusterOperationArn)
+
+		// when there are no changes, output.ClusterOperationArn is not returned leading to
+		// InvalidParameter: 1 validation error(s) found. - minimum field size of 1, DescribeClusterOperationInput.ClusterOperationArn.
+		// skip the wait if the EBS volume size is unchanged
+		if !tfawserr.ErrMessageContains(err, kafka.ErrCodeBadRequestException, "The request does not include any updates to the EBS volumes of the cluster") {
+			_, err = waitClusterOperationCompleted(ctx, conn, clusterOperationARN, d.Timeout(schema.TimeoutUpdate))
+
+			if err != nil {
+				return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+			}
+		}
+	}
+
 	if d.HasChange("broker_node_group_info.0.connectivity_info") {
 		input := &kafka.UpdateConnectivityInput{
 			ClusterArn:     aws.String(d.Id()),

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -1316,6 +1316,10 @@ func flattenBrokerNodeGroupInfo(apiObject *kafka.BrokerNodeGroupInfo) map[string
 	}
 
 	if v := apiObject.StorageInfo; v != nil {
+		tfMap["storage_info"] = flattenStorageInfo(v)
+	}
+
+	if v := apiObject.StorageInfo; v != nil {
 		if v := v.EbsStorageInfo; v != nil {
 			if v := v.VolumeSize; v != nil {
 				tfMap["ebs_volume_size"] = aws.Int64Value(v)
@@ -1338,6 +1342,56 @@ func flattenConnectivityInfo(apiObject *kafka.ConnectivityInfo) map[string]inter
 	}
 
 	return tfMap
+}
+
+func flattenStorageInfo(apiObject *kafka.StorageInfo) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.EbsStorageInfo; v != nil {
+		tfMap["ebs_storage_info"] = flattenEbsStorageInfo(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenEbsStorageInfo(apiObject *kafka.EBSStorageInfo) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ProvisionedThroughput; v != nil {
+		tfMap["provisioned_throughput"] = flattenProvisionedThroughput(v)
+	}
+
+	if v := apiObject.VolumeSize; v != nil {
+		tfMap["volume_size"] = aws.Int64Value(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenProvisionedThroughput(apiObject *kafka.ProvisionedThroughput) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Enabled; v != nil {
+		tfMap["enabled"] = aws.BoolValue(v)
+	}
+
+	if v := apiObject.VolumeThroughput; v != nil {
+		tfMap["volume_throughput"] = aws.Int64Value(v)
+	}
+
+	return []interface{}{tfMap}
 }
 
 func flattenPublicAccess(apiObject *kafka.PublicAccess) map[string]interface{} {

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -930,6 +930,10 @@ func expandBrokerNodeGroupInfo(tfMap map[string]interface{}) *kafka.BrokerNodeGr
 		}
 	}
 
+	if v, ok := tfMap["storage_info"].([]interface{}); ok && len(v) > 0 {
+		apiObject.StorageInfo = expandStorageInfo(v[0].(map[string]interface{}))
+	}
+
 	return apiObject
 }
 
@@ -942,6 +946,56 @@ func expandConnectivityInfo(tfMap map[string]interface{}) *kafka.ConnectivityInf
 
 	if v, ok := tfMap["public_access"].([]interface{}); ok && len(v) > 0 {
 		apiObject.PublicAccess = expandPublicAccess(v[0].(map[string]interface{}))
+	}
+
+	return apiObject
+}
+
+func expandStorageInfo(tfMap map[string]interface{}) *kafka.StorageInfo {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &kafka.StorageInfo{}
+
+	if v, ok := tfMap["ebs_storage_info"].([]interface{}); ok && len(v) > 0 {
+		apiObject.EbsStorageInfo = expandEbsStorageInfo(v[0].(map[string]interface{}))
+	}
+
+	return apiObject
+}
+
+func expandEbsStorageInfo(tfMap map[string]interface{}) *kafka.EBSStorageInfo {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &kafka.EBSStorageInfo{}
+
+	if v, ok := tfMap["provisioned_throughput"].([]interface{}); ok && len(v) > 0 {
+		apiObject.ProvisionedThroughput = expandProvisionedThroughput(v[0].(map[string]interface{}))
+	}
+
+	if v, ok := tfMap["volume_size"].(int); ok && v != 0 {
+		apiObject.VolumeSize = aws.Int64(int64(v))
+	}
+
+	return apiObject
+}
+
+func expandProvisionedThroughput(tfMap map[string]interface{}) *kafka.ProvisionedThroughput {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &kafka.ProvisionedThroughput{}
+
+	if v, ok := tfMap["enabled"].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["volume_throughput"].(int); ok && v != 0 {
+		apiObject.VolumeThroughput = aws.Int64(int64(v))
 	}
 
 	return apiObject

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -122,7 +122,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterBrokerNodeGroupInfoEbsVolumeSizeConfig(rName, 11),
+				Config: testAccClusterDeprecatedBrokerNodeGroupInfoEbsVolumeSizeConfig(rName, 11),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
@@ -139,7 +139,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize(t *testing.T) {
 			},
 			{
 				// BadRequestException: The minimum increase in storage size of the cluster should be atleast 100GB
-				Config: testAccClusterBrokerNodeGroupInfoEbsVolumeSizeConfig(rName, 112),
+				Config: testAccClusterDeprecatedBrokerNodeGroupInfoEbsVolumeSizeConfig(rName, 112),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster2),
 					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
@@ -218,7 +218,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 		Steps: []resource.TestStep{
 			{
 				// init with the deprecated ebs_volume_size
-				Config: testAccClusterBrokerNodeGroupInfoEbsVolumeSizeConfig(rName, original_volume_size),
+				Config: testAccClusterDeprecatedBrokerNodeGroupInfoEbsVolumeSizeConfig(rName, original_volume_size),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
@@ -1469,7 +1469,7 @@ resource "aws_msk_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterBrokerNodeGroupInfoEbsVolumeSizeConfig(rName string, ebsVolumeSize int) string {
+func testAccClusterDeprecatedBrokerNodeGroupInfoEbsVolumeSizeConfig(rName string, ebsVolumeSize int) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -229,14 +229,8 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 			},
 			{
 				// refactor deprecated ebs_volume_size to storage_info
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName, original_volume_size, "kafka.m5.large"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(resourceName, &cluster1),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size", strconv.Itoa(original_volume_size)),
-				),
+				Config:   testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName, original_volume_size, "kafka.m5.large"),
+				PlanOnly: true,
 			},
 			{
 				// upgrade the instance type first. Multiple updates would cause a "The version of the cluster isn’t current. Check the current version and try again." error

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -165,7 +165,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoConfig2(rName, original_volume_size, "kafka.m5.4xlarge"),
+				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputNotEnabledConfig(rName, original_volume_size, "kafka.m5.4xlarge"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
@@ -186,7 +186,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo(t *testing.T) {
 			},
 			{
 				// update broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoConfig3(rName, updated_volume_size, "kafka.m5.4xlarge"),
+				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputEnabledConfig(rName, updated_volume_size, "kafka.m5.4xlarge"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster2),
 					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
@@ -235,7 +235,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 			},
 			{
 				// refactor deprecated ebs_volume_size to storage_info
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoConfig1(rName, original_volume_size, "kafka.m5.large"),
+				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName, original_volume_size, "kafka.m5.large"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
@@ -254,7 +254,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 			},
 			{
 				// upgrade the instance type first. Multiple updates would cause a "The version of the cluster isn’t current. Check the current version and try again." error
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoConfig1(rName, original_volume_size, "kafka.m5.4xlarge"),
+				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName, original_volume_size, "kafka.m5.4xlarge"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
@@ -273,7 +273,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 			},
 			{
 				// update storage and enable provisioned throughput
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoConfig3(rName, updated_volume_size, "kafka.m5.4xlarge"),
+				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputEnabledConfig(rName, updated_volume_size, "kafka.m5.4xlarge"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster2),
 					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
@@ -1486,7 +1486,7 @@ resource "aws_msk_cluster" "test" {
 `, rName, ebsVolumeSize))
 }
 
-func testAccClusterBrokerNodeGroupInfoStorageInfoConfig1(rName string, ebsVolumeSize int, instanceType string) string {
+func testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName string, ebsVolumeSize int, instanceType string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
@@ -1507,7 +1507,7 @@ resource "aws_msk_cluster" "test" {
 `, rName, ebsVolumeSize, instanceType))
 }
 
-func testAccClusterBrokerNodeGroupInfoStorageInfoConfig2(rName string, ebsVolumeSize int, instanceType string) string {
+func testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputNotEnabledConfig(rName string, ebsVolumeSize int, instanceType string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
@@ -1531,7 +1531,7 @@ resource "aws_msk_cluster" "test" {
 `, rName, ebsVolumeSize, instanceType))
 }
 
-func testAccClusterBrokerNodeGroupInfoStorageInfoConfig3(rName string, ebsVolumeSize int, instanceType string) string {
+func testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputEnabledConfig(rName string, ebsVolumeSize int, instanceType string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -228,14 +228,6 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"current_version",
-				},
-			},
-			{
 				// refactor deprecated ebs_volume_size to storage_info
 				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName, original_volume_size, "kafka.m5.large"),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -245,14 +237,6 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size", strconv.Itoa(original_volume_size)),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"current_version",
-				},
 			},
 			{
 				// upgrade the instance type first. Multiple updates would cause a "The version of the cluster isn’t current. Check the current version and try again." error

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -244,14 +244,6 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"current_version",
-				},
-			},
-			{
 				// update storage and enable provisioned throughput
 				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputEnabledConfig(rName, updated_volume_size, "kafka.m5.4xlarge"),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -169,6 +169,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", strconv.Itoa(original_volume_size)),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size", strconv.Itoa(original_volume_size)),
@@ -191,6 +192,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo(t *testing.T) {
 					testAccCheckClusterExists(resourceName, &cluster2),
 					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", strconv.Itoa(updated_volume_size)),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size", strconv.Itoa(updated_volume_size)),

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -181,9 +181,9 @@ resource "aws_msk_cluster" "example" {
   broker_node_group_info {
     instance_type = "kafka.m5.4xlarge"
     client_subnets = [
-      "subnet-12345678912345678",
-      "subnet-98765432123456789",
-      "subnet-45678912345678912",
+      aws_subnet.subnet_az1.id,
+      aws_subnet.subnet_az2.id,
+      aws_subnet.subnet_az3.id,
     ]
     storage_info {
       ebs_storage_info {

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -108,13 +108,17 @@ resource "aws_msk_cluster" "example" {
   number_of_broker_nodes = 3
 
   broker_node_group_info {
-    instance_type   = "kafka.m5.large"
-    ebs_volume_size = 1000
+    instance_type = "kafka.m5.large"
     client_subnets = [
       aws_subnet.subnet_az1.id,
       aws_subnet.subnet_az2.id,
       aws_subnet.subnet_az3.id,
     ]
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
     security_groups = [aws_security_group.sg.id]
   }
 
@@ -214,7 +218,7 @@ The following arguments are supported:
 ### broker_node_group_info Argument Reference
 
 * `client_subnets` - (Required) A list of subnets to connect to in client VPC ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-prop-brokernodegroupinfo-clientsubnets)).
-* `ebs_volume_size` - (Required) The size in GiB of the EBS volume for the data drive on each broker node.
+* `ebs_volume_size` - (**Deprecated**) The size in GiB of the EBS volume for the data drive on each broker node.
 * `instance_type` - (Required) Specify the instance type to use for the kafka brokersE.g., kafka.m5.large. ([Pricing info](https://aws.amazon.com/msk/pricing/))
 * `security_groups` - (Required) A list of the security groups to associate with the elastic network interfaces to control who can communicate with the cluster.
 * `az_distribution` - (Optional) The distribution of broker nodes across availability zones ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-brokerazdistribution)). Currently the only valid value is `DEFAULT`.

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -194,7 +194,7 @@ resource "aws_msk_cluster" "example" {
         volume_size = 1000
       }
     }
-    security_groups = ["sg-12345678912345678"]
+    security_groups = [aws_security_group.sg.id]
   }
 }
 ```

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -12,6 +12,8 @@ Manages AWS Managed Streaming for Kafka cluster
 
 ## Example Usage
 
+### Basic
+
 ```terraform
 resource "aws_vpc" "vpc" {
   cidr_block = "192.168.0.0/22"
@@ -164,6 +166,35 @@ output "bootstrap_brokers_tls" {
 }
 ```
 
+### With volume_throughput argument
+
+```terraform
+resource "aws_msk_cluster" "example" {
+  cluster_name           = "example"
+  kafka_version          = "2.7.1"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    instance_type = "kafka.m5.4xlarge"
+    client_subnets = [
+      "subnet-12345678912345678",
+      "subnet-98765432123456789",
+      "subnet-45678912345678912",
+    ]
+    storage_info {
+      ebs_storage_info {
+        provisioned_throughput {
+          enabled           = true
+          volume_throughput = 250
+        }
+        volume_size = 1000
+      }
+    }
+    security_groups = ["sg-12345678912345678"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -188,6 +219,7 @@ The following arguments are supported:
 * `security_groups` - (Required) A list of the security groups to associate with the elastic network interfaces to control who can communicate with the cluster.
 * `az_distribution` - (Optional) The distribution of broker nodes across availability zones ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-brokerazdistribution)). Currently the only valid value is `DEFAULT`.
 * `connectivity_info` - (Optional) Information about the cluster access configuration. See below. For security reasons, you can't turn on public access while creating an MSK cluster. However, you can update an existing cluster to make it publicly accessible. You can also create a new cluster and then update it to make it publicly accessible ([documentation](https://docs.aws.amazon.com/msk/latest/developerguide/public-access.html)).
+* `storage_info` - (Optional) A block that contains information about storage volumes attached to MSK broker nodes. See below.
 
 ### broker_node_group_info connectivity_info Argument Reference
 
@@ -196,6 +228,20 @@ The following arguments are supported:
 ### connectivity_info public_access Argument Reference
 
 * `type` - (Optional) Public access type. Valida values: `DISABLED`, `SERVICE_PROVIDED_EIPS`.
+
+### broker_node_group_info storage_info Argument Reference
+
+* `ebs_storage_info` - (Optional) A block that contains EBS volume information. See below.
+
+### storage_info ebs_storage_info Argument Reference
+
+* `provisioned_throughput` - (Optional) A block that contains EBS volume provisioned throughput information. To provision storage throughput, you must choose broker type kafka.m5.4xlarge or larger. See below.
+* `volume_size` - (Optional) The size in GiB of the EBS volume for the data drive on each broker node. Minimum value of `1` and maximum value of `16384`.
+
+### ebs_storage_info provisioned_throughput Argument Reference
+
+* `enabled` - (Optional) Controls whether provisioned throughput is enabled or not. Default value: `false`.
+* `volume_throughput` - (Optional) Throughput value of the EBS volumes for the data drive on each kafka broker node in MiB per second. The minimum value is `250`. The maximum value varies between broker type. You can refer to the valid values for the maximum volume throughput at the following [documentation on throughput bottlenecks](https://docs.aws.amazon.com/msk/latest/developerguide/msk-provision-throughput.html#throughput-bottlenecks)
 
 ### client_authentication Argument Reference
 

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -218,7 +218,7 @@ The following arguments are supported:
 ### broker_node_group_info Argument Reference
 
 * `client_subnets` - (Required) A list of subnets to connect to in client VPC ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-prop-brokernodegroupinfo-clientsubnets)).
-* `ebs_volume_size` - (**Deprecated**) The size in GiB of the EBS volume for the data drive on each broker node.
+* `ebs_volume_size` - (Optional, **Deprecated** use `storage_info.ebs_storage_info.volume_size` instead) The size in GiB of the EBS volume for the data drive on each broker node.
 * `instance_type` - (Required) Specify the instance type to use for the kafka brokersE.g., kafka.m5.large. ([Pricing info](https://aws.amazon.com/msk/pricing/))
 * `security_groups` - (Required) A list of the security groups to associate with the elastic network interfaces to control who can communicate with the cluster.
 * `az_distribution` - (Optional) The distribution of broker nodes across availability zones ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-brokerazdistribution)). Currently the only valid value is `DEFAULT`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24464

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolume\|TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo\|TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize' PKG=kafka
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafka/... -v -count 1 -parallel 20  -run=TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolume\|TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo\|TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize -timeout 180m
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo (2134.04s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize (2138.68s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo (5049.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      5049.916s
...
```
