### PR TITLE
storagegateway: Clean up const, func names

### DIFF
--- a/internal/service/storagegateway/cache_test.go
+++ b/internal/service/storagegateway/cache_test.go
@@ -14,7 +14,7 @@ import (
 	tfstoragegateway "github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
 )
 
-func TestDecodeStorageGatewayCacheID(t *testing.T) {
+func TestDecodeCacheID(t *testing.T) {
 	var testCases = []struct {
 		Input              string
 		ExpectedGatewayARN string

--- a/internal/service/storagegateway/cached_iscsi_volume_test.go
+++ b/internal/service/storagegateway/cached_iscsi_volume_test.go
@@ -16,7 +16,7 @@ import (
 	tfstoragegateway "github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
 )
 
-func TestParseStorageGatewayVolumeGatewayARNAndTargetNameFromARN(t *testing.T) {
+func TestParseVolumeGatewayARNAndTargetNameFromARN(t *testing.T) {
 	var testCases = []struct {
 		Input              string
 		ExpectedGatewayARN string

--- a/internal/service/storagegateway/status.go
+++ b/internal/service/storagegateway/status.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	storageGatewayGatewayStatusConnected = "GatewayConnected"
-	storediSCSIVolumeStatusNotFound      = "NotFound"
+	gatewayStatusConnected          = "GatewayConnected"
+	storediSCSIVolumeStatusNotFound = "NotFound"
 )
 
 func statusGateway(conn *storagegateway.StorageGateway, gatewayARN string) resource.StateRefreshFunc {
@@ -29,7 +29,7 @@ func statusGateway(conn *storagegateway.StorageGateway, gatewayARN string) resou
 			return output, "", err
 		}
 
-		return output, storageGatewayGatewayStatusConnected, nil
+		return output, gatewayStatusConnected, nil
 	}
 }
 

--- a/internal/service/storagegateway/upload_buffer_test.go
+++ b/internal/service/storagegateway/upload_buffer_test.go
@@ -14,7 +14,7 @@ import (
 	tfstoragegateway "github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
 )
 
-func TestDecodeStorageGatewayUploadBufferID(t *testing.T) {
+func TestDecodeUploadBufferID(t *testing.T) {
 	var testCases = []struct {
 		Input              string
 		ExpectedGatewayARN string

--- a/internal/service/storagegateway/wait.go
+++ b/internal/service/storagegateway/wait.go
@@ -8,26 +8,26 @@ import (
 )
 
 const (
-	storageGatewayGatewayConnectedMinTimeout                = 10 * time.Second
-	storageGatewayGatewayConnectedContinuousTargetOccurence = 6
-	storageGatewayGatewayJoinDomainJoinedTimeout            = 5 * time.Minute
-	storediSCSIVolumeAvailableTimeout                       = 5 * time.Minute
-	nfsFileShareAvailableDelay                              = 5 * time.Second
-	nfsFileShareDeletedDelay                                = 5 * time.Second
-	smbFileShareAvailableDelay                              = 5 * time.Second
-	smbFileShareDeletedDelay                                = 5 * time.Second
-	fileSystemAssociationAvailableDelay                     = 5 * time.Second
-	fileSystemAssociationDeletedDelay                       = 5 * time.Second
+	gatewayConnectedMinTimeout                = 10 * time.Second
+	gatewayConnectedContinuousTargetOccurence = 6
+	gatewayJoinDomainJoinedTimeout            = 5 * time.Minute
+	storediSCSIVolumeAvailableTimeout         = 5 * time.Minute
+	nfsFileShareAvailableDelay                = 5 * time.Second
+	nfsFileShareDeletedDelay                  = 5 * time.Second
+	smbFileShareAvailableDelay                = 5 * time.Second
+	smbFileShareDeletedDelay                  = 5 * time.Second
+	fileSystemAssociationAvailableDelay       = 5 * time.Second
+	fileSystemAssociationDeletedDelay         = 5 * time.Second
 )
 
 func waitGatewayConnected(conn *storagegateway.StorageGateway, gatewayARN string, timeout time.Duration) (*storagegateway.DescribeGatewayInformationOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{storagegateway.ErrorCodeGatewayNotConnected},
-		Target:                    []string{storageGatewayGatewayStatusConnected},
+		Target:                    []string{gatewayStatusConnected},
 		Refresh:                   statusGateway(conn, gatewayARN),
 		Timeout:                   timeout,
-		MinTimeout:                storageGatewayGatewayConnectedMinTimeout,
-		ContinuousTargetOccurence: storageGatewayGatewayConnectedContinuousTargetOccurence, // Gateway activations can take a few seconds and can trigger a reboot of the Gateway
+		MinTimeout:                gatewayConnectedMinTimeout,
+		ContinuousTargetOccurence: gatewayConnectedContinuousTargetOccurence, // Gateway activations can take a few seconds and can trigger a reboot of the Gateway
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -45,7 +45,7 @@ func waitGatewayJoinDomainJoined(conn *storagegateway.StorageGateway, volumeARN 
 		Pending: []string{storagegateway.ActiveDirectoryStatusJoining},
 		Target:  []string{storagegateway.ActiveDirectoryStatusJoined},
 		Refresh: statusGatewayJoinDomain(conn, volumeARN),
-		Timeout: storageGatewayGatewayJoinDomainJoinedTimeout,
+		Timeout: gatewayJoinDomainJoinedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/internal/service/storagegateway/working_storage_test.go
+++ b/internal/service/storagegateway/working_storage_test.go
@@ -14,7 +14,7 @@ import (
 	tfstoragegateway "github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
 )
 
-func TestDecodeStorageGatewayWorkingStorageID(t *testing.T) {
+func TestDecodeWorkingStorageID(t *testing.T) {
 	var testCases = []struct {
 		Input              string
 		ExpectedGatewayARN string


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
