### PR TITLE
r/servicecatalog_provisioned_product: add `TAINTED` to target states in waiters

### DIFF
--- a/.changelog/24804.txt
+++ b/.changelog/24804.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_servicecatalog_provisioned_product: Add possible `TAINTED` target state for resource update and remove one of the internal waiters during read
+```

--- a/internal/service/servicecatalog/provisioned_product.go
+++ b/internal/service/servicecatalog/provisioned_product.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -415,9 +416,16 @@ func resourceProvisionedProductRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("status_message", detail.StatusMessage)
 	d.Set("type", detail.Type)
 
-	// tags are only available from the record tied to the provisioned product
+	// Previously, we waited for the record to return a target state of 'SUCCEEDED' or 'AVAILABLE'
+	// but this can interfere complete reads of this resource when an error occurs after initial creation
+	// or after an invalid update. Thus, waiters are now present in the CREATE and UPDATE methods of this resource instead.
+	// TODO: determine if waiter is needed in the IMPORT case
+	recordInput := &servicecatalog.DescribeRecordInput{
+		Id:             detail.LastProvisioningRecordId,
+		AcceptLanguage: aws.String(acceptLanguage),
+	}
 
-	recordOutput, err := WaitRecordReady(conn, acceptLanguage, aws.StringValue(detail.LastProvisioningRecordId), RecordReadyTimeout)
+	recordOutput, err := conn.DescribeRecord(recordInput)
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Service Catalog Provisioned Product (%s) Record (%s) not found, unable to set tags", d.Id(), aws.StringValue(detail.LastProvisioningRecordId))
@@ -432,12 +440,25 @@ func resourceProvisionedProductRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error getting Service Catalog Provisioned Product (%s) Record (%s): empty response", d.Id(), aws.StringValue(detail.LastProvisioningRecordId))
 	}
 
+	// To enable debugging of potential errors, log as a warning
+	// instead of exiting prematurely with an error.
+	if errors := recordOutput.RecordDetail.RecordErrors; len(errors) > 0 {
+		var errs *multierror.Error
+
+		for _, err := range errors {
+			errs = multierror.Append(errs, fmt.Errorf("%s: %s", aws.StringValue(err.Code), aws.StringValue(err.Description)))
+		}
+
+		log.Printf("[WARN] Errors found when describing Service Catalog Provisioned Product (%s) Record (%s): %s", d.Id(), aws.StringValue(detail.LastProvisioningRecordId), errs.ErrorOrNil())
+	}
+
 	if err := d.Set("outputs", flattenRecordOutputs(recordOutput.RecordOutputs)); err != nil {
 		return fmt.Errorf("error setting outputs: %w", err)
 	}
 
 	d.Set("path_id", recordOutput.RecordDetail.PathId)
 
+	// tags are only available from the record tied to the provisioned product
 	tags := recordKeyValueTags(recordOutput.RecordDetail.RecordTags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002

--- a/internal/service/servicecatalog/status.go
+++ b/internal/service/servicecatalog/status.go
@@ -388,34 +388,6 @@ func StatusProvisionedProduct(conn *servicecatalog.ServiceCatalog, acceptLanguag
 	}
 }
 
-func StatusRecord(conn *servicecatalog.ServiceCatalog, acceptLanguage, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		input := &servicecatalog.DescribeRecordInput{
-			Id: aws.String(id),
-		}
-
-		if acceptLanguage != "" {
-			input.AcceptLanguage = aws.String(acceptLanguage)
-		}
-
-		output, err := conn.DescribeRecord(input)
-
-		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
-			return nil, StatusNotFound, err
-		}
-
-		if err != nil {
-			return nil, servicecatalog.StatusFailed, err
-		}
-
-		if output == nil || output.RecordDetail == nil {
-			return nil, StatusNotFound, err
-		}
-
-		return output, aws.StringValue(output.RecordDetail.Status), err
-	}
-}
-
 func StatusPortfolioConstraints(conn *servicecatalog.ServiceCatalog, acceptLanguage, portfolioID, productID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		input := &servicecatalog.ListConstraintsForPortfolioInput{

--- a/internal/service/servicecatalog/wait.go
+++ b/internal/service/servicecatalog/wait.go
@@ -2,13 +2,11 @@ package servicecatalog
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -50,7 +48,6 @@ const (
 	ProvisioningArtifactReadTimeout            = 10 * time.Minute
 	ProvisioningArtifactReadyTimeout           = 3 * time.Minute
 	ProvisioningArtifactUpdateTimeout          = 3 * time.Minute
-	RecordReadyTimeout                         = 30 * time.Minute
 	ServiceActionDeleteTimeout                 = 3 * time.Minute
 	ServiceActionReadTimeout                   = 10 * time.Minute
 	ServiceActionReadyTimeout                  = 3 * time.Minute
@@ -535,36 +532,6 @@ func WaitProvisionedProductTerminated(conn *servicecatalog.ServiceCatalog, accep
 	_, err := stateConf.WaitForState()
 
 	return err
-}
-
-func WaitRecordReady(conn *servicecatalog.ServiceCatalog, acceptLanguage, id string, timeout time.Duration) (*servicecatalog.DescribeRecordOutput, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{StatusNotFound, StatusUnavailable, servicecatalog.ProvisionedProductStatusUnderChange, servicecatalog.ProvisionedProductStatusPlanInProgress},
-		Target:                    []string{servicecatalog.RecordStatusSucceeded, servicecatalog.StatusAvailable},
-		Refresh:                   StatusRecord(conn, acceptLanguage, id),
-		Timeout:                   timeout,
-		ContinuousTargetOccurence: ContinuousTargetOccurrence,
-		NotFoundChecks:            NotFoundChecks,
-		MinTimeout:                MinTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if output, ok := outputRaw.(*servicecatalog.DescribeRecordOutput); ok {
-		if errors := output.RecordDetail.RecordErrors; len(errors) > 0 {
-			var errs *multierror.Error
-
-			for _, err := range output.RecordDetail.RecordErrors {
-				errs = multierror.Append(errs, fmt.Errorf("%s: %s", aws.StringValue(err.Code), aws.StringValue(err.Description)))
-			}
-
-			tfresource.SetLastError(err, errs.ErrorOrNil())
-		}
-
-		return output, err
-	}
-
-	return nil, err
 }
 
 func WaitPortfolioConstraintsReady(conn *servicecatalog.ServiceCatalog, acceptLanguage, portfolioID, productID string, timeout time.Duration) ([]*servicecatalog.ConstraintDetail, error) {

--- a/internal/service/servicecatalog/wait.go
+++ b/internal/service/servicecatalog/wait.go
@@ -502,8 +502,10 @@ func WaitLaunchPathsReady(conn *servicecatalog.ServiceCatalog, acceptLanguage, p
 
 func WaitProvisionedProductReady(conn *servicecatalog.ServiceCatalog, acceptLanguage, id, name string, timeout time.Duration) (*servicecatalog.DescribeProvisionedProductOutput, error) {
 	stateConf := &resource.StateChangeConf{
+		// "TAINTED" is a valid target state as its described as a stable state per API docs, though can result from a failed update
+		// such that the stack rolls back to a previous version.
 		Pending:                   []string{StatusNotFound, StatusUnavailable, servicecatalog.ProvisionedProductStatusUnderChange, servicecatalog.ProvisionedProductStatusPlanInProgress},
-		Target:                    []string{servicecatalog.StatusAvailable},
+		Target:                    []string{servicecatalog.StatusAvailable, servicecatalog.ProvisionedProductStatusTainted},
 		Refresh:                   StatusProvisionedProduct(conn, acceptLanguage, id, name),
 		Timeout:                   timeout,
 		ContinuousTargetOccurence: ContinuousTargetOccurrence,


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24574

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccServiceCatalogProvisionedProduct_' PKG=servicecatalog
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20  -run=TestAccServiceCatalogProvisionedProduct_ -timeout 180m
go: downloading github.com/aws/aws-sdk-go v1.44.13
=== RUN   TestAccServiceCatalogProvisionedProduct_basic
=== PAUSE TestAccServiceCatalogProvisionedProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_update
=== PAUSE TestAccServiceCatalogProvisionedProduct_update
=== RUN   TestAccServiceCatalogProvisionedProduct_disappears
=== PAUSE TestAccServiceCatalogProvisionedProduct_disappears
=== RUN   TestAccServiceCatalogProvisionedProduct_tags
=== PAUSE TestAccServiceCatalogProvisionedProduct_tags
=== CONT  TestAccServiceCatalogProvisionedProduct_basic
=== CONT  TestAccServiceCatalogProvisionedProduct_disappears
=== CONT  TestAccServiceCatalogProvisionedProduct_update
=== CONT  TestAccServiceCatalogProvisionedProduct_tags
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (163.59s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (189.30s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (282.63s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (284.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	287.636s
```
