### PR TITLE
aws_waf_web_acl: Remove COUNT from default_action allowed values list

### DIFF
--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 ### `default_action` Configuration Block
 
 * `type` - (Required) Specifies how you want AWS WAF to respond to requests that don't match the criteria in any of the `rules`.
-  e.g., `ALLOW`, `BLOCK` or `COUNT`
+  e.g., `ALLOW` or `BLOCK`
 
 ### `logging_configuration` Configuration Block
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #24812

Output from acceptance testing: n/a, docs

### Information

Currently, the documentation for `aws_waf_web_acl.default_action` incorrectly states that `COUNT` is a valid option. This PR removes this, as it's invalid.

- Resource [uses `waf.CreateWebACL`](https://github.com/hashicorp/terraform-provider-aws/blob/3e72775d073cb3e0e5e765e36121bf4384f16a66/internal/service/waf/web_acl.go#L159-L170)
- [documentation for `waf.CreateWebACLInput`](https://docs.aws.amazon.com/sdk-for-go/api/service/waf/#CreateWebACLInput), has `DefaultAction` field of type `*WafAction`
- [type `WafAction` documentation](https://docs.aws.amazon.com/sdk-for-go/api/service/waf/#WafAction), has the following note:

```plaintext
    //    * COUNT: AWS WAF increments a counter of the requests that match all of
    //    the conditions in the rule. AWS WAF then continues to inspect the web
    //    request based on the remaining rules in the web ACL. You can't specify
    //    COUNT for the default action for a WebACL.
```