### PR TITLE
route53: Clean up names

### DIFF
--- a/internal/service/route53/health_check_test.go
+++ b/internal/service/route53/health_check_test.go
@@ -143,7 +143,7 @@ func TestAccRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 		CheckDestroy:      testAccCheckHealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckConfig_withChildHealthChecks,
+				Config: testAccHealthCheckConfig_childHealthChecks,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHealthCheckExists(resourceName, &check),
 				),
@@ -253,7 +253,7 @@ func TestAccRoute53HealthCheck_cloudWatchAlarmCheck(t *testing.T) {
 		CheckDestroy:      testAccCheckHealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckCloudWatchAlarm,
+				Config: testAccHealthCheckConfig_cloudWatchAlarm,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm_name", "cloudwatch-healthcheck-alarm"),
@@ -278,7 +278,7 @@ func TestAccRoute53HealthCheck_withSNI(t *testing.T) {
 		CheckDestroy:      testAccCheckHealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckConfigWithoutSNI,
+				Config: testAccHealthCheckConfig_noSNI,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "enable_sni", "true"),
@@ -514,7 +514,7 @@ resource "aws_route53_health_check" "test" {
 `, ip)
 }
 
-const testAccRoute53HealthCheckConfig_withChildHealthChecks = `
+const testAccHealthCheckConfig_childHealthChecks = `
 resource "aws_route53_health_check" "child1" {
   fqdn              = "child1.example.com"
   port              = 80
@@ -554,7 +554,7 @@ resource "aws_route53_health_check" "test" {
 `, strings.Join(regions, "\", \""))
 }
 
