### PR TITLE
Support json body matching in wafv2 byte match rule

### DIFF
--- a/.changelog/24772.txt
+++ b/.changelog/24772.txt
@@ -1,7 +1,7 @@
-```release-notes:enhancement
-resource/aws_wafv2_web_acl: Add support for `json_body` field matching to `byte_match_statement` rule.
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add `json_body` attribute to the `field_to_match` block
 ```
 
-```release-notes:enhancement
-resource/aws_wafv2_rule_group: Add support for `json_body` field matching to `byte_match_statement` rule.
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `json_body` attribute to the `field_to_match` block
 ```

--- a/.changelog/24772.txt
+++ b/.changelog/24772.txt
@@ -1,0 +1,7 @@
+```release-notes:enhancement
+resource/aws_wafv2_web_acl: Add support for `json_body` field matching to `byte_match_statement` rule.
+```
+
+```release-notes:enhancement
+resource/aws_wafv2_rule_group: Add support for `json_body` field matching to `byte_match_statement` rule.
+```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1095,7 +1095,7 @@ func flattenCookiesMatchPattern(c *wafv2.CookieMatchPattern) interface{} {
 	}
 
 	m := map[string]interface{}{
-		"all":              c.All,
+		"all":              make([]map[string]interface{}, 1),
 		"included_cookies": aws.StringValueSlice(c.IncludedCookies),
 		"excluded_cookies": aws.StringValueSlice(c.ExcludedCookies),
 	}
