### PR TITLE
waf: Clean up const, func names

### DIFF
--- a/internal/service/waf/ipset_test.go
+++ b/internal/service/waf/ipset_test.go
@@ -235,7 +235,7 @@ func TestAccWAFIPSet_IPSetDescriptors_1000UpdateLimit(t *testing.T) {
 	})
 }
 
-func TestDiffWafIpSetDescriptors(t *testing.T) {
+func TestDiffIPSetDescriptors(t *testing.T) {
 	testCases := []struct {
 		Old             []interface{}
 		New             []interface{}

--- a/internal/service/waf/rule.go
+++ b/internal/service/waf/rule.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	WafRuleDeleteTimeout = 5 * time.Minute
+	RuleDeleteTimeout = 5 * time.Minute
 )
 
 func ResourceRule() *schema.Resource {
@@ -228,7 +228,7 @@ func resourceRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	wr := NewRetryer(conn)
-	err := resource.Retry(WafRuleDeleteTimeout, func() *resource.RetryError {
+	err := resource.Retry(RuleDeleteTimeout, func() *resource.RetryError {
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.DeleteRuleInput{
 				ChangeToken: token,

--- a/internal/service/wafregional/ipset_test.go
+++ b/internal/service/wafregional/ipset_test.go
@@ -235,7 +235,7 @@ func TestAccWAFRegionalIPSet_noDescriptors(t *testing.T) {
 	})
 }
 
-func TestDiffWafRegionalIpSetDescriptors(t *testing.T) {
+func TestDiffIPSetDescriptors(t *testing.T) {
 	testCases := []struct {
 		Old             []interface{}
 		New             []interface{}

--- a/internal/service/wafregional/web_acl_association_test.go
+++ b/internal/service/wafregional/web_acl_association_test.go
@@ -25,7 +25,7 @@ func TestAccWAFRegionalWebACLAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckWebACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWafRegionalWebAclAssociationConfig_basic,
+				Config: testAccWebACLAssociationConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLAssociationExists(resourceName),
 				),
@@ -47,7 +47,7 @@ func TestAccWAFRegionalWebACLAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckWebACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWafRegionalWebAclAssociationConfig_basic,
+				Config: testAccWebACLAssociationConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLAssociationExists("aws_wafregional_web_acl_association.foo"),
 					testAccCheckWebACLAssociationDisappears("aws_wafregional_web_acl_association.foo"),
@@ -194,7 +194,7 @@ func testAccCheckWebACLAssociationDisappears(resourceName string) resource.TestC
 	}
 }
 
-const testAccCheckWafRegionalWebAclAssociationConfig_basic = `
+const testAccWebACLAssociationConfig_basic = `
 resource "aws_wafregional_rule" "foo" {
   name        = "foo"
   metric_name = "foo"
@@ -254,7 +254,7 @@ resource "aws_wafregional_web_acl_association" "foo" {
 }
 `
 
-const testAccCheckWafRegionalWebAclAssociationConfig_multipleAssociations = testAccCheckWafRegionalWebAclAssociationConfig_basic + `
+const testAccCheckWafRegionalWebAclAssociationConfig_multipleAssociations = testAccWebACLAssociationConfig_basic + `
 resource "aws_alb" "bar" {
   internal = true
   subnets  = [aws_subnet.foo.id, aws_subnet.bar.id]

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	Wafv2WebACLAssociationCreateTimeout = 5 * time.Minute
+	WebACLAssociationCreateTimeout = 5 * time.Minute
 )
 
 func ResourceWebACLAssociation() *schema.Resource {
@@ -63,7 +63,7 @@ func resourceWebACLAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		WebACLArn:   aws.String(webAclArn),
 	}
 
-	err := resource.Retry(Wafv2WebACLAssociationCreateTimeout, func() *resource.RetryError {
+	err := resource.Retry(WebACLAssociationCreateTimeout, func() *resource.RetryError {
 		_, err := conn.AssociateWebACL(params)
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, wafv2.ErrCodeWAFUnavailableEntityException) {

--- a/internal/service/workspaces/status.go
+++ b/internal/service/workspaces/status.go
@@ -23,6 +23,7 @@ func StatusDirectoryState(conn *workspaces.WorkSpaces, id string) resource.State
 	}
 }
 
+// nosemgrep: workspaces-in-func-name
 func StatusWorkspaceState(conn *workspaces.WorkSpaces, workspaceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := conn.DescribeWorkspaces(&workspaces.DescribeWorkspacesInput{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