-const testAccRoute53HealthCheckCloudWatchAlarm = `
+const testAccHealthCheckConfig_cloudWatchAlarm = `
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name          = "cloudwatch-healthcheck-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -597,7 +597,7 @@ resource "aws_route53_health_check" "test" {
 `, search, invert)
 }
 
-const testAccRoute53HealthCheckConfigWithoutSNI = `
+const testAccHealthCheckConfig_noSNI = `
 resource "aws_route53_health_check" "test" {
   fqdn               = "dev.example.com"
   port               = 443

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -131,7 +131,7 @@ func TestAccRoute53Record_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfig,
+				Config: testAccRecordConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -157,7 +157,7 @@ func TestAccRoute53Record_underscored(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigUnderscoreInName,
+				Config: testAccRecordConfig_underscoreInName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -184,7 +184,7 @@ func TestAccRoute53Record_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfig,
+				Config: testAccRecordConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("aws_route53_zone.main", &zone1),
 					testAccCheckRecordExists(resourceName, &record1),
@@ -207,7 +207,7 @@ func TestAccRoute53Record_Disappears_multipleRecords(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigMultiple,
+				Config: testAccRecordConfig_multiple,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("aws_route53_zone.test", &zone1),
 					testAccCheckRecordExists("aws_route53_record.test.0", &record1),
@@ -234,7 +234,7 @@ func TestAccRoute53Record_Basic_fqdn(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfig_fqdn,
+				Config: testAccRecordConfig_fqdn,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -253,7 +253,7 @@ func TestAccRoute53Record_Basic_fqdn(t *testing.T) {
 			// non-empty plan would appear, and the record will fail to exist in
 			// testAccCheckRecordExists
 			{
-				Config: testAccRoute53RecordConfig_fqdn_no_op,
+				Config: testAccRecordConfig_fqdnNoOp,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record2),
 				),
@@ -275,7 +275,7 @@ func TestAccRoute53Record_Basic_trailingPeriodAndZoneID(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfig_nameWithTrailingPeriod,
+				Config: testAccRecordConfig_nameTrailingPeriod,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -301,7 +301,7 @@ func TestAccRoute53Record_txtSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigTXT,
+				Config: testAccRecordConfig_txt,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -327,7 +327,7 @@ func TestAccRoute53Record_spfSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigSPF,
+				Config: testAccRecordConfig_spf,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					resource.TestCheckTypeSetElemAttr(resourceName, "records.*", "include:domain.test"),
@@ -354,7 +354,7 @@ func TestAccRoute53Record_caaSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigCAA,
+				Config: testAccRecordConfig_caa,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					resource.TestCheckTypeSetElemAttr(resourceName, "records.*", "0 issue \"domainca.test;\""),
@@ -381,7 +381,7 @@ func TestAccRoute53Record_dsSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigDS,
+				Config: testAccRecordConfig_ds,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -406,7 +406,7 @@ func TestAccRoute53Record_generatesSuffix(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigSuffix,
+				Config: testAccRecordConfig_suffix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -432,7 +432,7 @@ func TestAccRoute53Record_wildcard(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53WildCardRecordConfig,
+				Config: testAccRecordConfig_wildcard,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -446,7 +446,7 @@ func TestAccRoute53Record_wildcard(t *testing.T) {
 
 			// Cause a change, which will trigger a refresh
 			{
-				Config: testAccRoute53WildCardRecordConfigUpdate,
+				Config: testAccRecordConfig_wildcardUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record2),
 				),
@@ -466,7 +466,7 @@ func TestAccRoute53Record_failover(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53FailoverCNAMERecord,
+				Config: testAccRecordConfig_failoverCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					testAccCheckRecordExists("aws_route53_record.www-secondary", &record2),
@@ -493,7 +493,7 @@ func TestAccRoute53Record_Weighted_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53WeightedCNAMERecord,
+				Config: testAccRecordConfig_weightedCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.www-dev", &record1),
 					testAccCheckRecordExists(resourceName, &record2),
@@ -521,7 +521,7 @@ func TestAccRoute53Record_WeightedToSimple_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testaccRoute53RecordConfigWithWeightedRoutingPolicy,
+				Config: testaccRecordConfig_weightedRoutingPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -533,7 +533,7 @@ func TestAccRoute53Record_WeightedToSimple_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 			{
-				Config: testaccRoute53RecordConfigWithSimpleRoutingPolicy,
+				Config: testaccRecordConfig_simpleRoutingPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -547,7 +547,7 @@ func TestAccRoute53Record_Alias_elb(t *testing.T) {
 	resourceName := "aws_route53_record.alias"
 
 	rs := sdkacctest.RandString(10)
-	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
+	config := fmt.Sprintf(testAccRecordConfig_aliasELB, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
@@ -633,7 +633,7 @@ func TestAccRoute53Record_Alias_uppercase(t *testing.T) {
 	resourceName := "aws_route53_record.alias"
 
 	rs := sdkacctest.RandString(10)
-	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
+	config := fmt.Sprintf(testAccRecordConfig_aliasELBUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
@@ -667,7 +667,7 @@ func TestAccRoute53Record_Weighted_alias(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53WeightedElbAliasRecord,
+				Config: testAccRecordConfig_weightedELBAliasRecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					testAccCheckRecordExists("aws_route53_record.elb_weighted_alias_dev", &record2),
@@ -681,7 +681,7 @@ func TestAccRoute53Record_Weighted_alias(t *testing.T) {
 			},
 
 			{
-				Config: testAccRoute53WeightedR53AliasRecord,
+				Config: testAccRecordConfig_weightedAliasRecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.green_origin", &record3),
 					testAccCheckRecordExists("aws_route53_record.r53_weighted_alias_live", &record4),
@@ -704,7 +704,7 @@ func TestAccRoute53Record_Geolocation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53GeolocationCNAMERecord,
+				Config: testAccRecordConfig_geolocationCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.default", &record1),
 					testAccCheckRecordExists("aws_route53_record.california", &record2),
@@ -825,7 +825,7 @@ func TestAccRoute53Record_typeChange(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordTypeChangePre,
+				Config: testAccRecordConfig_typeChangePre,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -839,7 +839,7 @@ func TestAccRoute53Record_typeChange(t *testing.T) {
 
 			// Cause a change, which will trigger a refresh
 			{
-				Config: testAccRoute53RecordTypeChangePost,
+				Config: testAccRecordConfig_typeChangePost,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record2),
 				),
@@ -859,7 +859,7 @@ func TestAccRoute53Record_nameChange(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordNameChangePre,
+				Config: testAccRecordConfig_nameChangePre,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -873,7 +873,7 @@ func TestAccRoute53Record_nameChange(t *testing.T) {
 
 			// Cause a change, which will trigger a refresh
 			{
-				Config: testAccRoute53RecordNameChangePost,
+				Config: testAccRecordConfig_nameChangePost,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record2),
 					testAccCheckRecordDoesNotExist("aws_route53_zone.main", "sample", "CNAME"),
@@ -894,7 +894,7 @@ func TestAccRoute53Record_setIdentifierChange(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordSetIdentifierChangePre,
+				Config: testAccRecordConfig_setIdentifierChangePre,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -908,7 +908,7 @@ func TestAccRoute53Record_setIdentifierChange(t *testing.T) {
 
 			// Cause a change, which will trigger a refresh
 			{
-				Config: testAccRoute53RecordSetIdentifierChangePost,
+				Config: testAccRecordConfig_setIdentifierChangePost,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record2),
 				),
@@ -928,7 +928,7 @@ func TestAccRoute53Record_aliasChange(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordAliasChangePre,
+				Config: testAccRecordConfig_aliasChangePre,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -942,7 +942,7 @@ func TestAccRoute53Record_aliasChange(t *testing.T) {
 
 			// Cause a change, which will trigger a refresh
 			{
-				Config: testAccRoute53RecordAliasChangePost,
+				Config: testAccRecordConfig_aliasChangePost,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record2),
 				),
@@ -962,7 +962,7 @@ func TestAccRoute53Record_empty(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigEmptyName,
+				Config: testAccRecordConfig_emptyName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -983,7 +983,7 @@ func TestAccRoute53Record_longTXTrecord(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53RecordConfigLongTxtRecord,
+				Config: testAccRecordConfig_longTxtRecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -1009,7 +1009,7 @@ func TestAccRoute53Record_MultiValueAnswer_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53MultiValueAnswerARecord,
+				Config: testAccRecordConfig_multiValueAnswerARecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.www-server1", &record1),
 					testAccCheckRecordExists("aws_route53_record.www-server2", &record2),
@@ -1277,7 +1277,7 @@ resource "aws_route53_record" "overwriting" {
 `, allowOverwrite)
 }
 
