### PR TITLE
s3: Clean up const, var, func names

### DIFF
--- a/internal/service/s3/bucket_analytics_configuration_test.go
+++ b/internal/service/s3/bucket_analytics_configuration_test.go
@@ -714,7 +714,7 @@ resource "aws_s3_bucket" "destination" {
 `, name, prefix, bucket)
 }
 
-func TestExpandS3AnalyticsFilter(t *testing.T) {
+func TestExpandAnalyticsFilter(t *testing.T) {
 	testCases := map[string]struct {
 		Input    []interface{}
 		Expected *s3.AnalyticsFilter
@@ -856,7 +856,7 @@ func TestExpandS3AnalyticsFilter(t *testing.T) {
 	}
 }
 
-func TestExpandS3StorageClassAnalysis(t *testing.T) {
+func TestExpandStorageClassAnalysis(t *testing.T) {
 	testCases := map[string]struct {
 		Input    []interface{}
 		Expected *s3.StorageClassAnalysis
@@ -1002,7 +1002,7 @@ func TestExpandS3StorageClassAnalysis(t *testing.T) {
 	}
 }
 
-func TestFlattenS3AnalyticsFilter(t *testing.T) {
+func TestFlattenAnalyticsFilter(t *testing.T) {
 	testCases := map[string]struct {
 		Input    *s3.AnalyticsFilter
 		Expected []map[string]interface{}
@@ -1122,7 +1122,7 @@ func TestFlattenS3AnalyticsFilter(t *testing.T) {
 	}
 }
 
-func TestFlattenS3StorageClassAnalysis(t *testing.T) {
+func TestFlattenStorageClassAnalysis(t *testing.T) {
 	testCases := map[string]struct {
 		Input    *s3.StorageClassAnalysis
 		Expected []map[string]interface{}

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -20,7 +20,7 @@ import (
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 )
 
-func TestExpandS3MetricsFilter(t *testing.T) {
+func TestExpandMetricsFilter(t *testing.T) {
 	testCases := []struct {
 		Config                  map[string]interface{}
 		ExpectedS3MetricsFilter *s3.MetricsFilter
@@ -133,7 +133,7 @@ func TestExpandS3MetricsFilter(t *testing.T) {
 	}
 }
 
-func TestFlattenS3MetricsFilter(t *testing.T) {
+func TestFlattenMetricsFilter(t *testing.T) {
 	testCases := []struct {
 		S3MetricsFilter *s3.MetricsFilter
 		ExpectedConfig  map[string]interface{}

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -208,7 +208,7 @@ func resourceBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	var resp *s3.HeadObjectOutput
 
-	err := resource.Retry(s3ObjectCreationTimeout, func() *resource.RetryError {
+	err := resource.Retry(objectCreationTimeout, func() *resource.RetryError {
 		var err error
 
 		resp, err = conn.HeadObject(input)

--- a/internal/service/s3/bucket_policy_data_source_test.go
+++ b/internal/service/s3/bucket_policy_data_source_test.go
@@ -15,7 +15,7 @@ import (
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 )
 
-func TestAccDataSourceBucketPolicy_basic(t *testing.T) {
+func TestAccS3BucketPolicyDataSource_basic(t *testing.T) {
 	var conf s3.GetBucketPolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_s3_bucket_policy.test"

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-const s3ObjectCreationTimeout = 2 * time.Minute
+const objectCreationTimeout = 2 * time.Minute
 
 func ResourceObject() *schema.Resource {
 	return &schema.Resource{
@@ -205,7 +205,7 @@ func resourceObjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	var resp *s3.HeadObjectOutput
 
-	err := resource.Retry(s3ObjectCreationTimeout, func() *resource.RetryError {
+	err := resource.Retry(objectCreationTimeout, func() *resource.RetryError {
 		var err error
 
 		resp, err = conn.HeadObject(input)

--- a/internal/service/s3control/bucket.go
+++ b/internal/service/s3control/bucket.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Maximum amount of time to wait for s3control Bucket state to propagate
-	s3controlBucketStatePropagationTimeout = 5 * time.Minute
+	bucketStatePropagationTimeout = 5 * time.Minute
 )
 
 func ResourceBucket() *schema.Resource {
@@ -213,7 +213,7 @@ func resourceBucketDelete(d *schema.ResourceData, meta interface{}) error {
 	// S3 Control Bucket have a backend state which cannot be checked so this error
 	// can occur on deletion:
 	//   InvalidBucketState: Bucket is in an invalid state
-	err = resource.Retry(s3controlBucketStatePropagationTimeout, func() *resource.RetryError {
+	err = resource.Retry(bucketStatePropagationTimeout, func() *resource.RetryError {
 		_, err := conn.DeleteBucket(input)
 
 		if tfawserr.ErrCodeEquals(err, "InvalidBucketState") {

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -146,7 +146,7 @@ var (
 		},
 	}
 
-	sqsQueueAttributeMap = attrmap.New(map[string]string{
+	queueAttributeMap = attrmap.New(map[string]string{
 		"arn":                               sqs.QueueAttributeNameQueueArn,
 		"content_based_deduplication":       sqs.QueueAttributeNameContentBasedDeduplication,
 		"deduplication_scope":               sqs.QueueAttributeNameDeduplicationScope,
@@ -201,7 +201,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		QueueName: aws.String(name),
 	}
 
-	attributes, err := sqsQueueAttributeMap.ResourceDataToApiAttributesCreate(d)
+	attributes, err := queueAttributeMap.ResourceDataToApiAttributesCreate(d)
 
 	if err != nil {
 		return err
@@ -285,7 +285,7 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	output := outputRaw.(map[string]string)
 
-	err = sqsQueueAttributeMap.ApiAttributesToResourceData(output, d)
+	err = queueAttributeMap.ApiAttributesToResourceData(output, d)
 
 	if err != nil {
 		return err
@@ -336,7 +336,7 @@ func resourceQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SQSConn
 
 	if d.HasChangesExcept("tags", "tags_all") {
-		attributes, err := sqsQueueAttributeMap.ResourceDataToApiAttributesUpdate(d)
+		attributes, err := queueAttributeMap.ResourceDataToApiAttributesUpdate(d)
 
 		if err != nil {
 			return err

--- a/internal/service/sqs/queue_policy.go
+++ b/internal/service/sqs/queue_policy.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	sqsQueueEmptyPolicyAttributes = map[string]string{
+	queueEmptyPolicyAttributes = map[string]string{
 		sqs.QueueAttributeNamePolicy: "",
 	}
 )
@@ -127,7 +127,7 @@ func resourceQueuePolicyDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting SQS Queue Policy: %s", d.Id())
 	_, err := conn.SetQueueAttributes(&sqs.SetQueueAttributesInput{
-		Attributes: aws.StringMap(sqsQueueEmptyPolicyAttributes),
+		Attributes: aws.StringMap(queueEmptyPolicyAttributes),
 		QueueUrl:   aws.String(d.Id()),
 	})
 
@@ -139,7 +139,7 @@ func resourceQueuePolicyDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error deleting SQS Queue Policy (%s): %w", d.Id(), err)
 	}
 
-	err = waitQueueAttributesPropagated(conn, d.Id(), sqsQueueEmptyPolicyAttributes)
+	err = waitQueueAttributesPropagated(conn, d.Id(), queueEmptyPolicyAttributes)
 
 	if err != nil {
 		return fmt.Errorf("error waiting for SQS Queue Policy (%s) to delete: %w", d.Id(), err)

--- a/internal/service/wafregional/web_acl_association_test.go
+++ b/internal/service/wafregional/web_acl_association_test.go
@@ -68,7 +68,7 @@ func TestAccWAFRegionalWebACLAssociation_multipleAssociations(t *testing.T) {
 		CheckDestroy:      testAccCheckWebACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWafRegionalWebAclAssociationConfig_multipleAssociations,
+				Config: testAccWebACLAssociationConfig_multipleAssociations,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLAssociationExists(resourceName),
 					testAccCheckWebACLAssociationExists("aws_wafregional_web_acl_association.bar"),
@@ -254,7 +254,7 @@ resource "aws_wafregional_web_acl_association" "foo" {
 }
 `
 
-const testAccCheckWafRegionalWebAclAssociationConfig_multipleAssociations = testAccWebACLAssociationConfig_basic + `
+const testAccWebACLAssociationConfig_multipleAssociations = testAccWebACLAssociationConfig_basic + `
 resource "aws_alb" "bar" {
   internal = true
   subnets  = [aws_subnet.foo.id, aws_subnet.bar.id]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