@@ -1124,7 +1124,7 @@ func flattenJSONMatchPattern(p *wafv2.JsonMatchPattern) []interface{} {
 	}
 
 	m := map[string]interface{}{
-		"all":            p.All,
+		"all":            make([]map[string]interface{}, 1),
 		"included_paths": flex.FlattenStringList(p.IncludedPaths),
 	}
 

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -523,7 +523,7 @@ func expandJSONMatchPattern(l []interface{}) *wafv2.JsonMatchPattern {
 	m := l[0].(map[string]interface{})
 	jsonMatchPattern := &wafv2.JsonMatchPattern{}
 
-	if v, ok := m["all"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := m["all"].([]interface{}); ok && len(v) > 0 {
 		jsonMatchPattern.All = &wafv2.All{}
 	}
 

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -502,17 +502,17 @@ func expandJSONBody(l []interface{}) *wafv2.JsonBody {
 
 	m := l[0].(map[string]interface{})
 
-	b := wafv2.JsonBody{
-		MatchPattern:     expandJSONMatchPattern(m["match_pattern"].([]interface{})),
+	jsonBody := &wafv2.JsonBody{
 		MatchScope:       aws.String(m["match_scope"].(string)),
 		OversizeHandling: aws.String(m["oversize_handling"].(string)),
+		MatchPattern:     expandJSONMatchPattern(m["match_pattern"].([]interface{})),
 	}
 
 	if v, ok := m["invalid_fallback_behavior"].(string); ok && v != "" {
-		b.InvalidFallbackBehavior = aws.String(v)
+		jsonBody.InvalidFallbackBehavior = aws.String(v)
 	}
 
-	return &b
+	return jsonBody
 }
 
 func expandJSONMatchPattern(l []interface{}) *wafv2.JsonMatchPattern {
@@ -521,17 +521,17 @@ func expandJSONMatchPattern(l []interface{}) *wafv2.JsonMatchPattern {
 	}
 
 	m := l[0].(map[string]interface{})
-	p := wafv2.JsonMatchPattern{}
+	jsonMatchPattern := &wafv2.JsonMatchPattern{}
 
 	if v, ok := m["all"]; ok && len(v.([]interface{})) > 0 {
-		p.All = &wafv2.All{}
+		jsonMatchPattern.All = &wafv2.All{}
 	}
 
 	if v, ok := m["included_paths"]; ok && len(v.([]interface{})) > 0 {
-		p.IncludedPaths = flex.ExpandStringList(v.([]interface{}))
+		jsonMatchPattern.IncludedPaths = flex.ExpandStringList(v.([]interface{}))
 	}
 
-	return &p
+	return jsonMatchPattern
 }
 
 func expandSingleHeader(l []interface{}) *wafv2.SingleHeader {
@@ -1123,14 +1123,9 @@ func flattenJSONMatchPattern(p *wafv2.JsonMatchPattern) []interface{} {
 		return []interface{}{}
 	}
 
-	m := map[string]interface{}{}
-
-	if p.All != nil {
-		m["all"] = []interface{}{map[string]interface{}{}}
-	}
-
-	if p.IncludedPaths != nil {
-		m["included_paths"] = flex.FlattenStringList(p.IncludedPaths)
+	m := map[string]interface{}{
+		"all":            p.All,
+		"included_paths": flex.FlattenStringList(p.IncludedPaths),
 	}
 
 	return []interface{}{m}

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1095,9 +1095,12 @@ func flattenCookiesMatchPattern(c *wafv2.CookieMatchPattern) interface{} {
 	}
 
 	m := map[string]interface{}{
-		"all":              make([]map[string]interface{}, 1),
 		"included_cookies": aws.StringValueSlice(c.IncludedCookies),
 		"excluded_cookies": aws.StringValueSlice(c.ExcludedCookies),
+	}
+
+	if c.All != nil {
+		m["all"] = make([]map[string]interface{}, 1)
 	}
 
 	return []interface{}{m}
@@ -1124,8 +1127,11 @@ func flattenJSONMatchPattern(p *wafv2.JsonMatchPattern) []interface{} {
 	}
 
 	m := map[string]interface{}{
-		"all":            make([]map[string]interface{}, 1),
 		"included_paths": flex.FlattenStringList(p.IncludedPaths),
+	}
+
+	if p.All != nil {
+		m["all"] = make([]map[string]interface{}, 1)
 	}
 
 	return []interface{}{m}

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -380,6 +380,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
@@ -401,6 +402,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
@@ -436,6 +438,27 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccRuleGroupConfig_byteMatchStatementFieldToMatchJSONBody(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                                                                                      "1",
+						"statement.0.byte_match_statement.#":                                                               "1",
+						"statement.0.byte_match_statement.0.field_to_match.#":                                              "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_scope":                      "VALUE",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.invalid_fallback_behavior":        "MATCH",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.oversize_handling":                "CONTINUE",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.#":                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.#": "2",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.0": "/dogs/0/name",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.1": "/dogs/1/name",
+					}),
+				),
+			},
+			{
 				Config: testAccRuleGroupConfig_byteMatchStatementFieldToMatchMethod(ruleGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(resourceName, &v),
@@ -448,6 +471,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
@@ -469,6 +493,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
@@ -490,6 +515,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "1",
@@ -512,6 +538,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":        "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                     "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":              "0",
@@ -534,6 +561,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
@@ -2442,6 +2470,60 @@ resource "aws_wafv2_rule_group" "test" {
 
         field_to_match {
           body {}
+        }
+
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name)
+}
+
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchJSONBody(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 20
+  name     = "%s"
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        positional_constraint = "CONTAINS"
+        search_string         = "Clifford"
+
+        field_to_match {
+          json_body {
+            match_scope               = "VALUE"
+            invalid_fallback_behavior = "MATCH"
+            oversize_handling         = "CONTINUE"
+            match_pattern {
+              included_paths = ["/dogs/0/name", "/dogs/1/name"]
+            }
+          }
         }
 
         text_transformation {

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -464,12 +464,7 @@ func jsonMatchPattern() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"all": {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem:     &schema.Resource{Schema: map[string]*schema.Schema{}},
-				},
+				"all": emptySchema(),
 				"included_paths": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -329,6 +329,7 @@ func xssMatchStatementSchema() *schema.Schema {
 		},
 	}
 }
+
 func fieldToMatchBaseSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -372,6 +373,7 @@ func fieldToMatchBaseSchema() *schema.Resource {
 					},
 				},
 			},
+			"json_body":    jsonBodySchema(),
 			"method":       emptySchema(),
 			"query_string": emptySchema(),
 			"single_header": {
@@ -423,6 +425,64 @@ func fieldToMatchSchema() *schema.Schema {
 		Optional: true,
 		MaxItems: 1,
 		Elem:     fieldToMatchBaseSchema(),
+	}
+}
+
+func jsonBodySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"invalid_fallback_behavior": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.BodyParsingFallbackBehavior_Values(), false),
+				},
+				"match_pattern": jsonMatchPattern(),
+				"match_scope": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.JsonMatchScope_Values(), false),
+				},
+				"oversize_handling": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      wafv2.OversizeHandlingContinue,
+					ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
+				},
+			},
+		},
+	}
+}
+
+func jsonMatchPattern() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"all": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem:     &schema.Resource{Schema: map[string]*schema.Schema{}},
+				},
+				"included_paths": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MinItems: 1,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.All(
+							validation.StringLenBetween(1, 512),
+							validation.StringMatch(regexp.MustCompile(`(/)|(/(([^~])|(~[01]))+)`), "must be a valid JSON pointer")),
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -798,6 +798,65 @@ func TestAccWAFV2WebACL_ByteMatchStatement_basic(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACL_ByteMatchStatement_jsonBody(t *testing.T) {
+	var v wafv2.WebACL
+	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckScopeRegional(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, wafv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_byteMatchStatementJSONBody(webACLName, wafv2.JsonMatchScopeValue, wafv2.FallbackBehaviorMatch, wafv2.OversizeHandlingNoMatch, `included_paths = ["/dogs/0/name", "/dogs/1/name"]`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_scope":                      "VALUE",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.invalid_fallback_behavior":        "MATCH",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.oversize_handling":                "NO_MATCH",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.#":                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.all.#":            "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.#": "2",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.0": "/dogs/0/name",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.1": "/dogs/1/name",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_byteMatchStatementJSONBody(webACLName, wafv2.JsonMatchScopeAll, wafv2.FallbackBehaviorNoMatch, wafv2.OversizeHandlingContinue, "all {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_scope":                      "ALL",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.invalid_fallback_behavior":        "NO_MATCH",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.oversize_handling":                "CONTINUE",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.#":                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.all.#":            "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.0.match_pattern.0.included_paths.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACL_GeoMatch_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1978,6 +2037,62 @@ resource "aws_wafv2_web_acl" "test" {
   }
 }
 `, name, positionalConstraint, searchString)
+}
+
+func testAccWebACLConfig_byteMatchStatementJSONBody(name, matchScope, invalidFallbackBehavior, oversizeHandling, matchPattern string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = "%[1]s"
+  description = "%[1]s"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          json_body {
+            match_scope               = "%[2]s"
+            invalid_fallback_behavior = "%[3]s"
+            oversize_handling         = "%[4]s"
+            match_pattern {
+              %[5]s
+            }
+          }
+        }
+        positional_constraint = "CONTAINS_WORD"
+        search_string         = "Buddy"
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name, matchScope, invalidFallbackBehavior, oversizeHandling, matchPattern)
 }
 
 func testAccWebACLConfig_geoMatchStatement(name, countryCodes string) string {

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -492,12 +492,13 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers.
 * `cookies` - (Optional) Inspect the request cookies.
+* `json_body` - (Optional) Inspect the request body as JSON. See [JSON Body](#json-body) for details.
 * `method` - (Optional) Inspect the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Inspect a single header. See [Single Header](#single-header) below for details.
@@ -524,6 +525,22 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 * `fallback_behavior` - (Required) - The match status to assign to the web request if the request doesn't have a valid IP address in the specified position. Valid values include: `MATCH` or `NO_MATCH`.
 * `header_name` - (Required) - The name of the HTTP header to use for the IP address.
 * `position` - (Required) - The position in the header to search for the IP address. Valid values include: `FIRST`, `LAST`, or `ANY`. If `ANY` is specified and the header contains more than 10 IP addresses, AWS WAFv2 inspects the last 10.
+
+### JSON Body
+
+The `json_body` block supports the following arguments:
+
+* `invalid_fallback_behavior` - (Optional) What to do when JSON parsing fails. Defaults to evaluating up to the first parsing failure. Valid values are `EVALUATE_AS_STRING`, `MATCH` and `NO_MATCH`.
+* `match_pattern` - (Required) The patterns to look for in the JSON body. See [JSON Match Pattern](#json-match-pattern) for details.
+* `match_scope` - (Required) The parts of the JSON to match against using the `match_pattern`. Valid values are `ALL`, `KEY` and `VALUE`.
+* `oversize_handling` - (Optional) What to do if the body is larger than can be inspected. Valid values are `CONTINUE` (default), `MATCH` and `NO_MATCH`.
+
+### JSON Match Pattern
+
+The `match_pattern` block supports the following arguments. You must specify either `all` or `included_paths`, but not both.
+
+* `all` - (Optional) Match all the elements.
+* `included_paths` - (Optional) Match only the specified paths. Paths are defined using [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) syntax (e.g., `/dogs/0/name`).
 
 ### Single Header
 

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -531,16 +531,9 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 The `json_body` block supports the following arguments:
 
 * `invalid_fallback_behavior` - (Optional) What to do when JSON parsing fails. Defaults to evaluating up to the first parsing failure. Valid values are `EVALUATE_AS_STRING`, `MATCH` and `NO_MATCH`.
-* `match_pattern` - (Required) The patterns to look for in the JSON body. See [JSON Match Pattern](#json-match-pattern) for details.
+* `match_pattern` - (Required) The patterns to look for in the JSON body. You must specify exactly one setting: either `all` or `included_paths`. See [JsonMatchPattern](https://docs.aws.amazon.com/waf/latest/APIReference/API_JsonMatchPattern.html) for details.
 * `match_scope` - (Required) The parts of the JSON to match against using the `match_pattern`. Valid values are `ALL`, `KEY` and `VALUE`.
 * `oversize_handling` - (Optional) What to do if the body is larger than can be inspected. Valid values are `CONTINUE` (default), `MATCH` and `NO_MATCH`.
-
-### JSON Match Pattern
-
-The `match_pattern` block supports the following arguments. You must specify either `all` or `included_paths`, but not both.
-
-* `all` - (Optional) Match all the elements.
-* `included_paths` - (Optional) Match only the specified paths. Paths are defined using [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) syntax (e.g., `/dogs/0/name`).
 
 ### Single Header
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -584,16 +584,9 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 The `json_body` block supports the following arguments:
 
 * `invalid_fallback_behavior` - (Optional) What to do when JSON parsing fails. Defaults to evaluating up to the first parsing failure. Valid values are `EVALUATE_AS_STRING`, `MATCH` and `NO_MATCH`.
-* `match_pattern` - (Required) The patterns to look for in the JSON body. See [JSON Match Pattern](#json-match-pattern) for details.
+* `match_pattern` - (Required) The patterns to look for in the JSON body. You must specify exactly one setting: either `all` or `included_paths`. See [JsonMatchPattern](https://docs.aws.amazon.com/waf/latest/APIReference/API_JsonMatchPattern.html) for details.
 * `match_scope` - (Required) The parts of the JSON to match against using the `match_pattern`. Valid values are `ALL`, `KEY` and `VALUE`.
 * `oversize_handling` - (Optional) What to do if the body is larger than can be inspected. Valid values are `CONTINUE` (default), `MATCH` and `NO_MATCH`.
-
-### JSON Match Pattern
-
-The `match_pattern` block supports the following arguments. You must specify either `all` or `included_paths`, but not both.
-
-* `all` - (Optional) Match all the elements.
-* `included_paths` - (Optional) Match only the specified paths. Paths are defined using [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) syntax (e.g., `/dogs/0/name`).
 
 ### Single Header
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -545,12 +545,13 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers.
 * `cookies` - (Optional) Inspect the request cookies.
+* `json_body` - (Optional) Inspect the request body as JSON. See [JSON Body](#json-body) for details.
 * `method` - (Optional) Inspect the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Inspect a single header. See [Single Header](#single-header) below for details.
@@ -577,6 +578,22 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 * `fallback_behavior` - (Required) - Match status to assign to the web request if the request doesn't have a valid IP address in the specified position. Valid values include: `MATCH` or `NO_MATCH`.
 * `header_name` - (Required) - Name of the HTTP header to use for the IP address.
 * `position` - (Required) - Position in the header to search for the IP address. Valid values include: `FIRST`, `LAST`, or `ANY`. If `ANY` is specified and the header contains more than 10 IP addresses, AWS WAFv2 inspects the last 10.
+
+### JSON Body
+
+The `json_body` block supports the following arguments:
+
+* `invalid_fallback_behavior` - (Optional) What to do when JSON parsing fails. Defaults to evaluating up to the first parsing failure. Valid values are `EVALUATE_AS_STRING`, `MATCH` and `NO_MATCH`.
+* `match_pattern` - (Required) The patterns to look for in the JSON body. See [JSON Match Pattern](#json-match-pattern) for details.
+* `match_scope` - (Required) The parts of the JSON to match against using the `match_pattern`. Valid values are `ALL`, `KEY` and `VALUE`.
+* `oversize_handling` - (Optional) What to do if the body is larger than can be inspected. Valid values are `CONTINUE` (default), `MATCH` and `NO_MATCH`.
+
+### JSON Match Pattern
+
+The `match_pattern` block supports the following arguments. You must specify either `all` or `included_paths`, but not both.
+
+* `all` - (Optional) Match all the elements.
+* `included_paths` - (Optional) Match only the specified paths. Paths are defined using [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) syntax (e.g., `/dogs/0/name`).
 
 ### Single Header
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #18515.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/25845.

Output from acceptance testing:

```
$ make testacc TESTS=TestAccWAFV2WebACL_ByteMatchStatement PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_ByteMatchStatement'  -timeout 180m
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (53.41s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (53.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	54.959s

$ make testacc TESTS=TestAccWAFV2RuleGroup_ByteMatchStatement PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RuleGroup_ByteMatchStatement_'  -timeout 180m
=== RUN   TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== PAUSE TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== CONT  TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (167.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	168.807s
```