### PR TITLE
Fix reading existing organizations accounts

### DIFF
--- a/.changelog/24899.txt
+++ b/.changelog/24899.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_organizations_account: Fix reading account state for existing accounts
+```

--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -17,7 +17,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceAccount() *schema.Resource {
@@ -140,6 +139,7 @@ func resourceAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(aws.StringValue(output.AccountId))
+	d.Set("govcloud_id", output.GovCloudAccountId)
 
 	if v, ok := d.GetOk("parent_id"); ok {
 		oldParentAccountID, err := findParentAccountID(conn, d.Id())
@@ -195,14 +195,6 @@ func resourceAccountRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", account.Name)
 	d.Set("parent_id", parentAccountID)
 	d.Set("status", account.Status)
-
-	s, err := findCreateAccountStatusByID(conn, d.Id())
-
-	if err != nil {
-		return names.Error(names.Organizations, "finding", "Create Account Status", d.Id(), err)
-	}
-
-	d.Set("govcloud_id", s.GovCloudAccountId)
 
 	tags, err := ListTags(conn, d.Id())
 

--- a/internal/service/organizations/account_test.go
+++ b/internal/service/organizations/account_test.go
@@ -83,6 +83,7 @@ func testAccAccount_CloseOnDeletion(t *testing.T) {
 					testAccCheckAccountExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "govcloud_id", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "joined_method"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "joined_timestamp"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/internal/service/organizations/account_test.go
+++ b/internal/service/organizations/account_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func testAccAccountImportStep(n string) resource.TestStep {
+	return resource.TestStep{
+		ResourceName:      n,
+		ImportState:       true,
+		ImportStateVerify: true,
+		ImportStateVerifyIgnore: []string{
+			"close_on_deletion",
+			"create_govcloud",
+			"govcloud_id",
+		},
+	}
+}
+
 func testAccAccount_basic(t *testing.T) {
 	key := "TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN"
 	orgsEmailDomain := os.Getenv(key)
@@ -48,12 +61,7 @@ func testAccAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"close_on_deletion"},
-			},
+			testAccAccountImportStep(resourceName),
 		},
 	})
 }
@@ -92,12 +100,7 @@ func testAccAccount_CloseOnDeletion(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"close_on_deletion"},
-			},
+			testAccAccountImportStep(resourceName),
 		},
 	})
 }
@@ -130,12 +133,7 @@ func testAccAccount_ParentID(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "parent_id", parentIdResourceName1, "id"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"close_on_deletion"},
-			},
+			testAccAccountImportStep(resourceName),
 			{
 				Config: testAccAccountParentId2Config(name, email),
 				Check: resource.ComposeTestCheckFunc(
@@ -174,12 +172,7 @@ func testAccAccount_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"close_on_deletion"},
-			},
+			testAccAccountImportStep(resourceName),
 			{
 				Config: testAccAccountTags2Config(name, email, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
@@ -227,12 +220,7 @@ func testAccAccount_govCloud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "govcloud_id"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"create_govcloud", "govcloud_id"},
-			},
+			testAccAccountImportStep(resourceName),
 		},
 	})
 }

--- a/internal/service/organizations/account_test.go
+++ b/internal/service/organizations/account_test.go
@@ -226,6 +226,12 @@ func testAccAccount_govCloud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "govcloud_id"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"create_govcloud", "govcloud_id"},
+			},
 		},
 	})
 }

--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -2,7 +2,21 @@ package organizations_test
 
 import (
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
+
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(organizations.EndpointsID, testAccErrorCheckSkip)
+}
+
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"MASTER_ACCOUNT_NOT_GOVCLOUD_ENABLED",
+	)
+}
 
 func TestAccOrganizations_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #24897

During every account read (also of existing accounts) the create account status is read here
https://github.com/hashicorp/terraform-provider-aws/blob/5b2d3d9aa24ab96f83498f2f0aca44a7b77148c6/internal/service/organizations/account.go#L199
which calls the following SDK function
https://github.com/hashicorp/terraform-provider-aws/blob/5b2d3d9aa24ab96f83498f2f0aca44a7b77148c6/internal/service/organizations/account.go#L390

As per the [AWS docs](https://docs.aws.amazon.com/organizations/latest/APIReference/API_DescribeCreateAccountStatus.html#API_DescribeCreateAccountStatus_RequestSyntax), this `DescribeCreateAccountStatus` function can only be called with the ID of the account creation which looks like this `^car-[a-z0-9]{8,32}$`.
For existing accounts `d.Id()` is the account id (12 digit number) which causes this function to fail with the following error

```
-----------------------------------------------------: timestamp=2022-05-20T11:45:21.246+0200
2022-05-20T11:45:21.246+0200 [DEBUG] provider.terraform-provider-aws_v4.15.0_x5: [aws-sdk-go] {"__type":"InvalidInputException","Message":"You provided a value that does not match the required pattern.","Reason":"INVALID_PATTERN:CREATE_ACCOUNT_REQUEST_ID"}: timestamp=2022-05-20T11:45:21.246+0200
2022-05-20T11:45:21.246+0200 [DEBUG] provider.terraform-provider-aws_v4.15.0_x5: [aws-sdk-go] DEBUG: Validate Response organizations/DescribeCreateAccountStatus failed, attempt 0/25, error InvalidInputException: You provided a value that does not match the required pattern.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "censored"
  },
  Message_: "You provided a value that does not match the required pattern.",
  Reason: "INVALID_PATTERN:CREATE_ACCOUNT_REQUEST_ID"
}: timestamp=2022-05-20T11:45:21.246+0200
2022-05-20T11:45:21.247+0200 [ERROR] vertex "censored" error: finding AWS Organizations Create Account Status (censored): InvalidInputException: You provided a value that does not match the required pattern.

```



**Sorry I did not understand how to do the testing after reading the docs** and also have no way of testing a govcloud account - Support is appreciated - or just go ahead and reuse this fix in a new PR.

### TODOs

- [x] Changelog
- [ ] Testing

<!--
Output from acceptance testing:

Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->
