### PR TITLE
elb-guardduty: AWS in names

### DIFF
--- a/internal/service/elb/hosted_zone_id_data_source_test.go
+++ b/internal/service/elb/hosted_zone_id_data_source_test.go
@@ -16,13 +16,13 @@ func TestAccELBHostedZoneIDDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAWSElbHostedZoneIdConfig,
+				Config: testAccHostedZoneIDDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_elb_hosted_zone_id.main", "id", tfelb.HostedZoneIdPerRegionMap[acctest.Region()]),
 				),
 			},
 			{
-				Config: testAccCheckAWSElbHostedZoneIdExplicitRegionConfig,
+				Config: testAccHostedZoneIDDataSourceConfig_explicitRegion,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_elb_hosted_zone_id.regional", "id", "Z32O12XQLNTSW2"),
 				),
@@ -31,12 +31,12 @@ func TestAccELBHostedZoneIDDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccCheckAWSElbHostedZoneIdConfig = `
+const testAccHostedZoneIDDataSourceConfig_basic = `
 data "aws_elb_hosted_zone_id" "main" {}
 `
 
 //lintignore:AWSAT003
-const testAccCheckAWSElbHostedZoneIdExplicitRegionConfig = `
+const testAccHostedZoneIDDataSourceConfig_explicitRegion = `
 data "aws_elb_hosted_zone_id" "regional" {
   region = "eu-west-1"
 }

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -345,18 +345,18 @@ func TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate(t *tes
 		CheckDestroy:      testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccELBConfig_Listener_IAMServerCertificate(rName, certificate, key, "tcp"),
+				Config:      testAccLBConfig_Listener_iamServerCertificate(rName, certificate, key, "tcp"),
 				ExpectError: regexp.MustCompile(`ssl_certificate_id may be set only when protocol is 'https' or 'ssl'`),
 			},
 			{
-				Config: testAccELBConfig_Listener_IAMServerCertificate(rName, certificate, key, "https"),
+				Config: testAccLBConfig_Listener_iamServerCertificate(rName, certificate, key, "https"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoadBalancerExists(resourceName, &conf),
 					testCheck,
 				),
 			},
 			{
-				Config:      testAccELBConfig_Listener_IAMServerCertificate_AddInvalidListener(rName, certificate, key),
+				Config:      testAccLBConfig_Listener_iamServerCertificateAddInvalidListener(rName, certificate, key),
 				ExpectError: regexp.MustCompile(`ssl_certificate_id may be set only when protocol is 'https' or 'ssl'`),
 			},
 		},
@@ -767,8 +767,8 @@ func TestLoadBalancerListenerHash(t *testing.T) {
 }
 
 func TestValidLoadBalancerNameCannotBeginWithHyphen(t *testing.T) {
-	var elbName = "-Testing123"
-	_, errors := tfelb.ValidName(elbName, "SampleKey")
+	var n = "-Testing123"
+	_, errors := tfelb.ValidName(n, "SampleKey")
 
 	if len(errors) != 1 {
 		t.Fatalf("Expected the ELB Name to trigger a validation error")
@@ -776,8 +776,8 @@ func TestValidLoadBalancerNameCannotBeginWithHyphen(t *testing.T) {
 }
 
 func TestValidLoadBalancerNameCanBeAnEmptyString(t *testing.T) {
-	var elbName = ""
-	_, errors := tfelb.ValidName(elbName, "SampleKey")
+	var n = ""
+	_, errors := tfelb.ValidName(n, "SampleKey")
 
 	if len(errors) != 0 {
 		t.Fatalf("Expected the ELB Name to pass validation")
@@ -785,8 +785,8 @@ func TestValidLoadBalancerNameCanBeAnEmptyString(t *testing.T) {
 }
 
 func TestValidLoadBalancerNameCannotBeLongerThan32Characters(t *testing.T) {
-	var elbName = "Testing123dddddddddddddddddddvvvv"
-	_, errors := tfelb.ValidName(elbName, "SampleKey")
+	var n = "Testing123dddddddddddddddddddvvvv"
+	_, errors := tfelb.ValidName(n, "SampleKey")
 
 	if len(errors) != 1 {
 		t.Fatalf("Expected the ELB Name to trigger a validation error")
@@ -794,8 +794,8 @@ func TestValidLoadBalancerNameCannotBeLongerThan32Characters(t *testing.T) {
 }
 
 func TestValidLoadBalancerNameCannotHaveSpecialCharacters(t *testing.T) {
-	var elbName = "Testing123%%"
-	_, errors := tfelb.ValidName(elbName, "SampleKey")
+	var n = "Testing123%%"
+	_, errors := tfelb.ValidName(n, "SampleKey")
 
 	if len(errors) != 1 {
 		t.Fatalf("Expected the ELB Name to trigger a validation error")
@@ -803,8 +803,8 @@ func TestValidLoadBalancerNameCannotHaveSpecialCharacters(t *testing.T) {
 }
 
 func TestValidLoadBalancerNameCannotEndWithHyphen(t *testing.T) {
-	var elbName = "Testing123-"
-	_, errors := tfelb.ValidName(elbName, "SampleKey")
+	var n = "Testing123-"
+	_, errors := tfelb.ValidName(n, "SampleKey")
 
 	if len(errors) != 1 {
 		t.Fatalf("Expected the ELB Name to trigger a validation error")
@@ -1692,7 +1692,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-func testAccELBConfig_Listener_IAMServerCertificate(certName, certificate, key, lbProtocol string) string {
+func testAccLBConfig_Listener_iamServerCertificate(certName, certificate, key, lbProtocol string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -1723,7 +1723,7 @@ resource "aws_elb" "test" {
 `, certName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key), lbProtocol)
 }
 
