### PR TITLE
d/aws_connect_user_hierarchy_group

### DIFF
--- a/.changelog/24777.txt
+++ b/.changelog/24777.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_connect_user_hierarchy_group
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -506,6 +506,7 @@ func Provider() *schema.Provider {
 			"aws_connect_quick_connect":               connect.DataSourceQuickConnect(),
 			"aws_connect_routing_profile":             connect.DataSourceRoutingProfile(),
 			"aws_connect_security_profile":            connect.DataSourceSecurityProfile(),
+			"aws_connect_user_hierarchy_group":        connect.DataSourceUserHierarchyGroup(),
 			"aws_connect_user_hierarchy_structure":    connect.DataSourceUserHierarchyStructure(),
 
 			"aws_cur_report_definition": cur.DataSourceReportDefinition(),

--- a/internal/service/connect/enum.go
+++ b/internal/service/connect/enum.go
@@ -45,6 +45,9 @@ const (
 	// ListSecurityProfilesMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
 	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListSecurityProfiles.html
 	ListSecurityProfilesMaxResults = 60
+	// ListUserHierarchyGroupsMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
+	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListUserHierarchyGroups.html
+	ListUserHierarchyGroupsMaxResults = 60
 )
 
 func InstanceAttributeMapping() map[string]string {

--- a/internal/service/connect/user_hierarchy_group_data_source.go
+++ b/internal/service/connect/user_hierarchy_group_data_source.go
@@ -1,13 +1,21 @@
 package connect
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/connect"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
 func DataSourceUserHierarchyGroup() *schema.Resource {
 	return &schema.Resource{
+		ReadContext: dataSourceUserHierarchyGroupRead,
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -70,4 +78,96 @@ func DataSourceUserHierarchyGroup() *schema.Resource {
 			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
+}
+
+func dataSourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ConnectConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	instanceID := d.Get("instance_id").(string)
+
+	input := &connect.DescribeUserHierarchyGroupInput{
+		InstanceId: aws.String(instanceID),
+	}
+
+	if v, ok := d.GetOk("hierarchy_group_id"); ok {
+		input.HierarchyGroupId = aws.String(v.(string))
+	} else if v, ok := d.GetOk("name"); ok {
+		name := v.(string)
+		hierarchyGroupSummary, err := dataSourceGetConnectUserHierarchyGroupSummaryByName(ctx, conn, instanceID, name)
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error finding Connect Hierarchy Group Summary by name (%s): %w", name, err))
+		}
+
+		if hierarchyGroupSummary == nil {
+			return diag.FromErr(fmt.Errorf("error finding Connect Hierarchy Group Summary by name (%s): not found", name))
+		}
+
+		input.HierarchyGroupId = hierarchyGroupSummary.Id
+	}
+
+	resp, err := conn.DescribeUserHierarchyGroupWithContext(ctx, input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting Connect Hierarchy Group: %w", err))
+	}
+
+	if resp == nil || resp.HierarchyGroup == nil {
+		return diag.FromErr(fmt.Errorf("error getting Connect Hierarchy Group: empty response"))
+	}
+
+	hierarchyGroup := resp.HierarchyGroup
+
+	d.Set("arn", hierarchyGroup.Arn)
+	d.Set("hierarchy_group_id", hierarchyGroup.Id)
+	d.Set("instance_id", instanceID)
+	d.Set("level_id", hierarchyGroup.LevelId)
+	d.Set("name", hierarchyGroup.Name)
+
+	if err := d.Set("hierarchy_path", flattenUserHierarchyPath(hierarchyGroup.HierarchyPath)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting Connect User Hierarchy Group hierarchy_path (%s): %w", d.Id(), err))
+	}
+
+	if err := d.Set("tags", KeyValueTags(hierarchyGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags: %s", err))
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(hierarchyGroup.Id)))
+
+	return nil
+}
+
+func dataSourceGetConnectUserHierarchyGroupSummaryByName(ctx context.Context, conn *connect.Connect, instanceID, name string) (*connect.HierarchyGroupSummary, error) {
+	var result *connect.HierarchyGroupSummary
+
+	input := &connect.ListUserHierarchyGroupsInput{
+		InstanceId: aws.String(instanceID),
+		MaxResults: aws.Int64(ListUserHierarchyGroupsMaxResults),
+	}
+
+	err := conn.ListUserHierarchyGroupsPagesWithContext(ctx, input, func(page *connect.ListUserHierarchyGroupsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, qs := range page.UserHierarchyGroupSummaryList {
+			if qs == nil {
+				continue
+			}
+
+			if aws.StringValue(qs.Name) == name {
+				result = qs
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/internal/service/connect/user_hierarchy_group_data_source.go
+++ b/internal/service/connect/user_hierarchy_group_data_source.go
@@ -1,0 +1,73 @@
+package connect
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceUserHierarchyGroup() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hierarchy_group_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"hierarchy_group_id", "name"},
+			},
+			"hierarchy_path": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"level_one": func() *schema.Schema {
+							schema := connectUserHierarchyPathLevelSchema()
+							return schema
+						}(),
+						"level_two": func() *schema.Schema {
+							schema := connectUserHierarchyPathLevelSchema()
+							return schema
+						}(),
+						"level_three": func() *schema.Schema {
+							schema := connectUserHierarchyPathLevelSchema()
+							return schema
+						}(),
+						"level_four": func() *schema.Schema {
+							schema := connectUserHierarchyPathLevelSchema()
+							return schema
+						}(),
+						"level_five": func() *schema.Schema {
+							schema := connectUserHierarchyPathLevelSchema()
+							return schema
+						}(),
+					},
+				},
+			},
+			"instance_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"level_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"name", "hierarchy_group_id"},
+			},
+			// parent_group_id is not returned by DescribeUserHierarchyGroup
+			// "parent_group_id": {
+			// 	Type:     schema.TypeString,
+			// 	Computed: true,
+			// },
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}

