### PR TITLE
r/aws_cloudwatch_metric_stream support statistics_configurations resource

### DIFF
--- a/24882.txt
+++ b/24882.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-r/aws_cloudwatch_metric_stream: Add support for statistics_configurations field
+r/aws_cloudwatch_metric_stream: Add `statistics_configuration` argument
 ```

--- a/24882.txt
+++ b/24882.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+r/aws_cloudwatch_metric_stream: Add support for statistics_configurations field
+```

--- a/internal/service/cloudwatch/metric_stream.go
+++ b/internal/service/cloudwatch/metric_stream.go
@@ -381,12 +381,12 @@ func expandMetricStreamStatisticsConfigurations(s *schema.Set) []*cloudwatch.Met
 		mConfiguration := configurationRaw.(map[string]interface{})
 
 		if v, ok := mConfiguration["additional_statistics"].(*schema.Set); ok && v.Len() > 0 {
-			log.Printf("[DEBUG] additional_statistics: %#v", v)
+			log.Printf("[DEBUG] CloudWatch Metric Stream StatisticsConfigurations additional_statistics: %#v", v)
 			configuration.AdditionalStatistics = flex.ExpandStringSet(v)
 		}
 
 		if v, ok := mConfiguration["include_metrics"].(*schema.Set); ok && v.Len() > 0 {
-			log.Printf("[DEBUG] include_metrics: %#v", v)
+			log.Printf("[DEBUG] CloudWatch Metric Stream StatisticsConfigurations include_metrics: %#v", v)
 			configuration.IncludeMetrics = expandMetricStreamStatisticsConfigurationsIncludeMetrics(v)
 		}
 
@@ -429,30 +429,32 @@ func expandMetricStreamStatisticsConfigurationsIncludeMetrics(metrics *schema.Se
 }
 
 func flattenMetricStreamStatisticsConfigurations(configurations []*cloudwatch.MetricStreamStatisticsConfiguration) []map[string]interface{} {
-	flatConfigurations := make([]map[string]interface{}, 0)
+	flatConfigurations := make([]map[string]interface{}, len(configurations))
 
-	for _, configuration := range configurations {
+	for i, configuration := range configurations {
 		flatConfiguration := map[string]interface{}{
 			"additional_statistics": flex.FlattenStringSet(configuration.AdditionalStatistics),
 			"include_metrics":       flattenMetricStreamStatisticsConfigurationsIncludeMetrics(configuration.IncludeMetrics),
 		}
 
-		flatConfigurations = append(flatConfigurations, flatConfiguration)
+		// flatConfigurations = append(flatConfigurations, flatConfiguration)
+		flatConfigurations[i] = flatConfiguration
 	}
 
 	return flatConfigurations
 }
 
 func flattenMetricStreamStatisticsConfigurationsIncludeMetrics(metrics []*cloudwatch.MetricStreamStatisticsMetric) []map[string]interface{} {
-	flatMetrics := make([]map[string]interface{}, 0)
+	flatMetrics := make([]map[string]interface{}, len(metrics))
 
-	for _, metric := range metrics {
+	for i, metric := range metrics {
 		flatMetric := map[string]interface{}{
 			"metric_name": aws.StringValue(metric.MetricName),
 			"namespace":   aws.StringValue(metric.Namespace),
 		}
 
-		flatMetrics = append(flatMetrics, flatMetric)
+		// flatMetrics = append(flatMetrics, flatMetric)
+		flatMetrics[i] = flatMetric
 	}
 
 	return flatMetrics

--- a/internal/service/cloudwatch/metric_stream.go
+++ b/internal/service/cloudwatch/metric_stream.go
@@ -437,7 +437,6 @@ func flattenMetricStreamStatisticsConfigurations(configurations []*cloudwatch.Me
 			"include_metrics":       flattenMetricStreamStatisticsConfigurationsIncludeMetrics(configuration.IncludeMetrics),
 		}
 
-		// flatConfigurations = append(flatConfigurations, flatConfiguration)
 		flatConfigurations[i] = flatConfiguration
 	}
 
@@ -453,7 +452,6 @@ func flattenMetricStreamStatisticsConfigurationsIncludeMetrics(metrics []*cloudw
 			"namespace":   aws.StringValue(metric.Namespace),
 		}
 
-		// flatMetrics = append(flatMetrics, flatMetric)
 		flatMetrics[i] = flatMetric
 	}
 

--- a/internal/service/cloudwatch/metric_stream.go
+++ b/internal/service/cloudwatch/metric_stream.go
@@ -114,7 +114,7 @@ func ResourceMetricStream() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"statistics_configurations": {
+			"statistics_configuration": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -142,7 +142,7 @@ func ResourceMetricStream() *schema.Resource {
 								),
 							},
 						},
