### PR TITLE
opqr: Remove aws from names

### DIFF
--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -47,8 +47,8 @@ type opsworksLayerType struct {
 }
 
 var (
-	opsworksTrueString  = "true"
-	opsworksFalseString = "false"
+	trueString  = "true"
+	falseString = "false"
 )
 
 func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
@@ -696,9 +696,9 @@ func (lt *opsworksLayerType) AttributeMap(d *schema.ResourceData) (map[string]*s
 		case schema.TypeBool:
 			boolValue := value.(bool)
 			if boolValue {
-				attrs[def.AttrName] = &opsworksTrueString
+				attrs[def.AttrName] = &trueString
 			} else {
-				attrs[def.AttrName] = &opsworksFalseString
+				attrs[def.AttrName] = &falseString
 			}
 		default:
 			// should never happen
@@ -733,7 +733,7 @@ func (lt *opsworksLayerType) SetAttributeMap(d *schema.ResourceData, attrs map[s
 				}
 			case schema.TypeBool:
 				boolValue := true
-				if strValue == opsworksFalseString {
+				if strValue == falseString {
 					boolValue = false
 				}
 				d.Set(key, boolValue)

--- a/internal/service/organizations/organization.go
+++ b/internal/service/organizations/organization.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-const organizationsPolicyTypeStatusDisabled = "DISABLED"
+const policyTypeStatusDisabled = "DISABLED"
 
 func ResourceOrganization() *schema.Resource {
 	return &schema.Resource{
@@ -505,7 +505,7 @@ func getOrganizationDefaultRootPolicyTypeRefreshFunc(conn *organizations.Organiz
 			}
 		}
 
-		return &organizations.PolicyTypeSummary{}, organizationsPolicyTypeStatusDisabled, nil
+		return &organizations.PolicyTypeSummary{}, policyTypeStatusDisabled, nil
 	}
 }
 
@@ -515,7 +515,7 @@ func waitForOrganizationDefaultRootPolicyTypeDisable(conn *organizations.Organiz
 			organizations.PolicyTypeStatusEnabled,
 			organizations.PolicyTypeStatusPendingDisable,
 		},
-		Target:  []string{organizationsPolicyTypeStatusDisabled},
+		Target:  []string{policyTypeStatusDisabled},
 		Refresh: getOrganizationDefaultRootPolicyTypeRefreshFunc(conn, policyType),
 		Timeout: 5 * time.Minute,
 	}
@@ -528,7 +528,7 @@ func waitForOrganizationDefaultRootPolicyTypeDisable(conn *organizations.Organiz
 func waitForOrganizationDefaultRootPolicyTypeEnable(conn *organizations.Organizations, policyType string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
-			organizationsPolicyTypeStatusDisabled,
+			policyTypeStatusDisabled,
 			organizations.PolicyTypeStatusPendingEnable,
 		},
 		Target:  []string{organizations.PolicyTypeStatusEnabled},

--- a/internal/service/organizations/organization_data_source_test.go
+++ b/internal/service/organizations/organization_data_source_test.go
@@ -21,10 +21,10 @@ func testAccOrganizationDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAWSOrganizationResourceOnlyConfig,
+				Config: testAccOrganizationConfig_resourceOnly,
 			},
 			{
-				Config: testAccCheckAWSOrganizationConfig,
+				Config: testAccOrganizationConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "accounts.#", dataSourceName, "accounts.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -43,17 +43,17 @@ func testAccOrganizationDataSource_basic(t *testing.T) {
 			{
 				// This is to make sure the data source isn't around trying to read the resource
 				// when the resource is being destroyed
-				Config: testAccCheckAWSOrganizationResourceOnlyConfig,
+				Config: testAccOrganizationConfig_resourceOnly,
 			},
 		},
 	})
 }
 
-const testAccCheckAWSOrganizationResourceOnlyConfig = `
+const testAccOrganizationConfig_resourceOnly = `
 resource "aws_organizations_organization" "test" {}
 `
 
-const testAccCheckAWSOrganizationConfig = `
+const testAccOrganizationConfig_basic = `
 resource "aws_organizations_organization" "test" {}
 
 data "aws_organizations_organization" "test" {}

--- a/internal/service/organizations/organization_test.go
+++ b/internal/service/organizations/organization_test.go
@@ -56,7 +56,7 @@ func testAccOrganization_basic(t *testing.T) {
 	})
 }
 
-func testAccOrganization_AwsServiceAccessPrincipals(t *testing.T) {
+func testAccOrganization_serviceAccessPrincipals(t *testing.T) {
 	var organization organizations.Organization
 	resourceName := "aws_organizations_organization.test"
 
@@ -375,7 +375,7 @@ resource "aws_organizations_organization" "test" {
 `, featureSet)
 }
 