--- a/internal/service/connect/user_hierarchy_group_data_source_test.go
+++ b/internal/service/connect/user_hierarchy_group_data_source_test.go
@@ -46,6 +46,42 @@ func TestAccConnectUserHierarchyGroupDataSource_hierarchyGroupID(t *testing.T) {
 	})
 }
 
+func TestAccConnectUserHierarchyGroupDataSource_name(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName3 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_user_hierarchy_group.test"
+	resourceName2 := "aws_connect_user_hierarchy_group.parent"
+	datasourceName := "data.aws_connect_user_hierarchy_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserHierarchyGroupDataSourceConfig_Name(rName, rName2, rName3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_group_id", resourceName, "hierarchy_group_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.#", resourceName, "hierarchy_path.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_one.0.arn", resourceName2, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_one.0.id", resourceName2, "hierarchy_group_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_one.0.name", resourceName2, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_two.0.arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_two.0.id", resourceName, "hierarchy_group_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_two.0.name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "level_id", resourceName, "level_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Name", resourceName, "tags.Name"),
+				),
+			},
+		},
+	})
+}
+
 func testAccUserHierarchyGroupBaseDataSourceConfig(rName, rName2, rName3 string) string {
 	return fmt.Sprintf(`
 resource "aws_connect_instance" "test" {
@@ -113,6 +149,17 @@ func testAccUserHierarchyGroupDataSourceConfig_UserHierarchyGroupID(rName, rName
 data "aws_connect_user_hierarchy_group" "test" {
   instance_id        = aws_connect_instance.test.id
   hierarchy_group_id = aws_connect_user_hierarchy_group.test.hierarchy_group_id
+}
+`)
+}
+
+func testAccUserHierarchyGroupDataSourceConfig_Name(rName, rName2, rName3 string) string {
+	return acctest.ConfigCompose(
+		testAccUserHierarchyGroupBaseDataSourceConfig(rName, rName2, rName3),
+		`
+data "aws_connect_user_hierarchy_group" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = aws_connect_user_hierarchy_group.test.name
 }
 `)
 }