-						"include_metrics": {
+						"include_metric": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem: &schema.Resource{
@@ -195,7 +195,7 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 		params.ExcludeFilters = expandMetricStreamFilters(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("statistics_configurations"); ok && v.(*schema.Set).Len() > 0 {
+	if v, ok := d.GetOk("statistics_configuration"); ok && v.(*schema.Set).Len() > 0 {
 		params.StatisticsConfigurations = expandMetricStreamStatisticsConfigurations(v.(*schema.Set))
 	}
 
@@ -279,8 +279,8 @@ func resourceMetricStreamRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if output.StatisticsConfigurations != nil {
-		if err := d.Set("statistics_configurations", flattenMetricStreamStatisticsConfigurations(output.StatisticsConfigurations)); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting statistics_configurations error: %w", err))
+		if err := d.Set("statistics_configuration", flattenMetricStreamStatisticsConfigurations(output.StatisticsConfigurations)); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting statistics_configuration error: %w", err))
 		}
 	}
 
@@ -385,7 +385,7 @@ func expandMetricStreamStatisticsConfigurations(s *schema.Set) []*cloudwatch.Met
 			configuration.AdditionalStatistics = flex.ExpandStringSet(v)
 		}
 
-		if v, ok := mConfiguration["include_metrics"].(*schema.Set); ok && v.Len() > 0 {
+		if v, ok := mConfiguration["include_metric"].(*schema.Set); ok && v.Len() > 0 {
 			log.Printf("[DEBUG] CloudWatch Metric Stream StatisticsConfigurations include_metrics: %#v", v)
 			configuration.IncludeMetrics = expandMetricStreamStatisticsConfigurationsIncludeMetrics(v)
 		}
@@ -434,7 +434,7 @@ func flattenMetricStreamStatisticsConfigurations(configurations []*cloudwatch.Me
 	for i, configuration := range configurations {
 		flatConfiguration := map[string]interface{}{
 			"additional_statistics": flex.FlattenStringSet(configuration.AdditionalStatistics),
-			"include_metrics":       flattenMetricStreamStatisticsConfigurationsIncludeMetrics(configuration.IncludeMetrics),
+			"include_metric":        flattenMetricStreamStatisticsConfigurationsIncludeMetrics(configuration.IncludeMetrics),
 		}
 
 		flatConfigurations[i] = flatConfiguration

--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -2,6 +2,7 @@ package cloudwatch_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -244,6 +245,77 @@ func TestAccCloudWatchMetricStream_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricStreamExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudWatchMetricStream_additional_statistics(t *testing.T) {
+	resourceName := "aws_cloudwatch_metric_stream.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, cloudwatch.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckMetricStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMetricStreamAdditionalStatisticsConfig(rName, "p0"),
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricStreamAdditionalStatisticsConfig(rName, "p100"),
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricStreamAdditionalStatisticsConfig(rName, "p"),
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricStreamAdditionalStatisticsConfig(rName, "tm"),
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricStreamAdditionalStatisticsConfig(rName, "tc()"),
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricStreamAdditionalStatisticsConfig(rName, "p99.12345678901"),
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "IQM"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetricStreamExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+				),
+			},
+			{
+				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "PR(:50)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetricStreamExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+				),
+			},
+			{
+				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "TS(50.5:)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetricStreamExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+				),
+			},
+			{
+				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "TC(1:100)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetricStreamExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
 				),
 			},
 			{
@@ -567,4 +639,41 @@ resource "aws_cloudwatch_metric_stream" "test" {
   }
 }
 `, rName)
+}
+
+func testAccMetricStreamAdditionalStatisticsConfig(rName string, stat string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudwatch_metric_stream" "test" {
+  name          = %[1]q
+  role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/MyRole"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
+  output_format = "json"
+
+  statistics_configurations {
+	  additional_statistics = [
+	    "p1", "tm99"
+    ]
+
+    include_metrics {
+        metric_name = "CPUUtilization"
+        namespace = "AWS/EC2"
+    }
+  }
+
+  statistics_configurations {
+	  additional_statistics = [
+	  %[2]q
+    ]
+
+    include_metrics {
+        metric_name = "CPUUtilization"
+        namespace = "AWS/EC2"
+    }
+  }
+}
+`, rName, stat)
 }

--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -654,24 +654,24 @@ resource "aws_cloudwatch_metric_stream" "test" {
   output_format = "json"
 
   statistics_configurations {
-	  additional_statistics = [
-	    "p1", "tm99"
+    additional_statistics = [
+      "p1", "tm99"
     ]
 
     include_metrics {
-        metric_name = "CPUUtilization"
-        namespace = "AWS/EC2"
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/EC2"
     }
   }
 
   statistics_configurations {
-	  additional_statistics = [
+    additional_statistics = [
 	  %[2]q
     ]
 
     include_metrics {
-        metric_name = "CPUUtilization"
-        namespace = "AWS/EC2"
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/EC2"
     }
   }
 }

--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -294,28 +294,28 @@ func TestAccCloudWatchMetricStream_additional_statistics(t *testing.T) {
 				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "IQM"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricStreamExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configuration.#", "2"),
 				),
 			},
 			{
 				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "PR(:50)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricStreamExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configuration.#", "2"),
 				),
 			},
 			{
 				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "TS(50.5:)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricStreamExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configuration.#", "2"),
 				),
 			},
 			{
 				Config: testAccMetricStreamAdditionalStatisticsConfig(rName, "TC(1:100)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricStreamExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "statistics_configurations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "statistics_configuration.#", "2"),
 				),
 			},
 			{
@@ -653,23 +653,23 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
-  statistics_configurations {
+  statistics_configuration {
     additional_statistics = [
       "p1", "tm99"
     ]
 
-    include_metrics {
+    include_metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
     }
   }
 
-  statistics_configurations {
+  statistics_configuration {
     additional_statistics = [
 	  %[2]q
     ]
 
-    include_metrics {
+    include_metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
     }

--- a/website/docs/r/cloudwatch_metric_stream.html.markdown
+++ b/website/docs/r/cloudwatch_metric_stream.html.markdown
@@ -152,14 +152,29 @@ The following arguments are optional:
 * `name` - (Optional, Forces new resource) Friendly name of the metric stream. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `statistics_configurations` - (Optional) For each entry in this array, you specify one or more metrics and the list of additional statistics to stream for those metrics. The additional statistics that you can stream depend on the stream's OutputFormat. If the OutputFormat is json, you can stream any additional statistic that is supported by CloudWatch, listed in [CloudWatch statistics definitions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.html). If the OutputFormat is opentelemetry0.7, you can stream percentile statistics (p??).
 
-### `exclude_filter`
+### Nested Fields
+
+#### `exclude_filter`
 
 * `namespace` - (Required) Name of the metric namespace in the filter.
 
-### `include_filter`
+#### `include_filter`
 
 * `namespace` - (Required) Name of the metric namespace in the filter.
+
+#### `statistics_configurations`
+
+* `additional_statistics` - (Required) The additional statistics to stream for the metrics listed in `include_metrics`.
+
+* `include_metrics` - (Required) An array that defines the metrics that are to have additional statistics streamed.
+
+#### `include_metrics`
+
+* `metric_name` - (Required) The name of the metric.
+
+* `namespace` - (Required) The namespace of the metric.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloudwatch_metric_stream.html.markdown
+++ b/website/docs/r/cloudwatch_metric_stream.html.markdown
@@ -152,7 +152,7 @@ The following arguments are optional:
 * `name` - (Optional, Forces new resource) Friendly name of the metric stream. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `statistics_configurations` - (Optional) For each entry in this array, you specify one or more metrics and the list of additional statistics to stream for those metrics. The additional statistics that you can stream depend on the stream's `output_format`. If the OutputFormat is `json`, you can stream any additional statistic that is supported by CloudWatch, listed in [CloudWatch statistics definitions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.html). If the OutputFormat is `opentelemetry0.7`, you can stream percentile statistics (p99 etc.). See details below.
+* `statistics_configuration` - (Optional) For each entry in this array, you specify one or more metrics and the list of additional statistics to stream for those metrics. The additional statistics that you can stream depend on the stream's `output_format`. If the OutputFormat is `json`, you can stream any additional statistic that is supported by CloudWatch, listed in [CloudWatch statistics definitions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.html). If the OutputFormat is `opentelemetry0.7`, you can stream percentile statistics (p99 etc.). See details below.
 
 ### Nested Fields
 
@@ -167,13 +167,11 @@ The following arguments are optional:
 #### `statistics_configurations`
 
 * `additional_statistics` - (Required) The additional statistics to stream for the metrics listed in `include_metrics`.
-
-* `include_metrics` - (Required) An array that defines the metrics that are to have additional statistics streamed. See details below.
+* `include_metric` - (Required) An array that defines the metrics that are to have additional statistics streamed. See details below.
 
 #### `include_metrics`
 
 * `metric_name` - (Required) The name of the metric.
-
 * `namespace` - (Required) The namespace of the metric.
 
 ## Attributes Reference

--- a/website/docs/r/cloudwatch_metric_stream.html.markdown
+++ b/website/docs/r/cloudwatch_metric_stream.html.markdown
@@ -12,6 +12,8 @@ Provides a CloudWatch Metric Stream resource.
 
 ## Example Usage
 
+### Filters
+
 ```terraform
 resource "aws_cloudwatch_metric_stream" "main" {
   name          = "my-metric-stream"
@@ -133,6 +135,39 @@ resource "aws_kinesis_firehose_delivery_stream" "s3_stream" {
   s3_configuration {
     role_arn   = aws_iam_role.firehose_to_s3.arn
     bucket_arn = aws_s3_bucket.bucket.arn
+  }
+}
+```
+
+### Additional Statistics
+
+```terraform
+resource "aws_cloudwatch_metric_stream" "main" {
+  name          = "my-metric-stream"
+  role_arn      = aws_iam_role.metric_stream_to_firehose.arn
+  firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
+  output_format = "json"
+
+  statistics_configuration {
+    additional_statistics = [
+      "p1", "tm99"
+    ]
+
+    include_metric {
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/EC2"
+    }
+  }
+
+  statistics_configuration {
+    additional_statistics = [
+	    "TS(50.5:)"
+    ]
+
+    include_metric {
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/EC2"
+    }
   }
 }
 ```

--- a/website/docs/r/cloudwatch_metric_stream.html.markdown
+++ b/website/docs/r/cloudwatch_metric_stream.html.markdown
@@ -152,7 +152,7 @@ The following arguments are optional:
 * `name` - (Optional, Forces new resource) Friendly name of the metric stream. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `statistics_configurations` - (Optional) For each entry in this array, you specify one or more metrics and the list of additional statistics to stream for those metrics. The additional statistics that you can stream depend on the stream's OutputFormat. If the OutputFormat is json, you can stream any additional statistic that is supported by CloudWatch, listed in [CloudWatch statistics definitions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.html). If the OutputFormat is opentelemetry0.7, you can stream percentile statistics (p??).
+* `statistics_configurations` - (Optional) For each entry in this array, you specify one or more metrics and the list of additional statistics to stream for those metrics. The additional statistics that you can stream depend on the stream's `output_format`. If the OutputFormat is `json`, you can stream any additional statistic that is supported by CloudWatch, listed in [CloudWatch statistics definitions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.html). If the OutputFormat is `opentelemetry0.7`, you can stream percentile statistics (p99 etc.). See details below.
 
 ### Nested Fields
 
@@ -168,7 +168,7 @@ The following arguments are optional:
 
 * `additional_statistics` - (Required) The additional statistics to stream for the metrics listed in `include_metrics`.
 
-* `include_metrics` - (Required) An array that defines the metrics that are to have additional statistics streamed.
+* `include_metrics` - (Required) An array that defines the metrics that are to have additional statistics streamed. See details below.
 
 #### `include_metrics`
 

--- a/website/docs/r/cloudwatch_metric_stream.html.markdown
+++ b/website/docs/r/cloudwatch_metric_stream.html.markdown
@@ -161,7 +161,7 @@ resource "aws_cloudwatch_metric_stream" "main" {
 
   statistics_configuration {
     additional_statistics = [
-	    "TS(50.5:)"
+      "TS(50.5:)"
     ]
 
     include_metric {


### PR DESCRIPTION
AWS CloudWatch Metric Streams recently added support for streaming additional statistics of metrics: https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-cloudwatch-metric-streams-additional-statistics/

This PR adds support for this new feature by implementing the `statistics_configurations` field and it's nested fields for Metric Stream resources.

Closes #24716.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCloudWatchMetricStream_additional_statistics PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricStream_additional_statistics'  -timeout 180m
go: downloading github.com/aws/aws-sdk-go v1.44.15
=== RUN   TestAccCloudWatchMetricStream_additional_statistics
=== PAUSE TestAccCloudWatchMetricStream_additional_statistics
=== CONT  TestAccCloudWatchMetricStream_additional_statistics
--- PASS: TestAccCloudWatchMetricStream_additional_statistics (59.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	63.531s
...
```