-func testAccELBConfig_Listener_IAMServerCertificate_AddInvalidListener(certName, certificate, key string) string {
+func testAccLBConfig_Listener_iamServerCertificateAddInvalidListener(certName, certificate, key string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/elb/service_account_data_source_test.go
+++ b/internal/service/elb/service_account_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccELBServiceAccountDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAWSElbServiceAccountConfig,
+				Config: testAccServiceAccountDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
 					acctest.CheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "root"),
@@ -51,7 +51,7 @@ func TestAccELBServiceAccountDataSource_region(t *testing.T) {
 	})
 }
 
-const testAccCheckAWSElbServiceAccountConfig = `
+const testAccServiceAccountDataSourceConfig_basic = `
 data "aws_elb_service_account" "main" {}
 `
 

--- a/internal/service/emr/instance_group.go
+++ b/internal/service/emr/instance_group.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	emrInstanceGroupCreateTimeout = 30 * time.Minute
-	emrInstanceGroupUpdateTimeout = 30 * time.Minute
+	instanceGroupCreateTimeout = 30 * time.Minute
+	instanceGroupUpdateTimeout = 30 * time.Minute
 )
 
 func ResourceInstanceGroup() *schema.Resource {
@@ -189,7 +189,7 @@ func resourceInstanceGroupCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	d.SetId(aws.StringValue(resp.InstanceGroupIds[0]))
 
-	if err := waitForInstanceGroupStateRunning(conn, d.Get("cluster_id").(string), d.Id(), emrInstanceGroupCreateTimeout); err != nil {
+	if err := waitForInstanceGroupStateRunning(conn, d.Get("cluster_id").(string), d.Id(), instanceGroupCreateTimeout); err != nil {
 		return fmt.Errorf("error waiting for EMR Instance Group (%s) creation: %s", d.Id(), err)
 	}
 
@@ -319,7 +319,7 @@ func resourceInstanceGroupUpdate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("error modifying EMR Instance Group (%s): %s", d.Id(), err)
 		}
 
-		if err := waitForInstanceGroupStateRunning(conn, d.Get("cluster_id").(string), d.Id(), emrInstanceGroupUpdateTimeout); err != nil {
+		if err := waitForInstanceGroupStateRunning(conn, d.Get("cluster_id").(string), d.Id(), instanceGroupUpdateTimeout); err != nil {
 			return fmt.Errorf("error waiting for EMR Instance Group (%s) modification: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/emr/security_configuration_test.go
+++ b/internal/service/emr/security_configuration_test.go
@@ -23,7 +23,7 @@ func TestAccEMRSecurityConfiguration_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmrSecurityConfigurationConfig,
+				Config: testAccSecurityConfigurationConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "creation_date"),
@@ -99,7 +99,7 @@ func testAccCheckSecurityConfigurationExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccEmrSecurityConfigurationConfig = `
+const testAccSecurityConfigurationConfig_basic = `
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -34,7 +34,7 @@ func ResourceBus() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validCustomEventBusEventSourceName,
+				ValidateFunc: validSourceName,
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -180,7 +180,7 @@ func TestAccEventsBus_partnerEventSource(t *testing.T) {
 		CheckDestroy:      testAccCheckBusDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBusPartnerEventSourceConfig(busName),
+				Config: testAccBusConfig_partnerSource(busName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusExists(resourceName, &busOutput),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "events", fmt.Sprintf("event-bus/%s", busName)),
@@ -291,7 +291,7 @@ resource "aws_cloudwatch_event_bus" "test" {
 `, name, key1, value1, key2, value2)
 }
 