-const testAccRoute53RecordConfig = `
+const testAccRecordConfig_basic = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1291,7 +1291,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfig_nameWithTrailingPeriod = `
+const testAccRecordConfig_nameTrailingPeriod = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1305,7 +1305,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfigMultiple = `
+const testAccRecordConfig_multiple = `
 resource "aws_route53_zone" "test" {
   name = "domain.test"
 }
@@ -1321,7 +1321,7 @@ resource "aws_route53_record" "test" {
 }
 `
 
-const testAccRoute53RecordConfig_fqdn = `
+const testAccRecordConfig_fqdn = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1339,7 +1339,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfig_fqdn_no_op = `
+const testAccRecordConfig_fqdnNoOp = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1357,7 +1357,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfigSuffix = `
+const testAccRecordConfig_suffix = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1371,7 +1371,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53WildCardRecordConfig = `
+const testAccRecordConfig_wildcard = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1393,7 +1393,7 @@ resource "aws_route53_record" "wildcard" {
 }
 `
 
-const testAccRoute53WildCardRecordConfigUpdate = `
+const testAccRecordConfig_wildcardUpdate = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1415,7 +1415,7 @@ resource "aws_route53_record" "wildcard" {
 }
 `
 
-const testAccRoute53RecordConfigTXT = `
+const testAccRecordConfig_txt = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1429,7 +1429,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfigSPF = `
+const testAccRecordConfig_spf = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1443,7 +1443,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfigCAA = `
+const testAccRecordConfig_caa = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1458,7 +1458,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53RecordConfigDS = `
+const testAccRecordConfig_ds = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1472,7 +1472,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRoute53FailoverCNAMERecord = `
+const testAccRecordConfig_failoverCNAMERecord = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1520,7 +1520,7 @@ resource "aws_route53_record" "www-secondary" {
 }
 `
 
