### PR TITLE
r/aws_location_place_index - new resource

### DIFF
--- a/.changelog/24821.txt
+++ b/.changelog/24821.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_location_place_index
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1610,7 +1610,8 @@ func Provider() *schema.Provider {
 			"aws_lightsail_static_ip":             lightsail.ResourceStaticIP(),
 			"aws_lightsail_static_ip_attachment":  lightsail.ResourceStaticIPAttachment(),
 
-			"aws_location_map": location.ResourceMap(),
+			"aws_location_map":         location.ResourceMap(),
+			"aws_location_place_index": location.ResourcePlaceIndex(),
 
 			"aws_macie_member_account_association": macie.ResourceMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":      macie.ResourceS3BucketAssociation(),

--- a/internal/service/location/place_index.go
+++ b/internal/service/location/place_index.go
@@ -1,0 +1,224 @@
+package location
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func ResourcePlaceIndex() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePlaceIndexCreate,
+		Read:   resourcePlaceIndexRead,
+		Update: resourcePlaceIndexUpdate,
+		Delete: resourcePlaceIndexDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"data_source_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"intended_use": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      locationservice.IntendedUseSingleUse,
+							ValidateFunc: validation.StringInSlice(locationservice.IntendedUse_Values(), false),
+						},
+					},
+				},
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1000),
+			},
+			"index_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"index_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePlaceIndexCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.CreatePlaceIndexInput{}
+
+	if v, ok := d.GetOk("data_source"); ok {
+		input.DataSource = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("data_source_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.DataSourceConfiguration = expandDataSourceConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("index_name"); ok {
+		input.IndexName = aws.String(v.(string))
+	}
+
+	output, err := conn.CreatePlaceIndex(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating place index: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error creating place index: empty result")
+	}
+
+	d.SetId(aws.StringValue(output.IndexName))
+
+	return resourcePlaceIndexRead(d, meta)
+}
+
+func resourcePlaceIndexRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.DescribePlaceIndexInput{
+		IndexName: aws.String(d.Id()),
+	}
+
+	output, err := conn.DescribePlaceIndex(input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Location Service Place Index (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting Location Service Place Index (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Location Service Place Index (%s): empty response", d.Id())
+	}
+
+	d.Set("create_time", aws.TimeValue(output.CreateTime).Format(time.RFC3339))
+	d.Set("data_source", output.DataSource)
+
+	if output.DataSourceConfiguration != nil {
+		d.Set("data_source_configuration", []interface{}{flattenDataSourceConfiguration(output.DataSourceConfiguration)})
+	} else {
+		d.Set("data_source_configuration", nil)
+	}
+
+	d.Set("description", output.Description)
+	d.Set("index_arn", output.IndexArn)
+	d.Set("index_name", output.IndexName)
+	d.Set("update_time", aws.TimeValue(output.UpdateTime).Format(time.RFC3339))
+
+	return nil
+}
+
+func resourcePlaceIndexUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	if d.HasChanges("data_source_configuration", "description") {
+		input := &locationservice.UpdatePlaceIndexInput{
+			IndexName: aws.String(d.Id()),
+			// Deprecated but still required by the API
+			PricingPlan: aws.String(locationservice.PricingPlanRequestBasedUsage),
+		}
+
+		if v, ok := d.GetOk("data_source_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			input.DataSourceConfiguration = expandDataSourceConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		}
+
+		if v, ok := d.GetOk("description"); ok {
+			input.Description = aws.String(v.(string))
+		}
+
+		_, err := conn.UpdatePlaceIndex(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating Location Service Place Index (%s): %w", d.Id(), err)
+		}
+	}
+
+	return resourcePlaceIndexRead(d, meta)
+}
+
+func resourcePlaceIndexDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.DeletePlaceIndexInput{
+		IndexName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeletePlaceIndex(input)
+
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Location Service Place Index (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandDataSourceConfiguration(tfMap map[string]interface{}) *locationservice.DataSourceConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &locationservice.DataSourceConfiguration{}
+
+	if v, ok := tfMap["intended_use"].(string); ok && v != "" {
+		apiObject.IntendedUse = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenDataSourceConfiguration(apiObject *locationservice.DataSourceConfiguration) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.IntendedUse; v != nil {
+		tfMap["intended_use"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}

--- a/internal/service/location/place_index_test.go
+++ b/internal/service/location/place_index_test.go
@@ -1,0 +1,226 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
+)
+
+func TestAccLocationPlaceIndex_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_place_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckPlaceIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigPlaceIndex_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlaceIndexExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "create_time"),
+					resource.TestCheckResourceAttr(resourceName, "data_source", "Here"),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.0.intended_use", locationservice.IntendedUseSingleUse),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "index_arn", "geo", fmt.Sprintf("place-index/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "index_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "update_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationPlaceIndex_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_place_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigPlaceIndex_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlaceIndexExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourcePlaceIndex(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_place_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigPlaceIndex_dataSourceConfigurationIntendedUse(rName, locationservice.IntendedUseSingleUse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlaceIndexExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.0.intended_use", locationservice.IntendedUseSingleUse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigPlaceIndex_dataSourceConfigurationIntendedUse(rName, locationservice.IntendedUseStorage),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlaceIndexExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.0.intended_use", locationservice.IntendedUseStorage),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLocationPlaceIndex_description(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_place_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckPlaceIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigPlaceIndex_description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlaceIndexExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigPlaceIndex_description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlaceIndexExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPlaceIndexDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_location_place_index" {
+			continue
+		}
+
+		input := &locationservice.DescribePlaceIndexInput{
+			IndexName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribePlaceIndex(input)
+
+		if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Location Service Place Index (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("Location Service Place Index (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckPlaceIndexExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+		input := &locationservice.DescribePlaceIndexInput{
+			IndexName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribePlaceIndex(input)
+
+		if err != nil {
+			return fmt.Errorf("error getting Location Service Place Index (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccConfigPlaceIndex_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_place_index" "test" {
+  data_source = "Here"
+  index_name  = %[1]q
+}
+`, rName)
+}
+
+func testAccConfigPlaceIndex_dataSourceConfigurationIntendedUse(rName, intendedUse string) string {
+	return fmt.Sprintf(`
+resource "aws_location_place_index" "test" {
+  data_source = "Here"
+
+  data_source_configuration {
+    intended_use = %[2]q
+  }
+
+  index_name = %[1]q
+}
+`, rName, intendedUse)
+}
+
+func testAccConfigPlaceIndex_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_location_place_index" "test" {
+  data_source = "Here"
+  description = %[2]q
+  index_name  = %[1]q
+}
+`, rName, description)
+}

--- a/internal/service/location/place_index_test.go
+++ b/internal/service/location/place_index_test.go
@@ -287,7 +287,7 @@ func testAccConfigPlaceIndex_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"
-  index_name    = %[1]q
+  index_name  = %[1]q
 
   tags = {
     %[2]q = %[3]q

--- a/website/docs/r/location_place_index.html.markdown
+++ b/website/docs/r/location_place_index.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_place_index"
+description: |-
+    Provides a Location Service Place Index.
+---
+
+# Resource: aws_location_place_index
+
+Provides a Location Service Place Index.
+
+## Example Usage
+
+```terraform
+resource "aws_location_place_index" "example" {
+  data_source = "Here"
+  index_name  = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `data_source` - (Required) Specifies the geospatial data provider for the new place index.
+* `index_name` - (Required) The name of the place index resource.
+
+The following arguments are optional:
+
+* `data_source_configuration` - (Optional) Configuration block with the data storage option chosen for requesting Places. Detailed below.
+* `description` - (Optional) The optional description for the place index resource.
+* `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### data_source_configuration
+
+The following arguments are optional:
+
+* `intended_use` - (Optional) Specifies how the results of an operation will be stored by the caller. Valid values: `SingleUse`, `Storage`. Default: `SingleUse`.
+
+## Attributes Reference
+
+* `create_time` - The timestamp for when the place index resource was created in ISO 8601 format.
+* `index_arn` - The Amazon Resource Name (ARN) for the place index resource. Used to specify a resource across AWS.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
+* `update_time` - The timestamp for when the place index resource was last update in ISO 8601.
+
+## Import
+
+`aws_location_place_index` resources can be imported using the place index name, e.g.:
+
+```
+$ terraform import aws_location_place_index.example example
+```

--- a/website/docs/r/location_place_index.html.markdown
+++ b/website/docs/r/location_place_index.html.markdown
@@ -40,6 +40,8 @@ The following arguments are optional:
 
 ## Attributes Reference
 
+In addition to all arguments above, the following attributes are exported:
+
 * `create_time` - The timestamp for when the place index resource was created in ISO 8601 format.
 * `index_arn` - The Amazon Resource Name (ARN) for the place index resource. Used to specify a resource across AWS.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationPlaceIndex_"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationPlaceIndex_'  -timeout 180m
=== RUN   TestAccLocationPlaceIndex_basic
=== PAUSE TestAccLocationPlaceIndex_basic
=== RUN   TestAccLocationPlaceIndex_disappears
=== PAUSE TestAccLocationPlaceIndex_disappears
=== RUN   TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse
=== PAUSE TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse
=== RUN   TestAccLocationPlaceIndex_description
=== PAUSE TestAccLocationPlaceIndex_description
=== RUN   TestAccLocationPlaceIndex_tags
=== PAUSE TestAccLocationPlaceIndex_tags
=== CONT  TestAccLocationPlaceIndex_basic
=== CONT  TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse
=== CONT  TestAccLocationPlaceIndex_tags
=== CONT  TestAccLocationPlaceIndex_disappears
=== CONT  TestAccLocationPlaceIndex_description
--- PASS: TestAccLocationPlaceIndex_disappears (22.01s)
--- PASS: TestAccLocationPlaceIndex_basic (29.18s)
--- PASS: TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse (45.80s)
--- PASS: TestAccLocationPlaceIndex_description (46.03s)
--- PASS: TestAccLocationPlaceIndex_tags (64.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/location	66.088s
```