-func TestFlattenOrganizationsRoots(t *testing.T) {
+func TestFlattenRoots(t *testing.T) {
 	roots := []*organizations.Root{
 		{
 			Name: aws.String("Root1"),

--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -8,7 +8,7 @@ func TestAccOrganizations_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Organization": {
 			"basic":                      testAccOrganization_basic,
-			"AwsServiceAccessPrincipals": testAccOrganization_AwsServiceAccessPrincipals,
+			"AwsServiceAccessPrincipals": testAccOrganization_serviceAccessPrincipals,
 			"EnabledPolicyTypes":         testAccOrganization_EnabledPolicyTypes,
 			"FeatureSet_Basic":           testAccOrganization_FeatureSet,
 			"FeatureSet_Update":          testAccOrganization_FeatureSetUpdate,
@@ -40,7 +40,7 @@ func TestAccOrganizations_serial(t *testing.T) {
 			"Type_Backup":            testAccPolicy_type_Backup,
 			"Type_SCP":               testAccPolicy_type_SCP,
 			"Type_Tag":               testAccPolicy_type_Tag,
-			"ImportAwsManagedPolicy": testAccPolicy_ImportAwsManagedPolicy,
+			"ImportAwsManagedPolicy": testAccPolicy_importManagedPolicy,
 		},
 		"PolicyAttachment": {
 			"Account":            testAccPolicyAttachment_Account,

--- a/internal/service/organizations/policy_test.go
+++ b/internal/service/organizations/policy_test.go
@@ -385,7 +385,7 @@ func testAccPolicy_type_Tag(t *testing.T) {
 	})
 }
 
-func testAccPolicy_ImportAwsManagedPolicy(t *testing.T) {
+func testAccPolicy_importManagedPolicy(t *testing.T) {
 	resourceName := "aws_organizations_policy.test"
 
 	resourceID := "p-FullAWSAccess"
@@ -397,10 +397,10 @@ func testAccPolicy_ImportAwsManagedPolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicyConfig_AwsManagedPolicySetup,
+				Config: testAccPolicyConfig_managedPolicySetup,
 			},
 			{
-				Config:        testAccPolicyConfig_AwsManagedPolicy,
+				Config:        testAccPolicyConfig_managedPolicy,
 				ResourceName:  resourceName,
 				ImportStateId: resourceID,
 				ImportState:   true,
@@ -721,13 +721,13 @@ resource "aws_organizations_policy" "test" {
 `, strconv.Quote(content), rName, policyType)
 }
 
-const testAccPolicyConfig_AwsManagedPolicySetup = `
+const testAccPolicyConfig_managedPolicySetup = `
 resource "aws_organizations_organization" "test" {
   enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
 }
 `
 
-const testAccPolicyConfig_AwsManagedPolicy = `
+const testAccPolicyConfig_managedPolicy = `
 resource "aws_organizations_organization" "test" {
   enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
 }

--- a/internal/service/outposts/outposts_data_source.go
+++ b/internal/service/outposts/outposts_data_source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-func DataSourceOutposts() *schema.Resource {
+func DataSourceOutposts() *schema.Resource { // nosemgrep: outposts-in-func-name
 	return &schema.Resource{
 		Read: dataSourceOutpostsRead,
 
@@ -48,7 +48,7 @@ func DataSourceOutposts() *schema.Resource {
 	}
 }
 
-func dataSourceOutpostsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceOutpostsRead(d *schema.ResourceData, meta interface{}) error { // nosemgrep: outposts-in-func-name
 	conn := meta.(*conns.AWSClient).OutpostsConn
 
 	input := &outposts.ListOutpostsInput{}

--- a/internal/service/outposts/outposts_data_source_test.go
+++ b/internal/service/outposts/outposts_data_source_test.go
@@ -29,7 +29,7 @@ func TestAccOutpostsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckOutpostsAttributes(dataSourceName string) resource.TestCheckFunc {
+func testAccCheckOutpostsAttributes(dataSourceName string) resource.TestCheckFunc { // nosemgrep: outposts-in-func-name
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[dataSourceName]
 		if !ok {
@@ -48,7 +48,7 @@ func testAccCheckOutpostsAttributes(dataSourceName string) resource.TestCheckFun
 	}
 }
 
-func testAccOutpostsDataSourceConfig_basic() string {
+func testAccOutpostsDataSourceConfig_basic() string { // nosemgrep: outposts-in-func-name
 	return `
 data "aws_outposts_outposts" "test" {}
 `

--- a/internal/service/outposts/sites_data_source_test.go
+++ b/internal/service/outposts/sites_data_source_test.go
@@ -23,14 +23,14 @@ func TestAccOutpostsSitesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccSitesDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOutpostsSitesAttributes(dataSourceName),
+					testAccCheckSitesAttributes(dataSourceName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckOutpostsSitesAttributes(dataSourceName string) resource.TestCheckFunc {
+func testAccCheckSitesAttributes(dataSourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[dataSourceName]
 		if !ok {

--- a/internal/service/quicksight/data_source_test.go
+++ b/internal/service/quicksight/data_source_test.go
@@ -18,7 +18,7 @@ import (
 	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
 )
 
-func TestQuickSightDataSourcePermissionsDiff(t *testing.T) {
+func TestDataSourcePermissionsDiff(t *testing.T) {
 	testCases := []struct {
 		name            string
 		oldPermissions  []interface{}

--- a/internal/service/rds/parameter_group_test.go
+++ b/internal/service/rds/parameter_group_test.go
@@ -140,7 +140,7 @@ func TestAccRDSParameterGroup_limit(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: createParameterGroupsExceedDefaultAWSLimit(groupName),
+				Config: createParameterGroupsExceedDefaultLimit(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					testAccCheckParameterGroupAttributes(&v, groupName),
@@ -319,7 +319,7 @@ func TestAccRDSParameterGroup_limit(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: updateParameterGroupsExceedDefaultAWSLimit(groupName),
+				Config: updateParameterGroupsExceedDefaultLimit(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					testAccCheckParameterGroupAttributes(&v, groupName),
@@ -1253,7 +1253,7 @@ resource "aws_db_parameter_group" "test" {
 `, rName)
 }
 
-func createParameterGroupsExceedDefaultAWSLimit(rName string) string {
+func createParameterGroupsExceedDefaultLimit(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "test" {
   name        = %[1]q
@@ -1473,7 +1473,7 @@ resource "aws_db_parameter_group" "test" {
 `, rName)
 }
 
-func updateParameterGroupsExceedDefaultAWSLimit(rName string) string {
+func updateParameterGroupsExceedDefaultLimit(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "test" {
   name        = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