--- a/internal/service/connect/user_hierarchy_group_data_source_test.go
+++ b/internal/service/connect/user_hierarchy_group_data_source_test.go
@@ -1,0 +1,118 @@
+package connect_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/connect"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccConnectUserHierarchyGroupDataSource_hierarchyGroupID(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName3 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_user_hierarchy_group.test"
+	resourceName2 := "aws_connect_user_hierarchy_group.parent"
+	datasourceName := "data.aws_connect_user_hierarchy_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserHierarchyGroupDataSourceConfig_UserHierarchyGroupID(rName, rName2, rName3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_group_id", resourceName, "hierarchy_group_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.#", resourceName, "hierarchy_path.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_one.0.arn", resourceName2, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_one.0.id", resourceName2, "hierarchy_group_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_one.0.name", resourceName2, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_two.0.arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_two.0.id", resourceName, "hierarchy_group_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hierarchy_path.0.level_two.0.name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "level_id", resourceName, "level_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Name", resourceName, "tags.Name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserHierarchyGroupBaseDataSourceConfig(rName, rName2, rName3 string) string {
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+}
+
+resource "aws_connect_user_hierarchy_structure" "test" {
+  instance_id = aws_connect_instance.test.id
+
+  hierarchy_structure {
+    level_one {
+      name = "levelone"
+    }
+
+    level_two {
+      name = "leveltwo"
+    }
+
+    level_three {
+      name = "levelthree"
+    }
+
+    level_four {
+      name = "levelfour"
+    }
+
+    level_five {
+      name = "levelfive"
+    }
+  }
+}
+
+resource "aws_connect_user_hierarchy_group" "parent" {
+  instance_id = aws_connect_instance.test.id
+  name        = %[2]q
+
+  tags = {
+    "Name" = "Test User Hierarchy Group Parent"
+  }
+
+  depends_on = [
+    aws_connect_user_hierarchy_structure.test,
+  ]
+}
+
+resource "aws_connect_user_hierarchy_group" "test" {
+  instance_id     = aws_connect_instance.test.id
+  name            = %[3]q
+  parent_group_id = aws_connect_user_hierarchy_group.parent.hierarchy_group_id
+
+  tags = {
+    "Name" = "Test User Hierarchy Group Child"
+  }
+}
+`, rName, rName2, rName3)
+}
+
+func testAccUserHierarchyGroupDataSourceConfig_UserHierarchyGroupID(rName, rName2, rName3 string) string {
+	return acctest.ConfigCompose(
+		testAccUserHierarchyGroupBaseDataSourceConfig(rName, rName2, rName3),
+		`
+data "aws_connect_user_hierarchy_group" "test" {
+  instance_id        = aws_connect_instance.test.id
+  hierarchy_group_id = aws_connect_user_hierarchy_group.test.hierarchy_group_id
+}
+`)
+}

--- a/website/docs/d/connect_user_hierarchy_group.html.markdown
+++ b/website/docs/d/connect_user_hierarchy_group.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Connect"
+layout: "aws"
+page_title: "AWS: aws_connect_user_hierarchy_group"
+description: |-
+  Provides details about a specific Amazon Connect User Hierarchy Group.
+---
+
+# Data Source: aws_connect_user_hierarchy_group
+
+Provides details about a specific Amazon Connect User Hierarchy Group.
+
+## Example Usage
+
+By `name`
+
+```hcl
+data "aws_connect_user_hierarchy_group" "example" {
+  instance_id = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name        = "Example"
+}
+```
+
+By `hierarchy_group_id`
+
+```hcl
+data "aws_connect_user_hierarchy_group" "example" {
+  instance_id        = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  hierarchy_group_id = "cccccccc-bbbb-cccc-dddd-111111111111"
+}
+```
+
+## Argument Reference
+
+~> **NOTE:** `instance_id` and one of either `name` or `hierarchy_group_id` is required.
+
+The following arguments are supported:
+
+* `hierarchy_group_id` - (Optional) Returns information on a specific hierarchy group by hierarchy group id
+* `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
+* `name` - (Optional) Returns information on a specific hierarchy group by name
+
+## Attributes Reference
+
+In addition to all of the arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the hierarchy group.
+* `hierarchy_path` - A block that contains information about the levels in the hierarchy group. The `hierarchy_path` block is documented below.
+* `level_id` - The identifier of the level in the hierarchy group.
+* `id` - The identifier of the hosting Amazon Connect Instance and identifier of the hierarchy group separated by a colon (`:`).
+* `tags` - A map of tags to assign to the hierarchy group.
+
+A `hierarchy_path` block supports the following attributes:
+
+* `level_one` - A block that defines the details of level one. The level block is documented below.
+* `level_two` - A block that defines the details of level two. The level block is documented below.
+* `level_three` - A block that defines the details of level three. The level block is documented below.
+* `level_four` - A block that defines the details of level four. The level block is documented below.
+* `level_five` - A block that defines the details of level five. The level block is documented below.
+
+A level block supports the following attributes:
+
+* `arn` -  The Amazon Resource Name (ARN) of the hierarchy group.
+* `id` -  The identifier of the hierarchy group.
+* `name` - The name of the hierarchy group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24776 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccConnectUserHierarchyGroupDataSource' PKG=connect ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 1  -run=TestAccConnectUserHierarchyGroupDataSource -timeout 180m
=== RUN   TestAccConnectUserHierarchyGroupDataSource_hierarchyGroupID
--- PASS: TestAccConnectUserHierarchyGroupDataSource_hierarchyGroupID (82.83s)
=== RUN   TestAccConnectUserHierarchyGroupDataSource_name
--- PASS: TestAccConnectUserHierarchyGroupDataSource_name (82.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    165.737s
...
```