-const testAccRoute53WeightedCNAMERecord = `
+const testAccRecordConfig_weightedCNAMERecord = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1568,7 +1568,7 @@ resource "aws_route53_record" "www-off" {
 }
 `
 
-const testAccRoute53GeolocationCNAMERecord = `
+const testAccRecordConfig_geolocationCNAMERecord = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1681,7 +1681,7 @@ resource "aws_route53_record" "third_region" {
 `, firstRegion, secondRegion, thirdRegion)
 }
 
-const testAccRoute53RecordConfigAliasElb = `
+const testAccRecordConfig_aliasELB = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -1720,7 +1720,7 @@ resource "aws_elb" "main" {
 }
 `
 
-const testAccRoute53RecordConfigAliasElbUppercase = `
+const testAccRecordConfig_aliasELBUppercase = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -1982,7 +1982,7 @@ resource "aws_route53_record" "test" {
 `
 }
 
-const testAccRoute53WeightedElbAliasRecord = `
+const testAccRecordConfig_weightedELBAliasRecord = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -2057,7 +2057,7 @@ resource "aws_route53_record" "elb_weighted_alias_dev" {
 }
 `
 
-const testAccRoute53WeightedR53AliasRecord = `
+const testAccRecordConfig_weightedAliasRecord = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2115,7 +2115,7 @@ resource "aws_route53_record" "r53_weighted_alias_dev" {
 }
 `
 
-const testAccRoute53RecordTypeChangePre = `
+const testAccRecordConfig_typeChangePre = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2129,7 +2129,7 @@ resource "aws_route53_record" "sample" {
 }
 `
 
-const testAccRoute53RecordTypeChangePost = `
+const testAccRecordConfig_typeChangePost = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2143,7 +2143,7 @@ resource "aws_route53_record" "sample" {
 }
 `
 
-const testAccRoute53RecordNameChangePre = `
+const testAccRecordConfig_nameChangePre = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2157,7 +2157,7 @@ resource "aws_route53_record" "sample" {
 }
 `
 
-const testAccRoute53RecordNameChangePost = `
+const testAccRecordConfig_nameChangePost = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2171,7 +2171,7 @@ resource "aws_route53_record" "sample" {
 }
 `
 
-const testAccRoute53RecordSetIdentifierChangePre = `
+const testAccRecordConfig_setIdentifierChangePre = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2185,7 +2185,7 @@ resource "aws_route53_record" "basic_to_weighted" {
 }
 `
 
-const testAccRoute53RecordSetIdentifierChangePost = `
+const testAccRecordConfig_setIdentifierChangePost = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2204,7 +2204,7 @@ resource "aws_route53_record" "basic_to_weighted" {
 }
 `
 
-const testAccRoute53RecordAliasChangePre = `
+const testAccRecordConfig_aliasChangePre = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -2243,7 +2243,7 @@ resource "aws_route53_record" "elb_alias_change" {
 }
 `
 
-const testAccRoute53RecordAliasChangePost = `
+const testAccRecordConfig_aliasChangePost = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2257,7 +2257,7 @@ resource "aws_route53_record" "elb_alias_change" {
 }
 `
 
-const testAccRoute53RecordConfigEmptyName = `
+const testAccRecordConfig_emptyName = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2271,7 +2271,7 @@ resource "aws_route53_record" "empty" {
 }
 `
 
-const testAccRoute53RecordConfigLongTxtRecord = `
+const testAccRecordConfig_longTxtRecord = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2287,7 +2287,7 @@ resource "aws_route53_record" "long_txt" {
 }
 `
 
-const testAccRoute53RecordConfigUnderscoreInName = `
+const testAccRecordConfig_underscoreInName = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2301,7 +2301,7 @@ resource "aws_route53_record" "underscore" {
 }
 `
 
-const testAccRoute53MultiValueAnswerARecord = `
+const testAccRecordConfig_multiValueAnswerARecord = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2327,7 +2327,7 @@ resource "aws_route53_record" "www-server2" {
 }
 `
 
