### PR TITLE
Remove integer constant causing overflow on BSD `go-releaser` build

### DIFF
--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -160,12 +160,9 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 										ValidateFunc: verify.ValidRegionName,
 									},
 									"asn": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ValidateFunc: validation.Any(
-											validation.IntBetween(64512, 65534),
-											validation.IntBetween(4200000000, 4294967294),
-										),
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(64512, 65534),
 									},
 									"inside_cidr_blocks": {
 										Type:     schema.TypeList,

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -160,9 +160,8 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 										ValidateFunc: verify.ValidRegionName,
 									},
 									"asn": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validation.IntBetween(64512, 65534),
+										Type:     schema.TypeInt,
+										Optional: true,
 									},
 									"inside_cidr_blocks": {
 										Type:     schema.TypeList,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTS=TestAccNetworkManagerCoreNetworkPolicyDocument PKG=networkmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerCoreNetworkPolicyDocument'  -timeout 180m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (8.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     8.749s
```