-func testAccBusPartnerEventSourceConfig(name string) string {
+func testAccBusConfig_partnerSource(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name              = %[1]q

--- a/internal/service/events/source_data_source_test.go
+++ b/internal/service/events/source_data_source_test.go
@@ -32,7 +32,7 @@ func TestAccEventsSourceDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPartnerEventSourceDataSourceConfig(busName),
+				Config: testAccSourceDataSourceConfig_partnerEvent(busName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", busName),
 					resource.TestCheckResourceAttr(dataSourceName, "created_by", createdBy),
@@ -43,7 +43,7 @@ func TestAccEventsSourceDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccPartnerEventSourceDataSourceConfig(namePrefix string) string {
+func testAccSourceDataSourceConfig_partnerEvent(namePrefix string) string {
 	return fmt.Sprintf(`
 data "aws_cloudwatch_event_source" "test" {
   name_prefix = "%s"

--- a/internal/service/events/validate.go
+++ b/internal/service/events/validate.go
@@ -92,7 +92,7 @@ var validBusNameOrARN = validation.Any(
 	),
 )
 
-var validCustomEventBusEventSourceName = validation.All(
+var validSourceName = validation.All(
 	validation.StringLenBetween(1, 256),
 	validation.StringMatch(regexp.MustCompile(`^aws\.partner(/[\.\-_A-Za-z0-9]+){2,}$`), ""),
 )

--- a/internal/service/events/validate_test.go
+++ b/internal/service/events/validate_test.go
@@ -6,7 +6,7 @@ import (
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
-func TestValidCustomEventBusEventSourceName(t *testing.T) {
+func TestValidCustomEventBusSourceName(t *testing.T) {
 	cases := []struct {
 		Value   string
 		IsValid bool
@@ -41,7 +41,7 @@ func TestValidCustomEventBusEventSourceName(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, errors := validCustomEventBusEventSourceName(tc.Value, "aws_cloudwatch_event_bus_event_source_name")
+		_, errors := validSourceName(tc.Value, "aws_cloudwatch_event_bus_event_source_name")
 		isValid := len(errors) == 0
 		if tc.IsValid && !isValid {
 			t.Errorf("expected %q to return valid, but did not", tc.Value)

--- a/internal/service/fsx/sweep.go
+++ b/internal/service/fsx/sweep.go
@@ -18,48 +18,48 @@ import (
 func init() {
 	resource.AddTestSweepers("aws_fsx_backup", &resource.Sweeper{
 		Name: "aws_fsx_backup",
-		F:    sweepFSXBackups,
+		F:    sweepBackups,
 	})
 
 	resource.AddTestSweepers("aws_fsx_lustre_file_system", &resource.Sweeper{
 		Name: "aws_fsx_lustre_file_system",
-		F:    sweepFSXLustreFileSystems,
+		F:    sweepLustreFileSystems,
 	})
 
 	resource.AddTestSweepers("aws_fsx_ontap_file_system", &resource.Sweeper{
 		Name:         "aws_fsx_ontap_file_system",
-		F:            sweepFSXOntapFileSystems,
+		F:            sweepOntapFileSystems,
 		Dependencies: []string{"aws_fsx_ontap_storage_virtual_machine"},
 	})
 
 	resource.AddTestSweepers("aws_fsx_ontap_storage_virtual_machine", &resource.Sweeper{
 		Name:         "aws_fsx_ontap_storage_virtual_machine",
-		F:            sweepFSXOntapStorageVirtualMachine,
+		F:            sweepOntapStorageVirtualMachine,
 		Dependencies: []string{"aws_fsx_ontap_volume"},
 	})
 
 	resource.AddTestSweepers("aws_fsx_ontap_volume", &resource.Sweeper{
 		Name: "aws_fsx_ontap_volume",
-		F:    sweepFSXOntapVolume,
+		F:    sweepOntapVolume,
 	})
 
 	resource.AddTestSweepers("aws_fsx_openzfs_file_system", &resource.Sweeper{
 		Name: "aws_fsx_openzfs_file_system",
-		F:    sweepFSXOpenzfsFileSystems,
+		F:    sweepOpenZFSFileSystems,
 	})
 
 	resource.AddTestSweepers("aws_fsx_openzfs_volume", &resource.Sweeper{
 		Name: "aws_fsx_openzfs_volume",
-		F:    sweepFSXOpenzfsVolume,
+		F:    sweepOpenZFSVolume,
 	})
 
 	resource.AddTestSweepers("aws_fsx_windows_file_system", &resource.Sweeper{
 		Name: "aws_fsx_windows_file_system",
-		F:    sweepFSXWindowsFileSystems,
+		F:    sweepWindowsFileSystems,
 	})
 }
 
-func sweepFSXBackups(region string) error {
+func sweepBackups(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -103,7 +103,7 @@ func sweepFSXBackups(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXLustreFileSystems(region string) error {
+func sweepLustreFileSystems(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -151,7 +151,7 @@ func sweepFSXLustreFileSystems(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXOntapFileSystems(region string) error {
+func sweepOntapFileSystems(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -199,7 +199,7 @@ func sweepFSXOntapFileSystems(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXOntapStorageVirtualMachine(region string) error {
+func sweepOntapStorageVirtualMachine(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -243,7 +243,7 @@ func sweepFSXOntapStorageVirtualMachine(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXOntapVolume(region string) error {
+func sweepOntapVolume(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -294,7 +294,7 @@ func sweepFSXOntapVolume(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXOpenzfsFileSystems(region string) error {
+func sweepOpenZFSFileSystems(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -342,7 +342,7 @@ func sweepFSXOpenzfsFileSystems(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXOpenzfsVolume(region string) error {
+func sweepOpenZFSVolume(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
@@ -393,7 +393,7 @@ func sweepFSXOpenzfsVolume(region string) error {
 	return errs.ErrorOrNil()
 }
 
-func sweepFSXWindowsFileSystems(region string) error {
+func sweepWindowsFileSystems(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {

--- a/internal/service/gamelift/fleet_test.go
+++ b/internal/service/gamelift/fleet_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestDiffGameLiftPortSettings(t *testing.T) {
+func TestDiffPortSettings(t *testing.T) {
 	testCases := []struct {
 		Old           []interface{}
 		New           []interface{}

--- a/internal/service/gamelift/script.go
+++ b/internal/service/gamelift/script.go
@@ -18,7 +18,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-const awsMutexGameLiftScript = `aws_gamelift_script`
+const scriptMutex = `aws_gamelift_script`
 
 func ResourceScript() *schema.Resource {
 	return &schema.Resource{
@@ -106,8 +106,8 @@ func resourceScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("zip_file"); ok {
-		conns.GlobalMutexKV.Lock(awsMutexGameLiftScript)
-		defer conns.GlobalMutexKV.Unlock(awsMutexGameLiftScript)
+		conns.GlobalMutexKV.Lock(scriptMutex)
+		defer conns.GlobalMutexKV.Unlock(scriptMutex)
 
 		file, err := loadFileContent(v.(string))
 		if err != nil {
@@ -212,8 +212,8 @@ func resourceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if d.HasChange("zip_file") {
 			if v, ok := d.GetOk("zip_file"); ok {
-				conns.GlobalMutexKV.Lock(awsMutexGameLiftScript)
-				defer conns.GlobalMutexKV.Unlock(awsMutexGameLiftScript)
+				conns.GlobalMutexKV.Lock(scriptMutex)
+				defer conns.GlobalMutexKV.Unlock(scriptMutex)
 
 				file, err := loadFileContent(v.(string))
 				if err != nil {

--- a/internal/service/globalaccelerator/accelerator.go
+++ b/internal/service/globalaccelerator/accelerator.go
@@ -21,7 +21,7 @@ import (
 // Global Route53 Zone ID for Global Accelerators, exported as a
 // convenience attribute for Route53 aliases (see
 // https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html).
-const globalAcceleratorRoute53ZoneID = "Z2BJ6XQ5FK7U4H"
+const route53ZoneID = "Z2BJ6XQ5FK7U4H"
 
 func ResourceAccelerator() *schema.Resource {
 	return &schema.Resource{
@@ -185,7 +185,7 @@ func resourceAcceleratorRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("enabled", accelerator.Enabled)
 	d.Set("dns_name", accelerator.DnsName)
-	d.Set("hosted_zone_id", globalAcceleratorRoute53ZoneID)
+	d.Set("hosted_zone_id", route53ZoneID)
 	d.Set("name", accelerator.Name)
 	d.Set("ip_address_type", accelerator.IpAddressType)
 

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -127,7 +127,7 @@ func dataSourceAcceleratorRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", accelerator.AcceleratorArn)
 	d.Set("enabled", accelerator.Enabled)
 	d.Set("dns_name", accelerator.DnsName)
-	d.Set("hosted_zone_id", globalAcceleratorRoute53ZoneID)
+	d.Set("hosted_zone_id", route53ZoneID)
 	d.Set("name", accelerator.Name)
 	d.Set("ip_address_type", accelerator.IpAddressType)
 	d.Set("ip_sets", flattenIPSets(accelerator.IpSets))

--- a/internal/service/guardduty/detector_test.go
+++ b/internal/service/guardduty/detector_test.go
@@ -24,7 +24,7 @@ func testAccDetector_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDetectorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGuardDutyDetectorConfig_basic1,
+				Config: testAccDetectorConfig_basic1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
@@ -40,21 +40,21 @@ func testAccDetector_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGuardDutyDetectorConfig_basic2,
+				Config: testAccDetectorConfig_basic2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
 			},
 			{
-				Config: testAccGuardDutyDetectorConfig_basic3,
+				Config: testAccDetectorConfig_basic3,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
 				),
 			},
 			{
-				Config: testAccGuardDutyDetectorConfig_basic4,
+				Config: testAccDetectorConfig_basic4,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "finding_publishing_frequency", "FIFTEEN_MINUTES"),
@@ -180,23 +180,23 @@ func testAccCheckDetectorExists(name string) resource.TestCheckFunc {
 	}
 }
 
-const testAccGuardDutyDetectorConfig_basic1 = `
+const testAccDetectorConfig_basic1 = `
 resource "aws_guardduty_detector" "test" {}
 `
 
-const testAccGuardDutyDetectorConfig_basic2 = `
+const testAccDetectorConfig_basic2 = `
 resource "aws_guardduty_detector" "test" {
   enable = false
 }
 `
 
-const testAccGuardDutyDetectorConfig_basic3 = `
+const testAccDetectorConfig_basic3 = `
 resource "aws_guardduty_detector" "test" {
   enable = true
 }
 `
 
-const testAccGuardDutyDetectorConfig_basic4 = `
+const testAccDetectorConfig_basic4 = `
 resource "aws_guardduty_detector" "test" {
   finding_publishing_frequency = "FIFTEEN_MINUTES"
 }

--- a/internal/service/guardduty/filter.go
+++ b/internal/service/guardduty/filter.go
@@ -288,14 +288,14 @@ func resourceFilterDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-const guardDutyFilterIDSeparator = ":"
+const filterIDSeparator = ":"
 
 func filterCreateID(detectorID, filterName string) string {
-	return detectorID + guardDutyFilterIDSeparator + filterName
+	return detectorID + filterIDSeparator + filterName
 }
 
 func FilterParseID(importedId string) (string, string, error) {
-	parts := strings.Split(importedId, guardDutyFilterIDSeparator)
+	parts := strings.Split(importedId, filterIDSeparator)
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf("GuardDuty filter ID must be of the form <Detector ID>:<Filter name>. Got %q.", importedId)
 	}

--- a/internal/service/guardduty/member_test.go
+++ b/internal/service/guardduty/member_test.go
@@ -234,7 +234,7 @@ resource "aws_guardduty_member" "test" {
   detector_id = aws_guardduty_detector.test.id
   email       = "%[3]s"
 }
-`, testAccGuardDutyDetectorConfig_basic1, accountID, email)
+`, testAccDetectorConfig_basic1, accountID, email)
 }
 
 func testAccMemberConfig_invite(accountID, email string, invite bool) string {
@@ -248,7 +248,7 @@ resource "aws_guardduty_member" "test" {
   email                      = "%[3]s"
   invite                     = %[4]t
 }
-`, testAccGuardDutyDetectorConfig_basic1, accountID, email, invite)
+`, testAccDetectorConfig_basic1, accountID, email, invite)
 }
 
 func testAccMemberConfig_invitationMessage(accountID, email, invitationMessage string) string {
@@ -263,5 +263,5 @@ resource "aws_guardduty_member" "test" {
   invitation_message         = "%[4]s"
   invite                     = true
 }
-`, testAccGuardDutyDetectorConfig_basic1, accountID, email, invitationMessage)
+`, testAccDetectorConfig_basic1, accountID, email, invitationMessage)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