-const testaccRoute53RecordConfigWithWeightedRoutingPolicy = `
+const testaccRecordConfig_weightedRoutingPolicy = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2347,7 +2347,7 @@ resource "aws_route53_record" "www-server1" {
 }
 `
 
-const testaccRoute53RecordConfigWithSimpleRoutingPolicy = `
+const testaccRecordConfig_simpleRoutingPolicy = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }

--- a/internal/service/route53/traffic_policy_document_model.go
+++ b/internal/service/route53/traffic_policy_document_model.go
@@ -1,19 +1,19 @@
 package route53
 
 const (
-	Route53TrafficPolicyDocEndpointValue      = "value"
-	Route53TrafficPolicyDocEndpointCloudfront = "cloudfront"
-	Route53TrafficPolicyDocEndpointElastic    = "elastic-load-balancer"
-	Route53TrafficPolicyDocEndpointS3         = "s3-website"
+	trafficPolicyDocEndpointValue      = "value"
+	trafficPolicyDocEndpointCloudfront = "cloudfront"
+	trafficPolicyDocEndpointElastic    = "elastic-load-balancer"
+	trafficPolicyDocEndpointS3         = "s3-website"
 )
 
 // TrafficPolicyDocEndpointType_values returns all elements of the endpoints types
 func TrafficPolicyDocEndpointType_values() []string {
 	return []string{
-		Route53TrafficPolicyDocEndpointValue,
-		Route53TrafficPolicyDocEndpointCloudfront,
-		Route53TrafficPolicyDocEndpointElastic,
-		Route53TrafficPolicyDocEndpointS3,
+		trafficPolicyDocEndpointValue,
+		trafficPolicyDocEndpointCloudfront,
+		trafficPolicyDocEndpointElastic,
+		trafficPolicyDocEndpointS3,
 	}
 }
 

--- a/internal/service/route53recoverycontrolconfig/wait.go
+++ b/internal/service/route53recoverycontrolconfig/wait.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	route53RecoveryControlConfigTimeout    = 60 * time.Second
-	route53RecoveryControlConfigMinTimeout = 5 * time.Second
+	timeout    = 60 * time.Second
+	minTimeout = 5 * time.Second
 )
 
 func waitClusterCreated(conn *r53rcc.Route53RecoveryControlConfig, clusterArn string) (*r53rcc.DescribeClusterOutput, error) {
@@ -17,8 +17,8 @@ func waitClusterCreated(conn *r53rcc.Route53RecoveryControlConfig, clusterArn st
 		Pending:    []string{r53rcc.StatusPending},
 		Target:     []string{r53rcc.StatusDeployed},
 		Refresh:    statusCluster(conn, clusterArn),
-		Timeout:    route53RecoveryControlConfigTimeout,
-		MinTimeout: route53RecoveryControlConfigMinTimeout,
+		Timeout:    timeout,
+		MinTimeout: minTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -35,8 +35,8 @@ func waitClusterDeleted(conn *r53rcc.Route53RecoveryControlConfig, clusterArn st
 		Pending:        []string{r53rcc.StatusPendingDeletion},
 		Target:         []string{},
 		Refresh:        statusCluster(conn, clusterArn),
-		Timeout:        route53RecoveryControlConfigTimeout,
-		Delay:          route53RecoveryControlConfigMinTimeout,
+		Timeout:        timeout,
+		Delay:          minTimeout,
 		NotFoundChecks: 1,
 	}
 
@@ -54,8 +54,8 @@ func waitRoutingControlCreated(conn *r53rcc.Route53RecoveryControlConfig, routin
 		Pending:    []string{r53rcc.StatusPending},
 		Target:     []string{r53rcc.StatusDeployed},
 		Refresh:    statusRoutingControl(conn, routingControlArn),
-		Timeout:    route53RecoveryControlConfigTimeout,
-		MinTimeout: route53RecoveryControlConfigMinTimeout,
+		Timeout:    timeout,
+		MinTimeout: minTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -72,8 +72,8 @@ func waitRoutingControlDeleted(conn *r53rcc.Route53RecoveryControlConfig, routin
 		Pending:        []string{r53rcc.StatusPendingDeletion},
 		Target:         []string{},
 		Refresh:        statusRoutingControl(conn, routingControlArn),
-		Timeout:        route53RecoveryControlConfigTimeout,
-		Delay:          route53RecoveryControlConfigMinTimeout,
+		Timeout:        timeout,
+		Delay:          minTimeout,
 		NotFoundChecks: 1,
 	}
 
@@ -91,8 +91,8 @@ func waitControlPanelCreated(conn *r53rcc.Route53RecoveryControlConfig, controlP
 		Pending:    []string{r53rcc.StatusPending},
 		Target:     []string{r53rcc.StatusDeployed},
 		Refresh:    statusControlPanel(conn, controlPanelArn),
-		Timeout:    route53RecoveryControlConfigTimeout,
-		MinTimeout: route53RecoveryControlConfigMinTimeout,
+		Timeout:    timeout,
+		MinTimeout: minTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -109,8 +109,8 @@ func waitControlPanelDeleted(conn *r53rcc.Route53RecoveryControlConfig, controlP
 		Pending:        []string{r53rcc.StatusPendingDeletion},
 		Target:         []string{},
 		Refresh:        statusControlPanel(conn, controlPanelArn),
-		Timeout:        route53RecoveryControlConfigTimeout,
-		Delay:          route53RecoveryControlConfigMinTimeout,
+		Timeout:        timeout,
+		Delay:          minTimeout,
 		NotFoundChecks: 1,
 	}
 
@@ -128,8 +128,8 @@ func waitSafetyRuleCreated(conn *r53rcc.Route53RecoveryControlConfig, safetyRule
 		Pending:    []string{r53rcc.StatusPending},
 		Target:     []string{r53rcc.StatusDeployed},
 		Refresh:    statusSafetyRule(conn, safetyRuleArn),
-		Timeout:    route53RecoveryControlConfigTimeout,
-		MinTimeout: route53RecoveryControlConfigMinTimeout,
+		Timeout:    timeout,
+		MinTimeout: minTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -146,8 +146,8 @@ func waitSafetyRuleDeleted(conn *r53rcc.Route53RecoveryControlConfig, safetyRule
 		Pending:        []string{r53rcc.StatusPendingDeletion},
 		Target:         []string{},
 		Refresh:        statusSafetyRule(conn, safetyRuleArn),
-		Timeout:        route53RecoveryControlConfigTimeout,
-		Delay:          route53RecoveryControlConfigMinTimeout,
+		Timeout:        timeout,
+		Delay:          minTimeout,
 		NotFoundChecks: 1,
 	}
 

--- a/internal/service/route53resolver/rule_test.go
+++ b/internal/service/route53resolver/rule_test.go
@@ -25,7 +25,7 @@ func TestAccRoute53ResolverRule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ResolverRuleConfig_basicNoTags,
+				Config: testAccRuleConfig_basicNoTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com"),
@@ -115,7 +115,7 @@ func TestAccRoute53ResolverRule_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ResolverRuleConfig_basicTags,
+				Config: testAccRuleConfig_basicTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com"),
@@ -131,7 +131,7 @@ func TestAccRoute53ResolverRule_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoute53ResolverRuleConfig_basicTagsChanged,
+				Config: testAccRuleConfig_basicTagsChanged,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com"),
@@ -142,7 +142,7 @@ func TestAccRoute53ResolverRule_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRoute53ResolverRuleConfig_basicNoTags,
+				Config: testAccRuleConfig_basicNoTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com"),
@@ -395,14 +395,14 @@ resource "aws_route53_resolver_rule" "example" {
 `, domainName)
 }
 
-const testAccRoute53ResolverRuleConfig_basicNoTags = `
+const testAccRuleConfig_basicNoTags = `
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"
 }
 `
 
-const testAccRoute53ResolverRuleConfig_basicTags = `
+const testAccRuleConfig_basicTags = `
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"
@@ -414,7 +414,7 @@ resource "aws_route53_resolver_rule" "example" {
 }
 `
 
-const testAccRoute53ResolverRuleConfig_basicTagsChanged = `
+const testAccRuleConfig_basicTagsChanged = `
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
