### PR TITLE
ec2: Fix config names

### DIFF
--- a/internal/service/ec2/ebs_default_kms_key_data_source_test.go
+++ b/internal/service/ec2/ebs_default_kms_key_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccEC2EBSDefaultKMSKeyDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSDefaultKMSKeyDataSourceConfig,
+				Config: testAccEBSDefaultKMSKeyDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSDefaultKMSKey("data.aws_ebs_default_kms_key.current"),
 				),
@@ -24,6 +24,6 @@ func TestAccEC2EBSDefaultKMSKeyDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccEBSDefaultKMSKeyDataSourceConfig = `
+const testAccEBSDefaultKMSKeyDataSourceConfig_basic = `
 data "aws_ebs_default_kms_key" "current" {}
 `

--- a/internal/service/ec2/ebs_encryption_by_default_data_source_test.go
+++ b/internal/service/ec2/ebs_encryption_by_default_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2EBSEncryptionByDefaultDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSEncryptionByDefaultDataSourceConfig,
+				Config: testAccEBSEncryptionByDefaultDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSEncryptionByDefaultDataSource("data.aws_ebs_encryption_by_default.current"),
 				),
@@ -57,6 +57,6 @@ func testAccCheckEBSEncryptionByDefaultDataSource(n string) resource.TestCheckFu
 	}
 }
 
-const testAccEBSEncryptionByDefaultDataSourceConfig = `
+const testAccEBSEncryptionByDefaultDataSourceConfig_basic = `
 data "aws_ebs_encryption_by_default" "current" {}
 `

--- a/internal/service/ec2/ebs_encryption_by_default_test.go
+++ b/internal/service/ec2/ebs_encryption_by_default_test.go
@@ -22,7 +22,7 @@ func TestAccEC2EBSEncryptionByDefault_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEncryptionByDefaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSEncryptionByDefaultConfig(false),
+				Config: testAccEBSEncryptionByDefaultConfig_basic(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSEncryptionByDefault(resourceName, false),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -34,7 +34,7 @@ func TestAccEC2EBSEncryptionByDefault_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSEncryptionByDefaultConfig(true),
+				Config: testAccEBSEncryptionByDefaultConfig_basic(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSEncryptionByDefault(resourceName, true),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -85,7 +85,7 @@ func testAccCheckEBSEncryptionByDefault(n string, enabled bool) resource.TestChe
 	}
 }
 
-func testAccEBSEncryptionByDefaultConfig(enabled bool) string {
+func testAccEBSEncryptionByDefaultConfig_basic(enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_ebs_encryption_by_default" "test" {
   enabled = %[1]t

--- a/internal/service/ec2/ebs_snapshot_copy_test.go
+++ b/internal/service/ec2/ebs_snapshot_copy_test.go
@@ -23,7 +23,7 @@ func TestAccEC2EBSSnapshotCopy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyConfig(),
+				Config: testAccEBSSnapshotCopyConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -45,7 +45,7 @@ func TestAccEC2EBSSnapshotCopy_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyTags1Config("key1", "value1"),
+				Config: testAccEBSSnapshotCopyConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -53,7 +53,7 @@ func TestAccEC2EBSSnapshotCopy_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEBSSnapshotCopyTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccEBSSnapshotCopyConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -62,7 +62,7 @@ func TestAccEC2EBSSnapshotCopy_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEBSSnapshotCopyTags1Config("key2", "value2"),
+				Config: testAccEBSSnapshotCopyConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -84,7 +84,7 @@ func TestAccEC2EBSSnapshotCopy_withDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyWithDescriptionConfig(),
+				Config: testAccEBSSnapshotCopyConfig_description(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					resource.TestCheckResourceAttr(resourceName, "description", "Copy Snapshot Acceptance Test"),
@@ -109,7 +109,7 @@ func TestAccEC2EBSSnapshotCopy_withRegions(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyWithRegionsConfig(),
+				Config: testAccEBSSnapshotCopyConfig_regions(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 				),
@@ -131,7 +131,7 @@ func TestAccEC2EBSSnapshotCopy_withKMS(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyWithKMSConfig(),
+				Config: testAccEBSSnapshotCopyConfig_kms(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
@@ -152,7 +152,7 @@ func TestAccEC2EBSSnapshotCopy_storageTier(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyStorageTierConfig(),
+				Config: testAccEBSSnapshotCopyConfig_storageTier(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "storage_tier", "archive"),
@@ -173,7 +173,7 @@ func TestAccEC2EBSSnapshotCopy_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotCopyConfig(),
+				Config: testAccEBSSnapshotCopyConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &snapshot),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceEBSSnapshotCopy(), resourceName),
@@ -197,13 +197,13 @@ resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 
   tags = {
-    Name = "testAccEBSSnapshotCopyConfig"
+    Name = "testAccEBSSnapshotCopyConfig_basic"
   }
 }
 `)
 }
 
-func testAccEBSSnapshotCopyConfig() string {
+func testAccEBSSnapshotCopyConfig_basic() string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(), `
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
@@ -212,7 +212,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 `)
 }
 
-func testAccEBSSnapshotCopyStorageTierConfig() string {
+func testAccEBSSnapshotCopyConfig_storageTier() string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(), `
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
@@ -222,28 +222,28 @@ resource "aws_ebs_snapshot_copy" "test" {
 `)
 }
 
-func testAccEBSSnapshotCopyTags1Config(tagKey1, tagValue1 string) string {
+func testAccEBSSnapshotCopyConfig_tags1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(), fmt.Sprintf(`
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
   source_region      = data.aws_region.current.name
 
   tags = {
-    Name = "testAccEBSSnapshotCopyConfig"
+    Name = "testAccEBSSnapshotCopyConfig_basic"
     "%s" = "%s"
   }
 }
 `, tagKey1, tagValue1))
 }
 
-func testAccEBSSnapshotCopyTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccEBSSnapshotCopyConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(), fmt.Sprintf(`
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
   source_region      = data.aws_region.current.name
 
   tags = {
-    Name = "testAccEBSSnapshotCopyConfig"
+    Name = "testAccEBSSnapshotCopyConfig_basic"
     "%s" = "%s"
     "%s" = "%s"
   }
@@ -251,7 +251,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccEBSSnapshotCopyWithDescriptionConfig() string {
+func testAccEBSSnapshotCopyConfig_description() string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(), `
 resource "aws_ebs_snapshot_copy" "test" {
   description        = "Copy Snapshot Acceptance Test"
@@ -259,13 +259,13 @@ resource "aws_ebs_snapshot_copy" "test" {
   source_region      = data.aws_region.current.name
 
   tags = {
-    Name = "testAccEBSSnapshotCopyWithDescriptionConfig"
+    Name = "testAccEBSSnapshotCopyConfig_description"
   }
 }
 `)
 }
 
-func testAccEBSSnapshotCopyWithRegionsConfig() string {
+func testAccEBSSnapshotCopyConfig_regions() string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), `
 data "aws_availability_zones" "alternate_available" {
   provider = "awsalternate"
@@ -286,7 +286,7 @@ resource "aws_ebs_volume" "test" {
   size              = 1
 
   tags = {
-    Name = "testAccEBSSnapshotCopyWithRegionsConfig"
+    Name = "testAccEBSSnapshotCopyConfig_regions"
   }
 }
 
@@ -295,7 +295,7 @@ resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 
   tags = {
-    Name = "testAccEBSSnapshotCopyWithRegionsConfig"
+    Name = "testAccEBSSnapshotCopyConfig_regions"
   }
 }
 
@@ -304,16 +304,16 @@ resource "aws_ebs_snapshot_copy" "test" {
   source_region      = data.aws_region.alternate.name
 
   tags = {
-    Name = "testAccEBSSnapshotCopyWithRegionsConfig"
+    Name = "testAccEBSSnapshotCopyConfig_regions"
   }
 }
 `)
 }
 
-func testAccEBSSnapshotCopyWithKMSConfig() string {
+func testAccEBSSnapshotCopyConfig_kms() string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(), `
 resource "aws_kms_key" "test" {
-  description             = "testAccEBSSnapshotCopyWithKMSConfig"
+  description             = "testAccEBSSnapshotCopyConfig_kms"
   deletion_window_in_days = 7
 }
 
@@ -324,7 +324,7 @@ resource "aws_ebs_snapshot_copy" "test" {
   kms_key_id         = aws_kms_key.test.arn
 
   tags = {
-    Name = "testAccEBSSnapshotCopyWithKMSConfig"
+    Name = "testAccEBSSnapshotCopyConfig_kms"
   }
 }
 `)

--- a/internal/service/ec2/ebs_snapshot_create_volume_permission_test.go
+++ b/internal/service/ec2/ebs_snapshot_create_volume_permission_test.go
@@ -25,7 +25,7 @@ func TestAccEC2EBSSnapshotCreateVolumePermission_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Scaffold everything
 			{
-				Config: testAccSnapshotCreateVolumePermissionConfig(true, accountId),
+				Config: testAccEBSSnapshotCreateVolumePermissionConfig_basic(true, accountId),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckResourceGetAttr("aws_ebs_snapshot.test", "id", &snapshotId),
 					testAccSnapshotCreateVolumePermissionExists(&accountId, &snapshotId),
@@ -33,7 +33,7 @@ func TestAccEC2EBSSnapshotCreateVolumePermission_basic(t *testing.T) {
 			},
 			// Drop just create volume permission to test destruction
 			{
-				Config: testAccSnapshotCreateVolumePermissionConfig(false, accountId),
+				Config: testAccEBSSnapshotCreateVolumePermissionConfig_basic(false, accountId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSnapshotCreateVolumePermissionDestroyed(&accountId, &snapshotId),
 				),
@@ -53,7 +53,7 @@ func TestAccEC2EBSSnapshotCreateVolumePermission_disappears(t *testing.T) {
 		CheckDestroy:      testAccSnapshotCreateVolumePermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotCreateVolumePermissionConfig(true, accountId),
+				Config: testAccEBSSnapshotCreateVolumePermissionConfig_basic(true, accountId),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckResourceGetAttr("aws_ebs_snapshot.test", "id", &snapshotId),
 					testAccSnapshotCreateVolumePermissionExists(&accountId, &snapshotId),
@@ -129,7 +129,7 @@ func testAccSnapshotCreateVolumePermissionDestroyed(accountId, snapshotId *strin
 	}
 }
 
-func testAccSnapshotCreateVolumePermissionConfig(includeCreateVolumePermission bool, accountID string) string {
+func testAccEBSSnapshotCreateVolumePermissionConfig_basic(includeCreateVolumePermission bool, accountID string) string {
 	base := `
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/ec2/ebs_snapshot_data_source_test.go
+++ b/internal/service/ec2/ebs_snapshot_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2EBSSnapshotDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckEBSSnapshotDataSourceConfig,
+				Config: testAccEBSSnapshotDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSSnapshotIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
@@ -50,7 +50,7 @@ func TestAccEC2EBSSnapshotDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckEBSSnapshotFilterDataSourceConfig,
+				Config: testAccEBSSnapshotDataSourceConfig_filter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSSnapshotIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
@@ -70,7 +70,7 @@ func TestAccEC2EBSSnapshotDataSource_mostRecent(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckEBSSnapshotMostRecentDataSourceConfig,
+				Config: testAccEBSSnapshotDataSourceConfig_mostRecent,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSSnapshotIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
@@ -94,7 +94,7 @@ func testAccCheckEBSSnapshotIDDataSource(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccCheckEBSSnapshotDataSourceConfig = acctest.ConfigAvailableAZsNoOptIn() + `
+var testAccEBSSnapshotDataSourceConfig_basic = acctest.ConfigAvailableAZsNoOptIn() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
@@ -110,7 +110,7 @@ data "aws_ebs_snapshot" "test" {
 }
 `
 
-var testAccCheckEBSSnapshotFilterDataSourceConfig = acctest.ConfigAvailableAZsNoOptIn() + `
+var testAccEBSSnapshotDataSourceConfig_filter = acctest.ConfigAvailableAZsNoOptIn() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
@@ -129,7 +129,7 @@ data "aws_ebs_snapshot" "test" {
 }
 `
 
-var testAccCheckEBSSnapshotMostRecentDataSourceConfig = acctest.ConfigAvailableAZsNoOptIn() + `
+var testAccEBSSnapshotDataSourceConfig_mostRecent = acctest.ConfigAvailableAZsNoOptIn() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"

--- a/internal/service/ec2/ebs_snapshot_import_test.go
+++ b/internal/service/ec2/ebs_snapshot_import_test.go
@@ -29,7 +29,7 @@ func TestAccEC2EBSSnapshotImport_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotImportBasicConfig(rName, t),
+				Config: testAccEBSSnapshotImportConfig_basic(rName, t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -54,7 +54,7 @@ func TestAccEC2EBSSnapshotImport_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotImportTags1Config(rName, t, "key1", "value1"),
+				Config: testAccEBSSnapshotImportConfig_tags1(rName, t, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -64,7 +64,7 @@ func TestAccEC2EBSSnapshotImport_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEBSSnapshotImportTags2Config(rName, t, "key1", "value1updated", "key2", "value2"),
+				Config: testAccEBSSnapshotImportConfig_tags2(rName, t, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -75,7 +75,7 @@ func TestAccEC2EBSSnapshotImport_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEBSSnapshotImportTags1Config(rName, t, "key2", "value2"),
+				Config: testAccEBSSnapshotImportConfig_tags1(rName, t, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -100,7 +100,7 @@ func TestAccEC2EBSSnapshotImport_storageTier(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotImportStorageTierConfig(rName, t),
+				Config: testAccEBSSnapshotImportConfig_storageTier(rName, t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "storage_tier", "archive"),
@@ -122,7 +122,7 @@ func TestAccEC2EBSSnapshotImport_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotImportBasicConfig(rName, t),
+				Config: testAccEBSSnapshotImportConfig_basic(rName, t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -149,7 +149,7 @@ func TestAccEC2EBSSnapshotImport_Disappears_s3Object(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotImportBasicConfig(rName, t),
+				Config: testAccEBSSnapshotImportConfig_basic(rName, t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -237,7 +237,7 @@ data "aws_iam_policy_document" "vmimport-trust" {
 `, testAccEBSSnapshotDisk(t))
 }
 
-func testAccEBSSnapshotImportBasicConfig(rName string, t *testing.T) string {
+func testAccEBSSnapshotImportConfig_basic(rName string, t *testing.T) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {
@@ -259,7 +259,7 @@ resource "aws_ebs_snapshot_import" "test" {
 `, rName))
 }
 
-func testAccEBSSnapshotImportStorageTierConfig(rName string, t *testing.T) string {
+func testAccEBSSnapshotImportConfig_storageTier(rName string, t *testing.T) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {
@@ -282,7 +282,7 @@ resource "aws_ebs_snapshot_import" "test" {
 `, rName))
 }
 
-func testAccEBSSnapshotImportTags1Config(rName string, t *testing.T, tagKey1 string, tagValue1 string) string {
+func testAccEBSSnapshotImportConfig_tags1(rName string, t *testing.T, tagKey1 string, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {
@@ -308,7 +308,7 @@ resource "aws_ebs_snapshot_import" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccEBSSnapshotImportTags2Config(rName string, t *testing.T, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccEBSSnapshotImportConfig_tags2(rName string, t *testing.T, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {

--- a/internal/service/ec2/ebs_snapshot_test.go
+++ b/internal/service/ec2/ebs_snapshot_test.go
@@ -27,7 +27,7 @@ func TestAccEC2EBSSnapshot_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotBasicConfig(rName),
+				Config: testAccEBSSnapshotConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
@@ -59,7 +59,7 @@ func TestAccEC2EBSSnapshot_storageTier(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotStorageTierConfig(rName, "archive"),
+				Config: testAccEBSSnapshotConfig_storageTier(rName, "archive"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "storage_tier", "archive"),
@@ -87,7 +87,7 @@ func TestAccEC2EBSSnapshot_outpost(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotOutpostConfig(rName),
+				Config: testAccEBSSnapshotConfig_outpost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "outpost_arn", outpostDataSourceName, "arn"),
@@ -114,7 +114,7 @@ func TestAccEC2EBSSnapshot_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotBasicTags1Config(rName, "key1", "value1"),
+				Config: testAccEBSSnapshotConfig_basicTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -127,7 +127,7 @@ func TestAccEC2EBSSnapshot_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSSnapshotBasicTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccEBSSnapshotConfig_basicTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -136,7 +136,7 @@ func TestAccEC2EBSSnapshot_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEBSSnapshotBasicTags1Config(rName, "key2", "value2"),
+				Config: testAccEBSSnapshotConfig_basicTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -159,7 +159,7 @@ func TestAccEC2EBSSnapshot_withDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotWithDescriptionConfig(rName),
+				Config: testAccEBSSnapshotConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
@@ -187,7 +187,7 @@ func TestAccEC2EBSSnapshot_withKMS(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotWithKMSConfig(rName),
+				Config: testAccEBSSnapshotConfig_kms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
@@ -214,7 +214,7 @@ func TestAccEC2EBSSnapshot_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEBSSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSSnapshotBasicConfig(rName),
+				Config: testAccEBSSnapshotConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceEBSSnapshot(), resourceName),
@@ -286,7 +286,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSSnapshotBasicConfig(rName string) string {
+func testAccEBSSnapshotConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), `
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
@@ -299,7 +299,7 @@ resource "aws_ebs_snapshot" "test" {
 `)
 }
 
-func testAccEBSSnapshotStorageTierConfig(rName, tier string) string {
+func testAccEBSSnapshotConfig_storageTier(rName, tier string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id    = aws_ebs_volume.test.id
@@ -313,7 +313,7 @@ resource "aws_ebs_snapshot" "test" {
 `, tier))
 }
 
-func testAccEBSSnapshotOutpostConfig(rName string) string {
+func testAccEBSSnapshotConfig_outpost(rName string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), `
 data "aws_outposts_outposts" "test" {}
 
@@ -333,7 +333,7 @@ resource "aws_ebs_snapshot" "test" {
 `)
 }
 
-func testAccEBSSnapshotBasicTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccEBSSnapshotConfig_basicTags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
@@ -351,7 +351,7 @@ resource "aws_ebs_snapshot" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccEBSSnapshotBasicTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccEBSSnapshotConfig_basicTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
@@ -370,7 +370,7 @@ resource "aws_ebs_snapshot" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccEBSSnapshotWithDescriptionConfig(rName string) string {
+func testAccEBSSnapshotConfig_description(rName string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id   = aws_ebs_volume.test.id
@@ -379,7 +379,7 @@ resource "aws_ebs_snapshot" "test" {
 `, rName))
 }
 
-func testAccEBSSnapshotWithKMSConfig(rName string) string {
+func testAccEBSSnapshotConfig_kms(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7

--- a/internal/service/ec2/ebs_volume_attachment_test.go
+++ b/internal/service/ec2/ebs_volume_attachment_test.go
@@ -27,7 +27,7 @@ func TestAccEC2EBSVolumeAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeAttachmentConfig(rName),
+				Config: testAccEBSVolumeAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
@@ -54,7 +54,7 @@ func TestAccEC2EBSVolumeAttachment_skipDestroy(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeAttachmentConfigSkipDestroy(rName),
+				Config: testAccEBSVolumeAttachmentConfig_skipDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
@@ -95,14 +95,14 @@ func TestAccEC2EBSVolumeAttachment_attachStopped(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeAttachmentBaseConfig(rName),
+				Config: testAccEBSVolumeAttachmentConfig_base(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.test", &i),
 				),
 			},
 			{
 				PreConfig: stopInstance,
-				Config:    testAccVolumeAttachmentConfig(rName),
+				Config:    testAccEBSVolumeAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
@@ -129,7 +129,7 @@ func TestAccEC2EBSVolumeAttachment_update(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeAttachmentUpdateConfig(rName, false),
+				Config: testAccEBSVolumeAttachmentConfig_update(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "force_detach", "false"),
 					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "false"),
@@ -146,7 +146,7 @@ func TestAccEC2EBSVolumeAttachment_update(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccVolumeAttachmentUpdateConfig(rName, true),
+				Config: testAccEBSVolumeAttachmentConfig_update(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "force_detach", "true"),
 					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "true"),
@@ -179,7 +179,7 @@ func TestAccEC2EBSVolumeAttachment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeAttachmentConfig(rName),
+				Config: testAccEBSVolumeAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.test", &i),
 					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
@@ -203,7 +203,7 @@ func TestAccEC2EBSVolumeAttachment_stopInstance(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeAttachmentStopInstanceConfig(rName),
+				Config: testAccEBSVolumeAttachmentConfig_stopInstance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeAttachmentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
@@ -287,7 +287,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccVolumeAttachmentBaseConfig(rName string) string {
+func testAccEBSVolumeAttachmentConfig_base(rName string) string {
 	return acctest.ConfigCompose(testAccVolumeAttachmentInstanceOnlyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -300,8 +300,8 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccVolumeAttachmentConfig(rName string) string {
-	return acctest.ConfigCompose(testAccVolumeAttachmentBaseConfig(rName), `
+func testAccEBSVolumeAttachmentConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccEBSVolumeAttachmentConfig_base(rName), `
 resource "aws_volume_attachment" "test" {
   device_name = "/dev/sdh"
   volume_id   = aws_ebs_volume.test.id
@@ -310,7 +310,7 @@ resource "aws_volume_attachment" "test" {
 `)
 }
 
-func testAccVolumeAttachmentStopInstanceConfig(rName string) string {
+func testAccEBSVolumeAttachmentConfig_stopInstance(rName string) string {
 	return acctest.ConfigCompose(testAccVolumeAttachmentInstanceOnlyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -330,8 +330,8 @@ resource "aws_volume_attachment" "test" {
 `, rName))
 }
 
-func testAccVolumeAttachmentConfigSkipDestroy(rName string) string {
-	return acctest.ConfigCompose(testAccVolumeAttachmentBaseConfig(rName), fmt.Sprintf(`
+func testAccEBSVolumeAttachmentConfig_skipDestroy(rName string) string {
+	return acctest.ConfigCompose(testAccEBSVolumeAttachmentConfig_base(rName), fmt.Sprintf(`
 data "aws_ebs_volume" "test" {
   filter {
     name   = "size"
@@ -358,8 +358,8 @@ resource "aws_volume_attachment" "test" {
 `, rName))
 }
 
-func testAccVolumeAttachmentUpdateConfig(rName string, detach bool) string {
-	return acctest.ConfigCompose(testAccVolumeAttachmentBaseConfig(rName), fmt.Sprintf(`
+func testAccEBSVolumeAttachmentConfig_update(rName string, detach bool) string {
+	return acctest.ConfigCompose(testAccEBSVolumeAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_volume_attachment" "test" {
   device_name  = "/dev/sdh"
   volume_id    = aws_ebs_volume.test.id

--- a/internal/service/ec2/ebs_volume_data_source_test.go
+++ b/internal/service/ec2/ebs_volume_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccEC2EBSVolumeDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckEBSVolumeDataSourceConfig(rName),
+				Config: testAccEBSVolumeDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSVolumeIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -48,7 +48,7 @@ func TestAccEC2EBSVolumeDataSource_multipleFilters(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckEBSVolumeWithMultipleFiltersDataSourceConfig(rName),
+				Config: testAccEBSVolumeDataSourceConfig_multipleFilters(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSVolumeIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "size", resourceName, "size"),
@@ -74,7 +74,7 @@ func testAccCheckEBSVolumeIDDataSource(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckEBSVolumeDataSourceConfig(rName string) string {
+func testAccEBSVolumeDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -104,7 +104,7 @@ data "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccCheckEBSVolumeWithMultipleFiltersDataSourceConfig(rName string) string {
+func testAccEBSVolumeDataSourceConfig_multipleFilters(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`

--- a/internal/service/ec2/ebs_volume_test.go
+++ b/internal/service/ec2/ebs_volume_test.go
@@ -120,7 +120,7 @@ func TestAccEC2EBSVolume_updateSize(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeBasicConfig(rName),
+				Config: testAccEBSVolumeConfig_tags1("Name", rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "1"),
@@ -156,7 +156,7 @@ func TestAccEC2EBSVolume_updateType(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeBasicConfig(rName),
+				Config: testAccEBSVolumeConfig_tags1("Name", rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "type", "gp2"),
@@ -825,20 +825,6 @@ resource "aws_ebs_volume" "test" {
   size              = 1
 }
 `)
-
-func testAccEBSVolumeBasicConfig(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_ebs_volume" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  type              = "gp2"
-  size              = 1
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName))
-}
 
 func testAccEBSVolumeConfig_attached(rName string) string {
 	return acctest.ConfigCompose(

--- a/internal/service/ec2/ebs_volume_test.go
+++ b/internal/service/ec2/ebs_volume_test.go
@@ -26,7 +26,7 @@ func TestAccEC2EBSVolume_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeConfig,
+				Config: testAccEBSVolumeConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -61,7 +61,7 @@ func TestAccEC2EBSVolume_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeConfig,
+				Config: testAccEBSVolumeConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceEBSVolume(), resourceName),
@@ -84,7 +84,7 @@ func TestAccEC2EBSVolume_updateAttachedEBSVolume(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSAttachedVolumeConfig(rName),
+				Config: testAccEBSVolumeConfig_attached(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "10"),
@@ -97,7 +97,7 @@ func TestAccEC2EBSVolume_updateAttachedEBSVolume(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSAttachedVolumeUpdateSizeConfig(rName),
+				Config: testAccEBSVolumeConfig_attachedUpdateSize(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "20"),
@@ -133,7 +133,7 @@ func TestAccEC2EBSVolume_updateSize(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeUpdateSizeConfig(rName),
+				Config: testAccEBSVolumeConfig_updateSize(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "10"),
@@ -169,7 +169,7 @@ func TestAccEC2EBSVolume_updateType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeUpdateTypeConfig(rName),
+				Config: testAccEBSVolumeConfig_updateType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "type", "sc1"),
@@ -192,7 +192,7 @@ func TestAccEC2EBSVolume_UpdateIops_io1(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeWithIopsIo1Config(rName),
+				Config: testAccEBSVolumeConfig_iopsIo1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "100"),
@@ -205,7 +205,7 @@ func TestAccEC2EBSVolume_UpdateIops_io1(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeWithIopsIo1UpdatedConfig(rName),
+				Config: testAccEBSVolumeConfig_iopsIo1Updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "200"),
@@ -228,7 +228,7 @@ func TestAccEC2EBSVolume_UpdateIops_io2(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeWithIopsIo2Config(rName),
+				Config: testAccEBSVolumeConfig_iopsIo2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "100"),
@@ -241,7 +241,7 @@ func TestAccEC2EBSVolume_UpdateIops_io2(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeWithIopsIo2UpdatedConfig(rName),
+				Config: testAccEBSVolumeConfig_iopsIo2Updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "200"),
@@ -265,7 +265,7 @@ func TestAccEC2EBSVolume_kmsKey(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeWithKMSKeyConfig(rName),
+				Config: testAccEBSVolumeConfig_kmsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "encrypted", "true"),
@@ -294,7 +294,7 @@ func TestAccEC2EBSVolume_noIops(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeWithNoIopsConfig(rName),
+				Config: testAccEBSVolumeConfig_noIOPS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
@@ -318,7 +318,7 @@ func TestAccEC2EBSVolume_invalidIopsForType(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEBSVolumeWithInvalidIopsForTypeConfig,
+				Config:      testAccEBSVolumeConfig_invalidIOPSForType,
 				ExpectError: regexp.MustCompile(`'iops' must not be set when 'type' is`),
 			},
 		},
@@ -333,7 +333,7 @@ func TestAccEC2EBSVolume_invalidThroughputForType(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEBSVolumeWithInvalidThroughputForTypeConfig,
+				Config:      testAccEBSVolumeConfig_invalidThroughputForType,
 				ExpectError: regexp.MustCompile(`'throughput' must not be set when 'type' is`),
 			},
 		},
@@ -351,7 +351,7 @@ func TestAccEC2EBSVolume_withTags(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeConfigTags1("key1", "value1"),
+				Config: testAccEBSVolumeConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -364,7 +364,7 @@ func TestAccEC2EBSVolume_withTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeConfigTags2("key1", "value1updated", "key2", "value2"),
+				Config: testAccEBSVolumeConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -373,7 +373,7 @@ func TestAccEC2EBSVolume_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEBSVolumeConfigTags1("key2", "value2"),
+				Config: testAccEBSVolumeConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -396,7 +396,7 @@ func TestAccEC2EBSVolume_multiAttach_io1(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeMultiAttachConfig(rName, "io1"),
+				Config: testAccEBSVolumeConfig_multiAttach(rName, "io1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", "true"),
@@ -425,7 +425,7 @@ func TestAccEC2EBSVolume_multiAttach_io2(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeMultiAttachConfig(rName, "io2"),
+				Config: testAccEBSVolumeConfig_multiAttach(rName, "io2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", "true"),
@@ -450,7 +450,7 @@ func TestAccEC2EBSVolume_multiAttach_gp2(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEBSVolumeWithInvalidMultiAttachEnabledForTypeConfig,
+				Config:      testAccEBSVolumeConfig_invalidMultiAttachEnabledForType,
 				ExpectError: regexp.MustCompile(`'multi_attach_enabled' must not be set when 'type' is`),
 			},
 		},
@@ -470,7 +470,7 @@ func TestAccEC2EBSVolume_outpost(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeOutpostConfig(rName),
+				Config: testAccEBSVolumeConfig_outpost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "outpost_arn", outpostDataSourceName, "arn"),
@@ -497,7 +497,7 @@ func TestAccEC2EBSVolume_GP3_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp3", "", ""),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp3", "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -535,7 +535,7 @@ func TestAccEC2EBSVolume_GP3_iops(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp3", "4000", "200"),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp3", "4000", "200"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -558,7 +558,7 @@ func TestAccEC2EBSVolume_GP3_iops(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp3", "5000", "200"),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp3", "5000", "200"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -591,7 +591,7 @@ func TestAccEC2EBSVolume_GP3_throughput(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp3", "", "400"),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp3", "", "400"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -614,7 +614,7 @@ func TestAccEC2EBSVolume_GP3_throughput(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp3", "", "600"),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp3", "", "600"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -647,7 +647,7 @@ func TestAccEC2EBSVolume_gp3ToGP2(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp3", "3000", "400"),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp3", "3000", "400"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -670,7 +670,7 @@ func TestAccEC2EBSVolume_gp3ToGP2(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, "10", "gp2", "", ""),
+				Config: testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, "10", "gp2", "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -704,7 +704,7 @@ func TestAccEC2EBSVolume_snapshotID(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeSnapshotIDConfig(rName),
+				Config: testAccEBSVolumeConfig_snapshotID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -743,7 +743,7 @@ func TestAccEC2EBSVolume_snapshotIDAndSize(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeSnapshotIdAndSizeConfig(rName, 20),
+				Config: testAccEBSVolumeConfig_snapshotIdAndSize(rName, 20),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`volume/vol-.+`)),
@@ -818,7 +818,7 @@ func testAccCheckVolumeExists(n string, v *ec2.Volume) resource.TestCheckFunc {
 	}
 }
 
-var testAccEBSVolumeConfig = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+var testAccEBSVolumeConfig_basic = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
@@ -840,7 +840,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSAttachedVolumeConfig(rName string) string {
+func testAccEBSVolumeConfig_attached(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		fmt.Sprintf(`
@@ -879,7 +879,7 @@ resource "aws_volume_attachment" "test" {
 `, rName))
 }
 
-func testAccEBSAttachedVolumeUpdateSizeConfig(rName string) string {
+func testAccEBSVolumeConfig_attachedUpdateSize(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		fmt.Sprintf(`
@@ -918,7 +918,7 @@ resource "aws_volume_attachment" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeUpdateSizeConfig(rName string) string {
+func testAccEBSVolumeConfig_updateSize(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -934,7 +934,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeUpdateTypeConfig(rName string) string {
+func testAccEBSVolumeConfig_updateType(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -950,7 +950,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeWithIopsIo1Config(rName string) string {
+func testAccEBSVolumeConfig_iopsIo1(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -967,7 +967,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeWithIopsIo1UpdatedConfig(rName string) string {
+func testAccEBSVolumeConfig_iopsIo1Updated(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -984,7 +984,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeWithIopsIo2Config(rName string) string {
+func testAccEBSVolumeConfig_iopsIo2(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1001,7 +1001,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeWithIopsIo2UpdatedConfig(rName string) string {
+func testAccEBSVolumeConfig_iopsIo2Updated(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1018,7 +1018,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeWithKMSKeyConfig(rName string) string {
+func testAccEBSVolumeConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1056,7 +1056,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeConfigTags1(tagKey1, tagValue1 string) string {
+func testAccEBSVolumeConfig_tags1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1071,7 +1071,7 @@ resource "aws_ebs_volume" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccEBSVolumeConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccEBSVolumeConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1087,7 +1087,7 @@ resource "aws_ebs_volume" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccEBSVolumeWithNoIopsConfig(rName string) string {
+func testAccEBSVolumeConfig_noIOPS(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1104,7 +1104,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-var testAccEBSVolumeWithInvalidIopsForTypeConfig = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+var testAccEBSVolumeConfig_invalidIOPSForType = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   size              = 10
@@ -1112,7 +1112,7 @@ resource "aws_ebs_volume" "test" {
 }
 `)
 
-var testAccEBSVolumeWithInvalidThroughputForTypeConfig = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+var testAccEBSVolumeConfig_invalidThroughputForType = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   size              = 10
@@ -1122,7 +1122,7 @@ resource "aws_ebs_volume" "test" {
 }
 `)
 
-var testAccEBSVolumeWithInvalidMultiAttachEnabledForTypeConfig = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+var testAccEBSVolumeConfig_invalidMultiAttachEnabledForType = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ebs_volume" "test" {
   availability_zone    = data.aws_availability_zones.available.names[0]
   size                 = 10
@@ -1131,7 +1131,7 @@ resource "aws_ebs_volume" "test" {
 }
 `)
 
-func testAccEBSVolumeOutpostConfig(rName string) string {
+func testAccEBSVolumeConfig_outpost(rName string) string {
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -1151,7 +1151,7 @@ resource "aws_ebs_volume" "test" {
 `, rName)
 }
 
-func testAccEBSVolumeMultiAttachConfig(rName, volumeType string) string {
+func testAccEBSVolumeConfig_multiAttach(rName, volumeType string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone    = data.aws_availability_zones.available.names[0]
@@ -1167,7 +1167,7 @@ resource "aws_ebs_volume" "test" {
 `, rName, volumeType))
 }
 
-func testAccEBSVolumeSizeTypeIopsThroughputConfig(rName, size, volumeType, iops, throughput string) string {
+func testAccEBSVolumeConfig_sizeTypeIOPSThroughput(rName, size, volumeType, iops, throughput string) string {
 	if volumeType == "" {
 		volumeType = "null"
 	}
@@ -1195,7 +1195,7 @@ resource "aws_ebs_volume" "test" {
 `, rName, size, volumeType, iops, throughput))
 }
 
-func testAccEBSVolumeSnapshotIDConfig(rName string) string {
+func testAccEBSVolumeConfig_snapshotID(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1227,7 +1227,7 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
-func testAccEBSVolumeSnapshotIdAndSizeConfig(rName string, size int) string {
+func testAccEBSVolumeConfig_snapshotIdAndSize(rName string, size int) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`

--- a/internal/service/ec2/ebs_volumes_data_source_test.go
+++ b/internal/service/ec2/ebs_volumes_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2EBSVolumesDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEBSVolumeIDsDataSourceConfig(rName),
+				Config: testAccEBSVolumesDataSourceConfig_volumeIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_ebs_volumes.by_tags", "ids.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volumes.by_filter", "ids.#", "1"),
@@ -31,7 +31,7 @@ func TestAccEC2EBSVolumesDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccEBSVolumeIDsDataSourceConfig(rName string) string {
+func testAccEBSVolumesDataSourceConfig_volumeIDs(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_region" "current" {}
 

--- a/internal/service/ec2/ec2_ami_copy_test.go
+++ b/internal/service/ec2/ec2_ami_copy_test.go
@@ -25,7 +25,7 @@ func TestAccEC2AMICopy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMICopyConfig(rName),
+				Config: testAccAMICopyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					testAccCheckAMICopyAttributes(&image, rName),
@@ -53,14 +53,14 @@ func TestAccEC2AMICopy_description(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMICopyDescriptionConfig(rName, "description1"),
+				Config: testAccAMICopyConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
 				),
 			},
 			{
-				Config: testAccAMICopyDescriptionConfig(rName, "description2"),
+				Config: testAccAMICopyConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -82,7 +82,7 @@ func TestAccEC2AMICopy_enaSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMICopyENASupportConfig(rName),
+				Config: testAccAMICopyConfig_enaSupport(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
@@ -105,7 +105,7 @@ func TestAccEC2AMICopy_destinationOutpost(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMICopyDestOutpostConfig(rName),
+				Config: testAccAMICopyConfig_destOutpost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_outpost_arn", outpostDataSourceName, "arn"),
@@ -127,7 +127,7 @@ func TestAccEC2AMICopy_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMICopyTags1Config(rName, "key1", "value1"),
+				Config: testAccAMICopyConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &ami),
 					testAccCheckAMICopyAttributes(&ami, rName),
@@ -136,7 +136,7 @@ func TestAccEC2AMICopy_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAMICopyTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAMICopyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &ami),
 					testAccCheckAMICopyAttributes(&ami, rName),
@@ -146,7 +146,7 @@ func TestAccEC2AMICopy_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAMICopyTags1Config(rName, "key2", "value2"),
+				Config: testAccAMICopyConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &ami),
 					testAccCheckAMICopyAttributes(&ami, rName),
@@ -220,7 +220,7 @@ resource "aws_ebs_snapshot" "test" {
 `, rName)
 }
 
-func testAccAMICopyTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccAMICopyConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccAMICopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ami" "test" {
   name                = %[1]q
@@ -245,7 +245,7 @@ resource "aws_ami_copy" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccAMICopyTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAMICopyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccAMICopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ami" "test" {
   name                = %[1]q
@@ -271,7 +271,7 @@ resource "aws_ami_copy" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccAMICopyConfig(rName string) string {
+func testAccAMICopyConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccAMICopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ami" "test" {
   name                = "%s-source"
@@ -292,7 +292,7 @@ resource "aws_ami_copy" "test" {
 `, rName, rName))
 }
 
-func testAccAMICopyDescriptionConfig(rName, description string) string {
+func testAccAMICopyConfig_description(rName, description string) string {
 	return acctest.ConfigCompose(testAccAMICopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ami" "test" {
   name                = "%s-source"
@@ -314,7 +314,7 @@ resource "aws_ami_copy" "test" {
 `, rName, description, rName))
 }
 
-func testAccAMICopyENASupportConfig(rName string) string {
+func testAccAMICopyConfig_enaSupport(rName string) string {
 	return acctest.ConfigCompose(testAccAMICopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ami" "test" {
   ena_support         = true
@@ -336,7 +336,7 @@ resource "aws_ami_copy" "test" {
 `, rName, rName))
 }
 
-func testAccAMICopyDestOutpostConfig(rName string) string {
+func testAccAMICopyConfig_destOutpost(rName string) string {
 	return acctest.ConfigCompose(testAccAMICopyBaseConfig(rName), fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -117,7 +117,7 @@ func TestAccEC2AMIDataSource_instanceStore(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLatestAmazonLinuxHVMInstanceStoreAMIConfig(),
+				Config: testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIIDDataSource(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
@@ -213,10 +213,10 @@ func testAccCheckAMIIDDataSource(n string) resource.TestCheckFunc {
 	}
 }
 
-// testAccLatestAmazonLinuxHVMInstanceStoreAMIConfig returns the configuration for a data source that
+// testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore returns the configuration for a data source that
 // describes the latest Amazon Linux AMI using HVM virtualization and an instance store root device.
 // The data source is named 'amzn-ami-minimal-hvm-instance-store'.
-func testAccLatestAmazonLinuxHVMInstanceStoreAMIConfig() string {
+func testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore() string {
 	return `
 data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
   most_recent = true

--- a/internal/service/ec2/ec2_ami_from_instance_test.go
+++ b/internal/service/ec2/ec2_ami_from_instance_test.go
@@ -24,7 +24,7 @@ func TestAccEC2AMIFromInstance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMIFromInstanceConfig(rName),
+				Config: testAccAMIFromInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
@@ -53,7 +53,7 @@ func TestAccEC2AMIFromInstance_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMIFromInstanceTags1Config(rName, "key1", "value1"),
+				Config: testAccAMIFromInstanceConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -61,7 +61,7 @@ func TestAccEC2AMIFromInstance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAMIFromInstanceTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAMIFromInstanceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -70,7 +70,7 @@ func TestAccEC2AMIFromInstance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAMIFromInstanceTags1Config(rName, "key2", "value2"),
+				Config: testAccAMIFromInstanceConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -93,7 +93,7 @@ func TestAccEC2AMIFromInstance_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMIFromInstanceConfig(rName),
+				Config: testAccAMIFromInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMIExists(resourceName, &image),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceAMIFromInstance(), resourceName),
@@ -120,7 +120,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccAMIFromInstanceConfig(rName string) string {
+func testAccAMIFromInstanceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccAMIFromInstanceBaseConfig(rName),
 		fmt.Sprintf(`
@@ -132,7 +132,7 @@ resource "aws_ami_from_instance" "test" {
 `, rName))
 }
 
-func testAccAMIFromInstanceTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccAMIFromInstanceConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		testAccAMIFromInstanceBaseConfig(rName),
 		fmt.Sprintf(`
@@ -148,7 +148,7 @@ resource "aws_ami_from_instance" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccAMIFromInstanceTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAMIFromInstanceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		testAccAMIFromInstanceBaseConfig(rName),
 		fmt.Sprintf(`

--- a/internal/service/ec2/ec2_ami_launch_permission_test.go
+++ b/internal/service/ec2/ec2_ami_launch_permission_test.go
@@ -26,7 +26,7 @@ func TestAccEC2AMILaunchPermission_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAMILaunchPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMILaunchPermissionAccountIDConfig(rName),
+				Config: testAccAMILaunchPermissionConfig_accountID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMILaunchPermissionExists(resourceName),
 					acctest.CheckResourceAttrAccountID(resourceName, "account_id"),
@@ -56,7 +56,7 @@ func TestAccEC2AMILaunchPermission_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAMILaunchPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMILaunchPermissionAccountIDConfig(rName),
+				Config: testAccAMILaunchPermissionConfig_accountID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMILaunchPermissionExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceAMILaunchPermission(), resourceName),
@@ -78,7 +78,7 @@ func TestAccEC2AMILaunchPermission_Disappears_ami(t *testing.T) {
 		CheckDestroy:      testAccCheckAMILaunchPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMILaunchPermissionAccountIDConfig(rName),
+				Config: testAccAMILaunchPermissionConfig_accountID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMILaunchPermissionExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceAMICopy(), "aws_ami_copy.test"),
@@ -100,7 +100,7 @@ func TestAccEC2AMILaunchPermission_group(t *testing.T) {
 		CheckDestroy:      testAccCheckAMILaunchPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMILaunchPermissionGroupConfig(rName),
+				Config: testAccAMILaunchPermissionConfig_group(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMILaunchPermissionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "account_id", ""),
@@ -130,7 +130,7 @@ func TestAccEC2AMILaunchPermission_organizationARN(t *testing.T) {
 		CheckDestroy:      testAccCheckAMILaunchPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMILaunchPermissionOrganizationARNConfig(rName),
+				Config: testAccAMILaunchPermissionConfig_organizationARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMILaunchPermissionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "account_id", ""),
@@ -160,7 +160,7 @@ func TestAccEC2AMILaunchPermission_organizationalUnitARN(t *testing.T) {
 		CheckDestroy:      testAccCheckAMILaunchPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMILaunchPermissionOrganizationalUnitARNConfig(rName),
+				Config: testAccAMILaunchPermissionConfig_organizationalUnitARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAMILaunchPermissionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "account_id", ""),
@@ -259,7 +259,7 @@ func testAccCheckAMILaunchPermissionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAMILaunchPermissionAccountIDConfig(rName string) string {
+func testAccAMILaunchPermissionConfig_accountID(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -279,7 +279,7 @@ resource "aws_ami_launch_permission" "test" {
 `, rName))
 }
 
-func testAccAMILaunchPermissionGroupConfig(rName string) string {
+func testAccAMILaunchPermissionConfig_group(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -298,7 +298,7 @@ resource "aws_ami_launch_permission" "test" {
 `, rName))
 }
 
-func testAccAMILaunchPermissionOrganizationARNConfig(rName string) string {
+func testAccAMILaunchPermissionConfig_organizationARN(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 data "aws_organizations_organization" "current" {}
 
@@ -318,7 +318,7 @@ resource "aws_ami_launch_permission" "test" {
 `, rName))
 }
 
-func testAccAMILaunchPermissionOrganizationalUnitARNConfig(rName string) string {
+func testAccAMILaunchPermissionConfig_organizationalUnitARN(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {}
 

--- a/internal/service/ec2/ec2_availability_zone_data_source_test.go
+++ b/internal/service/ec2/ec2_availability_zone_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccEC2AvailabilityZoneDataSource_allAvailabilityZones(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailabilityZoneAllAvailabilityZonesDataSourceConfig(),
+				Config: testAccAvailabilityZoneDataSourceConfig_allAZs(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
@@ -50,7 +50,7 @@ func TestAccEC2AvailabilityZoneDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailabilityZoneFilterDataSourceConfig(),
+				Config: testAccAvailabilityZoneDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
@@ -78,7 +78,7 @@ func TestAccEC2AvailabilityZoneDataSource_localZone(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailabilityZoneZoneTypeDataSourceConfig("local-zone"),
+				Config: testAccAvailabilityZoneDataSourceConfig_type("local-zone"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
@@ -106,7 +106,7 @@ func TestAccEC2AvailabilityZoneDataSource_name(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailabilityZoneNameDataSourceConfig(),
+				Config: testAccAvailabilityZoneDataSourceConfig_name(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
@@ -134,7 +134,7 @@ func TestAccEC2AvailabilityZoneDataSource_wavelengthZone(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailabilityZoneZoneTypeDataSourceConfig("wavelength-zone"),
+				Config: testAccAvailabilityZoneDataSourceConfig_type("wavelength-zone"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
@@ -162,7 +162,7 @@ func TestAccEC2AvailabilityZoneDataSource_zoneID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailabilityZoneZoneIDDataSourceConfig(),
+				Config: testAccAvailabilityZoneDataSourceConfig_id(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
@@ -205,7 +205,7 @@ func testAccPreCheckLocalZoneAvailable(t *testing.T) {
 	}
 }
 
-func testAccAvailabilityZoneAllAvailabilityZonesDataSourceConfig() string {
+func testAccAvailabilityZoneDataSourceConfig_allAZs() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		`
@@ -216,7 +216,7 @@ data "aws_availability_zone" "test" {
 `)
 }
 
-func testAccAvailabilityZoneFilterDataSourceConfig() string {
+func testAccAvailabilityZoneDataSourceConfig_filter() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		`
@@ -229,7 +229,7 @@ data "aws_availability_zone" "test" {
 `)
 }
 
-func testAccAvailabilityZoneNameDataSourceConfig() string {
+func testAccAvailabilityZoneDataSourceConfig_name() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		`
@@ -239,7 +239,7 @@ data "aws_availability_zone" "test" {
 `)
 }
 
-func testAccAvailabilityZoneZoneIDDataSourceConfig() string {
+func testAccAvailabilityZoneDataSourceConfig_id() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		`
@@ -249,7 +249,7 @@ data "aws_availability_zone" "test" {
 `)
 }
 
-func testAccAvailabilityZoneZoneTypeDataSourceConfig(zoneType string) string {
+func testAccAvailabilityZoneDataSourceConfig_type(zoneType string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/ec2/ec2_availability_zone_group_test.go
+++ b/internal/service/ec2/ec2_availability_zone_group_test.go
@@ -38,13 +38,13 @@ func TestAccEC2AvailabilityZoneGroup_optInStatus(t *testing.T) {
 			// InvalidOptInStatus: Opting out of Local Zones is not currently supported. Contact AWS Support for additional assistance.
 			/*
 				{
-					Config: testAccEc2AvailabilityZoneGroupConfigOptInStatus(ec2.AvailabilityZoneOptInStatusNotOptedIn),
+					Config: testAccAvailabilityZoneGroupConfig_optInStatus(ec2.AvailabilityZoneOptInStatusNotOptedIn),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusNotOptedIn),
 					),
 				},
 				{
-					Config: testAccEc2AvailabilityZoneGroupConfigOptInStatus(ec2.AvailabilityZoneOptInStatusOptedIn),
+					Config: testAccAvailabilityZoneGroupConfig_optInStatus(ec2.AvailabilityZoneOptInStatusOptedIn),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptedIn),
 					),

--- a/internal/service/ec2/ec2_availability_zones_data_source_test.go
+++ b/internal/service/ec2/ec2_availability_zones_data_source_test.go
@@ -99,7 +99,7 @@ func TestAccEC2AvailabilityZonesDataSource_allAvailabilityZones(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAvailabilityZonesAllAvailabilityZonesConfig(),
+				Config: testAccAvailabilityZonesDataSourceConfig_all(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAvailabilityZonesMeta(dataSourceName),
 				),
@@ -117,7 +117,7 @@ func TestAccEC2AvailabilityZonesDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAvailabilityZonesFilterConfig(),
+				Config: testAccAvailabilityZonesDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAvailabilityZonesMeta(dataSourceName),
 				),
@@ -136,7 +136,7 @@ func TestAccEC2AvailabilityZonesDataSource_excludeNames(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAvailabilityZonesExcludeNamesConfig(),
+				Config: testAccAvailabilityZonesDataSourceConfig_excludeNames(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAvailabilityZonesExcluded(allDataSourceName, excludeDataSourceName),
 				),
@@ -155,7 +155,7 @@ func TestAccEC2AvailabilityZonesDataSource_excludeZoneIDs(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAvailabilityZonesExcludeZoneIDsConfig(),
+				Config: testAccAvailabilityZonesDataSourceConfig_excludeZoneIDs(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAvailabilityZonesExcluded(allDataSourceName, excludeDataSourceName),
 				),
@@ -306,7 +306,7 @@ const testAccAvailabilityZonesDataSourceConfig_basic = `
 data "aws_availability_zones" "availability_zones" {}
 `
 
-func testAccCheckAvailabilityZonesAllAvailabilityZonesConfig() string {
+func testAccAvailabilityZonesDataSourceConfig_all() string {
 	return `
 data "aws_availability_zones" "test" {
   all_availability_zones = true
@@ -314,7 +314,7 @@ data "aws_availability_zones" "test" {
 `
 }
 
-func testAccCheckAvailabilityZonesFilterConfig() string {
+func testAccAvailabilityZonesDataSourceConfig_filter() string {
 	return `
 data "aws_availability_zones" "test" {
   filter {
@@ -325,7 +325,7 @@ data "aws_availability_zones" "test" {
 `
 }
 
-func testAccCheckAvailabilityZonesExcludeNamesConfig() string {
+func testAccAvailabilityZonesDataSourceConfig_excludeNames() string {
 	return `
 data "aws_availability_zones" "all" {}
 
@@ -335,7 +335,7 @@ data "aws_availability_zones" "test" {
 `
 }
 
-func testAccCheckAvailabilityZonesExcludeZoneIDsConfig() string {
+func testAccAvailabilityZonesDataSourceConfig_excludeZoneIDs() string {
 	return `
 data "aws_availability_zones" "all" {}
 

--- a/internal/service/ec2/ec2_eip_association_test.go
+++ b/internal/service/ec2/ec2_eip_association_test.go
@@ -78,7 +78,7 @@ func TestAccEC2EIPAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPAssociationConfig(rName),
+				Config: testAccEIPAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists("aws_eip.test.0", false, &a),
 					testAccCheckEIPAssociationExists("aws_eip_association.by_allocation_id", &a),
@@ -108,7 +108,7 @@ func TestAccEC2EIPAssociation_ec2Classic(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPAssociationConfig_ec2Classic(),
+				Config: testAccEIPAssociationConfig_classic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists("aws_eip.test", true, &a),
 					testAccCheckEIPAssociationClassicExists(resourceName, &a),
@@ -172,7 +172,7 @@ func TestAccEC2EIPAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPAssociationDisappearsConfig(rName),
+				Config: testAccEIPAssociationConfig_disappears(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists("aws_eip.test", false, &a),
 					testAccCheckEIPAssociationExists(resourceName, &a),
@@ -314,7 +314,7 @@ func testAccCheckEIPAssociationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccEIPAssociationConfig(rName string) string {
+func testAccEIPAssociationConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -383,7 +383,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccEIPAssociationDisappearsConfig(rName string) string {
+func testAccEIPAssociationConfig_disappears(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -426,7 +426,7 @@ resource "aws_eip_association" "test" {
 `, rName))
 }
 
-func testAccEIPAssociationConfig_ec2Classic() string { // nosemgrep:ec2-in-func-name
+func testAccEIPAssociationConfig_classic() string { // nosemgrep:ec2-in-func-name
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		testAccLatestAmazonLinuxPVEBSAMIConfig(),

--- a/internal/service/ec2/ec2_eip_data_source_test.go
+++ b/internal/service/ec2/ec2_eip_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccEC2EIPDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPFilterDataSourceConfig(rName),
+				Config: testAccEIPDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -42,7 +42,7 @@ func TestAccEC2EIPDataSource_id(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPIDDataSourceConfig,
+				Config: testAccEIPDataSourceConfig_id,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -63,7 +63,7 @@ func TestAccEC2EIPDataSource_PublicIP_ec2Classic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPPublicIPClassicDataSourceConfig(),
+				Config: testAccEIPDataSourceConfig_publicIPClassic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -84,7 +84,7 @@ func TestAccEC2EIPDataSource_PublicIP_vpc(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPPublicIPVPCDataSourceConfig,
+				Config: testAccEIPDataSourceConfig_publicIPVPC,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -107,7 +107,7 @@ func TestAccEC2EIPDataSource_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPTagsDataSourceConfig(rName),
+				Config: testAccEIPDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -128,7 +128,7 @@ func TestAccEC2EIPDataSource_networkInterface(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPNetworkInterfaceDataSourceConfig,
+				Config: testAccEIPDataSourceConfig_networkInterface,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "network_interface_id", resourceName, "network_interface"),
@@ -151,7 +151,7 @@ func TestAccEC2EIPDataSource_instance(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPInstanceDataSourceConfig,
+				Config: testAccEIPDataSourceConfig_instance,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "instance_id", resourceName, "instance"),
@@ -173,7 +173,7 @@ func TestAccEC2EIPDataSource_carrierIP(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPCarrierIPDataSourceConfig(rName),
+				Config: testAccEIPDataSourceConfig_carrierIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "carrier_ip", resourceName, "carrier_ip"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_ip", resourceName, "public_ip"),
@@ -193,7 +193,7 @@ func TestAccEC2EIPDataSource_customerOwnedIPv4Pool(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPCustomerOwnedIPv4PoolDataSourceConfig(),
+				Config: testAccEIPDataSourceConfig_customerOwnedIPv4Pool(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "customer_owned_ipv4_pool", dataSourceName, "customer_owned_ipv4_pool"),
 					resource.TestCheckResourceAttrPair(resourceName, "customer_owned_ip", dataSourceName, "customer_owned_ip"),
@@ -203,7 +203,7 @@ func TestAccEC2EIPDataSource_customerOwnedIPv4Pool(t *testing.T) {
 	})
 }
 
-func testAccEIPCustomerOwnedIPv4PoolDataSourceConfig() string {
+func testAccEIPDataSourceConfig_customerOwnedIPv4Pool() string {
 	return `
 data "aws_ec2_coip_pools" "test" {}
 
@@ -218,7 +218,7 @@ data "aws_eip" "test" {
 `
 }
 
-func testAccEIPFilterDataSourceConfig(rName string) string {
+func testAccEIPDataSourceConfig_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc = true
@@ -237,7 +237,7 @@ data "aws_eip" "test" {
 `, rName)
 }
 
-const testAccEIPIDDataSourceConfig = `
+const testAccEIPDataSourceConfig_id = `
 resource "aws_eip" "test" {
   vpc = true
 }
@@ -247,7 +247,7 @@ data "aws_eip" "test" {
 }
 `
 
-func testAccEIPPublicIPClassicDataSourceConfig() string {
+func testAccEIPDataSourceConfig_publicIPClassic() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		`
@@ -259,7 +259,7 @@ data "aws_eip" "test" {
 `)
 }
 
-const testAccEIPPublicIPVPCDataSourceConfig = `
+const testAccEIPDataSourceConfig_publicIPVPC = `
 resource "aws_eip" "test" {
   vpc = true
 }
@@ -269,7 +269,7 @@ data "aws_eip" "test" {
 }
 `
 
-func testAccEIPTagsDataSourceConfig(rName string) string {
+func testAccEIPDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc = true
@@ -287,7 +287,7 @@ data "aws_eip" "test" {
 `, rName)
 }
 
-const testAccEIPNetworkInterfaceDataSourceConfig = `
+const testAccEIPDataSourceConfig_networkInterface = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
@@ -318,7 +318,7 @@ data "aws_eip" "test" {
 }
 `
 
-var testAccEIPInstanceDataSourceConfig = acctest.ConfigCompose(
+var testAccEIPDataSourceConfig_instance = acctest.ConfigCompose(
 	acctest.ConfigAvailableAZsNoOptInDefaultExclude(), `
 resource "aws_vpc" "test" {
   cidr_block = "10.2.0.0/16"
@@ -362,7 +362,7 @@ data "aws_eip" "test" {
 }
 `)
 
-func testAccEIPCarrierIPDataSourceConfig(rName string) string {
+func testAccEIPDataSourceConfig_carrierIP(rName string) string {
 	return acctest.ConfigCompose(
 		testAccAvailableAZsWavelengthZonesDefaultExcludeConfig(),
 		fmt.Sprintf(`

--- a/internal/service/ec2/ec2_eip_test.go
+++ b/internal/service/ec2/ec2_eip_test.go
@@ -36,7 +36,7 @@ func TestAccEC2EIP_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPConfig,
+				Config: testAccEIPConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -64,7 +64,7 @@ func TestAccEC2EIP_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPConfig,
+				Config: testAccEIPConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceEIP(), resourceName),
@@ -86,7 +86,7 @@ func TestAccEC2EIP_instance(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPInstanceConfig(),
+				Config: testAccEIPConfig_instance(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -115,13 +115,13 @@ func TestAccEC2EIP_Instance_reassociate(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPInstanceReassociateConfig(rName),
+				Config: testAccEIPConfig_instanceReassociate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
 				),
 			},
 			{
-				Config: testAccEIPInstanceReassociateConfig(rName),
+				Config: testAccEIPConfig_instanceReassociate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
 				),
@@ -145,7 +145,7 @@ func TestAccEC2EIP_Instance_associatedUserPrivateIP(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPInstanceAssociatedConfig(rName),
+				Config: testAccEIPConfig_instanceAssociated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &one),
 					testAccCheckEIPAttributes(&one),
@@ -160,7 +160,7 @@ func TestAccEC2EIP_Instance_associatedUserPrivateIP(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
 			},
 			{
-				Config: testAccEIPInstanceAssociatedSwitchConfig(rName),
+				Config: testAccEIPConfig_instanceAssociatedSwitch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &one),
 					testAccCheckEIPAttributes(&one),
@@ -183,7 +183,7 @@ func TestAccEC2EIP_Instance_notAssociated(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPInstanceAssociateNotAssociatedConfig(),
+				Config: testAccEIPConfig_instanceAssociateNotAssociated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -195,7 +195,7 @@ func TestAccEC2EIP_Instance_notAssociated(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEIPInstanceAssociateAssociatedConfig(),
+				Config: testAccEIPConfig_instanceAssociateAssociated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -246,7 +246,7 @@ func TestAccEC2EIP_networkInterface(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPNetworkInterfaceConfig(rName),
+				Config: testAccEIPConfig_networkInterface(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -278,7 +278,7 @@ func TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPMultiNetworkInterfaceConfig(rName),
+				Config: testAccEIPConfig_multiNetworkInterface(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &one),
 					testAccCheckEIPAttributes(&one),
@@ -456,7 +456,7 @@ func TestAccEC2EIP_PublicIPv4Pool_default(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPPublicIPv4PoolDefaultConfig,
+				Config: testAccEIPConfig_publicIPv4PoolDefault,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -490,7 +490,7 @@ func TestAccEC2EIP_PublicIPv4Pool_custom(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPPublicIPv4PoolCustomConfig(poolName),
+				Config: testAccEIPConfig_publicIPv4PoolCustom(poolName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -518,7 +518,7 @@ func TestAccEC2EIP_customerOwnedIPv4Pool(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPCustomerOwnedIPv4PoolConfig(),
+				Config: testAccEIPConfig_customerOwnedIPv4Pool(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					resource.TestMatchResourceAttr(resourceName, "customer_owned_ipv4_pool", regexp.MustCompile(`^ipv4pool-coip-.+$`)),
@@ -545,7 +545,7 @@ func TestAccEC2EIP_networkBorderGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPNetworkBorderGroupConfig,
+				Config: testAccEIPConfig_networkBorderGroup,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -574,7 +574,7 @@ func TestAccEC2EIP_carrierIP(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPCarrierIPConfig(rName),
+				Config: testAccEIPConfig_carrierIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "carrier_ip"),
@@ -603,7 +603,7 @@ func TestAccEC2EIP_BYOIPAddress_default(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPConfig_BYOIPAddress_custom_default,
+				Config: testAccEIPConfig_byoipAddressCustomDefault,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -632,7 +632,7 @@ func TestAccEC2EIP_BYOIPAddress_custom(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPConfig_BYOIPAddress_custom(address),
+				Config: testAccEIPConfig_byoipAddressCustom(address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -666,7 +666,7 @@ func TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool(t *testing.T) {
 		CheckDestroy:      testAccCheckEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPConfig_BYOIPAddress_custom_with_PublicIPv4Pool(address, poolName),
+				Config: testAccEIPConfig_byoipAddressCustomPublicIPv4Pool(address, poolName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPExists(resourceName, false, &conf),
 					testAccCheckEIPAttributes(&conf),
@@ -881,7 +881,7 @@ func testAccCheckEIPPublicDNSClassic(resourceName string) resource.TestCheckFunc
 	}
 }
 
-const testAccEIPConfig = `
+const testAccEIPConfig_basic = `
 resource "aws_eip" "test" {
   vpc = true
 }
@@ -915,13 +915,13 @@ resource "aws_eip" "test" {
 `, vpcConfig, rName))
 }
 
-const testAccEIPPublicIPv4PoolDefaultConfig = `
+const testAccEIPConfig_publicIPv4PoolDefault = `
 resource "aws_eip" "test" {
   vpc = true
 }
 `
 
-func testAccEIPPublicIPv4PoolCustomConfig(poolName string) string {
+func testAccEIPConfig_publicIPv4PoolCustom(poolName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc              = true
@@ -947,13 +947,13 @@ resource "aws_eip" "test" {
 `)
 }
 
-const testAccEIPConfig_BYOIPAddress_custom_default = `
+const testAccEIPConfig_byoipAddressCustomDefault = `
 resource "aws_eip" "test" {
   vpc = true
 }
 `
 
-func testAccEIPConfig_BYOIPAddress_custom(address string) string {
+func testAccEIPConfig_byoipAddressCustom(address string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc     = true
@@ -962,7 +962,7 @@ resource "aws_eip" "test" {
 `, address)
 }
 
-func testAccEIPConfig_BYOIPAddress_custom_with_PublicIPv4Pool(address string, poolname string) string {
+func testAccEIPConfig_byoipAddressCustomPublicIPv4Pool(address string, poolname string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc              = true
@@ -972,7 +972,7 @@ resource "aws_eip" "test" {
 `, address, poolname)
 }
 
-func testAccEIPInstanceConfig() string {
+func testAccEIPConfig_instance() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
@@ -1005,7 +1005,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccEIPInstanceAssociatedConfig(rName string) string {
+func testAccEIPConfig_instanceAssociated(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -1074,7 +1074,7 @@ resource "aws_eip" "test" {
 `, rName))
 }
 
-func testAccEIPInstanceAssociatedSwitchConfig(rName string) string {
+func testAccEIPConfig_instanceAssociatedSwitch(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		fmt.Sprintf(`
@@ -1141,7 +1141,7 @@ resource "aws_eip" "test" {
 `, rName))
 }
 
-func testAccEIPNetworkInterfaceConfig(rName string) string {
+func testAccEIPConfig_networkInterface(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1179,7 +1179,7 @@ resource "aws_eip" "test" {
 `, rName))
 }
 
-func testAccEIPMultiNetworkInterfaceConfig(rName string) string {
+func testAccEIPConfig_multiNetworkInterface(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1225,7 +1225,7 @@ resource "aws_eip" "test2" {
 `, rName))
 }
 
-func testAccEIPInstanceReassociateConfig(rName string) string {
+func testAccEIPConfig_instanceReassociate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
@@ -1299,7 +1299,7 @@ resource "aws_route_table_association" "test" {
 `, rName))
 }
 
-func testAccEIPInstanceAssociateNotAssociatedConfig() string {
+func testAccEIPConfig_instanceAssociateNotAssociated() string {
 	return acctest.ConfigCompose(
 		acctest.AvailableEC2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -1329,7 +1329,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccEIPInstanceAssociateAssociatedConfig() string {
+func testAccEIPConfig_instanceAssociateAssociated() string {
 	return acctest.ConfigCompose(
 		acctest.AvailableEC2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -1361,7 +1361,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccEIPCustomerOwnedIPv4PoolConfig() string {
+func testAccEIPConfig_customerOwnedIPv4Pool() string {
 	return `
 data "aws_ec2_coip_pools" "test" {}
 
@@ -1372,7 +1372,7 @@ resource "aws_eip" "test" {
 `
 }
 
-const testAccEIPNetworkBorderGroupConfig = `
+const testAccEIPConfig_networkBorderGroup = `
 data "aws_region" current {}
 
 resource "aws_eip" "test" {
@@ -1381,7 +1381,7 @@ resource "aws_eip" "test" {
 }
 `
 
-func testAccEIPCarrierIPConfig(rName string) string {
+func testAccEIPConfig_carrierIP(rName string) string {
 	return acctest.ConfigCompose(
 		testAccAvailableAZsWavelengthZonesDefaultExcludeConfig(),
 		fmt.Sprintf(`

--- a/internal/service/ec2/ec2_eips_data_source_test.go
+++ b/internal/service/ec2/ec2_eips_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccEC2EIPsDataSource_vpcDomain(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPsVPCDomainDataSourceConfig(rName),
+				Config: testAccEIPsDataSourceConfig_vpcDomain(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue("data.aws_eips.all", "allocation_ids.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_eips.by_tags", "allocation_ids.#", "1"),
@@ -39,7 +39,7 @@ func TestAccEC2EIPsDataSource_standardDomain(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPsStandardDomainDataSourceConfig(),
+				Config: testAccEIPsDataSourceConfig_standardDomain(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue("data.aws_eips.all", "public_ips.#", "0"),
 				),
@@ -48,7 +48,7 @@ func TestAccEC2EIPsDataSource_standardDomain(t *testing.T) {
 	})
 }
 
-func testAccEIPsVPCDomainDataSourceConfig(rName string) string {
+func testAccEIPsDataSourceConfig_vpcDomain(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test1" {
   vpc = true
@@ -89,7 +89,7 @@ data "aws_eips" "none" {
 `, rName)
 }
 
-func testAccEIPsStandardDomainDataSourceConfig() string {
+func testAccEIPsDataSourceConfig_standardDomain() string {
 	return acctest.ConfigCompose(acctest.ConfigEC2ClassicRegionProvider(), `
 resource "aws_eip" "test" {}
 

--- a/internal/service/ec2/ec2_fleet_test.go
+++ b/internal/service/ec2/ec2_fleet_test.go
@@ -31,7 +31,7 @@ func TestAccEC2Fleet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_Basic(rName),
+				Config: testAccFleetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`fleet/.+`)),
@@ -80,7 +80,7 @@ func TestAccEC2Fleet_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_Basic(rName),
+				Config: testAccFleetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceFleet(), resourceName),
@@ -103,7 +103,7 @@ func TestAccEC2Fleet_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfigTags1(rName, "key1", "value1"),
+				Config: testAccFleetConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -117,7 +117,7 @@ func TestAccEC2Fleet_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccFleetConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -126,7 +126,7 @@ func TestAccEC2Fleet_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFleetConfigTags1(rName, "key2", "value2"),
+				Config: testAccFleetConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -149,7 +149,7 @@ func TestAccEC2Fleet_excessCapacityTerminationPolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_ExcessCapacityTerminationPolicy(rName, "no-termination"),
+				Config: testAccFleetConfig_excessCapacityTerminationPolicy(rName, "no-termination"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "no-termination"),
@@ -162,7 +162,7 @@ func TestAccEC2Fleet_excessCapacityTerminationPolicy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_ExcessCapacityTerminationPolicy(rName, "termination"),
+				Config: testAccFleetConfig_excessCapacityTerminationPolicy(rName, "termination"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -187,7 +187,7 @@ func TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID(
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateID(rName, launchTemplateResourceName1),
+				Config: testAccFleetConfig_launchTemplateID(rName, launchTemplateResourceName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -203,7 +203,7 @@ func TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID(
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateID(rName, launchTemplateResourceName2),
+				Config: testAccFleetConfig_launchTemplateID(rName, launchTemplateResourceName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -231,7 +231,7 @@ func TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateNam
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName(rName, launchTemplateResourceName1),
+				Config: testAccFleetConfig_launchTemplateName(rName, launchTemplateResourceName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -247,7 +247,7 @@ func TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateNam
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName(rName, launchTemplateResourceName2),
+				Config: testAccFleetConfig_launchTemplateName(rName, launchTemplateResourceName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -275,7 +275,7 @@ func TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version(t *testin
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_Version(rName, "t3.micro"),
+				Config: testAccFleetConfig_launchTemplateVersion(rName, "t3.micro"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(launchTemplateResourceName, &launchTemplate),
 					resource.TestCheckResourceAttr(launchTemplateResourceName, "instance_type", "t3.micro"),
@@ -294,7 +294,7 @@ func TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version(t *testin
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_Version(rName, "t3.small"),
+				Config: testAccFleetConfig_launchTemplateVersion(rName, "t3.small"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(launchTemplateResourceName, &launchTemplate),
 					resource.TestCheckResourceAttr(launchTemplateResourceName, "instance_type", "t3.small"),
@@ -324,7 +324,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_AvailabilityZone(rName, 0),
+				Config: testAccFleetConfig_launchTemplateOverrideAvailabilityZone(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -339,7 +339,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_AvailabilityZone(rName, 1),
+				Config: testAccFleetConfig_launchTemplateOverrideAvailabilityZone(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -362,7 +362,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryMiBAndVCP
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`memory_mib {
                        min = 500
                      }
@@ -388,7 +388,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryMiBAndVCP
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`memory_mib {
                        min = 500
                        max = 24000
@@ -432,7 +432,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorCoun
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_count {
                        min = 1
                      }
@@ -459,7 +459,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorCoun
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_count {
                        min = 1
                        max = 4
@@ -488,7 +488,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorCoun
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_count {
                        max = 0
                      }
@@ -529,7 +529,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorManu
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_manufacturers = ["amd"]
                      memory_mib {
                        min = 500
@@ -554,7 +554,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorManu
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_manufacturers = ["amazon-web-services", "amd", "nvidia", "xilinx"]
                      memory_mib {
                        min = 500
@@ -596,7 +596,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorName
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_names = ["a100"]
                      memory_mib {
                        min = 500
@@ -621,7 +621,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorName
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_names = ["a100", "v100", "k80", "t4", "m60", "radeon-pro-v520", "vu9p"]
                      memory_mib {
                        min = 500
@@ -666,7 +666,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTota
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_total_memory_mib {
                        min = 1000
                      }
@@ -693,7 +693,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTota
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_total_memory_mib {
                        max = 24000
                      }
@@ -720,7 +720,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTota
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_total_memory_mib {
                        min = 1000
                        max = 24000
@@ -763,7 +763,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorType
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_types = ["fpga"]
                      memory_mib {
                        min = 500
@@ -788,7 +788,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorType
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`accelerator_types = ["fpga", "gpu", "inference"]
                      memory_mib {
                        min = 500
@@ -829,7 +829,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_bareMetal(t *te
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`bare_metal = "excluded"
                      memory_mib {
                        min = 500
@@ -853,7 +853,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_bareMetal(t *te
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`bare_metal = "included"
                      memory_mib {
                        min = 500
@@ -877,7 +877,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_bareMetal(t *te
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`bare_metal = "required"
                      memory_mib {
                        min = 500
@@ -915,7 +915,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_baselineEBSBand
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`baseline_ebs_bandwidth_mbps {
                        min = 10
                      }
@@ -942,7 +942,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_baselineEBSBand
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`baseline_ebs_bandwidth_mbps {
                        max = 20000
                      }
@@ -969,7 +969,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_baselineEBSBand
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`baseline_ebs_bandwidth_mbps {
                        min = 10
                        max = 20000
@@ -1012,7 +1012,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_burstablePerfor
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`burstable_performance = "excluded"
                      memory_mib {
                        min = 500
@@ -1036,7 +1036,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_burstablePerfor
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`burstable_performance = "included"
                      memory_mib {
                        min = 1000
@@ -1060,7 +1060,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_burstablePerfor
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`burstable_performance = "required"
                      memory_mib {
                        min = 1000
@@ -1098,7 +1098,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_cpuManufacturer
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`cpu_manufacturers = ["amd"]
                      memory_mib {
                        min = 500
@@ -1123,7 +1123,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_cpuManufacturer
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`cpu_manufacturers = ["amazon-web-services", "amd", "intel"]
                      memory_mib {
                        min = 500
@@ -1164,7 +1164,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_excludedInstanc
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`excluded_instance_types = ["t2.nano"]
                      memory_mib {
                        min = 500
@@ -1189,7 +1189,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_excludedInstanc
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`excluded_instance_types = ["t2.nano", "t3*", "t4g.*"]
                      memory_mib {
                        min = 500
@@ -1230,7 +1230,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_instanceGenerat
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`instance_generations = ["current"]
                      memory_mib {
                        min = 500
@@ -1255,7 +1255,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_instanceGenerat
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`instance_generations = ["current", "previous"]
                      memory_mib {
                        min = 500
@@ -1295,7 +1295,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorage(t 
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`local_storage = "excluded"
                      memory_mib {
                        min = 500
@@ -1319,7 +1319,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorage(t 
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`local_storage = "included"
                      memory_mib {
                        min = 500
@@ -1343,7 +1343,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorage(t 
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`local_storage = "required"
                      memory_mib {
                        min = 500
@@ -1381,7 +1381,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorageTyp
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`local_storage_types = ["hdd"]
                      memory_mib {
                        min = 500
@@ -1406,7 +1406,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorageTyp
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`local_storage_types = ["hdd", "ssd"]
                      memory_mib {
                        min = 500
@@ -1446,7 +1446,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryGiBPerVCP
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`memory_gib_per_vcpu {
                        min = 0.5
                      }
@@ -1473,7 +1473,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryGiBPerVCP
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`memory_gib_per_vcpu {
                        max = 9.5
                      }
@@ -1500,7 +1500,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryGiBPerVCP
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`memory_gib_per_vcpu {
                        min = 0.5
                        max = 9.5
@@ -1543,7 +1543,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_networkInterfac
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`network_interface_count {
                        min = 1
                      }
@@ -1570,7 +1570,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_networkInterfac
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`network_interface_count {
                        max = 10
                      }
@@ -1597,7 +1597,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_networkInterfac
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`network_interface_count {
                        min = 1
                        max = 10
@@ -1640,7 +1640,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_onDemandMaxPric
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`on_demand_max_price_percentage_over_lowest_price = 50
                      memory_mib {
                        min = 500
@@ -1678,7 +1678,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_requireHibernat
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`require_hibernate_support = false
                      memory_mib {
                        min = 500
@@ -1702,7 +1702,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_requireHibernat
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`require_hibernate_support = true
                      memory_mib {
                        min = 500
@@ -1740,7 +1740,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_spotMaxPricePer
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`spot_max_price_percentage_over_lowest_price = 75
                      memory_mib {
                        min = 500
@@ -1778,7 +1778,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_totalLocalStora
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`total_local_storage_gb {
                        min = 0.5
                      }
@@ -1805,7 +1805,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_totalLocalStora
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`total_local_storage_gb {
                        max = 20.5
                      }
@@ -1832,7 +1832,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_totalLocalStora
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceRequirements(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
 					`total_local_storage_gb {
                        min = 0.5
                        max = 20.5
@@ -1876,7 +1876,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceType(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceType(rName, "t3.small"),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceType(rName, "t3.small"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -1891,7 +1891,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceType(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_InstanceType(rName, "t3.medium"),
+				Config: testAccFleetConfig_launchTemplateOverrideInstanceType(rName, "t3.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -1918,7 +1918,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_maxPrice(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_MaxPrice(rName, "1.01"),
+				Config: testAccFleetConfig_launchTemplateOverrideMaxPrice(rName, "1.01"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -1933,7 +1933,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_maxPrice(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_MaxPrice(rName, "1.02"),
+				Config: testAccFleetConfig_launchTemplateOverrideMaxPrice(rName, "1.02"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -1958,7 +1958,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_priority(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_Priority(rName, 1),
+				Config: testAccFleetConfig_launchTemplateOverridePriority(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -1973,7 +1973,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_priority(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_Priority(rName, 2),
+				Config: testAccFleetConfig_launchTemplateOverridePriority(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -1998,7 +1998,7 @@ func TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_Priority_Multiple(rName, 1, 2),
+				Config: testAccFleetConfig_launchTemplateOverridePriorityMultiple(rName, 1, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -2014,7 +2014,7 @@ func TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_Priority_Multiple(rName, 2, 1),
+				Config: testAccFleetConfig_launchTemplateOverridePriorityMultiple(rName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -2042,7 +2042,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_subnetID(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_SubnetID(rName, 0),
+				Config: testAccFleetConfig_launchTemplateOverrideSubnetID(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -2057,7 +2057,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_subnetID(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_SubnetID(rName, 1),
+				Config: testAccFleetConfig_launchTemplateOverrideSubnetID(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -2082,7 +2082,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_WeightedCapacity(rName, 1),
+				Config: testAccFleetConfig_launchTemplateOverrideWeightedCapacity(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -2097,7 +2097,7 @@ func TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_WeightedCapacity(rName, 2),
+				Config: testAccFleetConfig_launchTemplateOverrideWeightedCapacity(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -2122,7 +2122,7 @@ func TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple(t *testing.
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_WeightedCapacity_Multiple(rName, 1, 1),
+				Config: testAccFleetConfig_launchTemplateOverrideWeightedCapacityMultiple(rName, 1, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
@@ -2138,7 +2138,7 @@ func TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple(t *testing.
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_LaunchTemplateConfig_Override_WeightedCapacity_Multiple(rName, 1, 2),
+				Config: testAccFleetConfig_launchTemplateOverrideWeightedCapacityMultiple(rName, 1, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -2164,7 +2164,7 @@ func TestAccEC2Fleet_OnDemandOptions_allocationStrategy(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_OnDemandOptions_AllocationStrategy(rName, "prioritized"),
+				Config: testAccFleetConfig_onDemandOptionsAllocationStrategy(rName, "prioritized"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "on_demand_options.#", "1"),
@@ -2178,7 +2178,7 @@ func TestAccEC2Fleet_OnDemandOptions_allocationStrategy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_OnDemandOptions_AllocationStrategy(rName, "lowestPrice"),
+				Config: testAccFleetConfig_onDemandOptionsAllocationStrategy(rName, "lowestPrice"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2202,7 +2202,7 @@ func TestAccEC2Fleet_replaceUnhealthyInstances(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_ReplaceUnhealthyInstances(rName, true),
+				Config: testAccFleetConfig_replaceUnhealthyInstances(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "replace_unhealthy_instances", "true"),
@@ -2215,7 +2215,7 @@ func TestAccEC2Fleet_replaceUnhealthyInstances(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_ReplaceUnhealthyInstances(rName, false),
+				Config: testAccFleetConfig_replaceUnhealthyInstances(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2238,7 +2238,7 @@ func TestAccEC2Fleet_SpotOptions_allocationStrategy(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_SpotOptions_AllocationStrategy(rName, "diversified"),
+				Config: testAccFleetConfig_spotOptionsAllocationStrategy(rName, "diversified"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "spot_options.#", "1"),
@@ -2252,7 +2252,7 @@ func TestAccEC2Fleet_SpotOptions_allocationStrategy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_SpotOptions_AllocationStrategy(rName, "lowestPrice"),
+				Config: testAccFleetConfig_spotOptionsAllocationStrategy(rName, "lowestPrice"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2276,7 +2276,7 @@ func TestAccEC2Fleet_SpotOptions_capacityRebalance(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_SpotOptions_CapacityRebalance(rName, "diversified"),
+				Config: testAccFleetConfig_spotOptionsCapacityRebalance(rName, "diversified"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "spot_options.#", "1"),
@@ -2304,7 +2304,7 @@ func TestAccEC2Fleet_capacityRebalanceInvalidType(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccFleetConfigWithInvalidTypeForCapacityRebalance(rName),
+				Config:      testAccFleetConfig_invalidTypeForCapacityRebalance(rName),
 				ExpectError: regexp.MustCompile(`Capacity Rebalance maintenance strategies can only be specified for fleets of type maintain`),
 			},
 		},
@@ -2323,7 +2323,7 @@ func TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_SpotOptions_InstanceInterruptionBehavior(rName, "stop"),
+				Config: testAccFleetConfig_spotOptionsInstanceInterruptionBehavior(rName, "stop"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "spot_options.#", "1"),
@@ -2337,7 +2337,7 @@ func TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_SpotOptions_InstanceInterruptionBehavior(rName, "terminate"),
+				Config: testAccFleetConfig_spotOptionsInstanceInterruptionBehavior(rName, "terminate"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2361,7 +2361,7 @@ func TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_SpotOptions_InstancePoolsToUseCount(rName, 2),
+				Config: testAccFleetConfig_spotOptionsInstancePoolsToUseCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "spot_options.#", "1"),
@@ -2375,7 +2375,7 @@ func TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_SpotOptions_InstancePoolsToUseCount(rName, 3),
+				Config: testAccFleetConfig_spotOptionsInstancePoolsToUseCount(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2399,7 +2399,7 @@ func TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType(t *te
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_TargetCapacitySpecification_DefaultTargetCapacityType(rName, "on-demand"),
+				Config: testAccFleetConfig_targetCapacitySpecificationDefaultTargetCapacityType(rName, "on-demand"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity_specification.#", "1"),
@@ -2407,7 +2407,7 @@ func TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType(t *te
 				),
 			},
 			{
-				Config: testAccFleetConfig_TargetCapacitySpecification_DefaultTargetCapacityType(rName, "spot"),
+				Config: testAccFleetConfig_targetCapacitySpecificationDefaultTargetCapacityType(rName, "spot"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2431,7 +2431,7 @@ func TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDema
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_TargetCapacitySpecification_DefaultTargetCapacityType(rName, "on-demand"),
+				Config: testAccFleetConfig_targetCapacitySpecificationDefaultTargetCapacityType(rName, "on-demand"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity_specification.#", "1"),
@@ -2460,7 +2460,7 @@ func TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot(t
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_TargetCapacitySpecification_DefaultTargetCapacityType(rName, "spot"),
+				Config: testAccFleetConfig_targetCapacitySpecificationDefaultTargetCapacityType(rName, "spot"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity_specification.#", "1"),
@@ -2489,7 +2489,7 @@ func TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity(t *testing.
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_TargetCapacitySpecification_TotalTargetCapacity(rName, 1),
+				Config: testAccFleetConfig_targetCapacitySpecificationTotalTargetCapacity(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity_specification.#", "1"),
@@ -2503,7 +2503,7 @@ func TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity(t *testing.
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_TargetCapacitySpecification_TotalTargetCapacity(rName, 2),
+				Config: testAccFleetConfig_targetCapacitySpecificationTotalTargetCapacity(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetNotRecreated(&fleet1, &fleet2),
@@ -2527,7 +2527,7 @@ func TestAccEC2Fleet_terminateInstancesWithExpiration(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_TerminateInstancesWithExpiration(rName, true),
+				Config: testAccFleetConfig_terminateInstancesExpiration(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "terminate_instances_with_expiration", "true"),
@@ -2540,7 +2540,7 @@ func TestAccEC2Fleet_terminateInstancesWithExpiration(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"terminate_instances"},
 			},
 			{
-				Config: testAccFleetConfig_TerminateInstancesWithExpiration(rName, false),
+				Config: testAccFleetConfig_terminateInstancesExpiration(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet2),
 					testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2563,7 +2563,7 @@ func TestAccEC2Fleet_type(t *testing.T) {
 		CheckDestroy:      testAccCheckFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFleetConfig_Type(rName, "maintain"),
+				Config: testAccFleetConfig_type(rName, "maintain"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(resourceName, &fleet1),
 					resource.TestCheckResourceAttr(resourceName, "type", "maintain"),
@@ -2577,7 +2577,7 @@ func TestAccEC2Fleet_type(t *testing.T) {
 			},
 			// This configuration will fulfill immediately, skip until ValidFrom is implemented
 			// {
-			// 	Config: testAccFleetConfig_Type(rName, "request"),
+			// 	Config: testAccFleetConfig_type(rName, "request"),
 			// 	Check: resource.ComposeTestCheckFunc(
 			// 		testAccCheckFleetExists(resourceName, &fleet2),
 			// 		testAccCheckFleetRecreated(&fleet1, &fleet2),
@@ -2756,7 +2756,7 @@ resource "aws_launch_template" "test" {
 `, rName))
 }
 
-func testAccFleetConfig_Basic(rName string) string {
+func testAccFleetConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), `
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -2892,7 +2892,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName))
 }
 
-func testAccFleetConfig_ExcessCapacityTerminationPolicy(rName, excessCapacityTerminationPolicy string) string {
+func testAccFleetConfig_excessCapacityTerminationPolicy(rName, excessCapacityTerminationPolicy string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   excess_capacity_termination_policy = %[2]q
@@ -2916,7 +2916,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, excessCapacityTerminationPolicy))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateID(rName, launchTemplateResourceName string) string {
+func testAccFleetConfig_launchTemplateID(rName, launchTemplateResourceName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_launch_template" "test1" {
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -2950,7 +2950,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, launchTemplateResourceName))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName(rName, launchTemplateResourceName string) string {
+func testAccFleetConfig_launchTemplateName(rName, launchTemplateResourceName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_launch_template" "test1" {
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -2984,7 +2984,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, launchTemplateResourceName))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_LaunchTemplateSpecification_Version(rName, instanceType string) string {
+func testAccFleetConfig_launchTemplateVersion(rName, instanceType string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -3012,7 +3012,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, instanceType))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_AvailabilityZone(rName string, availabilityZoneIndex int) string {
+func testAccFleetConfig_launchTemplateOverrideAvailabilityZone(rName string, availabilityZoneIndex int) string {
 	return acctest.ConfigCompose(
 		testAccFleetConfig_BaseLaunchTemplate(rName),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3041,7 +3041,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, availabilityZoneIndex))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_InstanceRequirements(rName, instanceRequirements string) string {
+func testAccFleetConfig_launchTemplateOverrideInstanceRequirements(rName, instanceRequirements string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3069,7 +3069,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, instanceRequirements))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_InstanceType(rName, instanceType string) string {
+func testAccFleetConfig_launchTemplateOverrideInstanceType(rName, instanceType string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3095,7 +3095,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, instanceType))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_MaxPrice(rName, maxPrice string) string {
+func testAccFleetConfig_launchTemplateOverrideMaxPrice(rName, maxPrice string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3121,7 +3121,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, maxPrice))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_Priority(rName string, priority int) string {
+func testAccFleetConfig_launchTemplateOverridePriority(rName string, priority int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3147,7 +3147,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, priority))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_Priority_Multiple(rName string, priority1, priority2 int) string {
+func testAccFleetConfig_launchTemplateOverridePriorityMultiple(rName string, priority1, priority2 int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3179,7 +3179,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, priority1, priority2))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_SubnetID(rName string, subnetIndex int) string {
+func testAccFleetConfig_launchTemplateOverrideSubnetID(rName string, subnetIndex int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3224,7 +3224,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, subnetIndex))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_WeightedCapacity(rName string, weightedCapacity int) string {
+func testAccFleetConfig_launchTemplateOverrideWeightedCapacity(rName string, weightedCapacity int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3250,7 +3250,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, weightedCapacity))
 }
 
-func testAccFleetConfig_LaunchTemplateConfig_Override_WeightedCapacity_Multiple(rName string, weightedCapacity1, weightedCapacity2 int) string {
+func testAccFleetConfig_launchTemplateOverrideWeightedCapacityMultiple(rName string, weightedCapacity1, weightedCapacity2 int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3282,7 +3282,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, weightedCapacity1, weightedCapacity2))
 }
 
-func testAccFleetConfig_OnDemandOptions_AllocationStrategy(rName, allocationStrategy string) string {
+func testAccFleetConfig_onDemandOptionsAllocationStrategy(rName, allocationStrategy string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3308,7 +3308,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, allocationStrategy))
 }
 
-func testAccFleetConfig_ReplaceUnhealthyInstances(rName string, replaceUnhealthyInstances bool) string {
+func testAccFleetConfig_replaceUnhealthyInstances(rName string, replaceUnhealthyInstances bool) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   replace_unhealthy_instances = %[2]t
@@ -3332,7 +3332,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, replaceUnhealthyInstances))
 }
 
-func testAccFleetConfig_SpotOptions_AllocationStrategy(rName, allocationStrategy string) string {
+func testAccFleetConfig_spotOptionsAllocationStrategy(rName, allocationStrategy string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3358,7 +3358,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, allocationStrategy))
 }
 
-func testAccFleetConfig_SpotOptions_CapacityRebalance(rName, allocationStrategy string) string {
+func testAccFleetConfig_spotOptionsCapacityRebalance(rName, allocationStrategy string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3389,7 +3389,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, allocationStrategy))
 }
 
-func testAccFleetConfigWithInvalidTypeForCapacityRebalance(rName string) string {
+func testAccFleetConfig_invalidTypeForCapacityRebalance(rName string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   type = "request"
@@ -3422,7 +3422,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName))
 }
 
-func testAccFleetConfig_SpotOptions_InstanceInterruptionBehavior(rName, instanceInterruptionBehavior string) string {
+func testAccFleetConfig_spotOptionsInstanceInterruptionBehavior(rName, instanceInterruptionBehavior string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3448,7 +3448,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, instanceInterruptionBehavior))
 }
 
-func testAccFleetConfig_SpotOptions_InstancePoolsToUseCount(rName string, instancePoolsToUseCount int) string {
+func testAccFleetConfig_spotOptionsInstancePoolsToUseCount(rName string, instancePoolsToUseCount int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3474,7 +3474,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, instancePoolsToUseCount))
 }
 
-func testAccFleetConfigTags1(rName, key1, value1 string) string {
+func testAccFleetConfig_tags1(rName, key1, value1 string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3496,7 +3496,7 @@ resource "aws_ec2_fleet" "test" {
 `, key1, value1))
 }
 
-func testAccFleetConfigTags2(rName, key1, value1, key2, value2 string) string {
+func testAccFleetConfig_tags2(rName, key1, value1, key2, value2 string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3519,7 +3519,7 @@ resource "aws_ec2_fleet" "test" {
 `, key1, value1, key2, value2))
 }
 
-func testAccFleetConfig_TargetCapacitySpecification_DefaultTargetCapacityType(rName, defaultTargetCapacityType string) string {
+func testAccFleetConfig_targetCapacitySpecificationDefaultTargetCapacityType(rName, defaultTargetCapacityType string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
@@ -3541,7 +3541,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, defaultTargetCapacityType))
 }
 
-func testAccFleetConfig_TargetCapacitySpecification_TotalTargetCapacity(rName string, totalTargetCapacity int) string {
+func testAccFleetConfig_targetCapacitySpecificationTotalTargetCapacity(rName string, totalTargetCapacity int) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   terminate_instances = true
@@ -3565,7 +3565,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, totalTargetCapacity))
 }
 
-func testAccFleetConfig_TerminateInstancesWithExpiration(rName string, terminateInstancesWithExpiration bool) string {
+func testAccFleetConfig_terminateInstancesExpiration(rName string, terminateInstancesWithExpiration bool) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   terminate_instances_with_expiration = %[2]t
@@ -3589,7 +3589,7 @@ resource "aws_ec2_fleet" "test" {
 `, rName, terminateInstancesWithExpiration))
 }
 
-func testAccFleetConfig_Type(rName, fleetType string) string {
+func testAccFleetConfig_type(rName, fleetType string) string {
 	return acctest.ConfigCompose(testAccFleetConfig_BaseLaunchTemplate(rName), fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   type = %[2]q

--- a/internal/service/ec2/ec2_host_data_source_test.go
+++ b/internal/service/ec2/ec2_host_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccEC2HostDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostDataSourceConfig(rName),
+				Config: testAccHostDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "auto_placement", resourceName, "auto_placement"),
@@ -52,7 +52,7 @@ func TestAccEC2HostDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostFilterDataSourceConfig(rName),
+				Config: testAccHostDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "auto_placement", resourceName, "auto_placement"),
@@ -72,7 +72,7 @@ func TestAccEC2HostDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccHostDataSourceConfig(rName string) string {
+func testAccHostDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -89,7 +89,7 @@ data "aws_ec2_host" "test" {
 `, rName))
 }
 
-func testAccHostFilterDataSourceConfig(rName string) string {
+func testAccHostDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -26,7 +26,7 @@ func TestAccEC2Host_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckHostDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostConfig(),
+				Config: testAccHostConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dedicated-host/.+`)),
@@ -58,7 +58,7 @@ func TestAccEC2Host_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckHostDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostConfig(),
+				Config: testAccHostConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceHost(), resourceName),
@@ -81,7 +81,7 @@ func TestAccEC2Host_instanceFamily(t *testing.T) {
 		CheckDestroy:      testAccCheckHostDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostInstanceFamilyConfig(rName),
+				Config: testAccHostConfig_instanceFamily(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dedicated-host/.+`)),
@@ -100,7 +100,7 @@ func TestAccEC2Host_instanceFamily(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccHostInstanceTypeConfig(rName),
+				Config: testAccHostConfig_instanceType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dedicated-host/.+`)),
@@ -128,7 +128,7 @@ func TestAccEC2Host_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckHostDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostTags1Config("key1", "value1"),
+				Config: testAccHostConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -141,7 +141,7 @@ func TestAccEC2Host_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccHostTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccHostConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -150,7 +150,7 @@ func TestAccEC2Host_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccHostTags1Config("key2", "value2"),
+				Config: testAccHostConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostExists(resourceName, &host),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -210,7 +210,7 @@ func testAccCheckHostDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccHostConfig() string {
+func testAccHostConfig_basic() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -219,7 +219,7 @@ resource "aws_ec2_host" "test" {
 `)
 }
 
-func testAccHostInstanceFamilyConfig(rName string) string {
+func testAccHostConfig_instanceFamily(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   auto_placement    = "off"
@@ -234,7 +234,7 @@ resource "aws_ec2_host" "test" {
 `, rName))
 }
 
-func testAccHostInstanceTypeConfig(rName string) string {
+func testAccHostConfig_instanceType(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   auto_placement    = "on"
@@ -249,7 +249,7 @@ resource "aws_ec2_host" "test" {
 `, rName))
 }
 
-func testAccHostTags1Config(tagKey1, tagValue1 string) string {
+func testAccHostConfig_tags1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -262,7 +262,7 @@ resource "aws_ec2_host" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccHostTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccHostConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]

--- a/internal/service/ec2/ec2_instance_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccEC2InstanceDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceConfig(rName),
+				Config: testAccInstanceDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
@@ -46,7 +46,7 @@ func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceTagsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
@@ -68,7 +68,7 @@ func TestAccEC2InstanceDataSource_azUserData(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceAzUserDataConfig(rName),
+				Config: testAccInstanceDataSourceConfig_azUser(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
@@ -144,7 +144,7 @@ func TestAccEC2InstanceDataSource_blockDevices(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceBlockDevicesConfig(rName),
+				Config: testAccInstanceDataSourceConfig_blockDevices(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -204,7 +204,7 @@ func TestAccEC2InstanceDataSource_rootInstanceStore(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceRootInstanceStoreConfig(rName),
+				Config: testAccInstanceDataSourceConfig_rootStore(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -228,7 +228,7 @@ func TestAccEC2InstanceDataSource_privateIP(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourcePrivateIPConfig(rName),
+				Config: testAccInstanceDataSourceConfig_privateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -250,7 +250,7 @@ func TestAccEC2InstanceDataSource_secondaryPrivateIPs(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceSecondaryPrivateIPsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_secondaryPrivateIPs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -299,7 +299,7 @@ func TestAccEC2InstanceDataSource_keyPair(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceKeyPairConfig(rName, publicKey),
+				Config: testAccInstanceDataSourceConfig_keyPair(rName, publicKey),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
@@ -322,7 +322,7 @@ func TestAccEC2InstanceDataSource_vpc(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceVPCConfig(rName),
+				Config: testAccInstanceDataSourceConfig_vpc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -346,7 +346,7 @@ func TestAccEC2InstanceDataSource_placementGroup(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourcePlacementGroupConfig(rName),
+				Config: testAccInstanceDataSourceConfig_placementGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "placement_group", resourceName, "placement_group"),
 				),
@@ -366,7 +366,7 @@ func TestAccEC2InstanceDataSource_securityGroups(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceSecurityGroupsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_securityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -390,7 +390,7 @@ func TestAccEC2InstanceDataSource_vpcSecurityGroups(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceVPCSecurityGroupsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_vpcSecurityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -417,14 +417,14 @@ func TestAccEC2InstanceDataSource_GetPasswordData_trueToFalse(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceGetPasswordDataConfig(rName, publicKey, true),
+				Config: testAccInstanceDataSourceConfig_getPassword(rName, publicKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_password_data", "true"),
 					resource.TestCheckResourceAttrSet(datasourceName, "password_data"),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceGetPasswordDataConfig(rName, publicKey, false),
+				Config: testAccInstanceDataSourceConfig_getPassword(rName, publicKey, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_password_data", "false"),
 					resource.TestCheckNoResourceAttr(datasourceName, "password_data"),
@@ -449,14 +449,14 @@ func TestAccEC2InstanceDataSource_GetPasswordData_falseToTrue(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceGetPasswordDataConfig(rName, publicKey, false),
+				Config: testAccInstanceDataSourceConfig_getPassword(rName, publicKey, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_password_data", "false"),
 					resource.TestCheckNoResourceAttr(datasourceName, "password_data"),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceGetPasswordDataConfig(rName, publicKey, true),
+				Config: testAccInstanceDataSourceConfig_getPassword(rName, publicKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_password_data", "true"),
 					resource.TestCheckResourceAttrSet(datasourceName, "password_data"),
@@ -476,21 +476,21 @@ func TestAccEC2InstanceDataSource_getUserData(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceGetUserDataConfig(rName, true),
+				Config: testAccInstanceDataSourceConfig_getUser(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "user_data_base64", "IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo="),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceGetUserDataConfig(rName, false),
+				Config: testAccInstanceDataSourceConfig_getUser(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "false"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceGetUserDataConfig(rName, true),
+				Config: testAccInstanceDataSourceConfig_getUser(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "user_data_base64", "IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo="),
@@ -511,7 +511,7 @@ func TestAccEC2InstanceDataSource_GetUserData_noUserData(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceGetUserDataNoUserDataConfig(rName, true),
+				Config: testAccInstanceDataSourceConfig_getUserNoUser(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
@@ -519,7 +519,7 @@ func TestAccEC2InstanceDataSource_GetUserData_noUserData(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceGetUserDataNoUserDataConfig(rName, false),
+				Config: testAccInstanceDataSourceConfig_getUserNoUser(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "false"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
@@ -527,7 +527,7 @@ func TestAccEC2InstanceDataSource_GetUserData_noUserData(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceGetUserDataNoUserDataConfig(rName, true),
+				Config: testAccInstanceDataSourceConfig_getUserNoUser(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
@@ -548,14 +548,14 @@ func TestAccEC2InstanceDataSource_autoRecovery(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceAutoRecoveryConfig(rName, "default"),
+				Config: testAccInstanceDataSourceConfig_autoRecovery(rName, "default"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "maintenance_options.#", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "maintenance_options.0.auto_recovery", "default"),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceAutoRecoveryConfig(rName, "disabled"),
+				Config: testAccInstanceDataSourceConfig_autoRecovery(rName, "disabled"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "maintenance_options.#", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "maintenance_options.0.auto_recovery", "disabled"),
@@ -577,7 +577,7 @@ func TestAccEC2InstanceDataSource_creditSpecification(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccInstanceDataSourceCreditSpecificationConfig(rName),
+				Config: testAccInstanceDataSourceConfig_creditSpecification(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "credit_specification.#", resourceName, "credit_specification.#"),
@@ -599,7 +599,7 @@ func TestAccEC2InstanceDataSource_metadataOptions(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceMetadataOptionsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_metaOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.#", resourceName, "metadata_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
@@ -623,7 +623,7 @@ func TestAccEC2InstanceDataSource_enclaveOptions(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceEnclaveOptionsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_enclaveOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "enclave_options.#", resourceName, "enclave_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "enclave_options.0.enabled", resourceName, "enclave_options.0.enabled"),
@@ -644,7 +644,7 @@ func TestAccEC2InstanceDataSource_blockDeviceTags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceBlockDeviceTagsConfig(rName),
+				Config: testAccInstanceDataSourceConfig_blockDeviceTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
 				),
@@ -654,7 +654,7 @@ func TestAccEC2InstanceDataSource_blockDeviceTags(t *testing.T) {
 }
 
 // Lookup based on InstanceID
-func testAccInstanceDataSourceConfig(rName string) string {
+func testAccInstanceDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -675,7 +675,7 @@ data "aws_instance" "test" {
 }
 
 // Use the tags attribute to filter
-func testAccInstanceDataSourceTagsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_tags(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -697,7 +697,7 @@ data "aws_instance" "test" {
 }
 
 // filter on tag, populate more attributes
-func testAccInstanceDataSourceAzUserDataConfig(rName string) string {
+func testAccInstanceDataSourceConfig_azUser(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -768,7 +768,7 @@ data "aws_instance" "test" {
 }
 
 // Block Device
-func testAccInstanceDataSourceBlockDevicesConfig(rName string) string {
+func testAccInstanceDataSourceConfig_blockDevices(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -882,7 +882,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceRootInstanceStoreConfig(rName string) string {
+func testAccInstanceDataSourceConfig_rootStore(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -899,7 +899,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourcePrivateIPConfig(rName string) string {
+func testAccInstanceDataSourceConfig_privateIP(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -921,7 +921,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceSecondaryPrivateIPsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_secondaryPrivateIPs(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -965,7 +965,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceKeyPairConfig(rName, publicKey string) string {
+func testAccInstanceDataSourceConfig_keyPair(rName, publicKey string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
@@ -996,7 +996,7 @@ data "aws_instance" "test" {
 `, rName, publicKey))
 }
 
-func testAccInstanceDataSourceVPCConfig(rName string) string {
+func testAccInstanceDataSourceConfig_vpc(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -1021,7 +1021,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourcePlacementGroupConfig(rName string) string {
+func testAccInstanceDataSourceConfig_placementGroup(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -1053,7 +1053,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceSecurityGroupsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_securityGroups(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -1087,7 +1087,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceVPCSecurityGroupsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_vpcSecurityGroups(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
 		testAccInstanceVPCSecurityGroupConfig(rName),
@@ -1110,7 +1110,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceGetPasswordDataConfig(rName, publicKey string, val bool) string {
+func testAccInstanceDataSourceConfig_getPassword(rName, publicKey string, val bool) string {
 	return acctest.ConfigCompose(testAccLatestWindowsServer2016CoreAMIConfig(), fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
@@ -1135,7 +1135,7 @@ data "aws_instance" "test" {
 `, rName, publicKey, val))
 }
 
-func testAccInstanceDataSourceGetUserDataConfig(rName string, getUserData bool) string {
+func testAccInstanceDataSourceConfig_getUser(rName string, getUserData bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -1163,7 +1163,7 @@ data "aws_instance" "test" {
 `, rName, getUserData))
 }
 
-func testAccInstanceDataSourceGetUserDataNoUserDataConfig(rName string, getUserData bool) string {
+func testAccInstanceDataSourceConfig_getUserNoUser(rName string, getUserData bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -1185,7 +1185,7 @@ data "aws_instance" "test" {
 `, rName, getUserData))
 }
 
-func testAccInstanceDataSourceAutoRecoveryConfig(rName string, val string) string {
+func testAccInstanceDataSourceConfig_autoRecovery(rName string, val string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -1210,7 +1210,7 @@ data "aws_instance" "test" {
 `, rName, val))
 }
 
-func testAccInstanceDataSourceCreditSpecificationConfig(rName string) string {
+func testAccInstanceDataSourceConfig_creditSpecification(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 1),
@@ -1235,7 +1235,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceMetadataOptionsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_metaOptions(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -1264,7 +1264,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceEnclaveOptionsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_enclaveOptions(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -1290,7 +1290,7 @@ data "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceDataSourceBlockDeviceTagsConfig(rName string) string {
+func testAccInstanceDataSourceConfig_blockDeviceTags(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -115,7 +115,7 @@ func TestAccEC2Instance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigBasic(),
+				Config: testAccInstanceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`instance/i-[a-z0-9]+`)),
@@ -148,7 +148,7 @@ func TestAccEC2Instance_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigBasic(),
+				Config: testAccInstanceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceInstance(), resourceName),
@@ -174,7 +174,7 @@ func TestAccEC2Instance_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigTags1("key1", "value1"),
+				Config: testAccInstanceConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -188,7 +188,7 @@ func TestAccEC2Instance_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigTags2("key1", "value1updated", "key2", "value2"),
+				Config: testAccInstanceConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -197,7 +197,7 @@ func TestAccEC2Instance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigTags1("key2", "value2"),
+				Config: testAccInstanceConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -247,7 +247,7 @@ func TestAccEC2Instance_inDefaultVPCBySgID(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_inDefaultVPCBySgId(rName),
+				Config: testAccInstanceConfig_inDefaultVPCBySGID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -273,13 +273,13 @@ func TestAccEC2Instance_inEC2Classic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_ec2Classic(),
+				Config: testAccInstanceConfig_classic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceClassicExists(resourceName, &v),
 				),
 			},
 			{
-				Config:            testAccInstanceConfig_ec2Classic(),
+				Config:            testAccInstanceConfig_classic(),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -372,7 +372,7 @@ func TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceConfigEBSBlockDeviceInvalidIops,
+				Config:      testAccInstanceConfig_ebsBlockDeviceInvalidIOPS,
 				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for ebs_block_device with volume_type gp2`),
 			},
 		},
@@ -387,7 +387,7 @@ func TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType(t *testing
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceConfigEBSBlockDeviceInvalidThroughput,
+				Config:      testAccInstanceConfig_ebsBlockDeviceInvalidThroughput,
 				ExpectError: regexp.MustCompile(`error creating resource: throughput attribute not supported for ebs_block_device with volume_type gp2`),
 			},
 		},
@@ -409,7 +409,7 @@ func TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigEBSAndRootBlockDevice(rName),
+				Config: testAccInstanceConfig_ebsAndRootBlockDevice(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					// Instance must be stopped before detaching a root block device
@@ -465,7 +465,7 @@ func TestAccEC2Instance_userDataBase64(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserDataBase64(rName, "hello world"),
+				Config: testAccInstanceConfig_userDataBase64(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
@@ -493,14 +493,14 @@ func TestAccEC2Instance_userDataBase64_updateWithBashFile(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserDataBase64(rName, "hello world"),
+				Config: testAccInstanceConfig_userDataBase64(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithUserDataBase64_Base64EncodedFile(rName, "test-fixtures/userdata-test.sh"),
+				Config: testAccInstanceConfig_userDataBase64Base64EncodedFile(rName, "test-fixtures/userdata-test.sh"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -527,14 +527,14 @@ func TestAccEC2Instance_userDataBase64_updateWithZipFile(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserDataBase64(rName, "hello world"),
+				Config: testAccInstanceConfig_userDataBase64(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithUserDataBase64_Base64EncodedFile(rName, "test-fixtures/userdata-test.zip"),
+				Config: testAccInstanceConfig_userDataBase64Base64EncodedFile(rName, "test-fixtures/userdata-test.zip"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -561,14 +561,14 @@ func TestAccEC2Instance_userDataBase64_update(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserDataBase64(rName, "hello world"),
+				Config: testAccInstanceConfig_userDataBase64(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithUserDataBase64(rName, "new world"),
+				Config: testAccInstanceConfig_userDataBase64(rName, "new world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "bmV3IHdvcmxk"),
@@ -613,7 +613,7 @@ func TestAccEC2Instance_gp2IopsDevice(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceGP2IopsDevice(rName),
+				Config: testAccInstanceConfig_gp2IOPSDevice(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
@@ -646,7 +646,7 @@ func TestAccEC2Instance_gp2WithIopsValue(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceGP2WithIopsValue(rName),
+				Config:      testAccInstanceConfig_gp2IOPSValue(rName),
 				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for root_block_device with volume_type gp2`),
 			},
 		},
@@ -707,7 +707,7 @@ func TestAccEC2Instance_blockDevices(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceBlockDevicesConfig(rName, rootVolumeSize),
+				Config: testAccInstanceConfig_blockDevices(rName, rootVolumeSize),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
@@ -783,7 +783,7 @@ func TestAccEC2Instance_rootInstanceStore(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigRootInstanceStore(rName),
+				Config: testAccInstanceConfig_rootStore(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
@@ -839,7 +839,7 @@ func TestAccEC2Instance_noAMIEphemeralDevices(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigNoAMIEphemeralDevices(rName),
+				Config: testAccInstanceConfig_noAMIEphemeralDevices(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "false"),
@@ -894,7 +894,7 @@ func TestAccEC2Instance_sourceDestCheck(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigSourceDestDisable(rName),
+				Config: testAccInstanceConfig_sourceDestDisable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(false),
@@ -907,14 +907,14 @@ func TestAccEC2Instance_sourceDestCheck(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigSourceDestEnable(rName),
+				Config: testAccInstanceConfig_sourceDestEnable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(true),
 				),
 			},
 			{
-				Config: testAccInstanceConfigSourceDestDisable(rName),
+				Config: testAccInstanceConfig_sourceDestDisable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(false),
@@ -936,7 +936,7 @@ func TestAccEC2Instance_autoRecovery(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceAutoRecoveryConfig(rName, "default"),
+				Config: testAccInstanceConfig_autoRecovery(rName, "default"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_options.#", "1"),
@@ -950,7 +950,7 @@ func TestAccEC2Instance_autoRecovery(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceAutoRecoveryConfig(rName, "disabled"),
+				Config: testAccInstanceConfig_autoRecovery(rName, "disabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_options.#", "1"),
@@ -991,7 +991,7 @@ func TestAccEC2Instance_disableAPITermination(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigDisableAPITermination(rName, true),
+				Config: testAccInstanceConfig_disableAPITermination(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					checkDisableApiTermination(true),
@@ -1004,7 +1004,7 @@ func TestAccEC2Instance_disableAPITermination(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigDisableAPITermination(rName, false),
+				Config: testAccInstanceConfig_disableAPITermination(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					checkDisableApiTermination(false),
@@ -1060,7 +1060,7 @@ func TestAccEC2Instance_outpost(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigOutpost(rName),
+				Config: testAccInstanceConfig_outpost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "outpost_arn", outpostDataSourceName, "arn"),
@@ -1088,7 +1088,7 @@ func TestAccEC2Instance_placementGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPlacementGroup(rName),
+				Config: testAccInstanceConfig_placementGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "placement_group", rName),
@@ -1116,7 +1116,7 @@ func TestAccEC2Instance_placementPartitionNumber(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPlacementPartitionNumber(rName),
+				Config: testAccInstanceConfig_placementPartitionNumber(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "placement_group", rName),
@@ -1171,7 +1171,7 @@ func TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError(t *testing.T
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceConfig_ipv6ErrorConfig(rName),
+				Config:      testAccInstanceConfig_ipv6Error(rName),
 				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
 			},
 		},
@@ -1190,7 +1190,7 @@ func TestAccEC2Instance_IPv6_supportAddressCountWithIPv4(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_ipv6SupportWithv4(rName),
+				Config: testAccInstanceConfig_ipv6Supportv4(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
@@ -1218,7 +1218,7 @@ func TestAccEC2Instance_networkInstanceSecurityGroups(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceNetworkInstanceSecurityGroups(rName),
+				Config: testAccInstanceConfig_networkSecurityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -1245,7 +1245,7 @@ func TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
+				Config: testAccInstanceConfig_networkVPCSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
@@ -1259,7 +1259,7 @@ func TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName),
+				Config: testAccInstanceConfig_networkVPCRemoveSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
@@ -1283,7 +1283,7 @@ func TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
+				Config: testAccInstanceConfig_networkVPCSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
@@ -1312,7 +1312,7 @@ func TestAccEC2Instance_BlockDeviceTags_volumeTags(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsNoVolumeTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsNoVolumeTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckNoResourceAttr(resourceName, "volume_tags"),
@@ -1325,7 +1325,7 @@ func TestAccEC2Instance_BlockDeviceTags_volumeTags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ephemeral_block_device", "user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsVolumeTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsVolumeTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
@@ -1333,7 +1333,7 @@ func TestAccEC2Instance_BlockDeviceTags_volumeTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsVolumeTagsUpdate(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsVolumeTagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "2"),
@@ -1342,7 +1342,7 @@ func TestAccEC2Instance_BlockDeviceTags_volumeTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsNoVolumeTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsNoVolumeTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "0"),
@@ -1365,7 +1365,7 @@ func TestAccEC2Instance_BlockDeviceTags_withAttachedVolume(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsAttachedVolumeWithTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsAttachedVolumeTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(ebsVolumeName, "tags.%", "2"),
@@ -1375,7 +1375,7 @@ func TestAccEC2Instance_BlockDeviceTags_withAttachedVolume(t *testing.T) {
 			},
 			{
 				//https://github.com/hashicorp/terraform-provider-aws/issues/17074
-				Config: testAccInstanceConfigBlockDeviceTagsAttachedVolumeWithTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsAttachedVolumeTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(ebsVolumeName, "tags.%", "2"),
@@ -1384,7 +1384,7 @@ func TestAccEC2Instance_BlockDeviceTags_withAttachedVolume(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsAttachedVolumeWithTagsUpdate(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsAttachedVolumeTagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(ebsVolumeName, "tags.%", "2"),
@@ -1414,15 +1414,15 @@ func TestAccEC2Instance_BlockDeviceTags_ebsAndRoot(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceConfigBlockDeviceTagsRootTagsConflict(rName),
+				Config:      testAccInstanceConfig_blockDeviceTagsRootTagsConflict(rName),
 				ExpectError: regexp.MustCompile(`"root_block_device\.0\.tags": conflicts with volume_tags`),
 			},
 			{
-				Config:      testAccInstanceConfigBlockDeviceTagsEBSTagsConflict(rName),
+				Config:      testAccInstanceConfig_blockDeviceTagsEBSTagsConflict(rName),
 				ExpectError: regexp.MustCompile(`"ebs_block_device\.0\.tags": conflicts with volume_tags`),
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsEBSTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsEBSTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.tags.%", "0"),
@@ -1432,7 +1432,7 @@ func TestAccEC2Instance_BlockDeviceTags_ebsAndRoot(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsEBSAndRootTags(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsEBSAndRootTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.tags.%", "2"),
@@ -1441,7 +1441,7 @@ func TestAccEC2Instance_BlockDeviceTags_ebsAndRoot(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigBlockDeviceTagsEBSAndRootTagsUpdate(rName),
+				Config: testAccInstanceConfig_blockDeviceTagsEBSAndRootTagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.tags.%", "2"),
@@ -1482,7 +1482,7 @@ func TestAccEC2Instance_instanceProfileChange(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithoutInstanceProfile(rName1),
+				Config: testAccInstanceConfig_noProfile(rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -1494,20 +1494,20 @@ func TestAccEC2Instance_instanceProfileChange(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigWithInstanceProfile(rName1),
+				Config: testAccInstanceConfig_profile(rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckInstanceProfile(),
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithInstanceProfile(rName1),
+				Config: testAccInstanceConfig_profile(rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStopInstance(&v), // GH-8262: Error on EC2 instance role change when stopped
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithInstanceProfile(rName2),
+				Config: testAccInstanceConfig_profile(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckInstanceProfile(),
@@ -1539,7 +1539,7 @@ func TestAccEC2Instance_withIAMInstanceProfile(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithInstanceProfile(rName),
+				Config: testAccInstanceConfig_profile(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckInstanceProfile(),
@@ -1568,7 +1568,7 @@ func TestAccEC2Instance_withIAMInstanceProfilePath(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithInstanceProfilePath(rName),
+				Config: testAccInstanceConfig_profilePath(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 				),
@@ -1605,7 +1605,7 @@ func TestAccEC2Instance_privateIP(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrivateIP(rName),
+				Config: testAccInstanceConfig_privateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckPrivateIP(),
@@ -1643,7 +1643,7 @@ func TestAccEC2Instance_associatePublicIPAndPrivateIP(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigAssociatePublicIPAndPrivateIP(rName),
+				Config: testAccInstanceConfig_associatePublicIPAndPrivateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckPrivateIP(),
@@ -1683,7 +1683,7 @@ func TestAccEC2Instance_Empty_privateIP(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigEmptyPrivateIP(rName),
+				Config: testAccInstanceConfig_emptyPrivateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckPrivateIP(),
@@ -1719,7 +1719,7 @@ func TestAccEC2Instance_keyPairCheck(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigKeyPair(rName, publicKey),
+				Config: testAccInstanceConfig_keyPair(rName, publicKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "key_name", keyPairResourceName, "key_name"),
@@ -1741,7 +1741,7 @@ func TestAccEC2Instance_rootBlockDeviceMismatch(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigRootBlockDeviceMismatch(rName),
+				Config: testAccInstanceConfig_rootBlockDeviceMismatch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "13"),
@@ -1778,7 +1778,7 @@ func TestAccEC2Instance_forceNewAndTagsDrift(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigForceNewAndTagsDrift(rName),
+				Config: testAccInstanceConfig_forceNewAndTagsDrift(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					driftTags(&v),
@@ -1786,7 +1786,7 @@ func TestAccEC2Instance_forceNewAndTagsDrift(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccInstanceConfigForceNewAndTagsDrift_Update(rName),
+				Config: testAccInstanceConfig_forceNewAndTagsDriftUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -1814,7 +1814,7 @@ func TestAccEC2Instance_changeInstanceType(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithSmallInstanceType(rName),
+				Config: testAccInstanceConfig_smallType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.medium"),
@@ -1827,7 +1827,7 @@ func TestAccEC2Instance_changeInstanceType(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigUpdateInstanceType(rName),
+				Config: testAccInstanceConfig_updateType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(&before, &after),
@@ -1855,7 +1855,7 @@ func TestAccEC2Instance_changeInstanceTypeAndUserData(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigInstanceTypeAndUserData(rName, "t2.medium", "hello world"),
+				Config: testAccInstanceConfig_typeAndUserData(rName, "t2.medium", "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.medium"),
@@ -1863,7 +1863,7 @@ func TestAccEC2Instance_changeInstanceTypeAndUserData(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigInstanceTypeAndUserData(rName, "t2.large", "new world"),
+				Config: testAccInstanceConfig_typeAndUserData(rName, "t2.large", "new world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.large"),
@@ -1892,7 +1892,7 @@ func TestAccEC2Instance_changeInstanceTypeAndUserDataBase64(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigInstanceTypeAndUserDataBase64(rName, "t2.medium", "hello world"),
+				Config: testAccInstanceConfig_typeAndUserDataBase64(rName, "t2.medium", "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.medium"),
@@ -1900,7 +1900,7 @@ func TestAccEC2Instance_changeInstanceTypeAndUserDataBase64(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigInstanceTypeAndUserDataBase64(rName, "t2.large", "new world"),
+				Config: testAccInstanceConfig_typeAndUserDataBase64(rName, "t2.large", "new world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.large"),
@@ -1929,7 +1929,7 @@ func TestAccEC2Instance_EBSRootDevice_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceEBSRootDeviceBasic(rName),
+				Config: testAccInstanceConfig_ebsRootDeviceBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
@@ -1965,7 +1965,7 @@ func TestAccEC2Instance_EBSRootDevice_modifySize(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDevice(rName, originalSize, deleteOnTermination, volumeType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, originalSize, deleteOnTermination, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", originalSize),
@@ -1974,7 +1974,7 @@ func TestAccEC2Instance_EBSRootDevice_modifySize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDevice(rName, updatedSize, deleteOnTermination, volumeType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, updatedSize, deleteOnTermination, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2006,7 +2006,7 @@ func TestAccEC2Instance_EBSRootDevice_modifyType(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDevice(rName, volumeSize, deleteOnTermination, originalType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, volumeSize, deleteOnTermination, originalType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
@@ -2015,7 +2015,7 @@ func TestAccEC2Instance_EBSRootDevice_modifyType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDevice(rName, volumeSize, deleteOnTermination, updatedType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, volumeSize, deleteOnTermination, updatedType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2048,7 +2048,7 @@ func TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDeviceWithIOPS(rName, volumeSize, deleteOnTermination, volumeType, originalIOPS),
+				Config: testAccInstanceConfig_rootBlockDeviceIOPS(rName, volumeSize, deleteOnTermination, volumeType, originalIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
@@ -2058,7 +2058,7 @@ func TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDeviceWithIOPS(rName, volumeSize, deleteOnTermination, volumeType, updatedIOPS),
+				Config: testAccInstanceConfig_rootBlockDeviceIOPS(rName, volumeSize, deleteOnTermination, volumeType, updatedIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2092,7 +2092,7 @@ func TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDeviceWithIOPS(rName, volumeSize, deleteOnTermination, volumeType, originalIOPS),
+				Config: testAccInstanceConfig_rootBlockDeviceIOPS(rName, volumeSize, deleteOnTermination, volumeType, originalIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
@@ -2102,7 +2102,7 @@ func TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDeviceWithIOPS(rName, volumeSize, deleteOnTermination, volumeType, updatedIOPS),
+				Config: testAccInstanceConfig_rootBlockDeviceIOPS(rName, volumeSize, deleteOnTermination, volumeType, updatedIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2136,7 +2136,7 @@ func TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDeviceWithThroughput(rName, volumeSize, deleteOnTermination, volumeType, originalThroughput),
+				Config: testAccInstanceConfig_rootBlockDeviceThroughput(rName, volumeSize, deleteOnTermination, volumeType, originalThroughput),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
@@ -2146,7 +2146,7 @@ func TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDeviceWithThroughput(rName, volumeSize, deleteOnTermination, volumeType, updatedThroughput),
+				Config: testAccInstanceConfig_rootBlockDeviceThroughput(rName, volumeSize, deleteOnTermination, volumeType, updatedThroughput),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2179,7 +2179,7 @@ func TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDevice(rName, volumeSize, originalDeleteOnTermination, volumeType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, volumeSize, originalDeleteOnTermination, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
@@ -2188,7 +2188,7 @@ func TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDevice(rName, volumeSize, updatedDeleteOnTermination, volumeType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, volumeSize, updatedDeleteOnTermination, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2225,7 +2225,7 @@ func TestAccEC2Instance_EBSRootDevice_modifyAll(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceRootBlockDevice(rName, originalSize, originalDeleteOnTermination, originalType),
+				Config: testAccInstanceConfig_rootBlockDevice(rName, originalSize, originalDeleteOnTermination, originalType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", originalSize),
@@ -2234,7 +2234,7 @@ func TestAccEC2Instance_EBSRootDevice_modifyAll(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceRootBlockDeviceWithIOPS(rName, updatedSize, updatedDeleteOnTermination, updatedType, updatedIOPS),
+				Config: testAccInstanceConfig_rootBlockDeviceIOPS(rName, updatedSize, updatedDeleteOnTermination, updatedType, updatedIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -2266,7 +2266,7 @@ func TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize(t *testing.
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceBlockDevicesWithDeleteOnTerminateConfig(rName, originalRootVolumeSize, deleteOnTermination),
+				Config: testAccInstanceConfig_blockDevicesDeleteOnTerminate(rName, originalRootVolumeSize, deleteOnTermination),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", originalRootVolumeSize),
@@ -2282,7 +2282,7 @@ func TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize(t *testing.
 				),
 			},
 			{
-				Config: testAccInstanceBlockDevicesWithDeleteOnTerminateConfig(rName, updatedRootVolumeSize, deleteOnTermination),
+				Config: testAccInstanceConfig_blockDevicesDeleteOnTerminate(rName, updatedRootVolumeSize, deleteOnTermination),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(&before, &after),
@@ -2320,7 +2320,7 @@ func TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTerminat
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceBlockDevicesWithDeleteOnTerminateConfig(rName, rootVolumeSize, originalDeleteOnTermination),
+				Config: testAccInstanceConfig_blockDevicesDeleteOnTerminate(rName, rootVolumeSize, originalDeleteOnTermination),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", rootVolumeSize),
@@ -2337,7 +2337,7 @@ func TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTerminat
 				),
 			},
 			{
-				Config: testAccInstanceBlockDevicesWithDeleteOnTerminateConfig(rName, rootVolumeSize, updatedDeleteOnTermination),
+				Config: testAccInstanceConfig_blockDevicesDeleteOnTerminate(rName, rootVolumeSize, updatedDeleteOnTermination),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(&before, &after),
@@ -2371,7 +2371,7 @@ func TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices(t *testing.
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDynamicEBSBlockDevicesConfig(rName),
+				Config: testAccInstanceConfig_dynamicEBSBlockDevices(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "3"),
@@ -2440,7 +2440,7 @@ func TestAccEC2Instance_gp3RootBlockDevice(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigGP3RootBlockDevice(rName),
+				Config: testAccInstanceConfig_gp3RootBlockDevice(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
@@ -2475,7 +2475,7 @@ func TestAccEC2Instance_primaryNetworkInterface(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrimaryNetworkInterface(rName),
+				Config: testAccInstanceConfig_primaryNetworkInterface(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					testAccCheckENIExists(eniResourceName, &eni),
@@ -2511,7 +2511,7 @@ func TestAccEC2Instance_networkCardIndex(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigNetworkCardIndex(rName),
+				Config: testAccInstanceConfig_networkCardIndex(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
@@ -2545,7 +2545,7 @@ func TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck(rName),
+				Config: testAccInstanceConfig_primaryNetworkInterfaceSourceDestCheck(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					testAccCheckENIExists(eniResourceName, &eni),
@@ -2579,7 +2579,7 @@ func TestAccEC2Instance_addSecondaryInterface(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigAddSecondaryNetworkInterfaceBefore(rName),
+				Config: testAccInstanceConfig_addSecondaryNetworkInterfaceBefore(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					testAccCheckENIExists(eniPrimaryResourceName, &eniPrimary),
@@ -2593,7 +2593,7 @@ func TestAccEC2Instance_addSecondaryInterface(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"network_interface", "user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigAddSecondaryNetworkInterfaceAfter(rName),
+				Config: testAccInstanceConfig_addSecondaryNetworkInterfaceAfter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckENIExists(eniSecondaryResourceName, &eniSecondary),
@@ -2618,7 +2618,7 @@ func TestAccEC2Instance_addSecurityGroupNetworkInterface(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigAddSecurityGroupBefore(rName),
+				Config: testAccInstanceConfig_addSecurityGroupBefore(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
@@ -2631,7 +2631,7 @@ func TestAccEC2Instance_addSecurityGroupNetworkInterface(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigAddSecurityGroupAfter(rName),
+				Config: testAccInstanceConfig_addSecurityGroupAfter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "2"),
@@ -2654,7 +2654,7 @@ func TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs(t *te
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPublicAndPrivateSecondaryIPs(rName, true),
+				Config: testAccInstanceConfig_publicAndPrivateSecondaryIPs(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
@@ -2663,7 +2663,7 @@ func TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs(t *te
 				),
 			},
 			{
-				Config: testAccInstanceConfigPublicAndPrivateSecondaryIPs(rName, false),
+				Config: testAccInstanceConfig_publicAndPrivateSecondaryIPs(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
@@ -2695,7 +2695,7 @@ func TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPsNullPrivate(rName, secondaryIPs),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPsNullPrivate(rName, secondaryIPs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -2727,7 +2727,7 @@ func TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPsNullPrivate(rName, secondaryIPs),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPsNullPrivate(rName, secondaryIPs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -2735,7 +2735,7 @@ func TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
 				),
 			},
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPsNullPrivate(rName, ""),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPsNullPrivate(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -2743,7 +2743,7 @@ func TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
 				),
 			},
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPsNullPrivate(rName, secondaryIP),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPsNullPrivate(rName, secondaryIP),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -2775,7 +2775,7 @@ func TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs(t *t
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPs(rName, privateIP, secondaryIPs),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPs(rName, privateIP, secondaryIPs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "private_ip", privateIP),
@@ -2808,7 +2808,7 @@ func TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdat
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPs(rName, privateIP, secondaryIPs),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPs(rName, privateIP, secondaryIPs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "private_ip", privateIP),
@@ -2816,7 +2816,7 @@ func TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdat
 				),
 			},
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPs(rName, privateIP, ""),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPs(rName, privateIP, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -2824,7 +2824,7 @@ func TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdat
 				),
 			},
 			{
-				Config: testAccInstanceConfigPrivateIPAndSecondaryIPs(rName, privateIP, secondaryIP),
+				Config: testAccInstanceConfig_privateIPAndSecondaryIPs(rName, privateIP, secondaryIP),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "private_ip", privateIP),
@@ -2854,7 +2854,7 @@ func TestAccEC2Instance_AssociatePublic_defaultPrivate(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_defaultPrivate(rName),
+				Config: testAccInstanceConfig_associatePublicDefaultPrivate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
@@ -2884,7 +2884,7 @@ func TestAccEC2Instance_AssociatePublic_defaultPublic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_defaultPublic(rName),
+				Config: testAccInstanceConfig_associatePublicDefaultPublic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
@@ -2914,7 +2914,7 @@ func TestAccEC2Instance_AssociatePublic_explicitPublic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_explicitPublic(rName),
+				Config: testAccInstanceConfig_associatePublicExplicitPublic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
@@ -2944,7 +2944,7 @@ func TestAccEC2Instance_AssociatePublic_explicitPrivate(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_explicitPrivate(rName),
+				Config: testAccInstanceConfig_associatePublicExplicitPrivate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
@@ -2974,7 +2974,7 @@ func TestAccEC2Instance_AssociatePublic_overridePublic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_overridePublic(rName),
+				Config: testAccInstanceConfig_associatePublicOverridePublic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
@@ -3004,7 +3004,7 @@ func TestAccEC2Instance_AssociatePublic_overridePrivate(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_overridePrivate(rName),
+				Config: testAccInstanceConfig_associatePublicOverridePrivate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
@@ -3036,7 +3036,7 @@ func TestAccEC2Instance_LaunchTemplate_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_WithTemplate_Basic(rName),
+				Config: testAccInstanceConfig_templateBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
@@ -3065,7 +3065,7 @@ func TestAccEC2Instance_LaunchTemplate_overrideTemplate(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_WithTemplate_OverrideTemplate(rName),
+				Config: testAccInstanceConfig_templateOverrideTemplate(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
@@ -3090,7 +3090,7 @@ func TestAccEC2Instance_LaunchTemplate_setSpecificVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_WithTemplate_Basic(rName),
+				Config: testAccInstanceConfig_templateBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v1),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
@@ -3098,7 +3098,7 @@ func TestAccEC2Instance_LaunchTemplate_setSpecificVersion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_WithTemplate_SpecificVersion(rName),
+				Config: testAccInstanceConfig_templateSpecificVersion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v2),
 					testAccCheckInstanceNotRecreated(&v1, &v2),
@@ -3123,7 +3123,7 @@ func TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion(t *testing.T
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_WithTemplate_Basic(rName),
+				Config: testAccInstanceConfig_templateBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v1),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
@@ -3131,7 +3131,7 @@ func TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion(t *testing.T
 				),
 			},
 			{
-				Config: testAccInstanceConfig_WithTemplate_ModifyTemplate(rName),
+				Config: testAccInstanceConfig_templateModifyTemplate(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v2),
 					testAccCheckInstanceNotRecreated(&v1, &v2),
@@ -3156,7 +3156,7 @@ func TestAccEC2Instance_LaunchTemplate_updateTemplateVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_WithTemplate_SpecificVersion(rName),
+				Config: testAccInstanceConfig_templateSpecificVersion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v1),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
@@ -3164,7 +3164,7 @@ func TestAccEC2Instance_LaunchTemplate_updateTemplateVersion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_WithTemplate_UpdateVersion(rName),
+				Config: testAccInstanceConfig_templateUpdateVersion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v2),
 					testAccCheckInstanceRecreated(&v1, &v2),
@@ -3189,7 +3189,7 @@ func TestAccEC2Instance_LaunchTemplate_swapIDAndName(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_WithTemplate_Basic(rName),
+				Config: testAccInstanceConfig_templateBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v1),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
@@ -3197,7 +3197,7 @@ func TestAccEC2Instance_LaunchTemplate_swapIDAndName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_WithTemplate_WithName(rName),
+				Config: testAccInstanceConfig_templateName(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v2),
 					testAccCheckInstanceNotRecreated(&v1, &v2),
@@ -3311,7 +3311,7 @@ func TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_Empty_NonBurstable(rName),
+				Config: testAccInstanceConfig_creditSpecificationEmptyNonBurstable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3339,7 +3339,7 @@ func TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable(t *te
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_Unspecified_NonBurstable(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecifiedNonBurstable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 				),
@@ -3351,7 +3351,7 @@ func TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable(t *te
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_Empty_NonBurstable(rName),
+				Config: testAccInstanceConfig_creditSpecificationEmptyNonBurstable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 				),
@@ -3372,7 +3372,7 @@ func TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard(t *tes
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3401,7 +3401,7 @@ func TestAccEC2Instance_CreditSpecification_standardCPUCredits(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3415,7 +3415,7 @@ func TestAccEC2Instance_CreditSpecification_standardCPUCredits(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3438,7 +3438,7 @@ func TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unlimitedCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnlimitedCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3452,7 +3452,7 @@ func TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3475,7 +3475,7 @@ func TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unknownCPUCredits(rName, "t2.micro"),
+				Config: testAccInstanceConfig_creditSpecificationUnknownCPUCredits(rName, "t2.micro"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3504,7 +3504,7 @@ func TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unknownCPUCredits(rName, "t3.micro"),
+				Config: testAccInstanceConfig_creditSpecificationUnknownCPUCredits(rName, "t3.micro"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3533,7 +3533,7 @@ func TestAccEC2Instance_CreditSpecification_updateCPUCredits(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3547,7 +3547,7 @@ func TestAccEC2Instance_CreditSpecification_updateCPUCredits(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unlimitedCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnlimitedCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3555,7 +3555,7 @@ func TestAccEC2Instance_CreditSpecification_updateCPUCredits(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &third),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3578,7 +3578,7 @@ func TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable(t *testin
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rName),
+				Config: testAccInstanceConfig_creditSpecificationIsNotAppliedToNonBurstable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3605,7 +3605,7 @@ func TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited(t *
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecifiedT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3634,7 +3634,7 @@ func TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3648,7 +3648,7 @@ func TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecifiedT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3671,7 +3671,7 @@ func TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits(t *testing.T) 
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unlimitedCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnlimitedCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3685,7 +3685,7 @@ func TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits(t *testing.T) 
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnspecifiedT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3708,7 +3708,7 @@ func TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3722,7 +3722,7 @@ func TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unlimitedCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnlimitedCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3730,7 +3730,7 @@ func TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &third),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3753,7 +3753,7 @@ func TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint(t *tes
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3767,7 +3767,7 @@ func TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint(t *tes
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_standardCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationStandardCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3791,7 +3791,7 @@ func TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint(t *te
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unlimitedCPUCredits(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnlimitedCPUCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3805,7 +3805,7 @@ func TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint(t *te
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_CreditSpecification_unlimitedCPUCreditsT3(rName),
+				Config: testAccInstanceConfig_creditSpecificationUnlimitedCPUCreditsT3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -3829,7 +3829,7 @@ func TestAccEC2Instance_UserData(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserData(rName, "hello world"),
+				Config: testAccInstanceConfig_userData(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3856,13 +3856,13 @@ func TestAccEC2Instance_UserData_update(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserData(rName, "hello world"),
+				Config: testAccInstanceConfig_userData(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithUserData(rName, "new world"),
+				Config: testAccInstanceConfig_userData(rName, "new world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3889,13 +3889,13 @@ func TestAccEC2Instance_UserData_stringToEncodedString(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserData(rName, "hello world"),
+				Config: testAccInstanceConfig_userData(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
-				Config: testAccInstanceConfigWithUserDataBase64Encoded(rName, "new world"),
+				Config: testAccInstanceConfig_userDataBase64Encoded(rName, "new world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3922,7 +3922,7 @@ func TestAccEC2Instance_UserData_emptyStringToUnspecified(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData_EmptyString(rName),
+				Config: testAccInstanceConfig_userDataEmptyString(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3935,7 +3935,7 @@ func TestAccEC2Instance_UserData_emptyStringToUnspecified(t *testing.T) {
 			},
 			// Switching should show no difference
 			{
-				Config:             testAccInstanceConfig_UserData_Unspecified(rName),
+				Config:             testAccInstanceConfig_userDataUnspecified(rName),
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -3955,7 +3955,7 @@ func TestAccEC2Instance_UserData_unspecifiedToEmptyString(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData_Unspecified(rName),
+				Config: testAccInstanceConfig_userDataUnspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3968,7 +3968,7 @@ func TestAccEC2Instance_UserData_unspecifiedToEmptyString(t *testing.T) {
 			},
 			// Switching should show no difference
 			{
-				Config:             testAccInstanceConfig_UserData_EmptyString(rName),
+				Config:             testAccInstanceConfig_userDataEmptyString(rName),
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -3988,7 +3988,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_On(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData_Specified_With_Replace_Flag(rName, "TestData1", "true"),
+				Config: testAccInstanceConfig_userDataSpecifiedReplaceFlag(rName, "TestData1", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance1),
 				),
@@ -4001,7 +4001,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_On(t *testing.T) {
 			},
 			// Switching should force a recreate
 			{
-				Config: testAccInstanceConfig_UserData_Specified_With_Replace_Flag(rName, "TestData2", "true"),
+				Config: testAccInstanceConfig_userDataSpecifiedReplaceFlag(rName, "TestData2", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance2),
 					testAccCheckInstanceRecreated(&instance1, &instance2),
@@ -4023,7 +4023,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_On_Base64(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData64_Specified_With_Replace_Flag(rName, "3dc39dda39be1205215e776bad998da361a5955d", "true"),
+				Config: testAccInstanceConfig_userData64SpecifiedReplaceFlag(rName, "3dc39dda39be1205215e776bad998da361a5955d", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance1),
 				),
@@ -4036,7 +4036,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_On_Base64(t *testing.T) {
 			},
 			// Switching should force a recreate
 			{
-				Config: testAccInstanceConfig_UserData64_Specified_With_Replace_Flag(rName, "3dc39dda39be1205215e776bad998da361a5955e", "true"),
+				Config: testAccInstanceConfig_userData64SpecifiedReplaceFlag(rName, "3dc39dda39be1205215e776bad998da361a5955e", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance2),
 					testAccCheckInstanceRecreated(&instance1, &instance2),
@@ -4058,7 +4058,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_Off(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData_Specified_With_Replace_Flag(rName, "TestData1", "false"),
+				Config: testAccInstanceConfig_userDataSpecifiedReplaceFlag(rName, "TestData1", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance1),
 				),
@@ -4071,7 +4071,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_Off(t *testing.T) {
 			},
 			// Switching should not force a recreate
 			{
-				Config: testAccInstanceConfig_UserData_Specified_With_Replace_Flag(rName, "TestData2", "false"),
+				Config: testAccInstanceConfig_userDataSpecifiedReplaceFlag(rName, "TestData2", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance2),
 					testAccCheckInstanceNotRecreated(&instance1, &instance2),
@@ -4093,7 +4093,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData64_Specified_With_Replace_Flag(rName, "3dc39dda39be1205215e776bad998da361a5955d", "false"),
+				Config: testAccInstanceConfig_userData64SpecifiedReplaceFlag(rName, "3dc39dda39be1205215e776bad998da361a5955d", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance1),
 				),
@@ -4106,7 +4106,7 @@ func TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64(t *testing.T) {
 			},
 			// Switching should not force a recreate
 			{
-				Config: testAccInstanceConfig_UserData64_Specified_With_Replace_Flag(rName, "3dc39dda39be1205215e776bad998da361a5955e", "false"),
+				Config: testAccInstanceConfig_userData64SpecifiedReplaceFlag(rName, "3dc39dda39be1205215e776bad998da361a5955e", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance2),
 					testAccCheckInstanceNotRecreated(&instance1, &instance2),
@@ -4128,7 +4128,7 @@ func TestAccEC2Instance_hibernation(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigHibernation(rName, true),
+				Config: testAccInstanceConfig_hibernation(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "hibernation", "true"),
@@ -4141,7 +4141,7 @@ func TestAccEC2Instance_hibernation(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigHibernation(rName, false),
+				Config: testAccInstanceConfig_hibernation(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v2),
 					testAccCheckInstanceRecreated(&v1, &v2),
@@ -4164,7 +4164,7 @@ func TestAccEC2Instance_metadataOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigMetadataOptions(rName),
+				Config: testAccInstanceConfig_metadataOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
@@ -4175,7 +4175,7 @@ func TestAccEC2Instance_metadataOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigMetadataOptionsUpdated(rName),
+				Config: testAccInstanceConfig_metadataOptionsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
@@ -4207,7 +4207,7 @@ func TestAccEC2Instance_enclaveOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigEnclaveOptions(rName, true),
+				Config: testAccInstanceConfig_enclaveOptions(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "enclave_options.#", "1"),
@@ -4221,7 +4221,7 @@ func TestAccEC2Instance_enclaveOptions(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfigEnclaveOptions(rName, false),
+				Config: testAccInstanceConfig_enclaveOptions(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v2),
 					testAccCheckInstanceRecreated(&v1, &v2),
@@ -4245,7 +4245,7 @@ func TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_unspecified(rName),
+				Config: testAccInstanceConfig_capacityReservationSpecificationUnspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -4261,7 +4261,7 @@ func TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing
 			},
 			// Adding 'open' preference should show no difference
 			{
-				Config:             testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
+				Config:             testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "open"),
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -4281,7 +4281,7 @@ func TestAccEC2Instance_CapacityReservationPreference_open(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
+				Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -4311,7 +4311,7 @@ func TestAccEC2Instance_CapacityReservationPreference_none(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
+				Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -4341,7 +4341,7 @@ func TestAccEC2Instance_CapacityReservation_targetID(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_targetId(rName),
+				Config: testAccInstanceConfig_capacityReservationSpecificationTargetID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_target.#", "1"),
@@ -4372,7 +4372,7 @@ func TestAccEC2Instance_CapacityReservation_modifyPreference(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
+				Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "open"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -4380,13 +4380,13 @@ func TestAccEC2Instance_CapacityReservation_modifyPreference(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_target.#", "0"),
 				),
 			},
-			{Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
+			{Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStopInstance(&original), // Stop instance to modify capacity reservation
 				),
 			},
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
+				Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "none"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -4412,7 +4412,7 @@ func TestAccEC2Instance_CapacityReservation_modifyTarget(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
+				Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "none"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -4420,13 +4420,13 @@ func TestAccEC2Instance_CapacityReservation_modifyTarget(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_target.#", "0"),
 				),
 			},
-			{Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
+			{Config: testAccInstanceConfig_capacityReservationSpecificationPreference(rName, "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStopInstance(&original), // Stop instance to modify capacity reservation
 				),
 			},
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_targetId(rName),
+				Config: testAccInstanceConfig_capacityReservationSpecificationTargetID(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -4847,7 +4847,7 @@ resource "aws_subnet" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBasic() string {
+func testAccInstanceConfig_basic() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html#ec2-classic-instance-types
@@ -4861,7 +4861,7 @@ resource "aws_instance" "test" {
 `)
 }
 
-func testAccInstanceConfigTags1(tagKey1, tagValue1 string) string {
+func testAccInstanceConfig_tags1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -4874,7 +4874,7 @@ resource "aws_instance" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccInstanceConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccInstanceConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -4916,7 +4916,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_inDefaultVPCBySgId(rName string) string {
+func testAccInstanceConfig_inDefaultVPCBySGID(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -4944,7 +4944,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_ec2Classic() string { // nosempgrep:ec2-in-func-name
+func testAccInstanceConfig_classic() string { // nosempgrep:ec2-in-func-name
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -4959,7 +4959,7 @@ resource "aws_instance" "test" {
 
 func testAccInstanceConfig_atLeastOneOtherEBSVolume(rName string) string {
 	return acctest.ConfigCompose(
-		testAccLatestAmazonLinuxHVMInstanceStoreAMIConfig(),
+		testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore(),
 		testAccInstanceVPCConfig(rName, false, 0),
 		fmt.Sprintf(`
 # Ensure that there is at least 1 EBS volume in the current region.
@@ -4990,7 +4990,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigWithUserData(rName, userData string) string {
+func testAccInstanceConfig_userData(rName, userData string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5009,7 +5009,7 @@ resource "aws_instance" "test" {
 `, rName, userData))
 }
 
-func testAccInstanceConfigWithUserDataBase64Encoded(rName, userData string) string {
+func testAccInstanceConfig_userDataBase64Encoded(rName, userData string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5028,7 +5028,7 @@ resource "aws_instance" "test" {
 `, rName, userData))
 }
 
-func testAccInstanceConfigWithUserDataBase64(rName, userData string) string {
+func testAccInstanceConfig_userDataBase64(rName, userData string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5047,7 +5047,7 @@ resource "aws_instance" "test" {
 `, rName, userData))
 }
 
-func testAccInstanceConfigWithUserDataBase64_Base64EncodedFile(rName, filename string) string {
+func testAccInstanceConfig_userDataBase64Base64EncodedFile(rName, filename string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5066,7 +5066,7 @@ resource "aws_instance" "test" {
 `, rName, filename))
 }
 
-func testAccInstanceConfigWithSmallInstanceType(rName string) string {
+func testAccInstanceConfig_smallType(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5084,7 +5084,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigUpdateInstanceType(rName string) string {
+func testAccInstanceConfig_updateType(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5102,7 +5102,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigInstanceTypeAndUserData(rName, instanceType, userData string) string {
+func testAccInstanceConfig_typeAndUserData(rName, instanceType, userData string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5121,7 +5121,7 @@ resource "aws_instance" "test" {
 `, rName, instanceType, userData))
 }
 
-func testAccInstanceConfigInstanceTypeAndUserDataBase64(rName, instanceType, userData string) string {
+func testAccInstanceConfig_typeAndUserDataBase64(rName, instanceType, userData string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5140,7 +5140,7 @@ resource "aws_instance" "test" {
 `, rName, instanceType, userData))
 }
 
-func testAccInstanceGP2IopsDevice(rName string) string {
+func testAccInstanceConfig_gp2IOPSDevice(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5158,7 +5158,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceGP2WithIopsValue(rName string) string {
+func testAccInstanceConfig_gp2IOPSValue(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5178,8 +5178,8 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigRootInstanceStore(rName string) string {
-	return acctest.ConfigCompose(testAccLatestAmazonLinuxHVMInstanceStoreAMIConfig(), fmt.Sprintf(`
+func testAccInstanceConfig_rootStore(rName string) string {
+	return acctest.ConfigCompose(testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-instance-store.id
 
@@ -5195,7 +5195,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigNoAMIEphemeralDevices(rName string) string {
+func testAccInstanceConfig_noAMIEphemeralDevices(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -5226,7 +5226,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceEBSRootDeviceBasic(rName string) string {
+func testAccInstanceConfig_ebsRootDeviceBasic(rName string) string {
 	return acctest.ConfigCompose(testAccInstanceAMIWithEBSRootVolume, fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.ami.id
@@ -5240,11 +5240,11 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceRootBlockDevice(rName, size, delete, volumeType string) string {
-	return testAccInstanceRootBlockDeviceWithIOPS(rName, size, delete, volumeType, "")
+func testAccInstanceConfig_rootBlockDevice(rName, size, delete, volumeType string) string {
+	return testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, "")
 }
 
-func testAccInstanceRootBlockDeviceWithIOPS(rName, size, delete, volumeType, iops string) string {
+func testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, iops string) string {
 	if iops == "" {
 		iops = "null"
 	}
@@ -5269,7 +5269,7 @@ resource "aws_instance" "test" {
 `, rName, size, delete, volumeType, iops))
 }
 
-func testAccInstanceRootBlockDeviceWithThroughput(rName, size, delete, volumeType, throughput string) string {
+func testAccInstanceConfig_rootBlockDeviceThroughput(rName, size, delete, volumeType, throughput string) string {
 	if throughput == "" {
 		throughput = "null"
 	}
@@ -5294,7 +5294,7 @@ resource "aws_instance" "test" {
 `, rName, size, delete, volumeType, throughput))
 }
 
-func testAccInstanceConfigGP3RootBlockDevice(rName string) string {
+func testAccInstanceConfig_gp3RootBlockDevice(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5336,11 +5336,11 @@ data "aws_ami" "ami" {
 }
 `
 
-func testAccInstanceBlockDevicesConfig(rName, size string) string {
-	return testAccInstanceBlockDevicesWithDeleteOnTerminateConfig(rName, size, "")
+func testAccInstanceConfig_blockDevices(rName, size string) string {
+	return testAccInstanceConfig_blockDevicesDeleteOnTerminate(rName, size, "")
 }
 
-func testAccInstanceBlockDevicesWithDeleteOnTerminateConfig(rName, size, delete string) string {
+func testAccInstanceConfig_blockDevicesDeleteOnTerminate(rName, size, delete string) string {
 	if delete == "" {
 		delete = "null"
 	}
@@ -5404,7 +5404,7 @@ resource "aws_instance" "test" {
 `, rName, size, delete))
 }
 
-func testAccInstanceConfigSourceDestEnable(rName string) string {
+func testAccInstanceConfig_sourceDestEnable(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5421,7 +5421,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigSourceDestDisable(rName string) string {
+func testAccInstanceConfig_sourceDestDisable(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5439,7 +5439,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceAutoRecoveryConfig(rName string, val string) string {
+func testAccInstanceConfig_autoRecovery(rName string, val string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5459,7 +5459,7 @@ resource "aws_instance" "test" {
 `, rName, val))
 }
 
-func testAccInstanceConfigDisableAPITermination(rName string, val bool) string {
+func testAccInstanceConfig_disableAPITermination(rName string, val bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5502,7 +5502,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigOutpost(rName string) string {
+func testAccInstanceConfig_outpost(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -5550,7 +5550,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigPlacementGroup(rName string) string {
+func testAccInstanceConfig_placementGroup(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5578,7 +5578,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigPlacementPartitionNumber(rName string) string {
+func testAccInstanceConfig_placementPartitionNumber(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -5608,7 +5608,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_ipv6ErrorConfig(rName string) string {
+func testAccInstanceConfig_ipv6Error(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCIPv6Config(rName),
@@ -5645,7 +5645,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_ipv6SupportWithv4(rName string) string {
+func testAccInstanceConfig_ipv6Supportv4(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCIPv6Config(rName),
@@ -5723,7 +5723,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsAttachedVolumeWithTags(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsAttachedVolumeTags(rName string) string {
 	// https://github.com/hashicorp/terraform-provider-aws/issues/17074
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -5759,7 +5759,7 @@ resource "aws_volume_attachment" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsAttachedVolumeWithTagsUpdate(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsAttachedVolumeTagsUpdate(rName string) string {
 	// https://github.com/hashicorp/terraform-provider-aws/issues/17074
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -5795,7 +5795,7 @@ resource "aws_volume_attachment" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsRootTagsConflict(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsRootTagsConflict(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5827,7 +5827,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsEBSTagsConflict(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsEBSTagsConflict(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5859,7 +5859,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsNoVolumeTags(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsNoVolumeTags(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5901,7 +5901,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsEBSTags(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsEBSTags(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5938,7 +5938,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsEBSAndRootTags(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsEBSAndRootTags(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5980,7 +5980,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsEBSAndRootTagsUpdate(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsEBSAndRootTagsUpdate(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -6022,7 +6022,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-var testAccInstanceConfigEBSBlockDeviceInvalidIops = acctest.ConfigCompose(testAccInstanceAMIWithEBSRootVolume, `
+var testAccInstanceConfig_ebsBlockDeviceInvalidIOPS = acctest.ConfigCompose(testAccInstanceAMIWithEBSRootVolume, `
 resource "aws_instance" "test" {
   ami = data.aws_ami.ami.id
 
@@ -6037,7 +6037,7 @@ resource "aws_instance" "test" {
 }
 `)
 
-var testAccInstanceConfigEBSBlockDeviceInvalidThroughput = acctest.ConfigCompose(testAccInstanceAMIWithEBSRootVolume, `
+var testAccInstanceConfig_ebsBlockDeviceInvalidThroughput = acctest.ConfigCompose(testAccInstanceAMIWithEBSRootVolume, `
 resource "aws_instance" "test" {
   ami = data.aws_ami.ami.id
 
@@ -6052,7 +6052,7 @@ resource "aws_instance" "test" {
 }
 `)
 
-func testAccInstanceConfigEBSAndRootBlockDevice(rName string) string {
+func testAccInstanceConfig_ebsAndRootBlockDevice(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -6077,7 +6077,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsVolumeTags(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsVolumeTags(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -6123,7 +6123,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigBlockDeviceTagsVolumeTagsUpdate(rName string) string {
+func testAccInstanceConfig_blockDeviceTagsVolumeTagsUpdate(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -6170,7 +6170,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigWithoutInstanceProfile(rName string) string {
+func testAccInstanceConfig_noProfile(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -6206,7 +6206,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigWithInstanceProfile(rName string) string {
+func testAccInstanceConfig_profile(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -6248,7 +6248,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigWithInstanceProfilePath(rName string) string {
+func testAccInstanceConfig_profilePath(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -6293,7 +6293,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigPrivateIP(rName string) string {
+func testAccInstanceConfig_privateIP(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6311,7 +6311,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigEmptyPrivateIP(rName string) string {
+func testAccInstanceConfig_emptyPrivateIP(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6329,7 +6329,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigAssociatePublicIPAndPrivateIP(rName string) string {
+func testAccInstanceConfig_associatePublicIPAndPrivateIP(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6348,7 +6348,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceNetworkInstanceSecurityGroups(rName string) string {
+func testAccInstanceConfig_networkSecurityGroups(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6379,7 +6379,7 @@ resource "aws_eip" "test" {
 `, rName))
 }
 
-func testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName string) string {
+func testAccInstanceConfig_networkVPCSecurityGroupIDs(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6409,7 +6409,7 @@ resource "aws_eip" "test" {
 `, rName))
 }
 
-func testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName string) string {
+func testAccInstanceConfig_networkVPCRemoveSecurityGroupIDs(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6439,7 +6439,7 @@ resource "aws_eip" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigKeyPair(rName, publicKey string) string {
+func testAccInstanceConfig_keyPair(rName, publicKey string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		fmt.Sprintf(`
@@ -6460,7 +6460,7 @@ resource "aws_instance" "test" {
 `, rName, publicKey))
 }
 
-func testAccInstanceConfigRootBlockDeviceMismatch(rName string) string {
+func testAccInstanceConfig_rootBlockDeviceMismatch(rName string) string {
 	return acctest.ConfigCompose(
 		testAccInstanceVPCConfig(rName, false, 0), fmt.Sprintf(`
 resource "aws_instance" "test" {
@@ -6482,7 +6482,7 @@ resource "aws_instance" "test" {
 `, rName)) //lintignore:AWSAT002
 }
 
-func testAccInstanceConfigForceNewAndTagsDrift(rName string) string {
+func testAccInstanceConfig_forceNewAndTagsDrift(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6499,7 +6499,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigForceNewAndTagsDrift_Update(rName string) string {
+func testAccInstanceConfig_forceNewAndTagsDriftUpdate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6516,7 +6516,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigPrimaryNetworkInterface(rName string) string {
+func testAccInstanceConfig_primaryNetworkInterface(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6546,7 +6546,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigNetworkCardIndex(rName string) string {
+func testAccInstanceConfig_networkCardIndex(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6577,7 +6577,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck(rName string) string {
+func testAccInstanceConfig_primaryNetworkInterfaceSourceDestCheck(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6608,7 +6608,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigAddSecondaryNetworkInterfaceBefore(rName string) string {
+func testAccInstanceConfig_addSecondaryNetworkInterfaceBefore(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6647,7 +6647,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigAddSecondaryNetworkInterfaceAfter(rName string) string {
+func testAccInstanceConfig_addSecondaryNetworkInterfaceAfter(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6692,7 +6692,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigAddSecurityGroupBefore(rName string) string {
+func testAccInstanceConfig_addSecurityGroupBefore(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6752,7 +6752,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigAddSecurityGroupAfter(rName string) string {
+func testAccInstanceConfig_addSecurityGroupAfter(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6813,7 +6813,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigPublicAndPrivateSecondaryIPs(rName string, isPublic bool) string {
+func testAccInstanceConfig_publicAndPrivateSecondaryIPs(rName string, isPublic bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6844,7 +6844,7 @@ resource "aws_instance" "test" {
 `, rName, isPublic))
 }
 
-func testAccInstanceConfigPrivateIPAndSecondaryIPs(rName, privateIP, secondaryIPs string) string {
+func testAccInstanceConfig_privateIPAndSecondaryIPs(rName, privateIP, secondaryIPs string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6874,7 +6874,7 @@ resource "aws_instance" "test" {
 `, rName, privateIP, secondaryIPs))
 }
 
-func testAccInstanceConfigPrivateIPAndSecondaryIPsNullPrivate(rName, secondaryIPs string) string {
+func testAccInstanceConfig_privateIPAndSecondaryIPsNullPrivate(rName, secondaryIPs string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6904,7 +6904,7 @@ resource "aws_instance" "test" {
 `, rName, secondaryIPs))
 }
 
-func testAccInstanceConfig_associatePublic_defaultPrivate(rName string) string {
+func testAccInstanceConfig_associatePublicDefaultPrivate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6921,7 +6921,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_associatePublic_defaultPublic(rName string) string {
+func testAccInstanceConfig_associatePublicDefaultPublic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, true, 0),
@@ -6938,7 +6938,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_associatePublic_explicitPublic(rName string) string {
+func testAccInstanceConfig_associatePublicExplicitPublic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, true, 0),
@@ -6956,7 +6956,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_associatePublic_explicitPrivate(rName string) string {
+func testAccInstanceConfig_associatePublicExplicitPrivate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, true, 0),
@@ -6974,7 +6974,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_associatePublic_overridePublic(rName string) string {
+func testAccInstanceConfig_associatePublicOverridePublic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6992,7 +6992,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_associatePublic_overridePrivate(rName string) string {
+func testAccInstanceConfig_associatePublicOverridePrivate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, true, 0),
@@ -7031,7 +7031,7 @@ resource "aws_instance" "test" {
 `, rName, publicKey, val))
 }
 
-func testAccInstanceConfig_CreditSpecification_Empty_NonBurstable(rName string) string {
+func testAccInstanceConfig_creditSpecificationEmptyNonBurstable(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7050,7 +7050,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_CreditSpecification_Unspecified_NonBurstable(rName string) string {
+func testAccInstanceConfig_creditSpecificationUnspecifiedNonBurstable(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7067,7 +7067,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_creditSpecification_unspecified(rName string) string {
+func testAccInstanceConfig_creditSpecificationUnspecified(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7084,7 +7084,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_creditSpecification_unspecified_t3(rName string) string {
+func testAccInstanceConfig_creditSpecificationUnspecifiedT3(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7101,7 +7101,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_CreditSpecification_standardCPUCredits(rName string) string {
+func testAccInstanceConfig_creditSpecificationStandardCPUCredits(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7122,7 +7122,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_CreditSpecification_standardCPUCreditsT3(rName string) string {
+func testAccInstanceConfig_creditSpecificationStandardCPUCreditsT3(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7143,7 +7143,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_CreditSpecification_unlimitedCPUCredits(rName string) string {
+func testAccInstanceConfig_creditSpecificationUnlimitedCPUCredits(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7164,7 +7164,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_CreditSpecification_unlimitedCPUCreditsT3(rName string) string {
+func testAccInstanceConfig_creditSpecificationUnlimitedCPUCreditsT3(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7185,7 +7185,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rName string) string {
+func testAccInstanceConfig_creditSpecificationIsNotAppliedToNonBurstable(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7206,7 +7206,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_CreditSpecification_unknownCPUCredits(rName, instanceType string) string {
+func testAccInstanceConfig_creditSpecificationUnknownCPUCredits(rName, instanceType string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7225,7 +7225,7 @@ resource "aws_instance" "test" {
 `, rName, instanceType))
 }
 
-func testAccInstanceConfig_UserData_Unspecified(rName string) string {
+func testAccInstanceConfig_userDataUnspecified(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7242,7 +7242,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_UserData_EmptyString(rName string) string {
+func testAccInstanceConfig_userDataEmptyString(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7260,7 +7260,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_UserData_Specified_With_Replace_Flag(rName string, userData string, replaceOnChange string) string {
+func testAccInstanceConfig_userDataSpecifiedReplaceFlag(rName string, userData string, replaceOnChange string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7279,7 +7279,7 @@ resource "aws_instance" "test" {
 `, rName, userData, replaceOnChange))
 }
 
-func testAccInstanceConfig_UserData64_Specified_With_Replace_Flag(rName string, userData string, replaceOnChange string) string {
+func testAccInstanceConfig_userData64SpecifiedReplaceFlag(rName string, userData string, replaceOnChange string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7298,7 +7298,7 @@ resource "aws_instance" "test" {
 `, rName, userData, replaceOnChange))
 }
 
-func testAccInstanceConfigHibernation(rName string, hibernation bool) string {
+func testAccInstanceConfig_hibernation(rName string, hibernation bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		fmt.Sprintf(`
@@ -7338,7 +7338,7 @@ resource "aws_instance" "test" {
 `, rName, hibernation))
 }
 
-func testAccInstanceConfigMetadataOptions(rName string) string {
+func testAccInstanceConfig_metadataOptions(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7360,7 +7360,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigMetadataOptionsUpdated(rName string) string {
+func testAccInstanceConfig_metadataOptionsUpdated(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7385,7 +7385,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigEnclaveOptions(rName string, enabled bool) string {
+func testAccInstanceConfig_enclaveOptions(rName string, enabled bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -7407,7 +7407,7 @@ resource "aws_instance" "test" {
 `, rName, enabled))
 }
 
-func testAccInstanceDynamicEBSBlockDevicesConfig(rName string) string {
+func testAccInstanceConfig_dynamicEBSBlockDevices(rName string) string {
 	return acctest.ConfigCompose(testAccLatestAmazonLinuxPVEBSAMIConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-pv-ebs.id
@@ -7432,7 +7432,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigCapacityReservationSpecification_unspecified(rName string) string {
+func testAccInstanceConfig_capacityReservationSpecificationUnspecified(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t2.micro"),
@@ -7448,7 +7448,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigCapacityReservationSpecification_preference(rName, crPreference string) string {
+func testAccInstanceConfig_capacityReservationSpecificationPreference(rName, crPreference string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t2.micro"),
@@ -7468,7 +7468,7 @@ resource "aws_instance" "test" {
 `, rName, crPreference))
 }
 
-func testAccInstanceConfigCapacityReservationSpecification_targetId(rName string) string {
+func testAccInstanceConfig_capacityReservationSpecificationTargetID(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -7502,7 +7502,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 `, rName, ec2.CapacityReservationInstancePlatformLinuxUnix))
 }
 
-func testAccInstanceConfig_WithTemplate_Basic(rName string) string {
+func testAccInstanceConfig_templateBasic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
@@ -7525,7 +7525,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_WithTemplate_OverrideTemplate(rName string) string {
+func testAccInstanceConfig_templateOverrideTemplate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegionNamed("micro", "t3.micro", "t2.micro", "t1.micro", "m1.small"),
@@ -7551,7 +7551,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_WithTemplate_SpecificVersion(rName string) string {
+func testAccInstanceConfig_templateSpecificVersion(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
@@ -7575,7 +7575,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_WithTemplate_ModifyTemplate(rName string) string {
+func testAccInstanceConfig_templateModifyTemplate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.small", "t2.small", "t1.small", "m1.medium"),
@@ -7598,7 +7598,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_WithTemplate_UpdateVersion(rName string) string {
+func testAccInstanceConfig_templateUpdateVersion(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.small", "t2.small", "t1.small", "m1.medium"),
@@ -7624,7 +7624,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_WithTemplate_WithName(rName string) string {
+func testAccInstanceConfig_templateName(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),

--- a/internal/service/ec2/ec2_instance_type_offering_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_type_offering_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2InstanceTypeOfferingDataSource_filter(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypeOfferingFilterDataSourceConfig(),
+				Config: testAccInstanceTypeOfferingDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "instance_type"),
 				),
@@ -39,7 +39,7 @@ func TestAccEC2InstanceTypeOfferingDataSource_locationType(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypeOfferingLocationTypeDataSourceConfig(),
+				Config: testAccInstanceTypeOfferingDataSourceConfig_location(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "instance_type"),
 				),
@@ -58,7 +58,7 @@ func TestAccEC2InstanceTypeOfferingDataSource_preferredInstanceTypes(t *testing.
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypeOfferingPreferredInstanceTypesDataSourceConfig(),
+				Config: testAccInstanceTypeOfferingDataSourceConfig_preferreds(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "instance_type", "t3.micro"),
 				),
@@ -85,7 +85,7 @@ func testAccPreCheckInstanceTypeOffering(t *testing.T) {
 	}
 }
 
-func testAccInstanceTypeOfferingFilterDataSourceConfig() string {
+func testAccInstanceTypeOfferingDataSourceConfig_filter() string {
 	return `
 # Rather than hardcode an instance type in the testing,
 # use the first result from all available offerings.
@@ -100,7 +100,7 @@ data "aws_ec2_instance_type_offering" "test" {
 `
 }
 
-func testAccInstanceTypeOfferingLocationTypeDataSourceConfig() string {
+func testAccInstanceTypeOfferingDataSourceConfig_location() string {
 	return acctest.ConfigAvailableAZsNoOptIn() + `
 # Rather than hardcode an instance type in the testing,
 # use the first result from all available offerings.
@@ -129,7 +129,7 @@ data "aws_ec2_instance_type_offering" "test" {
 `
 }
 
-func testAccInstanceTypeOfferingPreferredInstanceTypesDataSourceConfig() string {
+func testAccInstanceTypeOfferingDataSourceConfig_preferreds() string {
 	return `
 data "aws_ec2_instance_type_offering" "test" {
   filter {

--- a/internal/service/ec2/ec2_instance_type_offerings_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_type_offerings_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccEC2InstanceTypeOfferingsDataSource_filter(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypeOfferingsFilterDataSourceConfig(),
+				Config: testAccInstanceTypeOfferingsDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceTypeOfferingsInstanceTypes(dataSourceName),
 				),
@@ -41,7 +41,7 @@ func TestAccEC2InstanceTypeOfferingsDataSource_locationType(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypeOfferingsLocationTypeDataSourceConfig(),
+				Config: testAccInstanceTypeOfferingsDataSourceConfig_location(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceTypeOfferingsInstanceTypes(dataSourceName),
 					testAccCheckInstanceTypeOfferingsLocations(dataSourceName),
@@ -107,7 +107,7 @@ func testAccPreCheckInstanceTypeOfferings(t *testing.T) {
 	}
 }
 
-func testAccInstanceTypeOfferingsFilterDataSourceConfig() string {
+func testAccInstanceTypeOfferingsDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_instance_type_offerings" "test" {
   filter {
@@ -118,7 +118,7 @@ data "aws_ec2_instance_type_offerings" "test" {
 `
 }
 
-func testAccInstanceTypeOfferingsLocationTypeDataSourceConfig() string {
+func testAccInstanceTypeOfferingsDataSourceConfig_location() string {
 	return acctest.ConfigAvailableAZsNoOptIn() + `
 data "aws_ec2_instance_type_offerings" "test" {
   filter {

--- a/internal/service/ec2/ec2_instance_types_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_types_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccEC2InstanceTypesDataSource_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypesDataSourceConfig(),
+				Config: testAccInstanceTypesDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", "0"),
 				),
@@ -38,7 +38,7 @@ func TestAccEC2InstanceTypesDataSource_filter(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceTypesDataSourceConfigFilter(),
+				Config: testAccInstanceTypesDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", "0"),
 				),
@@ -63,13 +63,13 @@ func testAccPreCheckInstanceTypes(t *testing.T) {
 	}
 }
 
-func testAccInstanceTypesDataSourceConfig() string {
+func testAccInstanceTypesDataSourceConfig_basic() string {
 	return `
 data "aws_ec2_instance_types" "test" {}
 `
 }
 
-func testAccInstanceTypesDataSourceConfigFilter() string {
+func testAccInstanceTypesDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_instance_types" "test" {
   filter {

--- a/internal/service/ec2/ec2_key_pair_data_source_test.go
+++ b/internal/service/ec2/ec2_key_pair_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccEC2KeyPairDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPairDataSourceConfig(rName, publicKey),
+				Config: testAccKeyPairDataSourceConfig_basic(rName, publicKey),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSource1Name, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "fingerprint", resourceName, "fingerprint"),
@@ -53,7 +53,7 @@ func TestAccEC2KeyPairDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccKeyPairDataSourceConfig(rName, publicKey string) string {
+func testAccKeyPairDataSourceConfig_basic(rName, publicKey string) string {
 	return fmt.Sprintf(`
 data "aws_key_pair" "by_name" {
   key_name = aws_key_pair.test.key_name

--- a/internal/service/ec2/ec2_key_pair_test.go
+++ b/internal/service/ec2/ec2_key_pair_test.go
@@ -33,7 +33,7 @@ func TestAccEC2KeyPair_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPairConfig(rName, publicKey),
+				Config: testAccKeyPairConfig_basic(rName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ec2", fmt.Sprintf("key-pair/%s", rName)),
@@ -70,7 +70,7 @@ func TestAccEC2KeyPair_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPairTags1Config(rName, publicKey, "key1", "value1"),
+				Config: testAccKeyPairConfig_tags1(rName, publicKey, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -84,7 +84,7 @@ func TestAccEC2KeyPair_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"public_key"},
 			},
 			{
-				Config: testAccKeyPairTags2Config(rName, publicKey, "key1", "value1updated", "key2", "value2"),
+				Config: testAccKeyPairConfig_tags2(rName, publicKey, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -93,7 +93,7 @@ func TestAccEC2KeyPair_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKeyPairTags1Config(rName, publicKey, "key2", "value2"),
+				Config: testAccKeyPairConfig_tags1(rName, publicKey, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -120,7 +120,7 @@ func TestAccEC2KeyPair_nameGenerated(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPairNameGeneratedConfig(publicKey),
+				Config: testAccKeyPairConfig_nameGenerated(publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "key_name"),
@@ -153,7 +153,7 @@ func TestAccEC2KeyPair_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckKeyPairNamePrefixConfig("tf-acc-test-prefix-", publicKey),
+				Config: testAccKeyPairConfig_namePrefix("tf-acc-test-prefix-", publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "key_name", "tf-acc-test-prefix-"),
@@ -187,7 +187,7 @@ func TestAccEC2KeyPair_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPairConfig(rName, publicKey),
+				Config: testAccKeyPairConfig_basic(rName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(resourceName, &keyPair),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceKeyPair(), resourceName),
@@ -247,7 +247,7 @@ func testAccCheckKeyPairExists(n string, v *ec2.KeyPairInfo) resource.TestCheckF
 	}
 }
 
-func testAccKeyPairConfig(rName, publicKey string) string {
+func testAccKeyPairConfig_basic(rName, publicKey string) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
@@ -256,7 +256,7 @@ resource "aws_key_pair" "test" {
 `, rName, publicKey)
 }
 
-func testAccKeyPairTags1Config(rName, publicKey, tagKey1, tagValue1 string) string {
+func testAccKeyPairConfig_tags1(rName, publicKey, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
@@ -269,7 +269,7 @@ resource "aws_key_pair" "test" {
 `, rName, publicKey, tagKey1, tagValue1)
 }
 
-func testAccKeyPairTags2Config(rName, publicKey, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccKeyPairConfig_tags2(rName, publicKey, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
@@ -283,7 +283,7 @@ resource "aws_key_pair" "test" {
 `, rName, publicKey, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccKeyPairNameGeneratedConfig(publicKey string) string {
+func testAccKeyPairConfig_nameGenerated(publicKey string) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   public_key = %[1]q
@@ -291,7 +291,7 @@ resource "aws_key_pair" "test" {
 `, publicKey)
 }
 
-func testAccCheckKeyPairNamePrefixConfig(namePrefix, publicKey string) string {
+func testAccKeyPairConfig_namePrefix(namePrefix, publicKey string) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name_prefix = %[1]q

--- a/internal/service/ec2/ec2_launch_template_data_source_test.go
+++ b/internal/service/ec2/ec2_launch_template_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccEC2LaunchTemplateDataSource_name(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateDataSourceNameConfig(rName),
+				Config: testAccLaunchTemplateDataSourceConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "block_device_mappings.#", dataSourceName, "block_device_mappings.#"),
@@ -78,7 +78,7 @@ func TestAccEC2LaunchTemplateDataSource_id(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateDataSourceIDConfig(rName),
+				Config: testAccLaunchTemplateDataSourceConfig_id(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
@@ -100,7 +100,7 @@ func TestAccEC2LaunchTemplateDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateDataSourceFilterConfig(rName),
+				Config: testAccLaunchTemplateDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
@@ -122,7 +122,7 @@ func TestAccEC2LaunchTemplateDataSource_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateDataSourceTagsConfig(rName),
+				Config: testAccLaunchTemplateDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
@@ -133,7 +133,7 @@ func TestAccEC2LaunchTemplateDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccLaunchTemplateDataSourceNameConfig(rName string) string {
+func testAccLaunchTemplateDataSourceConfig_name(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -230,7 +230,7 @@ data "aws_launch_template" "test" {
 `, rName))
 }
 
-func testAccLaunchTemplateDataSourceIDConfig(rName string) string {
+func testAccLaunchTemplateDataSourceConfig_id(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -242,7 +242,7 @@ data "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateDataSourceFilterConfig(rName string) string {
+func testAccLaunchTemplateDataSourceConfig_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -257,7 +257,7 @@ data "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateDataSourceTagsConfig(rName string) string {
+func testAccLaunchTemplateDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -28,7 +28,7 @@ func TestAccEC2LaunchTemplate_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateNameConfig(rName),
+				Config: testAccLaunchTemplateConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`launch-template/.+`)),
@@ -90,7 +90,7 @@ func TestAccEC2LaunchTemplate_Name_generated(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateNameGeneratedConfig(),
+				Config: testAccLaunchTemplateConfig_nameGenerated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -117,7 +117,7 @@ func TestAccEC2LaunchTemplate_Name_prefix(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateNamePrefixConfig("tf-acc-test-prefix-"),
+				Config: testAccLaunchTemplateConfig_namePrefix("tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
@@ -145,7 +145,7 @@ func TestAccEC2LaunchTemplate_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateNameConfig(rName),
+				Config: testAccLaunchTemplateConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &launchTemplate),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceLaunchTemplate(), resourceName),
@@ -168,7 +168,7 @@ func TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_BlockDeviceMappings_EBS(rName),
+				Config: testAccLaunchTemplateConfig_blockDeviceMappingsEBS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
@@ -199,7 +199,7 @@ func TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination(t *test
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_BlockDeviceMappings_EBS_DeleteOnTermination(rName, true),
+				Config: testAccLaunchTemplateConfig_blockDeviceMappingsEBSDeleteOnTermination(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
@@ -210,7 +210,7 @@ func TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination(t *test
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_BlockDeviceMappings_EBS_DeleteOnTermination(rName, false),
+				Config: testAccLaunchTemplateConfig_blockDeviceMappingsEBSDeleteOnTermination(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
@@ -241,7 +241,7 @@ func TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_BlockDeviceMappings_EBS_GP3(rName),
+				Config: testAccLaunchTemplateConfig_blockDeviceMappingsEBSGP3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
@@ -274,7 +274,7 @@ func TestAccEC2LaunchTemplate_ebsOptimized(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_EBSOptimized(rName, "true"),
+				Config: testAccLaunchTemplateConfig_ebsOptimized(rName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "true"),
@@ -286,28 +286,28 @@ func TestAccEC2LaunchTemplate_ebsOptimized(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateConfig_EBSOptimized(rName, "false"),
+				Config: testAccLaunchTemplateConfig_ebsOptimized(rName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "false"),
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_EBSOptimized(rName, "\"true\""),
+				Config: testAccLaunchTemplateConfig_ebsOptimized(rName, "\"true\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "true"),
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_EBSOptimized(rName, "\"false\""),
+				Config: testAccLaunchTemplateConfig_ebsOptimized(rName, "\"false\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "false"),
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_EBSOptimized(rName, "\"\""),
+				Config: testAccLaunchTemplateConfig_ebsOptimized(rName, "\"\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", ""),
@@ -329,7 +329,7 @@ func TestAccEC2LaunchTemplate_elasticInferenceAccelerator(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateElasticInferenceAcceleratorConfig(rName, "eia1.medium"),
+				Config: testAccLaunchTemplateConfig_elasticInferenceAccelerator(rName, "eia1.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template1),
 					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "1"),
@@ -342,7 +342,7 @@ func TestAccEC2LaunchTemplate_elasticInferenceAccelerator(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateElasticInferenceAcceleratorConfig(rName, "eia1.large"),
+				Config: testAccLaunchTemplateConfig_elasticInferenceAccelerator(rName, "eia1.large"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template1),
 					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "1"),
@@ -365,7 +365,7 @@ func TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination(t *testing.T
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_NetworkInterfaces_DeleteOnTermination(rName, "true"),
+				Config: testAccLaunchTemplateConfig_networkInterfacesDeleteOnTermination(rName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -374,7 +374,7 @@ func TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination(t *testing.T
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_NetworkInterfaces_DeleteOnTermination(rName, "false"),
+				Config: testAccLaunchTemplateConfig_networkInterfacesDeleteOnTermination(rName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -383,7 +383,7 @@ func TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination(t *testing.T
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_NetworkInterfaces_DeleteOnTermination(rName, "\"\""),
+				Config: testAccLaunchTemplateConfig_networkInterfacesDeleteOnTermination(rName, "\"\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -392,7 +392,7 @@ func TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination(t *testing.T
 				),
 			},
 			{
-				Config: testAccLaunchTemplateConfig_NetworkInterfaces_DeleteOnTermination(rName, "null"),
+				Config: testAccLaunchTemplateConfig_networkInterfacesDeleteOnTermination(rName, "null"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -502,7 +502,7 @@ func TestAccEC2LaunchTemplate_update(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_ASG_basic(rName),
+				Config: testAccLaunchTemplateConfig_asgBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
@@ -517,7 +517,7 @@ func TestAccEC2LaunchTemplate_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateConfig_ASG_update(rName),
+				Config: testAccLaunchTemplateConfig_asgUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
@@ -542,7 +542,7 @@ func TestAccEC2LaunchTemplate_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateTags1Config(rName, "key1", "value1"),
+				Config: testAccLaunchTemplateConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -555,7 +555,7 @@ func TestAccEC2LaunchTemplate_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccLaunchTemplateConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -564,7 +564,7 @@ func TestAccEC2LaunchTemplate_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLaunchTemplateTags1Config(rName, "key2", "value2"),
+				Config: testAccLaunchTemplateConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -587,7 +587,7 @@ func TestAccEC2LaunchTemplate_CapacityReservation_preference(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_capacityReservation_preference(rName, "open"),
+				Config: testAccLaunchTemplateConfig_capacityReservationPreference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -616,7 +616,7 @@ func TestAccEC2LaunchTemplate_CapacityReservation_target(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_capacityReservation_target(rName),
+				Config: testAccLaunchTemplateConfig_capacityReservationTarget(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -752,7 +752,7 @@ func TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateIAMInstanceProfileEmptyConfigurationBlockConfig(rName),
+				Config: testAccLaunchTemplateConfig_iamInstanceProfileEmptyConfigurationBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template1),
 				),
@@ -850,7 +850,7 @@ func TestAccEC2LaunchTemplate_networkInterfaceType(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_networkInterfaceType_efa(rName),
+				Config: testAccLaunchTemplateConfig_networkInterfaceTypeEFA(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -1119,7 +1119,7 @@ func TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplatePlacementHostResourceGroupARNConfig(rName),
+				Config: testAccLaunchTemplateConfig_placementHostResourceGroupARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttrPair(resourceName, "placement.0.host_resource_group_arn", "aws_resourcegroups_group.test", "arn"),
@@ -1146,7 +1146,7 @@ func TestAccEC2LaunchTemplate_Placement_partitionNum(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplatePartitionConfig(rName, 1),
+				Config: testAccLaunchTemplateConfig_partition(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "placement.0.partition_number", "1"),
@@ -1158,7 +1158,7 @@ func TestAccEC2LaunchTemplate_Placement_partitionNum(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplatePartitionConfig(rName, 2),
+				Config: testAccLaunchTemplateConfig_partition(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "placement.0.partition_number", "2"),
@@ -1180,7 +1180,7 @@ func TestAccEC2LaunchTemplate_privateDNSNameOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplatePrivateDNSNameOptionsConfig(rName),
+				Config: testAccLaunchTemplateConfig_privateDNSNameOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name_options.#", "1"),
@@ -1210,7 +1210,7 @@ func TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_networkInterface_ipv6Addresses(rName),
+				Config: testAccLaunchTemplateConfig_networkInterfaceIPv6Addresses(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -1238,7 +1238,7 @@ func TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_ipv6_count(rName),
+				Config: testAccLaunchTemplateConfig_ipv6Count(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -1267,7 +1267,7 @@ func TestAccEC2LaunchTemplate_instanceMarketOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateConfig_InstanceMarketOptions_basic(rName),
+				Config: testAccLaunchTemplateConfig_instanceMarketOptionsBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "instance_market_options.#", "1"),
@@ -1282,7 +1282,7 @@ func TestAccEC2LaunchTemplate_instanceMarketOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateConfig_InstanceMarketOptions_update(rName),
+				Config: testAccLaunchTemplateConfig_instanceMarketOptionsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "instance_market_options.#", "1"),
@@ -2764,7 +2764,7 @@ func TestAccEC2LaunchTemplate_hibernation(t *testing.T) {
 		CheckDestroy:      testAccCheckLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchTemplateHibernationConfig(rName, true),
+				Config: testAccLaunchTemplateConfig_hibernation(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "hibernation_options.0.configured", "true"),
@@ -2776,14 +2776,14 @@ func TestAccEC2LaunchTemplate_hibernation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateHibernationConfig(rName, false),
+				Config: testAccLaunchTemplateConfig_hibernation(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "hibernation_options.0.configured", "false"),
 				),
 			},
 			{
-				Config: testAccLaunchTemplateHibernationConfig(rName, true),
+				Config: testAccLaunchTemplateConfig_hibernation(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "hibernation_options.0.configured", "true"),
@@ -2861,7 +2861,7 @@ func TestAccEC2LaunchTemplate_updateDefaultVersion(t *testing.T) {
 			// Updating a field should create a new version but not update the default_version
 			// if update_default_version is set to false
 			{
-				Config: testAccLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, descriptionNew, false),
+				Config: testAccLaunchTemplateConfig_configDescriptionUpdateDefaultVersion(rName, descriptionNew, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
@@ -2870,7 +2870,7 @@ func TestAccEC2LaunchTemplate_updateDefaultVersion(t *testing.T) {
 			// Only updating the update_default_version to true should not create a new version
 			// but update the template version to the latest available
 			{
-				Config: testAccLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, descriptionNew, true),
+				Config: testAccLaunchTemplateConfig_configDescriptionUpdateDefaultVersion(rName, descriptionNew, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
@@ -2879,7 +2879,7 @@ func TestAccEC2LaunchTemplate_updateDefaultVersion(t *testing.T) {
 			// Updating a field should create a new version and update the default_version
 			// if update_default_version is set to true
 			{
-				Config: testAccLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, description, true),
+				Config: testAccLaunchTemplateConfig_configDescriptionUpdateDefaultVersion(rName, description, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "3"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "3"),
@@ -2946,7 +2946,7 @@ func testAccCheckLaunchTemplateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccLaunchTemplateNameConfig(rName string) string {
+func testAccLaunchTemplateConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -2954,13 +2954,13 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateNameGeneratedConfig() string {
+func testAccLaunchTemplateConfig_nameGenerated() string {
 	return `
 resource "aws_launch_template" "test" {}
 `
 }
 
-func testAccLaunchTemplateNamePrefixConfig(namePrefix string) string {
+func testAccLaunchTemplateConfig_namePrefix(namePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name_prefix = %[1]q
@@ -2968,7 +2968,7 @@ resource "aws_launch_template" "test" {
 `, namePrefix)
 }
 
-func testAccLaunchTemplateConfig_ipv6_count(rName string) string {
+func testAccLaunchTemplateConfig_ipv6Count(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -2980,7 +2980,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateConfig_BlockDeviceMappings_EBS(rName string) string {
+func testAccLaunchTemplateConfig_blockDeviceMappingsEBS(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3017,7 +3017,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
-func testAccLaunchTemplateConfig_BlockDeviceMappings_EBS_DeleteOnTermination(rName string, deleteOnTermination bool) string {
+func testAccLaunchTemplateConfig_blockDeviceMappingsEBSDeleteOnTermination(rName string, deleteOnTermination bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3055,7 +3055,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName, deleteOnTermination))
 }
 
-func testAccLaunchTemplateConfig_BlockDeviceMappings_EBS_GP3(rName string) string {
+func testAccLaunchTemplateConfig_blockDeviceMappingsEBSGP3(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3095,7 +3095,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
-func testAccLaunchTemplateConfig_NetworkInterfaces_DeleteOnTermination(rName string, deleteOnTermination string) string {
+func testAccLaunchTemplateConfig_networkInterfacesDeleteOnTermination(rName string, deleteOnTermination string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3109,7 +3109,7 @@ resource "aws_launch_template" "test" {
 `, rName, deleteOnTermination)
 }
 
-func testAccLaunchTemplateConfig_EBSOptimized(rName, ebsOptimized string) string {
+func testAccLaunchTemplateConfig_ebsOptimized(rName, ebsOptimized string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   ebs_optimized = %[1]s
@@ -3118,7 +3118,7 @@ resource "aws_launch_template" "test" {
 `, ebsOptimized, rName)
 }
 
-func testAccLaunchTemplateElasticInferenceAcceleratorConfig(rName, elasticInferenceAcceleratorType string) string {
+func testAccLaunchTemplateConfig_elasticInferenceAccelerator(rName, elasticInferenceAcceleratorType string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3224,7 +3224,7 @@ resource "aws_launch_template" "test" {
 `, rName)) //lintignore:AWSAT002
 }
 
-func testAccLaunchTemplateTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccLaunchTemplateConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3236,7 +3236,7 @@ resource "aws_launch_template" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccLaunchTemplateTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccLaunchTemplateConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3249,7 +3249,7 @@ resource "aws_launch_template" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccLaunchTemplateConfig_capacityReservation_preference(rName string, preference string) string {
+func testAccLaunchTemplateConfig_capacityReservationPreference(rName string, preference string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3261,7 +3261,7 @@ resource "aws_launch_template" "test" {
 `, rName, preference)
 }
 
-func testAccLaunchTemplateConfig_capacityReservation_target(rName string) string {
+func testAccLaunchTemplateConfig_capacityReservationTarget(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -3312,7 +3312,7 @@ resource "aws_launch_template" "test" {
 `, instanceType, rName, cpuCredits)
 }
 
-func testAccLaunchTemplateIAMInstanceProfileEmptyConfigurationBlockConfig(rName string) string {
+func testAccLaunchTemplateConfig_iamInstanceProfileEmptyConfigurationBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3386,7 +3386,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplatePartitionConfig(rName string, partNum int) string {
+func testAccLaunchTemplateConfig_partition(rName string, partNum int) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %[1]q
@@ -3404,7 +3404,7 @@ resource "aws_launch_template" "test" {
 `, rName, partNum)
 }
 
-func testAccLaunchTemplatePlacementHostResourceGroupARNConfig(rName string) string {
+func testAccLaunchTemplateConfig_placementHostResourceGroupARN(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_resourcegroups_group" "test" {
   name = %[1]q
@@ -3432,7 +3432,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplatePrivateDNSNameOptionsConfig(rName string) string {
+func testAccLaunchTemplateConfig_privateDNSNameOptions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3562,7 +3562,7 @@ resource "aws_launch_template" "test" {
 `, rName, associateCarrierIPAddress)
 }
 
-func testAccLaunchTemplateConfig_networkInterface_ipv6Addresses(rName string) string {
+func testAccLaunchTemplateConfig_networkInterfaceIPv6Addresses(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3577,7 +3577,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateConfig_networkInterfaceType_efa(rName string) string {
+func testAccLaunchTemplateConfig_networkInterfaceTypeEFA(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3650,7 +3650,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateConfig_ASG_basic(rName string) string {
+func testAccLaunchTemplateConfig_asgBasic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3677,7 +3677,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
-func testAccLaunchTemplateConfig_ASG_update(rName string) string {
+func testAccLaunchTemplateConfig_asgUpdate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3704,7 +3704,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
-func testAccLaunchTemplateConfig_InstanceMarketOptions_basic(rName string) string {
+func testAccLaunchTemplateConfig_instanceMarketOptionsBasic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3739,7 +3739,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
-func testAccLaunchTemplateConfig_InstanceMarketOptions_update(rName string) string {
+func testAccLaunchTemplateConfig_instanceMarketOptionsUpdate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3855,7 +3855,7 @@ resource "aws_launch_template" "test" {
 `, rName, enabled)
 }
 
-func testAccLaunchTemplateHibernationConfig(rName string, enabled bool) string {
+func testAccLaunchTemplateConfig_hibernation(rName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q
@@ -3877,7 +3877,7 @@ resource "aws_launch_template" "test" {
 `, rName, description, version)
 }
 
-func testAccLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, description string, update bool) string {
+func testAccLaunchTemplateConfig_configDescriptionUpdateDefaultVersion(rName, description string, update bool) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name                   = %[1]q

--- a/internal/service/ec2/ec2_placement_group_test.go
+++ b/internal/service/ec2/ec2_placement_group_test.go
@@ -26,7 +26,7 @@ func TestAccEC2PlacementGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlacementGroupConfig(rName),
+				Config: testAccPlacementGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &pg),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -55,7 +55,7 @@ func TestAccEC2PlacementGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlacementGroupConfig(rName),
+				Config: testAccPlacementGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &pg),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourcePlacementGroup(), resourceName),
@@ -78,7 +78,7 @@ func TestAccEC2PlacementGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlacementGroupTags1Config(rName, "key1", "value1"),
+				Config: testAccPlacementGroupConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &pg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -91,7 +91,7 @@ func TestAccEC2PlacementGroup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPlacementGroupTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccPlacementGroupConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &pg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -100,7 +100,7 @@ func TestAccEC2PlacementGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPlacementGroupTags1Config(rName, "key2", "value2"),
+				Config: testAccPlacementGroupConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &pg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -122,7 +122,7 @@ func TestAccEC2PlacementGroup_partitionCount(t *testing.T) {
 		CheckDestroy:      testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlacementGroupPartitionCountConfig(rName),
+				Config: testAccPlacementGroupConfig_partitionCount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &pg),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -188,7 +188,7 @@ func testAccCheckPlacementGroupExists(n string, v *ec2.PlacementGroup) resource.
 	}
 }
 
-func testAccPlacementGroupConfig(rName string) string {
+func testAccPlacementGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %[1]q
@@ -197,7 +197,7 @@ resource "aws_placement_group" "test" {
 `, rName)
 }
 
-func testAccPlacementGroupTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccPlacementGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %[1]q
@@ -210,7 +210,7 @@ resource "aws_placement_group" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccPlacementGroupTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccPlacementGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %[1]q
@@ -224,7 +224,7 @@ resource "aws_placement_group" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccPlacementGroupPartitionCountConfig(rName string) string {
+func testAccPlacementGroupConfig_partitionCount(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name            = %[1]q

--- a/internal/service/ec2/ec2_serial_console_access_data_source_test.go
+++ b/internal/service/ec2/ec2_serial_console_access_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2SerialConsoleAccessDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSerialConsoleAccessDataSourceConfig,
+				Config: testAccSerialConsoleAccessDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSerialConsoleAccessDataSource("data.aws_ec2_serial_console_access.current"),
 				),
@@ -57,6 +57,6 @@ func testAccCheckSerialConsoleAccessDataSource(n string) resource.TestCheckFunc 
 	}
 }
 
-const testAccSerialConsoleAccessDataSourceConfig = `
+const testAccSerialConsoleAccessDataSourceConfig_basic = `
 data "aws_ec2_serial_console_access" "current" {}
 `

--- a/internal/service/ec2/ec2_serial_console_access_test.go
+++ b/internal/service/ec2/ec2_serial_console_access_test.go
@@ -22,7 +22,7 @@ func TestAccEC2SerialConsoleAccess_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSerialConsoleAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSerialConsoleAccessConfig(false),
+				Config: testAccSerialConsoleAccessConfig_basic(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSerialConsoleAccess(resourceName, false),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -34,7 +34,7 @@ func TestAccEC2SerialConsoleAccess_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSerialConsoleAccessConfig(true),
+				Config: testAccSerialConsoleAccessConfig_basic(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSerialConsoleAccess(resourceName, true),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -85,7 +85,7 @@ func testAccCheckSerialConsoleAccess(n string, enabled bool) resource.TestCheckF
 	}
 }
 
-func testAccSerialConsoleAccessConfig(enabled bool) string {
+func testAccSerialConsoleAccessConfig_basic(enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_serial_console_access" "test" {
   enabled = %[1]t

--- a/internal/service/ec2/ec2_spot_datafeed_subscription_test.go
+++ b/internal/service/ec2/ec2_spot_datafeed_subscription_test.go
@@ -39,7 +39,7 @@ func testAccSpotDatafeedSubscription_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotDatafeedSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotDatafeedSubscription(rName),
+				Config: testAccSpotDatafeedSubscriptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSpotDatafeedSubscriptionExists(resourceName, &subscription),
 				),
@@ -65,7 +65,7 @@ func testAccSpotDatafeedSubscription_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotDatafeedSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotDatafeedSubscription(rName),
+				Config: testAccSpotDatafeedSubscriptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSpotDatafeedSubscriptionExists(resourceName, &subscription),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSpotDataFeedSubscription(), resourceName),
@@ -142,7 +142,7 @@ func testAccPreCheckSpotDatafeedSubscription(t *testing.T) {
 	}
 }
 
-func testAccSpotDatafeedSubscription(rName string) string {
+func testAccSpotDatafeedSubscriptionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_canonical_user_id" "current" {}
 

--- a/internal/service/ec2/ec2_spot_fleet_request_test.go
+++ b/internal/service/ec2/ec2_spot_fleet_request_test.go
@@ -37,7 +37,7 @@ func TestAccEC2SpotFleetRequest_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -74,7 +74,7 @@ func TestAccEC2SpotFleetRequest_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSpotFleetRequest(), resourceName),
@@ -103,7 +103,7 @@ func TestAccEC2SpotFleetRequest_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfigTags1(rName, publicKey, validUntil, "key1", "value1"),
+				Config: testAccSpotFleetRequestConfig_tags1(rName, publicKey, validUntil, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -117,7 +117,7 @@ func TestAccEC2SpotFleetRequest_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestConfigTags2(rName, publicKey, validUntil, "key1", "value1updated", "key2", "value2"),
+				Config: testAccSpotFleetRequestConfig_tags2(rName, publicKey, validUntil, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -126,7 +126,7 @@ func TestAccEC2SpotFleetRequest_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSpotFleetRequestConfigTags1(rName, publicKey, validUntil, "key2", "value2"),
+				Config: testAccSpotFleetRequestConfig_tags1(rName, publicKey, validUntil, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -155,7 +155,7 @@ func TestAccEC2SpotFleetRequest_associatePublicIPAddress(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestAssociatePublicIPAddressConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_associatePublicIPAddress(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -193,7 +193,7 @@ func TestAccEC2SpotFleetRequest_launchTemplate(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchTemplateConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchTemplate(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -229,7 +229,7 @@ func TestAccEC2SpotFleetRequest_LaunchTemplate_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchTemplateMultipleConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchTemplateMultiple(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -259,7 +259,7 @@ func TestAccEC2SpotFleetRequest_launchTemplateWithInstanceTypeOverrides(t *testi
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchTemplateWithInstanceTypeOverridesConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchTemplateInstanceTypeOverrides(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -309,7 +309,7 @@ func TestAccEC2SpotFleetRequest_launchTemplateWithInstanceRequirementsOverrides(
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchTemplateWithInstanceRequirementsOverridesConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchTemplateInstanceRequirementsOverrides(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -359,7 +359,7 @@ func TestAccEC2SpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchTemplateConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchTemplate(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -374,7 +374,7 @@ func TestAccEC2SpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -405,7 +405,7 @@ func TestAccEC2SpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -414,7 +414,7 @@ func TestAccEC2SpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSpotFleetRequestLaunchTemplateConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchTemplate(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -445,7 +445,7 @@ func TestAccEC2SpotFleetRequest_onDemandTargetCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestOnDemandTargetCapacityConfig(rName, publicKey, validUntil, 0),
+				Config: testAccSpotFleetRequestConfig_onDemandTargetCapacity(rName, publicKey, validUntil, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "on_demand_target_capacity", "0"),
@@ -458,14 +458,14 @@ func TestAccEC2SpotFleetRequest_onDemandTargetCapacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestOnDemandTargetCapacityConfig(rName, publicKey, validUntil, 1),
+				Config: testAccSpotFleetRequestConfig_onDemandTargetCapacity(rName, publicKey, validUntil, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "on_demand_target_capacity", "1"),
 				),
 			},
 			{
-				Config: testAccSpotFleetRequestOnDemandTargetCapacityConfig(rName, publicKey, validUntil, 0),
+				Config: testAccSpotFleetRequestConfig_onDemandTargetCapacity(rName, publicKey, validUntil, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "on_demand_target_capacity", "0"),
@@ -493,7 +493,7 @@ func TestAccEC2SpotFleetRequest_onDemandMaxTotalPrice(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestOnDemandMaxTotalPriceConfig(rName, publicKey, validUntil, "0.05"),
+				Config: testAccSpotFleetRequestConfig_onDemandMaxTotalPrice(rName, publicKey, validUntil, "0.05"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "on_demand_max_total_price", "0.05"),
@@ -527,7 +527,7 @@ func TestAccEC2SpotFleetRequest_onDemandAllocationStrategy(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestOnDemandAllocationStrategyConfig(rName, publicKey, validUntil, "prioritized"),
+				Config: testAccSpotFleetRequestConfig_onDemandAllocationStrategy(rName, publicKey, validUntil, "prioritized"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "on_demand_allocation_strategy", "prioritized"),
@@ -561,7 +561,7 @@ func TestAccEC2SpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -596,7 +596,7 @@ func TestAccEC2SpotFleetRequest_fleetType(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestFleetTypeConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_type(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -631,7 +631,7 @@ func TestAccEC2SpotFleetRequest_iamInstanceProfileARN(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestIAMInstanceProfileARNConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_iamInstanceProfileARN(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -666,7 +666,7 @@ func TestAccEC2SpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -681,7 +681,7 @@ func TestAccEC2SpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestChangeSpotBidPriceConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_changeBidPrice(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -712,7 +712,7 @@ func TestAccEC2SpotFleetRequest_updateTargetCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -726,14 +726,14 @@ func TestAccEC2SpotFleetRequest_updateTargetCapacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestTargetCapacityConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_targetCapacity(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "3"),
 				),
 			},
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -762,7 +762,7 @@ func TestAccEC2SpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -776,7 +776,7 @@ func TestAccEC2SpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestExcessCapacityTerminationConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_excessCapacityTermination(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "NoTermination"),
@@ -804,7 +804,7 @@ func TestAccEC2SpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -840,7 +840,7 @@ func TestAccEC2SpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestWithAzsConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_azs(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -877,7 +877,7 @@ func TestAccEC2SpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestWithSubnetConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_subnet(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -914,7 +914,7 @@ func TestAccEC2SpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestMultipleInstanceTypesinSameAzConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_multipleInstanceTypesinSameAZ(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -954,7 +954,7 @@ func TestAccEC2SpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestMultipleInstanceTypesinSameSubnetConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_multipleInstanceTypesinSameSubnet(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -990,7 +990,7 @@ func TestAccEC2SpotFleetRequest_overridingSpotPrice(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestOverridingSpotPriceConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_overridingPrice(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1031,7 +1031,7 @@ func TestAccEC2SpotFleetRequest_withoutSpotPrice(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestWithoutSpotPriceConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_noPrice(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1066,7 +1066,7 @@ func TestAccEC2SpotFleetRequest_diversifiedAllocation(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestDiversifiedAllocationConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_diversifiedAllocation(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1102,7 +1102,7 @@ func TestAccEC2SpotFleetRequest_multipleInstancePools(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestMultipleInstancePoolsConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_multipleInstancePools(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1153,7 +1153,7 @@ func TestAccEC2SpotFleetRequest_withWeightedCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestWithWeightedCapacityConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_weightedCapacity(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					fulfillSleep(),
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
@@ -1197,7 +1197,7 @@ func TestAccEC2SpotFleetRequest_withEBSDisk(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestEBSConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_ebs(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &config),
 					testAccCheckSpotFleetRequest_EBSAttributes(&config),
@@ -1231,7 +1231,7 @@ func TestAccEC2SpotFleetRequest_LaunchSpecificationEBSBlockDevice_kmsKeyID(t *te
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchSpecificationEBSBlockDeviceKMSKeyID(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceKMSKeyID(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &config),
 				),
@@ -1264,7 +1264,7 @@ func TestAccEC2SpotFleetRequest_LaunchSpecificationRootBlockDevice_kmsKeyID(t *t
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchSpecificationRootBlockDeviceKMSKeyID(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceKMSKeyID(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &config),
 				),
@@ -1296,7 +1296,7 @@ func TestAccEC2SpotFleetRequest_LaunchSpecification_ebsBlockDeviceGP3(t *testing
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchSpecificationEBSBlockDeviceGP3(rName, publicKey),
+				Config: testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceGP3(rName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &config),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "launch_specification.*.ebs_block_device.*", map[string]string{
@@ -1335,7 +1335,7 @@ func TestAccEC2SpotFleetRequest_LaunchSpecification_rootBlockDeviceGP3(t *testin
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestLaunchSpecificationRootBlockDeviceGP3(rName, publicKey),
+				Config: testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceGP3(rName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &config),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "launch_specification.*.root_block_device.*", map[string]string{
@@ -1374,7 +1374,7 @@ func TestAccEC2SpotFleetRequest_withTags(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestTagsConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_tags(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &config),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "launch_specification.*", map[string]string{
@@ -1413,7 +1413,7 @@ func TestAccEC2SpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestTenancyGroupConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_tenancyGroup(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1448,7 +1448,7 @@ func TestAccEC2SpotFleetRequest_withELBs(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestWithELBsConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_elbs(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1484,7 +1484,7 @@ func TestAccEC2SpotFleetRequest_withTargetGroups(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestWithTargetGroupsConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_targetGroups(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1520,7 +1520,7 @@ func TestAccEC2SpotFleetRequest_Zero_capacity(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestZeroCapacityConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_zeroCapacity(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "0"),
@@ -1533,14 +1533,14 @@ func TestAccEC2SpotFleetRequest_Zero_capacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotFleetRequestConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "2"),
 				),
 			},
 			{
-				Config: testAccSpotFleetRequestZeroCapacityConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_zeroCapacity(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "0"),
@@ -1568,7 +1568,7 @@ func TestAccEC2SpotFleetRequest_capacityRebalance(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestCapacityRebalance(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_capacityRebalance(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_maintenance_strategies.0.capacity_rebalance.0.replacement_strategy", "launch"),
@@ -1601,7 +1601,7 @@ func TestAccEC2SpotFleetRequest_withInstanceStoreAMI(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSpotFleetRequestLaunchSpecificationWithInstanceStoreAMI(rName, publicKey, validUntil),
+				Config:      testAccSpotFleetRequestConfig_launchSpecificationInstanceStoreAMI(rName, publicKey, validUntil),
 				ExpectError: regexp.MustCompile("Instance store backed AMIs do not provide a root device name"),
 			},
 		},
@@ -1626,7 +1626,7 @@ func TestAccEC2SpotFleetRequest_noTerminateInstancesWithExpiration(t *testing.T)
 		CheckDestroy:      testAccCheckSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotFleetRequestNoTerminateInstancesWithExpirationConfig(rName, publicKey, validUntil),
+				Config: testAccSpotFleetRequestConfig_noTerminateInstancesExpiration(rName, publicKey, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "terminate_instances_on_delete", "true"),
@@ -1869,7 +1869,7 @@ resource "aws_iam_policy_attachment" "test" {
 `, rName, publicKey))
 }
 
-func testAccSpotFleetRequestConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -1895,7 +1895,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestConfigTags1(rName, publicKey, validUntil, tagKey1, tagValue1 string) string {
+func testAccSpotFleetRequestConfig_tags1(rName, publicKey, validUntil, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -1925,7 +1925,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil, tagKey1, tagValue1))
 }
 
-func testAccSpotFleetRequestConfigTags2(rName, publicKey, validUntil, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccSpotFleetRequestConfig_tags2(rName, publicKey, validUntil, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -1956,7 +1956,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccSpotFleetRequestAssociatePublicIPAddressConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_associatePublicIPAddress(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -1982,7 +1982,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestTargetCapacityConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_targetCapacity(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2007,7 +2007,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchTemplateConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchTemplate(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
@@ -2045,7 +2045,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchTemplateMultipleConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchTemplateMultiple(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 data "aws_ec2_instance_type_offering" "test" {
   filter {
@@ -2114,7 +2114,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchTemplateWithInstanceTypeOverridesConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchTemplateInstanceTypeOverrides(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
@@ -2163,7 +2163,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchTemplateWithInstanceRequirementsOverridesConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchTemplateInstanceRequirementsOverrides(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
@@ -2219,7 +2219,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestExcessCapacityTerminationConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_excessCapacityTermination(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2245,7 +2245,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestFleetTypeConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_type(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2270,7 +2270,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestIAMInstanceProfileARNConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_iamInstanceProfileARN(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_iam_role" "test-role1" {
   name = "tf-test-role1-%[1]s"
@@ -2341,7 +2341,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestChangeSpotBidPriceConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_changeBidPrice(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2366,7 +2366,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestWithAzsConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_azs(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2403,7 +2403,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestWithSubnetConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_subnet(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2468,7 +2468,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestWithELBsConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_elbs(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2536,7 +2536,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestWithTargetGroupsConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_targetGroups(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2615,7 +2615,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestMultipleInstanceTypesinSameAzConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_multipleInstanceTypesinSameAZ(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2652,7 +2652,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestMultipleInstanceTypesinSameSubnetConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_multipleInstanceTypesinSameSubnet(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2703,7 +2703,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestOverridingSpotPriceConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_overridingPrice(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2741,7 +2741,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestWithoutSpotPriceConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_noPrice(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2777,7 +2777,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestMultipleInstancePoolsConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_multipleInstancePools(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2826,7 +2826,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestDiversifiedAllocationConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_diversifiedAllocation(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2875,7 +2875,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestWithWeightedCapacityConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_weightedCapacity(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2914,7 +2914,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestEBSConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_ebs(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -2950,7 +2950,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchSpecificationEBSBlockDeviceKMSKeyID(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceKMSKeyID(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -2996,7 +2996,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchSpecificationRootBlockDeviceKMSKeyID(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceKMSKeyID(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -3035,7 +3035,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestLaunchSpecificationEBSBlockDeviceGP3(rName, publicKey string) string {
+func testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceGP3(rName, publicKey string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -3072,7 +3072,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName))
 }
 
-func testAccSpotFleetRequestLaunchSpecificationRootBlockDeviceGP3(rName, publicKey string) string {
+func testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceGP3(rName, publicKey string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -3102,9 +3102,9 @@ resource "aws_spot_fleet_request" "test" {
 `, rName))
 }
 
-func testAccSpotFleetRequestLaunchSpecificationWithInstanceStoreAMI(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_launchSpecificationInstanceStoreAMI(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(
-		testAccLatestAmazonLinuxHVMInstanceStoreAMIConfig(),
+		testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore(),
 		testAccSpotFleetRequestBaseConfig(rName, publicKey),
 		fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
@@ -3129,7 +3129,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestTagsConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_tags(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -3155,7 +3155,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestTenancyGroupConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_tenancyGroup(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %[1]q
@@ -3186,7 +3186,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestZeroCapacityConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_zeroCapacity(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -3212,7 +3212,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestCapacityRebalance(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_capacityRebalance(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
@@ -3243,7 +3243,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotFleetRequestOnDemandTargetCapacityConfig(rName, publicKey, validUntil string, targetCapacity int) string {
+func testAccSpotFleetRequestConfig_onDemandTargetCapacity(rName, publicKey, validUntil string, targetCapacity int) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
@@ -3282,7 +3282,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil, targetCapacity))
 }
 
-func testAccSpotFleetRequestOnDemandMaxTotalPriceConfig(rName, publicKey, validUntil, price string) string {
+func testAccSpotFleetRequestConfig_onDemandMaxTotalPrice(rName, publicKey, validUntil, price string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
@@ -3321,7 +3321,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil, price))
 }
 
-func testAccSpotFleetRequestOnDemandAllocationStrategyConfig(rName, publicKey, validUntil, strategy string) string {
+func testAccSpotFleetRequestConfig_onDemandAllocationStrategy(rName, publicKey, validUntil, strategy string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
@@ -3360,7 +3360,7 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil, strategy))
 }
 
-func testAccSpotFleetRequestNoTerminateInstancesWithExpirationConfig(rName, publicKey, validUntil string) string {
+func testAccSpotFleetRequestConfig_noTerminateInstancesExpiration(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                  = aws_iam_role.test.arn

--- a/internal/service/ec2/ec2_spot_instance_request_test.go
+++ b/internal/service/ec2/ec2_spot_instance_request_test.go
@@ -28,7 +28,7 @@ func TestAccEC2SpotInstanceRequest_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig(rName),
+				Config: testAccSpotInstanceRequestConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributes(&sir),
@@ -60,7 +60,7 @@ func TestAccEC2SpotInstanceRequest_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig(rName),
+				Config: testAccSpotInstanceRequestConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSpotInstanceRequest(), resourceName),
@@ -83,7 +83,7 @@ func TestAccEC2SpotInstanceRequest_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfigTags1(rName, "key1", "value1"),
+				Config: testAccSpotInstanceRequestConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -97,7 +97,7 @@ func TestAccEC2SpotInstanceRequest_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change", "wait_for_fulfillment"},
 			},
 			{
-				Config: testAccSpotInstanceRequestConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccSpotInstanceRequestConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -106,7 +106,7 @@ func TestAccEC2SpotInstanceRequest_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSpotInstanceRequestConfigTags1(rName, "key2", "value2"),
+				Config: testAccSpotInstanceRequestConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -135,7 +135,7 @@ func TestAccEC2SpotInstanceRequest_keyName(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig_KeyName(rName, publicKey),
+				Config: testAccSpotInstanceRequestConfig_keyName(rName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttrPair(resourceName, "key_name", keyPairResourceName, "key_name"),
@@ -163,7 +163,7 @@ func TestAccEC2SpotInstanceRequest_withLaunchGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig_withLaunchGroup(rName),
+				Config: testAccSpotInstanceRequestConfig_launchGroup(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributes(&sir),
@@ -194,7 +194,7 @@ func TestAccEC2SpotInstanceRequest_withBlockDuration(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig_withBlockDuration(rName),
+				Config: testAccSpotInstanceRequestConfig_blockDuration(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributes(&sir),
@@ -225,7 +225,7 @@ func TestAccEC2SpotInstanceRequest_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestVPCConfig(rName),
+				Config: testAccSpotInstanceRequestConfig_vpc(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributes(&sir),
@@ -257,7 +257,7 @@ func TestAccEC2SpotInstanceRequest_validUntil(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestValidUntilConfig(rName, validUntil),
+				Config: testAccSpotInstanceRequestConfig_validUntil(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributes(&sir),
@@ -288,7 +288,7 @@ func TestAccEC2SpotInstanceRequest_withoutSpotPrice(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig_withoutSpotPrice(rName),
+				Config: testAccSpotInstanceRequestConfig_noPrice(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequestAttributesCheckSIRWithoutSpot(&sir),
@@ -318,7 +318,7 @@ func TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig_SubnetAndSGAndPublicIPAddress(rName),
+				Config: testAccSpotInstanceRequestConfig_subnetAndSGAndPublicIPAddress(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequest_InstanceAttributes(&sir, rName),
@@ -347,7 +347,7 @@ func TestAccEC2SpotInstanceRequest_networkInterfaceAttributes(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestConfig_SubnetAndSGAndPublicIPAddress(rName),
+				Config: testAccSpotInstanceRequestConfig_subnetAndSGAndPublicIPAddress(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckSpotInstanceRequest_InstanceAttributes(&sir, rName),
@@ -410,7 +410,7 @@ func TestAccEC2SpotInstanceRequest_interruptStop(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestInterruptConfig(rName, "stop"),
+				Config: testAccSpotInstanceRequestConfig_interrupt(rName, "stop"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
@@ -440,7 +440,7 @@ func TestAccEC2SpotInstanceRequest_interruptHibernate(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestInterruptConfig(rName, "hibernate"),
+				Config: testAccSpotInstanceRequestConfig_interrupt(rName, "hibernate"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
@@ -470,14 +470,14 @@ func TestAccEC2SpotInstanceRequest_interruptUpdate(t *testing.T) {
 		CheckDestroy:      testAccCheckSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotInstanceRequestInterruptConfig(rName, "hibernate"),
+				Config: testAccSpotInstanceRequestConfig_interrupt(rName, "hibernate"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir1),
 					resource.TestCheckResourceAttr(resourceName, "instance_interruption_behavior", "hibernate"),
 				),
 			},
 			{
-				Config: testAccSpotInstanceRequestInterruptConfig(rName, "terminate"),
+				Config: testAccSpotInstanceRequestConfig_interrupt(rName, "terminate"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSpotInstanceRequestExists(resourceName, &sir2),
 					testAccCheckSpotInstanceRequestRecreated(&sir1, &sir2),
@@ -660,7 +660,7 @@ func testAccCheckSpotInstanceRequestRecreated(before, after *ec2.SpotInstanceReq
 	}
 }
 
-func testAccSpotInstanceRequestConfig(rName string) string {
+func testAccSpotInstanceRequestConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -680,7 +680,7 @@ resource "aws_ec2_tag" "test" {
 `, rName))
 }
 
-func testAccSpotInstanceRequestConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccSpotInstanceRequestConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -704,7 +704,7 @@ resource "aws_ec2_tag" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccSpotInstanceRequestConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccSpotInstanceRequestConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -729,7 +729,7 @@ resource "aws_ec2_tag" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccSpotInstanceRequestValidUntilConfig(rName string, validUntil string) string {
+func testAccSpotInstanceRequestConfig_validUntil(rName string, validUntil string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -754,7 +754,7 @@ resource "aws_ec2_tag" "test" {
 `, rName, validUntil))
 }
 
-func testAccSpotInstanceRequestConfig_withoutSpotPrice(rName string) string {
+func testAccSpotInstanceRequestConfig_noPrice(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -777,7 +777,7 @@ resource "aws_ec2_tag" "test" {
 `, rName))
 }
 
-func testAccSpotInstanceRequestConfig_KeyName(rName, publicKey string) string {
+func testAccSpotInstanceRequestConfig_keyName(rName, publicKey string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -810,7 +810,7 @@ resource "aws_ec2_tag" "test" {
 `, rName, publicKey))
 }
 
-func testAccSpotInstanceRequestConfig_withLaunchGroup(rName string) string {
+func testAccSpotInstanceRequestConfig_launchGroup(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -835,7 +835,7 @@ resource "aws_ec2_tag" "test" {
 `, rName))
 }
 
-func testAccSpotInstanceRequestConfig_withBlockDuration(rName string) string {
+func testAccSpotInstanceRequestConfig_blockDuration(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -860,7 +860,7 @@ resource "aws_ec2_tag" "test" {
 `, rName))
 }
 
-func testAccSpotInstanceRequestVPCConfig(rName string) string {
+func testAccSpotInstanceRequestConfig_vpc(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -904,7 +904,7 @@ resource "aws_ec2_tag" "test" {
 `, rName))
 }
 
-func testAccSpotInstanceRequestConfig_SubnetAndSGAndPublicIPAddress(rName string) string {
+func testAccSpotInstanceRequestConfig_subnetAndSGAndPublicIPAddress(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -996,7 +996,7 @@ resource "aws_ec2_tag" "test" {
 `, rName, publicKey))
 }
 
-func testAccSpotInstanceRequestInterruptConfig(rName, interruptionBehavior string) string {
+func testAccSpotInstanceRequestConfig_interrupt(rName, interruptionBehavior string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("c5.large", "c4.large"),

--- a/internal/service/ec2/ec2_spot_price_data_source_test.go
+++ b/internal/service/ec2/ec2_spot_price_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccEC2SpotPriceDataSource_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotPriceDataSourceConfig(),
+				Config: testAccSpotPriceDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "spot_price", regexp.MustCompile(`^\d+\.\d+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "spot_price_timestamp", regexp.MustCompile(acctest.RFC3339RegexPattern)),
@@ -41,7 +41,7 @@ func TestAccEC2SpotPriceDataSource_filter(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSpotPriceFilterDataSourceConfig(),
+				Config: testAccSpotPriceDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "spot_price", regexp.MustCompile(`^\d+\.\d+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "spot_price_timestamp", regexp.MustCompile(acctest.RFC3339RegexPattern)),
@@ -69,7 +69,7 @@ func testAccPreCheckSpotPrice(t *testing.T) {
 	}
 }
 
-func testAccSpotPriceDataSourceConfig() string {
+func testAccSpotPriceDataSourceConfig_basic() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 data "aws_region" "current" {}
 
@@ -93,7 +93,7 @@ data "aws_ec2_spot_price" "test" {
 `)
 }
 
-func testAccSpotPriceFilterDataSourceConfig() string {
+func testAccSpotPriceDataSourceConfig_filter() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 data "aws_region" "current" {}
 

--- a/internal/service/ec2/ipam_byoip_test.go
+++ b/internal/service/ec2/ipam_byoip_test.go
@@ -54,7 +54,7 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCIPv6CIDRBlockAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: ipv4IPAMBYOIPIPv6DefaultNetmask(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv4IPv6DefaultNetmask(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpc/vpc-.+`)),
@@ -65,13 +65,13 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 			},
 			// disassociate ipv6
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_association_id", "")),
 			},
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPExplicitNetmask(p, m, s, netmaskLength),
+				Config: testAccIPAMBYOIPConfig_ipv6ExplicitNetmask(p, m, s, netmaskLength),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpc/vpc-.+`)),
@@ -82,13 +82,13 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 			},
 			// // disassociate ipv6
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_association_id", "")),
 			},
 			{
-				Config:   testAccIPAMConfig_ipv6BYOIPExplicitCIDR(p, m, s, ipv6CidrVPC),
+				Config:   testAccIPAMBYOIPConfig_ipv6ExplicitCIDR(p, m, s, ipv6CidrVPC),
 				SkipFunc: testAccIPAMConfig_ipv6BYOIPSkipExplicitCIDR(t, ipv6CidrVPC),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -99,7 +99,7 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 			},
 			// disassociate ipv6
 			{
-				Config:   testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config:   testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				SkipFunc: testAccIPAMConfig_ipv6BYOIPSkipExplicitCIDR(t, ipv6CidrVPC),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -107,7 +107,7 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 			},
 			// aws_vpc_ipv6_cidr_block_association
 			{
-				Config: testAccIPAMConfig_byoipIPv6CIDRBlockAssociationIPAMDefaultNetmask(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBlockAssociationDefaultNetmask(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					testAccCheckVPCIPv6CIDRBlockAssociationExists(assocName, &associationIPv6),
@@ -116,19 +116,19 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 			},
 			// disassociate ipv6
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc)),
 				// vpc will still have association id because its based on the aws_vpc_ipv6_cidr_block_association resource
 			},
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_association_id", "")),
 			},
 			{
-				Config: testAccIPAMConfig_byoipIPv6CIDRBlockAssociationIPAMExplicitNetmask(p, m, s, netmaskLength),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBlockAssociationExplicitNetmask(p, m, s, netmaskLength),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCIPv6CIDRBlockAssociationExists(assocName, &associationIPv6),
 					testAccCheckVPCAssociationIPv6CIDRPrefix(&associationIPv6, strconv.Itoa(netmaskLength)),
@@ -136,19 +136,19 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 			},
 			// disassociate ipv6
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc)),
 				// vpc will still have association id because its based on the aws_vpc_ipv6_cidr_block_association resource
 			},
 			{
-				Config: testAccIPAMConfig_ipv6BYOIPCIDRBase(p, m, s),
+				Config: testAccIPAMBYOIPConfig_ipv6CIDRBase(p, m, s),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_association_id", "")),
 			},
 			{
-				Config:   testAccIPAMConfig_byoipIPv6CIDRBlockAssociationIPAMExplicitCIDR(p, m, s, ipv6CidrAssoc),
+				Config:   testAccIPAMBYOIPConfig_ipv6CIDRBlockAssociationExplicitCIDR(p, m, s, ipv6CidrAssoc),
 				SkipFunc: testAccIPAMConfig_ipv6BYOIPSkipExplicitCIDR(t, ipv6CidrAssoc),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCIPv6CIDRBlockAssociationExists(assocName, &associationIPv6),
@@ -169,7 +169,7 @@ func testAccIPAMConfig_ipv6BYOIPSkipExplicitCIDR(t *testing.T, ipv6CidrVPC strin
 	}
 }
 
-func testAccIPAMConfig_ipv6BYOIPCIDRBase(cidr, msg, signature string) string {
+func testAccIPAMBYOIPConfig_ipv6CIDRBase(cidr, msg, signature string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -204,7 +204,7 @@ resource "aws_vpc" "test" {
 	`, cidr, msg, signature)
 }
 
-func ipv4IPAMBYOIPIPv6DefaultNetmask(cidr, msg, signature string) string {
+func testAccIPAMBYOIPConfig_ipv4IPv6DefaultNetmask(cidr, msg, signature string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -243,7 +243,7 @@ resource "aws_vpc" "test" {
 	`, cidr, msg, signature)
 }
 
-func testAccIPAMConfig_ipv6BYOIPExplicitNetmask(cidr, msg, signature string, netmask int) string {
+func testAccIPAMBYOIPConfig_ipv6ExplicitNetmask(cidr, msg, signature string, netmask int) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -283,7 +283,7 @@ resource "aws_vpc" "test" {
 	`, cidr, msg, signature, netmask)
 }
 
-func testAccIPAMConfig_ipv6BYOIPExplicitCIDR(cidr, msg, signature, vpcCidr string) string {
+func testAccIPAMBYOIPConfig_ipv6ExplicitCIDR(cidr, msg, signature, vpcCidr string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -323,7 +323,7 @@ resource "aws_vpc" "test" {
 	`, cidr, msg, signature, vpcCidr)
 }
 
-func testAccIPAMConfig_byoipIPv6CIDRBlockAssociationIPAMDefaultNetmask(cidr, msg, signature string) string {
+func testAccIPAMBYOIPConfig_ipv6CIDRBlockAssociationDefaultNetmask(cidr, msg, signature string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -366,7 +366,7 @@ resource "aws_vpc_ipv6_cidr_block_association" "test" {
 	`, cidr, msg, signature)
 }
 
-func testAccIPAMConfig_byoipIPv6CIDRBlockAssociationIPAMExplicitNetmask(cidr, msg, signature string, netmask int) string {
+func testAccIPAMBYOIPConfig_ipv6CIDRBlockAssociationExplicitNetmask(cidr, msg, signature string, netmask int) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -410,7 +410,7 @@ resource "aws_vpc_ipv6_cidr_block_association" "test" {
 	`, cidr, msg, signature, netmask)
 }
 
-func testAccIPAMConfig_byoipIPv6CIDRBlockAssociationIPAMExplicitCIDR(cidr, msg, signature, vpcCidr string) string {
+func testAccIPAMBYOIPConfig_ipv6CIDRBlockAssociationExplicitCIDR(cidr, msg, signature, vpcCidr string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 

--- a/internal/service/ec2/ipam_organization_admin_account_test.go
+++ b/internal/service/ec2/ipam_organization_admin_account_test.go
@@ -31,7 +31,7 @@ func TestAccIPAMOrganizationAdminAccount_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckIPAMOrganizationAdminAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMOrganizationAdminAccount_basic(),
+				Config: testAccIPAMOrganizationAdminAccountConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMOrganizationAdminAccountExists(resourceName, &organization),
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceIdentity, "account_id"),
@@ -114,7 +114,7 @@ func testAccCheckIPAMOrganizationAdminAccountExists(n string, org *organizations
 	}
 }
 
-func testAccIPAMOrganizationAdminAccount_basic() string {
+func testAccIPAMOrganizationAdminAccountConfig_basic() string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider() + `
 data "aws_caller_identity" "delegated" {
   provider = "awsalternate"

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -28,7 +28,7 @@ func TestAccIPAMPoolAllocation_ipv4Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckIPAMPoolAllocationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolAllocationConfig_ipv4(cidr),
+				Config: testAccIPAMPoolCIDRAllocationConfig_ipv4(cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMAllocationExists(resourceName, &allocation),
 					resource.TestCheckResourceAttr(resourceName, "cidr", cidr),
@@ -58,7 +58,7 @@ func TestAccIPAMPoolAllocation_ipv4BasicNetmask(t *testing.T) {
 		CheckDestroy:      testAccCheckIPAMPoolAllocationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolAllocationConfig_ipv4Netmask(netmask),
+				Config: testAccIPAMPoolCIDRAllocationConfig_ipv4Netmask(netmask),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMAllocationExists(resourceName, &allocation),
 					testAccCheckIPAMCIDRPrefix(&allocation, netmask),
@@ -87,7 +87,7 @@ func TestAccIPAMPoolAllocation_ipv4DisallowedCIDR(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolAllocationConfig_ipv4DisallowedCIDR(netmaskLength, disallowedCidr),
+				Config: testAccIPAMPoolCIDRAllocationConfig_ipv4Disallowed(netmaskLength, disallowedCidr),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cidr", expectedCidr),
 					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.#", "1"),
@@ -176,7 +176,7 @@ resource "aws_vpc_ipam_pool_cidr" "test" {
 }
 `
 
-func testAccIPAMPoolAllocationConfig_ipv4(cidr string) string {
+func testAccIPAMPoolCIDRAllocationConfig_ipv4(cidr string) string {
 	return acctest.ConfigCompose(
 		testAccIPAMPoolCIDRConfig_privateBase,
 		fmt.Sprintf(`
@@ -190,7 +190,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
 `, cidr))
 }
 
-func testAccIPAMPoolAllocationConfig_ipv4Netmask(netmask string) string {
+func testAccIPAMPoolCIDRAllocationConfig_ipv4Netmask(netmask string) string {
 	return acctest.ConfigCompose(
 		testAccIPAMPoolCIDRConfig_privateBase,
 		fmt.Sprintf(`
@@ -204,7 +204,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
 `, netmask))
 }
 
-func testAccIPAMPoolAllocationConfig_ipv4DisallowedCIDR(netmaskLength, disallowedCidr string) string {
+func testAccIPAMPoolCIDRAllocationConfig_ipv4Disallowed(netmaskLength, disallowedCidr string) string {
 	return acctest.ConfigCompose(
 		testAccIPAMPoolCIDRConfig_privateBase,
 		fmt.Sprintf(`

--- a/internal/service/ec2/ipam_pool_cidr_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_test.go
@@ -25,7 +25,7 @@ func TestAccIPAMPool_cidrIPv4Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckIPAMProvisionedPoolCIDRDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMConfig_provisionedPoolCIDRIPv4(cidr_range),
+				Config: testAccIPAMPoolCIDRConfig_provisionedIPv4(cidr_range),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMCIDRExists(resourceName, &cidr),
 					resource.TestCheckResourceAttr(resourceName, "cidr", cidr_range),
@@ -106,7 +106,7 @@ resource "aws_vpc_ipam_pool" "test" {
 }
 `
 
-func testAccIPAMConfig_provisionedPoolCIDRIPv4(cidr string) string {
+func testAccIPAMPoolCIDRConfig_provisionedIPv4(cidr string) string {
 	return testAccIPAMPoolCIDRConfig_base + testAccIPAMPoolCIDRConfig_privatePool + fmt.Sprintf(`
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id

--- a/internal/service/ec2/ipam_pool_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccIPAMPoolDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolOptions_basic,
+				Config: testAccIPAMPoolDataSourceConfig_optionsBasic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "address_family", resourceName, "address_family"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "allocation_default_netmask_length", resourceName, "allocation_default_netmask_length"),
@@ -43,7 +43,7 @@ func TestAccIPAMPoolDataSource_basic(t *testing.T) {
 	})
 }
 
-var testAccIPAMPoolOptions_basic = acctest.ConfigCompose(testAccIPAMPoolConfig_base, `
+var testAccIPAMPoolDataSourceConfig_optionsBasic = acctest.ConfigCompose(testAccIPAMPoolConfig_base, `
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv4"
   ipam_scope_id                     = aws_vpc_ipam.test.private_default_scope_id

--- a/internal/service/ec2/ipam_preview_next_cidr_data_source_test.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_data_source_test.go
@@ -76,7 +76,7 @@ func TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCIDR(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPreviewNextCIDRDataSourceConfig_ipv4DisallowedCIDR(netmaskLength, disallowedCidr),
+				Config: testAccIPAMPreviewNextCIDRDataSourceConfig_ipv4Disallowed(netmaskLength, disallowedCidr),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "cidr", expectedCidr),
 					resource.TestCheckResourceAttr(datasourceName, "disallowed_cidrs.#", "1"),
@@ -150,7 +150,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
 `, netmaskLength))
 }
 
-func testAccIPAMPreviewNextCIDRDataSourceConfig_ipv4DisallowedCIDR(netmaskLength, disallowedCidr string) string {
+func testAccIPAMPreviewNextCIDRDataSourceConfig_ipv4Disallowed(netmaskLength, disallowedCidr string) string {
 	return testAccIPAMPreviewNextCIDRDataSourceConfig_base + fmt.Sprintf(`
 data "aws_vpc_ipam_preview_next_cidr" "test" {
   ipam_pool_id   = aws_vpc_ipam_pool.test.id

--- a/internal/service/ec2/ipam_preview_next_cidr_test.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_test.go
@@ -79,7 +79,7 @@ func TestAccIPAMPreviewNextCIDR_ipv4DisallowedCIDR(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPreviewNextCIDRConfig_ipv4DisallowedCIDR(netmaskLength, disallowedCidr),
+				Config: testAccIPAMPreviewNextCIDRConfig_ipv4Disallowed(netmaskLength, disallowedCidr),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cidr", expectedCidr),
 					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.#", "1"),
@@ -150,7 +150,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
 `, netmaskLength))
 }
 
-func testAccIPAMPreviewNextCIDRConfig_ipv4DisallowedCIDR(netmaskLength, disallowedCidr string) string {
+func testAccIPAMPreviewNextCIDRConfig_ipv4Disallowed(netmaskLength, disallowedCidr string) string {
 	return testAccIPAMPreviewNextCIDRConfig_ipv4Base + fmt.Sprintf(`
 resource "aws_vpc_ipam_preview_next_cidr" "test" {
   ipam_pool_id   = aws_vpc_ipam_pool.test.id

--- a/internal/service/ec2/outposts_coip_pool_data_source_test.go
+++ b/internal/service/ec2/outposts_coip_pool_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccEC2OutpostsCoIPPoolDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoIPPoolDataSourceFilterDataSourceConfig(),
+				Config: testAccOutpostsCoIPPoolDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_route_table_id", regexp.MustCompile(`^lgw-rtb-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "pool_id", regexp.MustCompile(`^ipv4pool-coip-`)),
@@ -38,7 +38,7 @@ func TestAccEC2OutpostsCoIPPoolDataSource_id(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoIPPoolDataSourceIDDataSourceConfig(),
+				Config: testAccOutpostsCoIPPoolDataSourceConfig_id(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_route_table_id", regexp.MustCompile(`^lgw-rtb-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "pool_id", regexp.MustCompile(`^ipv4pool-coip-`)),
@@ -50,7 +50,7 @@ func TestAccEC2OutpostsCoIPPoolDataSource_id(t *testing.T) {
 	})
 }
 
-func testAccCoIPPoolDataSourceFilterDataSourceConfig() string {
+func testAccOutpostsCoIPPoolDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_coip_pools" "test" {}
 
@@ -63,7 +63,7 @@ data "aws_ec2_coip_pool" "test" {
 `
 }
 
-func testAccCoIPPoolDataSourceIDDataSourceConfig() string {
+func testAccOutpostsCoIPPoolDataSourceConfig_id() string {
 	return `
 data "aws_ec2_coip_pools" "test" {}
 

--- a/internal/service/ec2/outposts_coip_pools_data_source_test.go
+++ b/internal/service/ec2/outposts_coip_pools_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccEC2OutpostsCoIPPoolsDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoIPPoolsDataSourceConfig(),
+				Config: testAccOutpostsCoIPPoolsDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "pool_ids.#", "0"),
 				),
@@ -35,7 +35,7 @@ func TestAccEC2OutpostsCoIPPoolsDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoIPPoolsFilterDataSourceConfig(),
+				Config: testAccOutpostsCoIPPoolsDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "pool_ids.#", "1"),
 				),
@@ -44,13 +44,13 @@ func TestAccEC2OutpostsCoIPPoolsDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccCoIPPoolsDataSourceConfig() string {
+func testAccOutpostsCoIPPoolsDataSourceConfig_basic() string {
 	return `
 data "aws_ec2_coip_pools" "test" {}
 `
 }
 
-func testAccCoIPPoolsFilterDataSourceConfig() string {
+func testAccOutpostsCoIPPoolsDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_coip_pools" "all" {}
 

--- a/internal/service/ec2/outposts_local_gateway_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccEC2OutpostsLocalGatewayDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayIDDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayDataSourceConfig_id(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^lgw-`)),
 					acctest.MatchResourceAttrRegionalARN(dataSourceName, "outpost_arn", "outposts", regexp.MustCompile(`outpost/op-.+`)),
@@ -30,7 +30,7 @@ func TestAccEC2OutpostsLocalGatewayDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccLocalGatewayIDDataSourceConfig() string {
+func testAccOutpostsLocalGatewayDataSourceConfig_id() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 

--- a/internal/service/ec2/outposts_local_gateway_route_table_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableLocalGatewayRouteTableIDDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayRouteTableDataSourceConfig_routeTableID(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_id", regexp.MustCompile(`^lgw-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_route_table_id", regexp.MustCompile(`^lgw-rtb-`)),
@@ -39,7 +39,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableFilterDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayRouteTableDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_id", regexp.MustCompile(`^lgw-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_route_table_id", regexp.MustCompile(`^lgw-rtb-`)),
@@ -60,7 +60,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_localGatewayID(t *testin
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableLocalGatewayIDDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayRouteTableDataSourceConfig_localGatewayID(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_id", regexp.MustCompile(`^lgw-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_route_table_id", regexp.MustCompile(`^lgw-rtb-`)),
@@ -81,7 +81,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_outpostARN(t *testing.T)
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableOutpostARNDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayRouteTableDataSourceConfig_outpostARN(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_id", regexp.MustCompile(`^lgw-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_route_table_id", regexp.MustCompile(`^lgw-rtb-`)),
@@ -93,7 +93,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableDataSource_outpostARN(t *testing.T)
 	})
 }
 
-func testAccLocalGatewayRouteTableFilterDataSourceConfig() string {
+func testAccOutpostsLocalGatewayRouteTableDataSourceConfig_filter() string {
 	return `
 data "aws_outposts_outposts" "test" {}
 
@@ -106,7 +106,7 @@ data "aws_ec2_local_gateway_route_table" "test" {
 `
 }
 
-func testAccLocalGatewayRouteTableLocalGatewayIDDataSourceConfig() string {
+func testAccOutpostsLocalGatewayRouteTableDataSourceConfig_localGatewayID() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 
@@ -116,7 +116,7 @@ data "aws_ec2_local_gateway_route_table" "test" {
 `
 }
 
-func testAccLocalGatewayRouteTableLocalGatewayRouteTableIDDataSourceConfig() string {
+func testAccOutpostsLocalGatewayRouteTableDataSourceConfig_routeTableID() string {
 	return `
 data "aws_ec2_local_gateway_route_tables" "test" {}
 
@@ -126,7 +126,7 @@ data "aws_ec2_local_gateway_route_table" "test" {
 `
 }
 
-func testAccLocalGatewayRouteTableOutpostARNDataSourceConfig() string {
+func testAccOutpostsLocalGatewayRouteTableDataSourceConfig_outpostARN() string {
 	return `
 data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/ec2/outposts_local_gateway_route_table_vpc_association_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_vpc_association_test.go
@@ -27,7 +27,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_basic(t *testing.T) 
 		CheckDestroy:      testAccCheckLocalGatewayRouteTableVPCAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableVPCAssociationConfig(rName),
+				Config: testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteTableVPCAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_id", localGatewayRouteTableDataSourceName, "local_gateway_id"),
@@ -56,7 +56,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_disappears(t *testin
 		CheckDestroy:      testAccCheckLocalGatewayRouteTableVPCAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableVPCAssociationConfig(rName),
+				Config: testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteTableVPCAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceLocalGatewayRouteTableVPCAssociation(), resourceName),
@@ -78,7 +78,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckLocalGatewayRouteTableVPCAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTableVPCAssociationTags1Config(rName, "key1", "value1"),
+				Config: testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteTableVPCAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -91,7 +91,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLocalGatewayRouteTableVPCAssociationTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteTableVPCAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -100,7 +100,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLocalGatewayRouteTableVPCAssociationTags1Config(rName, "key2", "value2"),
+				Config: testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteTableVPCAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -182,7 +182,7 @@ resource "aws_vpc" "test" {
 `, rName)
 }
 
-func testAccLocalGatewayRouteTableVPCAssociationConfig(rName string) string {
+func testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLocalGatewayRouteTableVPCAssociationBaseConfig(rName),
 		`
@@ -193,7 +193,7 @@ resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
 `)
 }
 
-func testAccLocalGatewayRouteTableVPCAssociationTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		testAccLocalGatewayRouteTableVPCAssociationBaseConfig(rName),
 		fmt.Sprintf(`
@@ -208,7 +208,7 @@ resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccLocalGatewayRouteTableVPCAssociationTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccOutpostsLocalGatewayRouteTableVPCAssociationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		testAccLocalGatewayRouteTableVPCAssociationBaseConfig(rName),
 		fmt.Sprintf(`

--- a/internal/service/ec2/outposts_local_gateway_route_tables_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_tables_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTablesDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayRouteTablesDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ids.#", "0"),
 				),
@@ -35,7 +35,7 @@ func TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteTablesFilterDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayRouteTablesDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 				),
@@ -44,13 +44,13 @@ func TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccLocalGatewayRouteTablesDataSourceConfig() string {
+func testAccOutpostsLocalGatewayRouteTablesDataSourceConfig_basic() string {
 	return `
 data "aws_ec2_local_gateway_route_tables" "test" {}
 `
 }
 
-func testAccLocalGatewayRouteTablesFilterDataSourceConfig() string {
+func testAccOutpostsLocalGatewayRouteTablesDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_local_gateway_route_tables" "all" {}
 

--- a/internal/service/ec2/outposts_local_gateway_route_test.go
+++ b/internal/service/ec2/outposts_local_gateway_route_test.go
@@ -28,7 +28,7 @@ func TestAccEC2OutpostsLocalGatewayRoute_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckLocalGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteDestinationCIDRBlockConfig(destinationCidrBlock),
+				Config: testAccOutpostsLocalGatewayRouteConfig_destinationCIDRBlock(destinationCidrBlock),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidrBlock),
@@ -57,7 +57,7 @@ func TestAccEC2OutpostsLocalGatewayRoute_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckLocalGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayRouteDestinationCIDRBlockConfig(destinationCidrBlock),
+				Config: testAccOutpostsLocalGatewayRouteConfig_destinationCIDRBlock(destinationCidrBlock),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocalGatewayRouteExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceLocalGatewayRoute(), resourceName),
@@ -135,7 +135,7 @@ func testAccCheckLocalGatewayRouteDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccLocalGatewayRouteDestinationCIDRBlockConfig(destinationCidrBlock string) string {
+func testAccOutpostsLocalGatewayRouteConfig_destinationCIDRBlock(destinationCidrBlock string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "test" {}
 

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_filter(t *testing.
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceFilterDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^lgw-vif-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_address", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+/\d+$`)),
@@ -44,7 +44,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_id(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceIDDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceDataSourceConfig_id(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^lgw-vif-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_address", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+/\d+$`)),
@@ -70,7 +70,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags(t *testing.T)
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceTagsDataSourceConfig(rName),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", sourceDataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "local_address", sourceDataSourceName, "local_address"),
@@ -85,7 +85,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags(t *testing.T)
 	})
 }
 
-func testAccLocalGatewayVirtualInterfaceFilterDataSourceConfig() string {
+func testAccOutpostsLocalGatewayVirtualInterfaceDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 
@@ -102,7 +102,7 @@ data "aws_ec2_local_gateway_virtual_interface" "test" {
 `
 }
 
-func testAccLocalGatewayVirtualInterfaceIDDataSourceConfig() string {
+func testAccOutpostsLocalGatewayVirtualInterfaceDataSourceConfig_id() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 
@@ -116,7 +116,7 @@ data "aws_ec2_local_gateway_virtual_interface" "test" {
 `
 }
 
-func testAccLocalGatewayVirtualInterfaceTagsDataSourceConfig(rName string) string {
+func testAccOutpostsLocalGatewayVirtualInterfaceDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "test" {}
 

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_group_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_group_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_filter(t *tes
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceGroupFilterDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceGroupDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^lgw-vif-grp-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_id", regexp.MustCompile(`^lgw-`)),
@@ -40,7 +40,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_localGatewayI
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceGroupLocalGatewayIDDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceGroupDataSourceConfig_id(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^lgw-vif-grp-`)),
 					resource.TestMatchResourceAttr(dataSourceName, "local_gateway_id", regexp.MustCompile(`^lgw-`)),
@@ -62,7 +62,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags(t *testi
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceGroupTagsDataSourceConfig(rName),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceGroupDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", sourceDataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "local_gateway_id", sourceDataSourceName, "local_gateway_id"),
@@ -72,7 +72,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags(t *testi
 	})
 }
 
-func testAccLocalGatewayVirtualInterfaceGroupFilterDataSourceConfig() string {
+func testAccOutpostsLocalGatewayVirtualInterfaceGroupDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 
@@ -85,7 +85,7 @@ data "aws_ec2_local_gateway_virtual_interface_group" "test" {
 `
 }
 
-func testAccLocalGatewayVirtualInterfaceGroupLocalGatewayIDDataSourceConfig() string {
+func testAccOutpostsLocalGatewayVirtualInterfaceGroupDataSourceConfig_id() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 
@@ -95,7 +95,7 @@ data "aws_ec2_local_gateway_virtual_interface_group" "test" {
 `
 }
 
-func testAccLocalGatewayVirtualInterfaceGroupTagsDataSourceConfig(rName string) string {
+func testAccOutpostsLocalGatewayVirtualInterfaceGroupDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "test" {}
 

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_groups_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_groups_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_basic(t *tes
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceGroupsDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceGroupsDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "local_gateway_virtual_interface_ids.#", "2"),
@@ -38,7 +38,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_filter(t *te
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceGroupsFilterDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceGroupsDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "local_gateway_virtual_interface_ids.#", "2"),
@@ -58,7 +58,7 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags(t *test
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewayVirtualInterfaceGroupsTagsDataSourceConfig(rName),
+				Config: testAccOutpostsLocalGatewayVirtualInterfaceGroupsDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "local_gateway_virtual_interface_ids.#", "2"),
@@ -68,13 +68,13 @@ func TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags(t *test
 	})
 }
 
-func testAccLocalGatewayVirtualInterfaceGroupsDataSourceConfig() string {
+func testAccOutpostsLocalGatewayVirtualInterfaceGroupsDataSourceConfig_basic() string {
 	return `
 data "aws_ec2_local_gateway_virtual_interface_groups" "test" {}
 `
 }
 
-func testAccLocalGatewayVirtualInterfaceGroupsFilterDataSourceConfig() string {
+func testAccOutpostsLocalGatewayVirtualInterfaceGroupsDataSourceConfig_filter() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 
@@ -87,7 +87,7 @@ data "aws_ec2_local_gateway_virtual_interface_groups" "test" {
 `
 }
 
-func testAccLocalGatewayVirtualInterfaceGroupsTagsDataSourceConfig(rName string) string {
+func testAccOutpostsLocalGatewayVirtualInterfaceGroupsDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "test" {}
 

--- a/internal/service/ec2/outposts_local_gateways_data_source_test.go
+++ b/internal/service/ec2/outposts_local_gateways_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccEC2OutpostsLocalGatewaysDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLocalGatewaysDataSourceConfig(),
+				Config: testAccOutpostsLocalGatewaysDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ids.#", "0"),
 				),
@@ -26,7 +26,7 @@ func TestAccEC2OutpostsLocalGatewaysDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccLocalGatewaysDataSourceConfig() string {
+func testAccOutpostsLocalGatewaysDataSourceConfig_basic() string {
 	return `
 data "aws_ec2_local_gateways" "test" {}
 `

--- a/internal/service/ec2/transitgateway_connect_data_source_test.go
+++ b/internal/service/ec2/transitgateway_connect_data_source_test.go
@@ -22,7 +22,7 @@ func testAccTransitGatewayConnectDataSource_Filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectFilterDataSourceConfig(rName),
+				Config: testAccTransitGatewayConnectDataSourceConfig_filter(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "protocol", resourceName, "protocol"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
@@ -47,7 +47,7 @@ func testAccTransitGatewayConnectDataSource_ID(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectIDDataSourceConfig(rName),
+				Config: testAccTransitGatewayConnectDataSourceConfig_id(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "protocol", resourceName, "protocol"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
@@ -60,7 +60,7 @@ func testAccTransitGatewayConnectDataSource_ID(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayConnectFilterDataSourceConfig(rName string) string {
+func testAccTransitGatewayConnectDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -114,7 +114,7 @@ data "aws_ec2_transit_gateway_connect" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayConnectIDDataSourceConfig(rName string) string {
+func testAccTransitGatewayConnectDataSourceConfig_id(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_connect_peer_data_source_test.go
+++ b/internal/service/ec2/transitgateway_connect_peer_data_source_test.go
@@ -22,7 +22,7 @@ func testAccTransitGatewayConnectPeerDataSource_Filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectPeerFilterDataSourceConfig(rName),
+				Config: testAccTransitGatewayConnectPeerDataSourceConfig_filter(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bgp_asn", resourceName, "bgp_asn"),
@@ -50,7 +50,7 @@ func testAccTransitGatewayConnectPeerDataSource_ID(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectPeerIDDataSourceConfig(rName),
+				Config: testAccTransitGatewayConnectPeerDataSourceConfig_id(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bgp_asn", resourceName, "bgp_asn"),
@@ -66,7 +66,7 @@ func testAccTransitGatewayConnectPeerDataSource_ID(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayConnectPeerFilterDataSourceConfig(rName string) string {
+func testAccTransitGatewayConnectPeerDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -132,7 +132,7 @@ data "aws_ec2_transit_gateway_connect_peer" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayConnectPeerIDDataSourceConfig(rName string) string {
+func testAccTransitGatewayConnectPeerDataSourceConfig_id(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_connect_peer_test.go
+++ b/internal/service/ec2/transitgateway_connect_peer_test.go
@@ -27,7 +27,7 @@ func testAccTransitGatewayConnectPeer_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectPeerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectPeerConfig(rName),
+				Config: testAccTransitGatewayConnectPeerConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectPeerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "bgp_asn", "64512"),
@@ -59,7 +59,7 @@ func testAccTransitGatewayConnectPeer_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectPeerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectPeerConfig(rName),
+				Config: testAccTransitGatewayConnectPeerConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectPeerExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayConnectPeer(), resourceName),
@@ -133,7 +133,7 @@ func testAccTransitGatewayConnectPeer_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectPeerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectPeerConfigTags1(rName, "key1", "value1"),
+				Config: testAccTransitGatewayConnectPeerConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectPeerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -146,7 +146,7 @@ func testAccTransitGatewayConnectPeer_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayConnectPeerConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayConnectPeerConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectPeerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -155,7 +155,7 @@ func testAccTransitGatewayConnectPeer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayConnectPeerConfigTags1(rName, "key2", "value2"),
+				Config: testAccTransitGatewayConnectPeerConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectPeerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -178,7 +178,7 @@ func testAccTransitGatewayConnectPeer_TransitGatewayAddress(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectPeerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectPeerTransitGatewayAddressConfig(rName, "10.20.30.200"),
+				Config: testAccTransitGatewayConnectPeerConfig_address(rName, "10.20.30.200"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectPeerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_address", "10.20.30.200"),
@@ -237,7 +237,7 @@ func testAccCheckTransitGatewayConnectPeerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTransitGatewayConnectPeerConfig(rName string) string {
+func testAccTransitGatewayConnectPeerConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -352,7 +352,7 @@ resource "aws_ec2_transit_gateway_connect_peer" "test" {
 `, rName, bgpAsn))
 }
 
-func testAccTransitGatewayConnectPeerConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccTransitGatewayConnectPeerConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -411,7 +411,7 @@ resource "aws_ec2_transit_gateway_connect_peer" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccTransitGatewayConnectPeerConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayConnectPeerConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -530,7 +530,7 @@ resource "aws_ec2_transit_gateway_connect_peer" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayConnectPeerTransitGatewayAddressConfig(rName, transitGatewayAddress string) string {
+func testAccTransitGatewayConnectPeerConfig_address(rName, transitGatewayAddress string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_connect_test.go
+++ b/internal/service/ec2/transitgateway_connect_test.go
@@ -31,7 +31,7 @@ func testAccTransitGatewayConnect_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectConfig(rName),
+				Config: testAccTransitGatewayConnectConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "gre"),
@@ -63,7 +63,7 @@ func testAccTransitGatewayConnect_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectConfig(rName),
+				Config: testAccTransitGatewayConnectConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayConnect(), resourceName),
@@ -86,7 +86,7 @@ func testAccTransitGatewayConnect_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayConnectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectConfigTags1(rName, "key1", "value1"),
+				Config: testAccTransitGatewayConnectConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -99,7 +99,7 @@ func testAccTransitGatewayConnect_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayConnectConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayConnectConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -108,7 +108,7 @@ func testAccTransitGatewayConnect_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayConnectConfigTags1(rName, "key2", "value2"),
+				Config: testAccTransitGatewayConnectConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayConnectExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -133,7 +133,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociationAndP
 		CheckDestroy:      testAccCheckTransitGatewayConnectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTableAssociationAndPropagationDisabledConfig(rName),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTableAssociationAndPropagationDisabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect1),
@@ -166,7 +166,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociation(t *
 		CheckDestroy:      testAccCheckTransitGatewayConnectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTableAssociationConfig(rName, false),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTableAssociation(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect1),
@@ -180,7 +180,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociation(t *
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTableAssociationConfig(rName, true),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTableAssociation(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway2),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect2),
@@ -190,7 +190,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociation(t *
 				),
 			},
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTableAssociationConfig(rName, false),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTableAssociation(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway3),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect3),
@@ -217,7 +217,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTablePropagation(t *
 		CheckDestroy:      testAccCheckTransitGatewayConnectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTablePropagationConfig(rName, false),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTablePropagation(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect1),
@@ -231,7 +231,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTablePropagation(t *
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTablePropagationConfig(rName, true),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTablePropagation(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway2),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect2),
@@ -241,7 +241,7 @@ func testAccTransitGatewayConnect_TransitGatewayDefaultRouteTablePropagation(t *
 				),
 			},
 			{
-				Config: testAccTransitGatewayConnectTransitGatewayDefaultRouteTablePropagationConfig(rName, false),
+				Config: testAccTransitGatewayConnectConfig_defaultRouteTablePropagation(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway3),
 					testAccCheckTransitGatewayConnectExists(resourceName, &transitGatewayConnect3),
@@ -331,7 +331,7 @@ func testAccPreCheckTransitGatewayConnect(t *testing.T) {
 	}
 }
 
-func testAccTransitGatewayConnectConfig(rName string) string {
+func testAccTransitGatewayConnectConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -374,7 +374,7 @@ resource "aws_ec2_transit_gateway_connect" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayConnectConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccTransitGatewayConnectConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -421,7 +421,7 @@ resource "aws_ec2_transit_gateway_connect" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccTransitGatewayConnectConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayConnectConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -469,7 +469,7 @@ resource "aws_ec2_transit_gateway_connect" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccTransitGatewayConnectTransitGatewayDefaultRouteTableAssociationAndPropagationDisabledConfig(rName string) string {
+func testAccTransitGatewayConnectConfig_defaultRouteTableAssociationAndPropagationDisabled(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -523,7 +523,7 @@ resource "aws_ec2_transit_gateway_connect" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayConnectTransitGatewayDefaultRouteTableAssociationConfig(rName string, transitGatewayDefaultRouteTableAssociation bool) string {
+func testAccTransitGatewayConnectConfig_defaultRouteTableAssociation(rName string, transitGatewayDefaultRouteTableAssociation bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -572,7 +572,7 @@ resource "aws_ec2_transit_gateway_connect" "test" {
 `, rName, transitGatewayDefaultRouteTableAssociation))
 }
 
-func testAccTransitGatewayConnectTransitGatewayDefaultRouteTablePropagationConfig(rName string, transitGatewayDefaultRouteTablePropagation bool) string {
+func testAccTransitGatewayConnectConfig_defaultRouteTablePropagation(rName string, transitGatewayDefaultRouteTablePropagation bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_data_source_test.go
+++ b/internal/service/ec2/transitgateway_data_source_test.go
@@ -84,7 +84,7 @@ func testAccTransitGatewayDataSource_Filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayFilterDataSourceConfig(),
+				Config: testAccTransitGatewayDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "amazon_side_asn", dataSourceName, "amazon_side_asn"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -117,7 +117,7 @@ func testAccTransitGatewayDataSource_ID(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayIDDataSourceConfig(),
+				Config: testAccTransitGatewayDataSourceConfig_id(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "amazon_side_asn", dataSourceName, "amazon_side_asn"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -138,7 +138,7 @@ func testAccTransitGatewayDataSource_ID(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayFilterDataSourceConfig() string {
+func testAccTransitGatewayDataSourceConfig_filter() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {}
 
@@ -151,7 +151,7 @@ data "aws_ec2_transit_gateway" "test" {
 `
 }
 
-func testAccTransitGatewayIDDataSourceConfig() string {
+func testAccTransitGatewayDataSourceConfig_id() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {}
 

--- a/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source_test.go
@@ -27,7 +27,7 @@ func testAccTransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGat
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDxAttachmentDataSourceConfig(rName, rBgpAsn),
+				Config: testAccTransitGatewayDxGatewayAttachmentDataSourceConfig_transit(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -55,7 +55,7 @@ func testAccTransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDxAttachmentFilterDataSourceConfig(rName, rBgpAsn),
+				Config: testAccTransitGatewayDxGatewayAttachmentDataSourceConfig_transitFilter(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -66,7 +66,7 @@ func testAccTransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayDxAttachmentDataSourceConfig(rName string, rBgpAsn int) string {
+func testAccTransitGatewayDxGatewayAttachmentDataSourceConfig_transit(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q
@@ -96,7 +96,7 @@ data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccTransitGatewayDxAttachmentFilterDataSourceConfig(rName string, rBgpAsn int) string {
+func testAccTransitGatewayDxGatewayAttachmentDataSourceConfig_transitFilter(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q

--- a/internal/service/ec2/transitgateway_multicast_domain_association_test.go
+++ b/internal/service/ec2/transitgateway_multicast_domain_association_test.go
@@ -26,7 +26,7 @@ func testAccTransitGatewayMulticastDomainAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainAssociationConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainAssociationExists(resourceName, &v),
 				),
@@ -47,7 +47,7 @@ func testAccTransitGatewayMulticastDomainAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainAssociationConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainAssociationExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastDomainAssociation(), resourceName),
@@ -71,7 +71,7 @@ func testAccTransitGatewayMulticastDomainAssociation_Disappears_domain(t *testin
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainAssociationConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainAssociationExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastDomain(), domainResourceName),
@@ -95,7 +95,7 @@ func testAccTransitGatewayMulticastDomainAssociation_twoAssociations(t *testing.
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainAssociationTwoAssociationsConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainAssociationConfig_twoAssociations(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainAssociationExists(resource1Name, &v1),
 					testAccCheckTransitGatewayMulticastDomainAssociationExists(resource2Name, &v2),
@@ -166,7 +166,7 @@ func testAccCheckTransitGatewayMulticastDomainAssociationDestroy(s *terraform.St
 	return nil
 }
 
-func testAccTransitGatewayMulticastDomainAssociationConfig(rName string) string {
+func testAccTransitGatewayMulticastDomainAssociationConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -220,7 +220,7 @@ resource "aws_ec2_transit_gateway_multicast_domain_association" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayMulticastDomainAssociationTwoAssociationsConfig(rName string) string {
+func testAccTransitGatewayMulticastDomainAssociationConfig_twoAssociations(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_multicast_domain_data_source_test.go
+++ b/internal/service/ec2/transitgateway_multicast_domain_data_source_test.go
@@ -21,7 +21,7 @@ func testAccTransitGatewayMulticastDomainDataSource_Filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainFilterDataSourceConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainDataSourceConfig_filter(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttr(dataSourceName, "associations.#", "0"),
@@ -51,7 +51,7 @@ func testAccTransitGatewayMulticastDomainDataSource_ID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainIDDataSourceConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainDataSourceConfig_iD(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttr(dataSourceName, "associations.#", "1"),
@@ -70,7 +70,7 @@ func testAccTransitGatewayMulticastDomainDataSource_ID(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayMulticastDomainFilterDataSourceConfig(rName string) string {
+func testAccTransitGatewayMulticastDomainDataSourceConfig_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   multicast_support = "enable"
@@ -97,7 +97,7 @@ data "aws_ec2_transit_gateway_multicast_domain" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayMulticastDomainIDDataSourceConfig(rName string) string {
+func testAccTransitGatewayMulticastDomainDataSourceConfig_iD(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_multicast_domain_test.go
+++ b/internal/service/ec2/transitgateway_multicast_domain_test.go
@@ -27,7 +27,7 @@ func testAccTransitGatewayMulticastDomain_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`transit-gateway-multicast-domain/.+`)),
@@ -60,7 +60,7 @@ func testAccTransitGatewayMulticastDomain_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastDomain(), resourceName),
@@ -83,7 +83,7 @@ func testAccTransitGatewayMulticastDomain_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainConfigTags1(rName, "key1", "value1"),
+				Config: testAccTransitGatewayMulticastDomainConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -96,7 +96,7 @@ func testAccTransitGatewayMulticastDomain_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayMulticastDomainConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayMulticastDomainConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -104,7 +104,7 @@ func testAccTransitGatewayMulticastDomain_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayMulticastDomainConfigTags1(rName, "key2", "value2"),
+				Config: testAccTransitGatewayMulticastDomainConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -126,7 +126,7 @@ func testAccTransitGatewayMulticastDomain_igmpv2Support(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastDomainIGMPv2SupportConfig(rName),
+				Config: testAccTransitGatewayMulticastDomainConfig_igmpv2Support(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastDomainExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "auto_accept_shared_associations", "enable"),
@@ -192,7 +192,7 @@ func testAccCheckTransitGatewayMulticastDomainDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testAccTransitGatewayMulticastDomainConfig(rName string) string {
+func testAccTransitGatewayMulticastDomainConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   multicast_support = "enable"
@@ -208,7 +208,7 @@ resource "aws_ec2_transit_gateway_multicast_domain" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayMulticastDomainConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccTransitGatewayMulticastDomainConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   multicast_support = "enable"
@@ -228,7 +228,7 @@ resource "aws_ec2_transit_gateway_multicast_domain" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccTransitGatewayMulticastDomainConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayMulticastDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   multicast_support = "enable"
@@ -248,7 +248,7 @@ resource "aws_ec2_transit_gateway_multicast_domain" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccTransitGatewayMulticastDomainIGMPv2SupportConfig(rName string) string {
+func testAccTransitGatewayMulticastDomainConfig_igmpv2Support(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   multicast_support = "enable"

--- a/internal/service/ec2/transitgateway_multicast_group_member_test.go
+++ b/internal/service/ec2/transitgateway_multicast_group_member_test.go
@@ -26,7 +26,7 @@ func testAccTransitGatewayMulticastGroupMember_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupMemberConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupMemberConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupMemberExists(resourceName, &v),
 				),
@@ -47,7 +47,7 @@ func testAccTransitGatewayMulticastGroupMember_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupMemberConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupMemberConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupMemberExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastGroupMember(), resourceName),
@@ -71,7 +71,7 @@ func testAccTransitGatewayMulticastGroupMember_Disappears_domain(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupMemberConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupMemberConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupMemberExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastDomain(), domainResourceName),
@@ -95,7 +95,7 @@ func testAccTransitGatewayMulticastGroupMember_twoMembers(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupMemberTwoMembersConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupMemberConfig_twoMembers(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupMemberExists(resource1Name, &v1),
 					testAccCheckTransitGatewayMulticastGroupMemberExists(resource2Name, &v2),
@@ -166,7 +166,7 @@ func testAccCheckTransitGatewayMulticastGroupMemberDestroy(s *terraform.State) e
 	return nil
 }
 
-func testAccTransitGatewayMulticastGroupMemberConfig(rName string) string {
+func testAccTransitGatewayMulticastGroupMemberConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -234,7 +234,7 @@ resource "aws_ec2_transit_gateway_multicast_group_member" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayMulticastGroupMemberTwoMembersConfig(rName string) string {
+func testAccTransitGatewayMulticastGroupMemberConfig_twoMembers(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_multicast_group_source_test.go
+++ b/internal/service/ec2/transitgateway_multicast_group_source_test.go
@@ -26,7 +26,7 @@ func testAccTransitGatewayMulticastGroupSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupSourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupSourceConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupSourceExists(resourceName, &v),
 				),
@@ -47,7 +47,7 @@ func testAccTransitGatewayMulticastGroupSource_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupSourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupSourceConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupSourceExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastGroupSource(), resourceName),
@@ -71,7 +71,7 @@ func testAccTransitGatewayMulticastGroupSource_Disappears_domain(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayMulticastGroupSourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayMulticastGroupSourceConfig(rName),
+				Config: testAccTransitGatewayMulticastGroupSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayMulticastGroupSourceExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayMulticastDomain(), domainResourceName),
@@ -143,7 +143,7 @@ func testAccCheckTransitGatewayMulticastGroupSourceDestroy(s *terraform.State) e
 	return nil
 }
 
-func testAccTransitGatewayMulticastGroupSourceConfig(rName string) string {
+func testAccTransitGatewayMulticastGroupSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
@@ -33,7 +33,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *testing
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_basic_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", transitGatewayResourceNamePeer, "owner_id"),
@@ -45,7 +45,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *testing
 				),
 			},
 			{
-				Config:            testAccTransitGatewayPeeringAttachmentAccepterConfig_basic_sameAccount(rName),
+				Config:            testAccTransitGatewayPeeringAttachmentAccepterConfig_sameAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -71,7 +71,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *testing.
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_tags_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
@@ -82,7 +82,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *testing.
 				),
 			},
 			{
-				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsUpdated_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsUpdatedSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
@@ -93,7 +93,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *testing.
 				),
 			},
 			{
-				Config:            testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsUpdated_sameAccount(rName),
+				Config:            testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsUpdatedSameAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -122,7 +122,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_basic_differentAccount(t *te
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_basic_differentAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentAccepterConfig_differentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", transitGatewayResourceNamePeer, "owner_id"),
@@ -134,7 +134,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_basic_differentAccount(t *te
 				),
 			},
 			{
-				Config:            testAccTransitGatewayPeeringAttachmentAccepterConfig_basic_differentAccount(rName),
+				Config:            testAccTransitGatewayPeeringAttachmentAccepterConfig_differentAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -172,7 +172,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayPeeringAttachmentAccepterConfig_basic_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentAccepterConfig_sameAccount(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAlternateRegionProvider(),
 		testAccTransitGatewayPeeringAttachmentAccepterBaseConfig(rName),
@@ -183,7 +183,7 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "test" {
 `)
 }
 
-func testAccTransitGatewayPeeringAttachmentAccepterConfig_tags_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsSameAccount(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAlternateRegionProvider(),
 		testAccTransitGatewayPeeringAttachmentAccepterBaseConfig(rName),
@@ -200,7 +200,7 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsUpdated_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentAccepterConfig_tagsUpdatedSameAccount(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAlternateRegionProvider(),
 		testAccTransitGatewayPeeringAttachmentAccepterBaseConfig(rName),
@@ -229,7 +229,7 @@ provider "awsalternate" {
 `, os.Getenv(conns.EnvVarAlternateAccessKeyId), os.Getenv(conns.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(conns.EnvVarAlternateSecretAccessKey))
 }
 
-func testAccTransitGatewayPeeringAttachmentAccepterConfig_basic_differentAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentAccepterConfig_differentAccount(rName string) string {
 	return acctest.ConfigCompose(
 		testAccAlternateAccountAlternateRegionProviderConfig(),
 		testAccTransitGatewayPeeringAttachmentAccepterBaseConfig(rName),

--- a/internal/service/ec2/transitgateway_peering_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_data_source_test.go
@@ -27,7 +27,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Filter_sameAccount(t *test
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentFilterDataSourceConfig_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_filterSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_region", dataSourceName, "peer_region"),
@@ -59,7 +59,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Filter_differentAccount(t 
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentFilterDataSourceConfig_differentAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_filterDifferentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "peer_region", acctest.Region()),
 					resource.TestCheckResourceAttrPair(transitGatewayResourceName, "owner_id", dataSourceName, "peer_account_id"),
@@ -88,7 +88,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_ID_sameAccount(t *testing.
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentIDDataSourceConfig_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_iDSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_region", dataSourceName, "peer_region"),
@@ -120,7 +120,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_ID_differentAccount(t *tes
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentIDDataSourceConfig_differentAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_iDDifferentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "peer_region", acctest.Region()),
 					resource.TestCheckResourceAttrPair(transitGatewayResourceName, "owner_id", dataSourceName, "peer_account_id"),
@@ -149,7 +149,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentTagsDataSourceConfig_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_tagsSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_region", dataSourceName, "peer_region"),
@@ -162,9 +162,9 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Tags(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayPeeringAttachmentFilterDataSourceConfig_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentDataSourceConfig_filterSameAccount(rName string) string {
 	return acctest.ConfigCompose(
-		testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName),
+		testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
   filter {
@@ -175,9 +175,9 @@ data "aws_ec2_transit_gateway_peering_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayPeeringAttachmentIDDataSourceConfig_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentDataSourceConfig_iDSameAccount(rName string) string {
 	return acctest.ConfigCompose(
-		testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName),
+		testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
   id = aws_ec2_transit_gateway_peering_attachment.test.id
@@ -185,9 +185,9 @@ data "aws_ec2_transit_gateway_peering_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayPeeringAttachmentTagsDataSourceConfig_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentDataSourceConfig_tagsSameAccount(rName string) string {
 	return acctest.ConfigCompose(
-		testAccTransitGatewayPeeringAttachmentTags1Config_sameAccount(rName, "Name", rName),
+		testAccTransitGatewayPeeringAttachmentConfig_tags1SameAccount(rName, "Name", rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
   tags = {
@@ -197,9 +197,9 @@ data "aws_ec2_transit_gateway_peering_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayPeeringAttachmentFilterDataSourceConfig_differentAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentDataSourceConfig_filterDifferentAccount(rName string) string {
 	return acctest.ConfigCompose(
-		testAccTransitGatewayPeeringAttachmentBasicConfig_differentAccount(rName),
+		testAccTransitGatewayPeeringAttachmentConfig_differentAccount(rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
   provider = "awsalternate"
@@ -212,9 +212,9 @@ data "aws_ec2_transit_gateway_peering_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayPeeringAttachmentIDDataSourceConfig_differentAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentDataSourceConfig_iDDifferentAccount(rName string) string {
 	return acctest.ConfigCompose(
-		testAccTransitGatewayPeeringAttachmentBasicConfig_differentAccount(rName),
+		testAccTransitGatewayPeeringAttachmentConfig_differentAccount(rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
   provider = "awsalternate"

--- a/internal/service/ec2/transitgateway_peering_attachment_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_test.go
@@ -35,7 +35,7 @@ func testAccTransitGatewayPeeringAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					acctest.CheckResourceAttrAccountID(resourceName, "peer_account_id"),
@@ -46,7 +46,7 @@ func testAccTransitGatewayPeeringAttachment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName),
+				Config:            testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -72,7 +72,7 @@ func testAccTransitGatewayPeeringAttachment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					testAccCheckTransitGatewayPeeringAttachmentDisappears(&transitGatewayPeeringAttachment),
@@ -100,7 +100,7 @@ func testAccTransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentTags1Config_sameAccount(rName, "key1", "value1"),
+				Config: testAccTransitGatewayPeeringAttachmentConfig_tags1SameAccount(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -109,13 +109,13 @@ func testAccTransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccTransitGatewayPeeringAttachmentTags1Config_sameAccount(rName, "key1", "value1"),
+				Config:            testAccTransitGatewayPeeringAttachmentConfig_tags1SameAccount(rName, "key1", "value1"),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayPeeringAttachmentTags2Config_sameAccount(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayPeeringAttachmentConfig_tags2SameAccount(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -125,7 +125,7 @@ func testAccTransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -155,7 +155,7 @@ func testAccTransitGatewayPeeringAttachment_differentAccount(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPeeringAttachmentBasicConfig_differentAccount(rName),
+				Config: testAccTransitGatewayPeeringAttachmentConfig_differentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
 					// Test that the peer account ID != the primary (request) account ID
@@ -172,7 +172,7 @@ func testAccTransitGatewayPeeringAttachment_differentAccount(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccTransitGatewayPeeringAttachmentBasicConfig_differentAccount(rName),
+				Config:            testAccTransitGatewayPeeringAttachmentConfig_differentAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -286,7 +286,7 @@ func testAccTransitGatewayPeeringAttachmentConfig_differentAccount_base(rName st
 	return testAccAlternateAccountAlternateRegionProviderConfig() + testAccTransitGatewayPeeringAttachmentConfig_base(rName)
 }
 
-func testAccTransitGatewayPeeringAttachmentBasicConfig_sameAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName string) string {
 	return testAccTransitGatewayPeeringAttachmentConfig_sameAccount_base(rName) + fmt.Sprintf(`
 resource "aws_ec2_transit_gateway_peering_attachment" "test" {
   peer_region             = %[1]q
@@ -296,7 +296,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "test" {
 `, acctest.AlternateRegion())
 }
 
-func testAccTransitGatewayPeeringAttachmentBasicConfig_differentAccount(rName string) string {
+func testAccTransitGatewayPeeringAttachmentConfig_differentAccount(rName string) string {
 	return testAccTransitGatewayPeeringAttachmentConfig_differentAccount_base(rName) + fmt.Sprintf(`
 resource "aws_ec2_transit_gateway_peering_attachment" "test" {
   peer_account_id         = aws_ec2_transit_gateway.peer.owner_id
@@ -307,7 +307,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "test" {
 `, acctest.AlternateRegion())
 }
 
-func testAccTransitGatewayPeeringAttachmentTags1Config_sameAccount(rName, tagKey1, tagValue1 string) string {
+func testAccTransitGatewayPeeringAttachmentConfig_tags1SameAccount(rName, tagKey1, tagValue1 string) string {
 	return testAccTransitGatewayPeeringAttachmentConfig_sameAccount_base(rName) + fmt.Sprintf(`
 resource "aws_ec2_transit_gateway_peering_attachment" "test" {
   peer_region             = %[1]q
@@ -323,7 +323,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "test" {
 `, acctest.AlternateRegion(), rName, tagKey1, tagValue1)
 }
 
-func testAccTransitGatewayPeeringAttachmentTags2Config_sameAccount(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayPeeringAttachmentConfig_tags2SameAccount(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccTransitGatewayPeeringAttachmentConfig_sameAccount_base(rName) + fmt.Sprintf(`
 resource "aws_ec2_transit_gateway_peering_attachment" "test" {
   peer_region             = %[1]q

--- a/internal/service/ec2/transitgateway_prefix_list_reference_test.go
+++ b/internal/service/ec2/transitgateway_prefix_list_reference_test.go
@@ -31,7 +31,7 @@ func testAccTransitGatewayPrefixListReference_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayPrefixListReferenceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPrefixListReferenceConfig_Blackhole(rName),
+				Config: testAccTransitGatewayPrefixListReferenceConfig_blackhole(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccTransitGatewayPrefixListReferenceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "blackhole", "true"),
@@ -65,7 +65,7 @@ func testAccTransitGatewayPrefixListReference_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayPrefixListReferenceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPrefixListReferenceConfig_Blackhole(rName),
+				Config: testAccTransitGatewayPrefixListReferenceConfig_blackhole(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccTransitGatewayPrefixListReferenceExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayPrefixListReference(), resourceName),
@@ -92,7 +92,7 @@ func testAccTransitGatewayPrefixListReference_disappears_TransitGateway(t *testi
 		CheckDestroy:      testAccCheckTransitGatewayPrefixListReferenceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPrefixListReferenceConfig_Blackhole(rName),
+				Config: testAccTransitGatewayPrefixListReferenceConfig_blackhole(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccTransitGatewayPrefixListReferenceExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGateway(), transitGatewayResourceName),
@@ -120,7 +120,7 @@ func testAccTransitGatewayPrefixListReference_TransitGatewayAttachmentID(t *test
 		CheckDestroy:      testAccCheckTransitGatewayPrefixListReferenceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayPrefixListReferenceConfig_TransitGatewayAttachmentID(rName, 0),
+				Config: testAccTransitGatewayPrefixListReferenceConfig_attachmentID(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccTransitGatewayPrefixListReferenceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "blackhole", "false"),
@@ -133,7 +133,7 @@ func testAccTransitGatewayPrefixListReference_TransitGatewayAttachmentID(t *test
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayPrefixListReferenceConfig_TransitGatewayAttachmentID(rName, 1),
+				Config: testAccTransitGatewayPrefixListReferenceConfig_attachmentID(rName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccTransitGatewayPrefixListReferenceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "blackhole", "false"),
@@ -203,7 +203,7 @@ func testAccTransitGatewayPrefixListReferenceExists(n string) resource.TestCheck
 	}
 }
 
-func testAccTransitGatewayPrefixListReferenceConfig_Blackhole(rName string) string {
+func testAccTransitGatewayPrefixListReferenceConfig_blackhole(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
@@ -221,7 +221,7 @@ resource "aws_ec2_transit_gateway_prefix_list_reference" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayPrefixListReferenceConfig_TransitGatewayAttachmentID(rName string, index int) string {
+func testAccTransitGatewayPrefixListReferenceConfig_attachmentID(rName string, index int) string {
 	return fmt.Sprintf(`
 variable "index" {
   default = %[2]d

--- a/internal/service/ec2/transitgateway_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_route_table_association_test.go
@@ -26,7 +26,7 @@ func testAccTransitGatewayRouteTableAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableAssociationConfig(),
+				Config: testAccTransitGatewayRouteTableAssociationConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableAssociationExists(resourceName, &transitGatewayRouteTablePropagtion1),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),
@@ -113,7 +113,7 @@ func testAccCheckTransitGatewayRouteTableAssociationDestroy(s *terraform.State) 
 	return nil
 }
 
-func testAccTransitGatewayRouteTableAssociationConfig() string {
+func testAccTransitGatewayRouteTableAssociationConfig_basic() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_route_table_data_source_test.go
+++ b/internal/service/ec2/transitgateway_route_table_data_source_test.go
@@ -19,7 +19,7 @@ func testAccTransitGatewayRouteTableDataSource_Filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableFilterDataSourceConfig(),
+				Config: testAccTransitGatewayRouteTableDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "default_association_route_table", dataSourceName, "default_association_route_table"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_propagation_route_table", dataSourceName, "default_propagation_route_table"),
@@ -43,7 +43,7 @@ func testAccTransitGatewayRouteTableDataSource_ID(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableIDDataSourceConfig(),
+				Config: testAccTransitGatewayRouteTableDataSourceConfig_iD(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "default_association_route_table", dataSourceName, "default_association_route_table"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_propagation_route_table", dataSourceName, "default_propagation_route_table"),
@@ -56,7 +56,7 @@ func testAccTransitGatewayRouteTableDataSource_ID(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayRouteTableFilterDataSourceConfig() string {
+func testAccTransitGatewayRouteTableDataSourceConfig_filter() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {}
 
@@ -73,7 +73,7 @@ data "aws_ec2_transit_gateway_route_table" "test" {
 `
 }
 
-func testAccTransitGatewayRouteTableIDDataSourceConfig() string {
+func testAccTransitGatewayRouteTableDataSourceConfig_iD() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {}
 

--- a/internal/service/ec2/transitgateway_route_table_propagation_test.go
+++ b/internal/service/ec2/transitgateway_route_table_propagation_test.go
@@ -27,7 +27,7 @@ func testAccTransitGatewayRouteTablePropagation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteTablePropagationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTablePropagationConfig(),
+				Config: testAccTransitGatewayRouteTablePropagationConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTablePropagationExists(resourceName, &transitGatewayRouteTablePropagtion1),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),
@@ -118,7 +118,7 @@ func testAccCheckTransitGatewayRouteTablePropagationDestroy(s *terraform.State) 
 	return nil
 }
 
-func testAccTransitGatewayRouteTablePropagationConfig() string {
+func testAccTransitGatewayRouteTablePropagationConfig_basic() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_route_table_test.go
+++ b/internal/service/ec2/transitgateway_route_table_test.go
@@ -28,7 +28,7 @@ func testAccTransitGatewayRouteTable_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableConfig(),
+				Config: testAccTransitGatewayRouteTableConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableExists(resourceName, &transitGatewayRouteTable1),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`transit-gateway-route-table/tgw-rtb-.+`)),
@@ -58,7 +58,7 @@ func testAccTransitGatewayRouteTable_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableConfig(),
+				Config: testAccTransitGatewayRouteTableConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableExists(resourceName, &transitGatewayRouteTable1),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayRouteTable(), resourceName),
@@ -82,7 +82,7 @@ func testAccTransitGatewayRouteTable_disappears_TransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableConfig(),
+				Config: testAccTransitGatewayRouteTableConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayRouteTableExists(resourceName, &transitGatewayRouteTable1),
@@ -105,7 +105,7 @@ func testAccTransitGatewayRouteTable_Tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTableTags1Config("key1", "value1"),
+				Config: testAccTransitGatewayRouteTableConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableExists(resourceName, &transitGatewayRouteTable1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -118,7 +118,7 @@ func testAccTransitGatewayRouteTable_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayRouteTableTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayRouteTableConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableExists(resourceName, &transitGatewayRouteTable2),
 					testAccCheckTransitGatewayRouteTableNotRecreated(&transitGatewayRouteTable1, &transitGatewayRouteTable2),
@@ -128,7 +128,7 @@ func testAccTransitGatewayRouteTable_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayRouteTableTags1Config("key2", "value2"),
+				Config: testAccTransitGatewayRouteTableConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableExists(resourceName, &transitGatewayRouteTable3),
 					testAccCheckTransitGatewayRouteTableNotRecreated(&transitGatewayRouteTable2, &transitGatewayRouteTable3),
@@ -213,7 +213,7 @@ func testAccCheckTransitGatewayRouteTableNotRecreated(i, j *ec2.TransitGatewayRo
 	}
 }
 
-func testAccTransitGatewayRouteTableConfig() string {
+func testAccTransitGatewayRouteTableConfig_basic() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {}
 
@@ -223,7 +223,7 @@ resource "aws_ec2_transit_gateway_route_table" "test" {
 `
 }
 
-func testAccTransitGatewayRouteTableTags1Config(tagKey1, tagValue1 string) string {
+func testAccTransitGatewayRouteTableConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {}
 
@@ -237,7 +237,7 @@ resource "aws_ec2_transit_gateway_route_table" "test" {
 `, tagKey1, tagValue1)
 }
 
-func testAccTransitGatewayRouteTableTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayRouteTableConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {}
 

--- a/internal/service/ec2/transitgateway_route_tables_data_source_test.go
+++ b/internal/service/ec2/transitgateway_route_tables_data_source_test.go
@@ -20,7 +20,7 @@ func testAccTransitGatewayRouteTablesDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTablesDataSourceConfig(rName),
+				Config: testAccTransitGatewayRouteTablesDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ids.#", "0"),
 				),
@@ -39,7 +39,7 @@ func testAccTransitGatewayRouteTablesDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTablesTransitGatewayFilterDataSource(rName),
+				Config: testAccTransitGatewayRouteTablesDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
 				),
@@ -58,7 +58,7 @@ func testAccTransitGatewayRouteTablesDataSource_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTablesTransitGatewayTagsDataSource(rName),
+				Config: testAccTransitGatewayRouteTablesDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 				),
@@ -77,7 +77,7 @@ func testAccTransitGatewayRouteTablesDataSource_empty(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteTablesTransitGatewayEmptyDataSource(rName),
+				Config: testAccTransitGatewayRouteTablesDataSourceConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "0"),
 				),
@@ -86,7 +86,7 @@ func testAccTransitGatewayRouteTablesDataSource_empty(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayRouteTablesDataSourceConfig(rName string) string {
+func testAccTransitGatewayRouteTablesDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   tags = {
@@ -108,7 +108,7 @@ data "aws_ec2_transit_gateway_route_tables" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayRouteTablesTransitGatewayFilterDataSource(rName string) string {
+func testAccTransitGatewayRouteTablesDataSourceConfig_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   tags = {
@@ -135,7 +135,7 @@ data "aws_ec2_transit_gateway_route_tables" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayRouteTablesTransitGatewayTagsDataSource(rName string) string {
+func testAccTransitGatewayRouteTablesDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   tags = {
@@ -161,7 +161,7 @@ data "aws_ec2_transit_gateway_route_tables" "test" {
 `, rName)
 }
 
-func testAccTransitGatewayRouteTablesTransitGatewayEmptyDataSource(rName string) string {
+func testAccTransitGatewayRouteTablesDataSourceConfig_empty(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_transit_gateway_route_tables" "test" {
   tags = {

--- a/internal/service/ec2/transitgateway_route_test.go
+++ b/internal/service/ec2/transitgateway_route_test.go
@@ -28,7 +28,7 @@ func testAccTransitGatewayRoute_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteDestinationCIDRBlockConfig(rName),
+				Config: testAccTransitGatewayRouteConfig_destinationCIDRBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", "0.0.0.0/0"),
@@ -60,7 +60,7 @@ func testAccTransitGatewayRoute_basic_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteDestinationCIDRBlockConfig(rName),
+				Config: testAccTransitGatewayRouteConfig_destinationCIDRBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", "2001:db8::/56"),
@@ -91,7 +91,7 @@ func testAccTransitGatewayRoute_blackhole(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteDestinationCIDRBlockConfig(rName),
+				Config: testAccTransitGatewayRouteConfig_destinationCIDRBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", "10.1.0.0/16"),
@@ -121,7 +121,7 @@ func testAccTransitGatewayRoute_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteDestinationCIDRBlockConfig(rName),
+				Config: testAccTransitGatewayRouteConfig_destinationCIDRBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayRoute(), resourceName),
@@ -145,7 +145,7 @@ func testAccTransitGatewayRoute_disappears_TransitGatewayAttachment(t *testing.T
 		CheckDestroy:      testAccCheckTransitGatewayRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayRouteDestinationCIDRBlockConfig(rName),
+				Config: testAccTransitGatewayRouteConfig_destinationCIDRBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGatewayVPCAttachment(), transitGatewayVpcAttachmentResourceName),
@@ -217,7 +217,7 @@ func testAccCheckTransitGatewayRouteDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTransitGatewayRouteDestinationCIDRBlockConfig(rName string) string {
+func testAccTransitGatewayRouteConfig_destinationCIDRBlock(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -152,7 +152,7 @@ func testAccTransitGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConfig(),
+				Config: testAccTransitGatewayConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "amazon_side_asn", "64512"),
@@ -190,7 +190,7 @@ func testAccTransitGateway_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayConfig(),
+				Config: testAccTransitGatewayConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTransitGateway(), resourceName),
@@ -212,7 +212,7 @@ func testAccTransitGateway_AmazonSideASN(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayAmazonSideASNConfig(64513),
+				Config: testAccTransitGatewayConfig_amazonSideASN(64513),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "amazon_side_asn", "64513"),
@@ -224,7 +224,7 @@ func testAccTransitGateway_AmazonSideASN(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayAmazonSideASNConfig(64514),
+				Config: testAccTransitGatewayConfig_amazonSideASN(64514),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayRecreated(&transitGateway1, &transitGateway2),
@@ -246,7 +246,7 @@ func testAccTransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayAutoAcceptSharedAttachmentsConfig(ec2.AutoAcceptSharedAttachmentsValueEnable),
+				Config: testAccTransitGatewayConfig_autoAcceptSharedAttachments(ec2.AutoAcceptSharedAttachmentsValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "auto_accept_shared_attachments", ec2.AutoAcceptSharedAttachmentsValueEnable),
@@ -258,7 +258,7 @@ func testAccTransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayAutoAcceptSharedAttachmentsConfig(ec2.AutoAcceptSharedAttachmentsValueDisable),
+				Config: testAccTransitGatewayConfig_autoAcceptSharedAttachments(ec2.AutoAcceptSharedAttachmentsValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
@@ -328,7 +328,7 @@ func testAccTransitGateway_DefaultRouteTableAssociationAndPropagationDisabled(t 
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDefaultRouteTableAssociationAndPropagationDisabledConfig(),
+				Config: testAccTransitGatewayConfig_defaultRouteTableAssociationAndPropagationDisabled(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "default_route_table_association", ec2.DefaultRouteTableAssociationValueDisable),
@@ -355,7 +355,7 @@ func testAccTransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDefaultRouteTableAssociationConfig(ec2.DefaultRouteTableAssociationValueDisable),
+				Config: testAccTransitGatewayConfig_defaultRouteTableAssociation(ec2.DefaultRouteTableAssociationValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "default_route_table_association", ec2.DefaultRouteTableAssociationValueDisable),
@@ -367,7 +367,7 @@ func testAccTransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayDefaultRouteTableAssociationConfig(ec2.DefaultRouteTableAssociationValueEnable),
+				Config: testAccTransitGatewayConfig_defaultRouteTableAssociation(ec2.DefaultRouteTableAssociationValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayRecreated(&transitGateway1, &transitGateway2),
@@ -375,7 +375,7 @@ func testAccTransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayDefaultRouteTableAssociationConfig(ec2.DefaultRouteTableAssociationValueDisable),
+				Config: testAccTransitGatewayConfig_defaultRouteTableAssociation(ec2.DefaultRouteTableAssociationValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway3),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway2, &transitGateway3),
@@ -397,7 +397,7 @@ func testAccTransitGateway_DefaultRouteTablePropagation(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDefaultRouteTablePropagationConfig(ec2.DefaultRouteTablePropagationValueDisable),
+				Config: testAccTransitGatewayConfig_defaultRouteTablePropagation(ec2.DefaultRouteTablePropagationValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "default_route_table_propagation", ec2.DefaultRouteTablePropagationValueDisable),
@@ -409,7 +409,7 @@ func testAccTransitGateway_DefaultRouteTablePropagation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayDefaultRouteTablePropagationConfig(ec2.DefaultRouteTablePropagationValueEnable),
+				Config: testAccTransitGatewayConfig_defaultRouteTablePropagation(ec2.DefaultRouteTablePropagationValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayRecreated(&transitGateway1, &transitGateway2),
@@ -417,7 +417,7 @@ func testAccTransitGateway_DefaultRouteTablePropagation(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayDefaultRouteTablePropagationConfig(ec2.DefaultRouteTablePropagationValueDisable),
+				Config: testAccTransitGatewayConfig_defaultRouteTablePropagation(ec2.DefaultRouteTablePropagationValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway3),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway2, &transitGateway3),
@@ -439,7 +439,7 @@ func testAccTransitGateway_DNSSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDNSSupportConfig(ec2.DnsSupportValueDisable),
+				Config: testAccTransitGatewayConfig_dnsSupport(ec2.DnsSupportValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueDisable),
@@ -451,7 +451,7 @@ func testAccTransitGateway_DNSSupport(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayDNSSupportConfig(ec2.DnsSupportValueEnable),
+				Config: testAccTransitGatewayConfig_dnsSupport(ec2.DnsSupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
@@ -473,7 +473,7 @@ func testAccTransitGateway_VPNECMPSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPNECMPSupportConfig(ec2.VpnEcmpSupportValueDisable),
+				Config: testAccTransitGatewayConfig_vpnECMPSupport(ec2.VpnEcmpSupportValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "vpn_ecmp_support", ec2.VpnEcmpSupportValueDisable),
@@ -485,7 +485,7 @@ func testAccTransitGateway_VPNECMPSupport(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPNECMPSupportConfig(ec2.VpnEcmpSupportValueEnable),
+				Config: testAccTransitGatewayConfig_vpnECMPSupport(ec2.VpnEcmpSupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
@@ -507,7 +507,7 @@ func testAccTransitGateway_Description(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayDescriptionConfig("description1"),
+				Config: testAccTransitGatewayConfig_description("description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
@@ -519,7 +519,7 @@ func testAccTransitGateway_Description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayDescriptionConfig("description2"),
+				Config: testAccTransitGatewayConfig_description("description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
@@ -541,7 +541,7 @@ func testAccTransitGateway_Tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayTags1Config("key1", "value1"),
+				Config: testAccTransitGatewayConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -554,7 +554,7 @@ func testAccTransitGateway_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
@@ -564,7 +564,7 @@ func testAccTransitGateway_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayTags1Config("key2", "value2"),
+				Config: testAccTransitGatewayConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway3),
 					testAccCheckTransitGatewayNotRecreated(&transitGateway2, &transitGateway3),
@@ -777,13 +777,13 @@ func testAccPreCheckTransitGateway(t *testing.T) {
 	}
 }
 
-func testAccTransitGatewayConfig() string {
+func testAccTransitGatewayConfig_basic() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {}
 `
 }
 
-func testAccTransitGatewayAmazonSideASNConfig(amazonSideASN int) string {
+func testAccTransitGatewayConfig_amazonSideASN(amazonSideASN int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   amazon_side_asn = %d
@@ -791,7 +791,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, amazonSideASN)
 }
 
-func testAccTransitGatewayAutoAcceptSharedAttachmentsConfig(autoAcceptSharedAttachments string) string {
+func testAccTransitGatewayConfig_autoAcceptSharedAttachments(autoAcceptSharedAttachments string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   auto_accept_shared_attachments = %q
@@ -799,7 +799,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, autoAcceptSharedAttachments)
 }
 
-func testAccTransitGatewayDefaultRouteTableAssociationAndPropagationDisabledConfig() string {
+func testAccTransitGatewayConfig_defaultRouteTableAssociationAndPropagationDisabled() string {
 	return `
 resource "aws_ec2_transit_gateway" "test" {
   default_route_table_association = "disable"
@@ -808,7 +808,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `
 }
 
-func testAccTransitGatewayDefaultRouteTableAssociationConfig(defaultRouteTableAssociation string) string {
+func testAccTransitGatewayConfig_defaultRouteTableAssociation(defaultRouteTableAssociation string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   default_route_table_association = %q
@@ -816,7 +816,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, defaultRouteTableAssociation)
 }
 
-func testAccTransitGatewayDefaultRouteTablePropagationConfig(defaultRouteTablePropagation string) string {
+func testAccTransitGatewayConfig_defaultRouteTablePropagation(defaultRouteTablePropagation string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   default_route_table_propagation = %q
@@ -824,7 +824,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, defaultRouteTablePropagation)
 }
 
-func testAccTransitGatewayDNSSupportConfig(dnsSupport string) string {
+func testAccTransitGatewayConfig_dnsSupport(dnsSupport string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   dns_support = %q
@@ -832,7 +832,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, dnsSupport)
 }
 
-func testAccTransitGatewayVPNECMPSupportConfig(vpnEcmpSupport string) string {
+func testAccTransitGatewayConfig_vpnECMPSupport(vpnEcmpSupport string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   vpn_ecmp_support = %q
@@ -840,7 +840,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, vpnEcmpSupport)
 }
 
-func testAccTransitGatewayDescriptionConfig(description string) string {
+func testAccTransitGatewayConfig_description(description string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   description = %q
@@ -848,7 +848,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, description)
 }
 
-func testAccTransitGatewayTags1Config(tagKey1, tagValue1 string) string {
+func testAccTransitGatewayConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   tags = {
@@ -858,7 +858,7 @@ resource "aws_ec2_transit_gateway" "test" {
 `, tagKey1, tagValue1)
 }
 
-func testAccTransitGatewayTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   tags = {

--- a/internal/service/ec2/transitgateway_vpc_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_data_source_test.go
@@ -19,7 +19,7 @@ func testAccTransitGatewayVPCAttachmentDataSource_Filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentFilterDataSourceConfig(),
+				Config: testAccTransitGatewayVPCAttachmentDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "appliance_mode_support", dataSourceName, "appliance_mode_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_support", dataSourceName, "dns_support"),
@@ -46,7 +46,7 @@ func testAccTransitGatewayVPCAttachmentDataSource_ID(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentIDDataSourceConfig(),
+				Config: testAccTransitGatewayVPCAttachmentDataSourceConfig_iD(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "appliance_mode_support", dataSourceName, "appliance_mode_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_support", dataSourceName, "dns_support"),
@@ -62,7 +62,7 @@ func testAccTransitGatewayVPCAttachmentDataSource_ID(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayVPCAttachmentFilterDataSourceConfig() string {
+func testAccTransitGatewayVPCAttachmentDataSourceConfig_filter() string {
 	return acctest.ConfigAvailableAZsNoOptInDefaultExclude() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -99,7 +99,7 @@ data "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `
 }
 
-func testAccTransitGatewayVPCAttachmentIDDataSourceConfig() string {
+func testAccTransitGatewayVPCAttachmentDataSourceConfig_iD() string {
 	return acctest.ConfigAvailableAZsNoOptInDefaultExclude() + `
 # IncorrectState: Transit Gateway is not available in availability zone usw2-az4	
 

--- a/internal/service/ec2/transitgateway_vpc_attachment_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_test.go
@@ -31,7 +31,7 @@ func testAccTransitGatewayVPCAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentConfig(),
+				Config: testAccTransitGatewayVPCAttachmentConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueEnable),
@@ -65,7 +65,7 @@ func testAccTransitGatewayVPCAttachment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentConfig(),
+				Config: testAccTransitGatewayVPCAttachmentConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					testAccCheckTransitGatewayVPCAttachmentDisappears(&transitGatewayVpcAttachment1),
@@ -87,15 +87,15 @@ func testAccTransitGatewayVPCAttachment_ApplianceModeSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTransitGatewayVPCAttachmentApplianceModeSupportConfig("false"),
+				Config:      testAccTransitGatewayVPCAttachmentConfig_applianceModeSupport("false"),
 				ExpectError: regexp.MustCompile(`expected appliance_mode_support to be one of`),
 			},
 			{
-				Config:      testAccTransitGatewayVPCAttachmentApplianceModeSupportConfig("true"),
+				Config:      testAccTransitGatewayVPCAttachmentConfig_applianceModeSupport("true"),
 				ExpectError: regexp.MustCompile(`expected appliance_mode_support to be one of`),
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentApplianceModeSupportConfig(ec2.ApplianceModeSupportValueDisable),
+				Config: testAccTransitGatewayVPCAttachmentConfig_applianceModeSupport(ec2.ApplianceModeSupportValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					resource.TestCheckResourceAttr(resourceName, "appliance_mode_support", ec2.ApplianceModeSupportValueDisable),
@@ -107,7 +107,7 @@ func testAccTransitGatewayVPCAttachment_ApplianceModeSupport(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentApplianceModeSupportConfig(ec2.ApplianceModeSupportValueEnable),
+				Config: testAccTransitGatewayVPCAttachmentConfig_applianceModeSupport(ec2.ApplianceModeSupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment1, &transitGatewayVpcAttachment2),
@@ -129,7 +129,7 @@ func testAccTransitGatewayVPCAttachment_DNSSupport(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentDNSSupportConfig(ec2.DnsSupportValueDisable),
+				Config: testAccTransitGatewayVPCAttachmentConfig_dnsSupport(ec2.DnsSupportValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueDisable),
@@ -141,7 +141,7 @@ func testAccTransitGatewayVPCAttachment_DNSSupport(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentDNSSupportConfig(ec2.DnsSupportValueEnable),
+				Config: testAccTransitGatewayVPCAttachmentConfig_dnsSupport(ec2.DnsSupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment1, &transitGatewayVpcAttachment2),
@@ -164,7 +164,7 @@ func testAccTransitGatewayVPCAttachment_IPv6Support(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentIPv6SupportConfig(rName, ec2.Ipv6SupportValueEnable),
+				Config: testAccTransitGatewayVPCAttachmentConfig_ipv6Support(rName, ec2.Ipv6SupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_support", ec2.Ipv6SupportValueEnable),
@@ -176,7 +176,7 @@ func testAccTransitGatewayVPCAttachment_IPv6Support(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentIPv6SupportConfig(rName, ec2.Ipv6SupportValueDisable),
+				Config: testAccTransitGatewayVPCAttachmentConfig_ipv6Support(rName, ec2.Ipv6SupportValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment1, &transitGatewayVpcAttachment2),
@@ -204,13 +204,13 @@ func testAccTransitGatewayVPCAttachment_SharedTransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentSharedTransitGatewayConfig(rName),
+				Config: testAccTransitGatewayVPCAttachmentConfig_sharedTransitGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 				),
 			},
 			{
-				Config:            testAccTransitGatewayVPCAttachmentSharedTransitGatewayConfig(rName),
+				Config:            testAccTransitGatewayVPCAttachmentConfig_sharedTransitGateway(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -230,7 +230,7 @@ func testAccTransitGatewayVPCAttachment_SubnetIDs(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentSubnetIds2Config(),
+				Config: testAccTransitGatewayVPCAttachmentConfig_subnetIds2(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -242,7 +242,7 @@ func testAccTransitGatewayVPCAttachment_SubnetIDs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentSubnetIds1Config(),
+				Config: testAccTransitGatewayVPCAttachmentConfig_subnetIds1(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment1, &transitGatewayVpcAttachment2),
@@ -250,7 +250,7 @@ func testAccTransitGatewayVPCAttachment_SubnetIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentSubnetIds2Config(),
+				Config: testAccTransitGatewayVPCAttachmentConfig_subnetIds2(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment3),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment2, &transitGatewayVpcAttachment3),
@@ -272,7 +272,7 @@ func testAccTransitGatewayVPCAttachment_Tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentTags1Config("key1", "value1"),
+				Config: testAccTransitGatewayVPCAttachmentConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -285,7 +285,7 @@ func testAccTransitGatewayVPCAttachment_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccTransitGatewayVPCAttachmentConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment1, &transitGatewayVpcAttachment2),
@@ -295,7 +295,7 @@ func testAccTransitGatewayVPCAttachment_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentTags1Config("key2", "value2"),
+				Config: testAccTransitGatewayVPCAttachmentConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment3),
 					testAccCheckTransitGatewayVPCAttachmentNotRecreated(&transitGatewayVpcAttachment2, &transitGatewayVpcAttachment3),
@@ -320,7 +320,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociati
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTableAssociationAndPropagationDisabledConfig(),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTableAssociationAndPropagationDisabled(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
@@ -352,7 +352,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociati
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTableAssociationConfig(false),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTableAssociation(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
@@ -366,7 +366,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociati
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTableAssociationConfig(true),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTableAssociation(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway2),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
@@ -376,7 +376,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociati
 				),
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTableAssociationConfig(false),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTableAssociation(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway3),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment3),
@@ -402,7 +402,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTablePropagati
 		CheckDestroy:      testAccCheckTransitGatewayVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTablePropagationConfig(false),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTablePropagation(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway1),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
@@ -416,7 +416,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTablePropagati
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTablePropagationConfig(true),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTablePropagation(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway2),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
@@ -426,7 +426,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTablePropagati
 				),
 			},
 			{
-				Config: testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTablePropagationConfig(false),
+				Config: testAccTransitGatewayVPCAttachmentConfig_defaultRouteTablePropagation(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(transitGatewayResourceName, &transitGateway3),
 					testAccCheckTransitGatewayVPCAttachmentExists(resourceName, &transitGatewayVpcAttachment3),
@@ -546,7 +546,7 @@ func testAccPreCheckTransitGatewayVPCAttachment(t *testing.T) {
 	}
 }
 
-func testAccTransitGatewayVPCAttachmentConfig() string {
+func testAccTransitGatewayVPCAttachmentConfig_basic() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -576,7 +576,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayVPCAttachmentApplianceModeSupportConfig(appModeSupport string) string {
+func testAccTransitGatewayVPCAttachmentConfig_applianceModeSupport(appModeSupport string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -608,7 +608,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, appModeSupport))
 }
 
-func testAccTransitGatewayVPCAttachmentDNSSupportConfig(dnsSupport string) string {
+func testAccTransitGatewayVPCAttachmentConfig_dnsSupport(dnsSupport string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -640,7 +640,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, dnsSupport))
 }
 
-func testAccTransitGatewayVPCAttachmentIPv6SupportConfig(rName, ipv6Support string) string {
+func testAccTransitGatewayVPCAttachmentConfig_ipv6Support(rName, ipv6Support string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
@@ -681,7 +681,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, rName, ipv6Support))
 }
 
-func testAccTransitGatewayVPCAttachmentSharedTransitGatewayConfig(rName string) string {
+func testAccTransitGatewayVPCAttachmentConfig_sharedTransitGateway(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAlternateAccountProvider(),
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
@@ -740,7 +740,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, rName))
 }
 
-func testAccTransitGatewayVPCAttachmentSubnetIds1Config() string {
+func testAccTransitGatewayVPCAttachmentConfig_subnetIds1() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -772,7 +772,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayVPCAttachmentSubnetIds2Config() string {
+func testAccTransitGatewayVPCAttachmentConfig_subnetIds2() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -804,7 +804,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayVPCAttachmentTags1Config(tagKey1, tagValue1 string) string {
+func testAccTransitGatewayVPCAttachmentConfig_tags1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -838,7 +838,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccTransitGatewayVPCAttachmentTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTransitGatewayVPCAttachmentConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -873,7 +873,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTableAssociationAndPropagationDisabledConfig() string {
+func testAccTransitGatewayVPCAttachmentConfig_defaultRouteTableAssociationAndPropagationDisabled() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -908,7 +908,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `)
 }
 
-func testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTableAssociationConfig(transitGatewayDefaultRouteTableAssociation bool) string {
+func testAccTransitGatewayVPCAttachmentConfig_defaultRouteTableAssociation(transitGatewayDefaultRouteTableAssociation bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -940,7 +940,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 `, transitGatewayDefaultRouteTableAssociation))
 }
 
-func testAccTransitGatewayVPCAttachmentTransitGatewayDefaultRouteTablePropagationConfig(transitGatewayDefaultRouteTablePropagation bool) string {
+func testAccTransitGatewayVPCAttachmentConfig_defaultRouteTablePropagation(transitGatewayDefaultRouteTablePropagation bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_vpc_attachments_data_source_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachments_data_source_test.go
@@ -19,7 +19,7 @@ func testAccTransitGatewayVPCAttachmentsDataSource_Filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPCAttachmentsDataSourceConfig(rName),
+				Config: testAccTransitGatewayVPCAttachmentsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_ec2_transit_gateway_vpc_attachments.by_attachment_id", "ids.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_ec2_transit_gateway_vpc_attachments.by_gateway_id", "ids.#", "2"),
@@ -29,7 +29,7 @@ func testAccTransitGatewayVPCAttachmentsDataSource_Filter(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayVPCAttachmentsDataSourceConfig(rName string) string {
+func testAccTransitGatewayVPCAttachmentsDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/transitgateway_vpn_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_vpn_attachment_data_source_test.go
@@ -26,7 +26,7 @@ func testAccTransitGatewayVPNAttachmentDataSource_idAndVPNConnectionID(t *testin
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPNAttachmentDataSourceConfig_idAndVPNConnectionID2(rBgpAsn),
+				Config: testAccTransitGatewayVPNAttachmentDataSourceConfig_idAndConnectionID2(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -53,7 +53,7 @@ func testAccTransitGatewayVPNAttachmentDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckTransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitGatewayVPNAttachmentFilterDataSourceConfig(rBgpAsn),
+				Config: testAccTransitGatewayVPNAttachmentDataSourceConfig_filter(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -94,7 +94,7 @@ resource "aws_vpn_connection" "test" {
 `, rBgpAsn)
 }
 
-func testAccTransitGatewayVPNAttachmentDataSourceConfig_idAndVPNConnectionID2(rBgpAsn int) string {
+func testAccTransitGatewayVPNAttachmentDataSourceConfig_idAndConnectionID2(rBgpAsn int) string {
 	return testAccTransitGatewayVPNAttachmentBaseDataSourceConfig(rBgpAsn) + `
 data "aws_ec2_transit_gateway_vpn_attachment" "test" {
   transit_gateway_id = aws_ec2_transit_gateway.test.id
@@ -103,7 +103,7 @@ data "aws_ec2_transit_gateway_vpn_attachment" "test" {
 `
 }
 
-func testAccTransitGatewayVPNAttachmentFilterDataSourceConfig(rBgpAsn int) string {
+func testAccTransitGatewayVPNAttachmentDataSourceConfig_filter(rBgpAsn int) string {
 	return testAccTransitGatewayVPNAttachmentBaseDataSourceConfig(rBgpAsn) + `
 data "aws_ec2_transit_gateway_vpn_attachment" "test" {
   filter {

--- a/internal/service/ec2/vpc_data_source_test.go
+++ b/internal/service/ec2/vpc_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccVPCDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDataSourceConfig(rName, cidr),
+				Config: testAccVPCDataSourceConfig_basic(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", vpcResourceName, "arn"),
 					resource.TestCheckResourceAttr(ds1ResourceName, "cidr_block", cidr),
@@ -72,7 +72,7 @@ func TestAccVPCDataSource_CIDRBlockAssociations_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCCIDRBlockAssociationsMultipleDataSourceConfig(rName),
+				Config: testAccVPCDataSourceConfig_cidrBlockAssociationsMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cidr_block_associations.#", "2"),
 				),
@@ -81,7 +81,7 @@ func TestAccVPCDataSource_CIDRBlockAssociations_multiple(t *testing.T) {
 	})
 }
 
-func testAccVPCDataSourceConfig(rName, cidr string) string {
+func testAccVPCDataSourceConfig_basic(rName, cidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = %[2]q
@@ -116,7 +116,7 @@ data "aws_vpc" "by_filter" {
 `, rName, cidr)
 }
 
-func testAccVPCCIDRBlockAssociationsMultipleDataSourceConfig(rName string) string {
+func testAccVPCDataSourceConfig_cidrBlockAssociationsMultiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/vpc_default_network_acl_test.go
+++ b/internal/service/ec2/vpc_default_network_acl_test.go
@@ -28,7 +28,7 @@ func TestAccVPCDefaultNetworkACL_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`network-acl/acl-.+`)),
@@ -61,7 +61,7 @@ func TestAccVPCDefaultNetworkACL_basicIPv6VPC(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLIPv6Config(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
@@ -89,7 +89,7 @@ func TestAccVPCDefaultNetworkACL_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLTags1Config(rName, "key1", "value1"),
+				Config: testAccVPCDefaultNetworkACLConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -102,7 +102,7 @@ func TestAccVPCDefaultNetworkACL_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDefaultNetworkACLTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCDefaultNetworkACLConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -111,7 +111,7 @@ func TestAccVPCDefaultNetworkACL_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDefaultNetworkACLTags1Config(rName, "key2", "value2"),
+				Config: testAccVPCDefaultNetworkACLConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -134,7 +134,7 @@ func TestAccVPCDefaultNetworkACL_Deny_ingress(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLDenyIngressConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_denyIngress(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "1"),
@@ -170,7 +170,7 @@ func TestAccVPCDefaultNetworkACL_withIPv6Ingress(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLIncludingIPv6RuleConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_includingIPv6Rule(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
@@ -206,7 +206,7 @@ func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLSubnetsConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_subnets(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -223,7 +223,7 @@ func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 			// but have not been reassigned. The result is that the Subnets are still
 			// there, and we have a non-empty plan
 			{
-				Config: testAccDefaultNetworkACLSubnetsRemoveConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_subnetsRemove(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 				),
@@ -250,7 +250,7 @@ func TestAccVPCDefaultNetworkACL_subnetReassign(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultNetworkACLSubnetsConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_subnets(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -276,7 +276,7 @@ func TestAccVPCDefaultNetworkACL_subnetReassign(t *testing.T) {
 			// update occurs first, and the former's READ will correctly read zero
 			// subnets
 			{
-				Config: testAccDefaultNetworkACLSubnetsMoveConfig(rName),
+				Config: testAccVPCDefaultNetworkACLConfig_subnetsMove(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "0"),
@@ -325,7 +325,7 @@ func testAccCheckDefaultNetworkACLExists(n string, v *ec2.NetworkAcl) resource.T
 	}
 }
 
-func testAccDefaultNetworkACLConfig(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -341,7 +341,7 @@ resource "aws_default_network_acl" "test" {
 `, rName)
 }
 
-func testAccDefaultNetworkACLTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCDefaultNetworkACLConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -361,7 +361,7 @@ resource "aws_default_network_acl" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDefaultNetworkACLTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCDefaultNetworkACLConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -382,7 +382,7 @@ resource "aws_default_network_acl" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccDefaultNetworkACLIncludingIPv6RuleConfig(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_includingIPv6Rule(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -407,7 +407,7 @@ resource "aws_default_network_acl" "test" {
 `, rName)
 }
 
-func testAccDefaultNetworkACLDenyIngressConfig(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_denyIngress(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -462,7 +462,7 @@ resource "aws_subnet" "test2" {
 `, rName)
 }
 
-func testAccDefaultNetworkACLSubnetsConfig(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_subnets(rName string) string {
 	return acctest.ConfigCompose(testAccDefaultNetworkACLSubnetsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_acl" "test" {
   vpc_id = aws_vpc.test.id
@@ -480,7 +480,7 @@ resource "aws_default_network_acl" "test" {
 `, rName))
 }
 
-func testAccDefaultNetworkACLSubnetsRemoveConfig(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_subnetsRemove(rName string) string {
 	return acctest.ConfigCompose(testAccDefaultNetworkACLSubnetsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_acl" "test" {
   vpc_id = aws_vpc.test.id
@@ -498,7 +498,7 @@ resource "aws_default_network_acl" "test" {
 `, rName))
 }
 
-func testAccDefaultNetworkACLSubnetsMoveConfig(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_subnetsMove(rName string) string {
 	return acctest.ConfigCompose(testAccDefaultNetworkACLSubnetsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_acl" "test" {
   vpc_id = aws_vpc.test.id
@@ -518,7 +518,7 @@ resource "aws_default_network_acl" "test" {
 `, rName))
 }
 
-func testAccDefaultNetworkACLIPv6Config(rName string) string {
+func testAccVPCDefaultNetworkACLConfig_ipv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_default_route_table_test.go
+++ b/internal/service/ec2/vpc_default_route_table_test.go
@@ -31,16 +31,16 @@ func TestAccVPCDefaultRouteTable_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Verify non-existent Route Table ID behavior
 			{
-				Config:      testAccDefaultRouteTableConfigDefaultRouteTableId("rtb-00000000"),
+				Config:      testAccVPCDefaultRouteTableConfig_id("rtb-00000000"),
 				ExpectError: regexp.MustCompile(`EC2 Default Route Table \(rtb-00000000\): couldn't find resource`),
 			},
 			// Verify invalid Route Table ID behavior
 			{
-				Config:      testAccDefaultRouteTableConfigDefaultRouteTableId("vpc-00000000"),
+				Config:      testAccVPCDefaultRouteTableConfig_id("vpc-00000000"),
 				ExpectError: regexp.MustCompile(`EC2 Default Route Table \(vpc-00000000\): couldn't find resource`),
 			},
 			{
-				Config: testAccDefaultRouteTableConfigBasic(rName),
+				Config: testAccVPCDefaultRouteTableConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
@@ -75,7 +75,7 @@ func TestAccVPCDefaultRouteTable_Disappears_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfigBasic(rName),
+				Config: testAccVPCDefaultRouteTableConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					acctest.CheckVPCExists(vpcResourceName, &vpc),
@@ -101,7 +101,7 @@ func TestAccVPCDefaultRouteTable_Route_mode(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfig_ipv4InternetGateway(rName, destinationCidr),
+				Config: testAccVPCDefaultRouteTableConfig_ipv4InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -121,7 +121,7 @@ func TestAccVPCDefaultRouteTable_Route_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDefaultRouteTableConfigNoRouteBlock(rName),
+				Config: testAccVPCDefaultRouteTableConfig_noBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -137,7 +137,7 @@ func TestAccVPCDefaultRouteTable_Route_mode(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDefaultRouteTableConfigRouteBlocksExplicitZero(rName),
+				Config: testAccVPCDefaultRouteTableConfig_blocksExplicitZero(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -171,7 +171,7 @@ func TestAccVPCDefaultRouteTable_swap(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfig_ipv4InternetGateway(rName, destinationCidr1),
+				Config: testAccVPCDefaultRouteTableConfig_ipv4InternetGateway(rName, destinationCidr1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -197,7 +197,7 @@ func TestAccVPCDefaultRouteTable_swap(t *testing.T) {
 			// this case) a diff as the table now needs to be updated to match the
 			// config
 			{
-				Config: testAccDefaultRouteTableConfigSwap(rName, destinationCidr1, destinationCidr2),
+				Config: testAccVPCDefaultRouteTableConfig_swap(rName, destinationCidr1, destinationCidr2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -207,7 +207,7 @@ func TestAccVPCDefaultRouteTable_swap(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccDefaultRouteTableConfigSwap(rName, destinationCidr1, destinationCidr2),
+				Config: testAccVPCDefaultRouteTableConfig_swap(rName, destinationCidr1, destinationCidr2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -241,7 +241,7 @@ func TestAccVPCDefaultRouteTable_ipv4ToTransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfig_ipv4TransitGateway(rName, destinationCidr),
+				Config: testAccVPCDefaultRouteTableConfig_ipv4TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -277,7 +277,7 @@ func TestAccVPCDefaultRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfig_ipv4VPCEndpoint(rName, destinationCidr),
+				Config: testAccVPCDefaultRouteTableConfig_ipv4Endpoint(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -295,7 +295,7 @@ func TestAccVPCDefaultRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 			// VPC Endpoints will not delete unless the route is removed prior, otherwise will error:
 			// InvalidParameter: Endpoint must be removed from route table before deletion
 			{
-				Config: testAccDefaultRouteTableConfig_ipv4VPCEndpointNoRoute(rName),
+				Config: testAccVPCDefaultRouteTableConfig_ipv4EndpointNo(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 				),
@@ -318,7 +318,7 @@ func TestAccVPCDefaultRouteTable_vpcEndpointAssociation(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfig_vpcEndpointAssociation(rName, destinationCidr),
+				Config: testAccVPCDefaultRouteTableConfig_endpointAssociation(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -348,7 +348,7 @@ func TestAccVPCDefaultRouteTable_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfigTags1(rName, "key1", "value1"),
+				Config: testAccVPCDefaultRouteTableConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -356,7 +356,7 @@ func TestAccVPCDefaultRouteTable_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDefaultRouteTableConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCDefaultRouteTableConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -365,7 +365,7 @@ func TestAccVPCDefaultRouteTable_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDefaultRouteTableConfigTags1(rName, "key2", "value2"),
+				Config: testAccVPCDefaultRouteTableConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -391,14 +391,14 @@ func TestAccVPCDefaultRouteTable_conditionalCIDRBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfig_conditionalIPv4v6(rName, destinationCidr, destinationIpv6Cidr, false),
+				Config: testAccVPCDefaultRouteTableConfig_conditionalIPv4v6(rName, destinationCidr, destinationIpv6Cidr, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableRoute(resourceName, "cidr_block", destinationCidr, "gateway_id", igwResourceName, "id"),
 				),
 			},
 			{
-				Config: testAccDefaultRouteTableConfig_conditionalIPv4v6(rName, destinationCidr, destinationIpv6Cidr, true),
+				Config: testAccVPCDefaultRouteTableConfig_conditionalIPv4v6(rName, destinationCidr, destinationIpv6Cidr, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableRoute(resourceName, "ipv6_cidr_block", destinationIpv6Cidr, "gateway_id", igwResourceName, "id"),
@@ -428,7 +428,7 @@ func TestAccVPCDefaultRouteTable_prefixListToInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfigPrefixListInternetGateway(rName),
+				Config: testAccVPCDefaultRouteTableConfig_prefixListInternetGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -446,7 +446,7 @@ func TestAccVPCDefaultRouteTable_prefixListToInternetGateway(t *testing.T) {
 			// Managed prefix lists will not delete unless the route is removed prior, otherwise will error:
 			// "unexpected state 'delete-failed', wanted target 'delete-complete'"
 			{
-				Config: testAccDefaultRouteTableConfigPrefixListInternetGatewayNoRoute(rName),
+				Config: testAccVPCDefaultRouteTableConfig_prefixListInternetGatewayNo(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 				),
@@ -472,7 +472,7 @@ func TestAccVPCDefaultRouteTable_revokeExistingRules(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTableConfigRevokeExistingRulesCustomRouteTable(rName),
+				Config: testAccVPCDefaultRouteTableConfig_revokeExistingRulesCustom(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -485,7 +485,7 @@ func TestAccVPCDefaultRouteTable_revokeExistingRules(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDefaultRouteTableConfigRevokeExistingRulesCustomRouteTableToMain(rName),
+				Config: testAccVPCDefaultRouteTableConfig_revokeExistingRulesCustomToMain(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -498,7 +498,7 @@ func TestAccVPCDefaultRouteTable_revokeExistingRules(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDefaultRouteTableConfigRevokeExistingRulesDefaultRouteTableOverlaysCustomRouteTable(rName),
+				Config: testAccVPCDefaultRouteTableConfig_revokeExistingRulesOverlaysCustom(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -551,7 +551,7 @@ func testAccDefaultRouteTableImportStateIdFunc(resourceName string) resource.Imp
 	}
 }
 
-func testAccDefaultRouteTableConfigDefaultRouteTableId(defaultRouteTableId string) string {
+func testAccVPCDefaultRouteTableConfig_id(defaultRouteTableId string) string {
 	return fmt.Sprintf(`
 resource "aws_default_route_table" "test" {
   default_route_table_id = %[1]q
@@ -559,7 +559,7 @@ resource "aws_default_route_table" "test" {
 `, defaultRouteTableId)
 }
 
-func testAccDefaultRouteTableConfigBasic(rName string) string {
+func testAccVPCDefaultRouteTableConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -575,7 +575,7 @@ resource "aws_default_route_table" "test" {
 `, rName)
 }
 
-func testAccDefaultRouteTableConfig_ipv4InternetGateway(rName, destinationCidr string) string {
+func testAccVPCDefaultRouteTableConfig_ipv4InternetGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.1.0.0/16"
@@ -609,7 +609,7 @@ resource "aws_internet_gateway" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccDefaultRouteTableConfigNoRouteBlock(rName string) string {
+func testAccVPCDefaultRouteTableConfig_noBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.1.0.0/16"
@@ -637,7 +637,7 @@ resource "aws_internet_gateway" "test" {
 }`, rName)
 }
 
-func testAccDefaultRouteTableConfigRouteBlocksExplicitZero(rName string) string {
+func testAccVPCDefaultRouteTableConfig_blocksExplicitZero(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.1.0.0/16"
@@ -667,7 +667,7 @@ resource "aws_internet_gateway" "test" {
 }`, rName)
 }
 
-func testAccDefaultRouteTableConfigSwap(rName, destinationCidr1, destinationCidr2 string) string {
+func testAccVPCDefaultRouteTableConfig_swap(rName, destinationCidr1, destinationCidr2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.1.0.0/16"
@@ -719,7 +719,7 @@ resource "aws_main_route_table_association" "test" {
 `, rName, destinationCidr1, destinationCidr2)
 }
 
-func testAccDefaultRouteTableConfig_ipv4TransitGateway(rName, destinationCidr string) string {
+func testAccVPCDefaultRouteTableConfig_ipv4TransitGateway(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -770,7 +770,7 @@ resource "aws_default_route_table" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccDefaultRouteTableConfig_ipv4VPCEndpoint(rName, destinationCidr string) string {
+func testAccVPCDefaultRouteTableConfig_ipv4Endpoint(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -848,7 +848,7 @@ resource "aws_default_route_table" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccDefaultRouteTableConfig_ipv4VPCEndpointNoRoute(rName string) string {
+func testAccVPCDefaultRouteTableConfig_ipv4EndpointNo(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -926,7 +926,7 @@ resource "aws_default_route_table" "test" {
 `, rName))
 }
 
-func testAccDefaultRouteTableConfig_vpcEndpointAssociation(rName, destinationCidr string) string {
+func testAccVPCDefaultRouteTableConfig_endpointAssociation(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -971,7 +971,7 @@ resource "aws_default_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccDefaultRouteTableConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCDefaultRouteTableConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -991,7 +991,7 @@ resource "aws_default_route_table" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDefaultRouteTableConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCDefaultRouteTableConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1012,7 +1012,7 @@ resource "aws_default_route_table" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccDefaultRouteTableConfig_conditionalIPv4v6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
+func testAccVPCDefaultRouteTableConfig_conditionalIPv4v6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1054,7 +1054,7 @@ resource "aws_default_route_table" "test" {
 `, rName, destinationCidr, destinationIpv6Cidr, ipv6Route)
 }
 
-func testAccDefaultRouteTableConfigPrefixListInternetGateway(rName string) string {
+func testAccVPCDefaultRouteTableConfig_prefixListInternetGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1093,7 +1093,7 @@ resource "aws_default_route_table" "test" {
 `, rName)
 }
 
-func testAccDefaultRouteTableConfigPrefixListInternetGatewayNoRoute(rName string) string {
+func testAccVPCDefaultRouteTableConfig_prefixListInternetGatewayNo(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1132,7 +1132,7 @@ resource "aws_default_route_table" "test" {
 `, rName)
 }
 
-func testAccDefaultRouteTableConfigRevokeExistingRulesCustomRouteTable(rName string) string {
+func testAccVPCDefaultRouteTableConfig_revokeExistingRulesCustom(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1180,9 +1180,9 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccDefaultRouteTableConfigRevokeExistingRulesCustomRouteTableToMain(rName string) string {
+func testAccVPCDefaultRouteTableConfig_revokeExistingRulesCustomToMain(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDefaultRouteTableConfigRevokeExistingRulesCustomRouteTable(rName),
+		testAccVPCDefaultRouteTableConfig_revokeExistingRulesCustom(rName),
 		`
 resource "aws_main_route_table_association" "test" {
   vpc_id         = aws_vpc.test.id
@@ -1191,9 +1191,9 @@ resource "aws_main_route_table_association" "test" {
 `)
 }
 
-func testAccDefaultRouteTableConfigRevokeExistingRulesDefaultRouteTableOverlaysCustomRouteTable(rName string) string {
+func testAccVPCDefaultRouteTableConfig_revokeExistingRulesOverlaysCustom(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDefaultRouteTableConfigRevokeExistingRulesCustomRouteTableToMain(rName),
+		testAccVPCDefaultRouteTableConfig_revokeExistingRulesCustomToMain(rName),
 		fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id

--- a/internal/service/ec2/vpc_default_security_group_test.go
+++ b/internal/service/ec2/vpc_default_security_group_test.go
@@ -25,7 +25,7 @@ func TestAccVPCDefaultSecurityGroup_VPC_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSecurityGroupConfig_VPC,
+				Config: testAccVPCDefaultSecurityGroupConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "default"),
@@ -54,7 +54,7 @@ func TestAccVPCDefaultSecurityGroup_VPC_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccDefaultSecurityGroupConfig_VPC,
+				Config:   testAccVPCDefaultSecurityGroupConfig_basic,
 				PlanOnly: true,
 			},
 			{
@@ -78,7 +78,7 @@ func TestAccVPCDefaultSecurityGroup_VPC_empty(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSecurityGroupConfig_VPC_empty,
+				Config: testAccVPCDefaultSecurityGroupConfig_empty,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
@@ -106,7 +106,7 @@ func TestAccVPCDefaultSecurityGroup_Classic_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSecurityGroupConfig_Classic(),
+				Config: testAccVPCDefaultSecurityGroupConfig_classic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultSecurityGroupClassicExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "default"),
@@ -128,11 +128,11 @@ func TestAccVPCDefaultSecurityGroup_Classic_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccDefaultSecurityGroupConfig_Classic(),
+				Config:   testAccVPCDefaultSecurityGroupConfig_classic(),
 				PlanOnly: true,
 			},
 			{
-				Config:                  testAccDefaultSecurityGroupConfig_Classic(),
+				Config:                  testAccVPCDefaultSecurityGroupConfig_classic(),
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -158,7 +158,7 @@ func TestAccVPCDefaultSecurityGroup_Classic_empty(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSecurityGroupConfig_Classic_empty(),
+				Config: testAccVPCDefaultSecurityGroupConfig_classicEmpty(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDefaultSecurityGroupClassicExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
@@ -234,7 +234,7 @@ func testAccCheckDefaultSecurityGroupARNClassic(resourceName string, group *ec2.
 	}
 }
 
-const testAccDefaultSecurityGroupConfig_VPC = `
+const testAccVPCDefaultSecurityGroupConfig_basic = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -266,7 +266,7 @@ resource "aws_default_security_group" "test" {
 }
 `
 
-const testAccDefaultSecurityGroupConfig_VPC_empty = `
+const testAccVPCDefaultSecurityGroupConfig_empty = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -280,7 +280,7 @@ resource "aws_default_security_group" "test" {
 }
 `
 
-func testAccDefaultSecurityGroupConfig_Classic() string {
+func testAccVPCDefaultSecurityGroupConfig_classic() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		`
@@ -299,7 +299,7 @@ resource "aws_default_security_group" "test" {
 `)
 }
 
-func testAccDefaultSecurityGroupConfig_Classic_empty() string {
+func testAccVPCDefaultSecurityGroupConfig_classicEmpty() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		`

--- a/internal/service/ec2/vpc_default_subnet_test.go
+++ b/internal/service/ec2/vpc_default_subnet_test.go
@@ -88,7 +88,7 @@ func testAccDefaultSubnet_Existing_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSubnetDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSubnetConfig(),
+				Config: testAccVPCDefaultSubnetConfig_basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -132,7 +132,7 @@ func testAccDefaultSubnet_Existing_forceDestroy(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSubnetDestroyNotFound,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSubnetForceDestroyConfig(),
+				Config: testAccVPCDefaultSubnetConfig_forceDestroy(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "existing_default_subnet", "true"),
@@ -158,7 +158,7 @@ func testAccDefaultSubnet_Existing_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSubnetDestroyNotFound,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSubnetIPv6Config(),
+				Config: testAccVPCDefaultSubnetConfig_ipv6(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -203,7 +203,7 @@ func testAccDefaultSubnet_Existing_privateDNSNameOptionsOnLaunch(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSubnetDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSubnetConfig_privateDNSNameOptionsOnLaunch(rName),
+				Config: testAccVPCDefaultSubnetConfig_privateDNSNameOptionsOnLaunch(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -248,7 +248,7 @@ func testAccDefaultSubnet_NotFound_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSubnetDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSubnetNotFoundConfig(),
+				Config: testAccVPCDefaultSubnetConfig_notFound(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -292,7 +292,7 @@ func testAccDefaultSubnet_NotFound_ipv6Native(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultSubnetDestroyNotFound,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultSubnetIPv6NativeConfig(),
+				Config: testAccVPCDefaultSubnetConfig_ipv6Native(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -429,7 +429,7 @@ data "aws_subnet" "test" {
 }
 `
 
-func testAccDefaultSubnetConfig() string {
+func testAccVPCDefaultSubnetConfig_basic() string {
 	return acctest.ConfigCompose(testAccDefaultSubnetConfigBaseExisting, `
 resource "aws_default_subnet" "test" {
   availability_zone = data.aws_subnet.test.availability_zone
@@ -437,7 +437,7 @@ resource "aws_default_subnet" "test" {
 `)
 }
 
-func testAccDefaultSubnetNotFoundConfig() string {
+func testAccVPCDefaultSubnetConfig_notFound() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_default_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -445,7 +445,7 @@ resource "aws_default_subnet" "test" {
 `)
 }
 
-func testAccDefaultSubnetForceDestroyConfig() string {
+func testAccVPCDefaultSubnetConfig_forceDestroy() string {
 	return acctest.ConfigCompose(testAccDefaultSubnetConfigBaseExisting, `
 resource "aws_default_subnet" "test" {
   availability_zone = data.aws_subnet.test.availability_zone
@@ -454,7 +454,7 @@ resource "aws_default_subnet" "test" {
 `)
 }
 
-func testAccDefaultSubnetIPv6Config() string {
+func testAccVPCDefaultSubnetConfig_ipv6() string {
 	return acctest.ConfigCompose(testAccDefaultSubnetConfigBaseExisting, `
 resource "aws_default_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
@@ -477,7 +477,7 @@ resource "aws_default_subnet" "test" {
 `)
 }
 
-func testAccDefaultSubnetIPv6NativeConfig() string {
+func testAccVPCDefaultSubnetConfig_ipv6Native() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_default_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
@@ -500,7 +500,7 @@ resource "aws_default_subnet" "test" {
 `)
 }
 
-func testAccDefaultSubnetConfig_privateDNSNameOptionsOnLaunch(rName string) string {
+func testAccVPCDefaultSubnetConfig_privateDNSNameOptionsOnLaunch(rName string) string {
 	return acctest.ConfigCompose(testAccDefaultSubnetConfigBaseExisting, fmt.Sprintf(`
 resource "aws_default_subnet" "test" {
   availability_zone = data.aws_subnet.test.availability_zone

--- a/internal/service/ec2/vpc_default_vpc_dhcp_options_test.go
+++ b/internal/service/ec2/vpc_default_vpc_dhcp_options_test.go
@@ -22,7 +22,7 @@ func TestAccVPCDefaultVPCDHCPOptions_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCDHCPOptionsBasicConfig,
+				Config: testAccVPCDefaultVPCDHCPOptionsConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dhcp-options/dopt-.+`)),
@@ -48,7 +48,7 @@ func TestAccVPCDefaultVPCDHCPOptions_owner(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCDHCPOptionsOwnerConfig,
+				Config: testAccVPCDefaultVPCDHCPOptionsConfig_owner,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dhcp-options/dopt-.+`)),
@@ -68,7 +68,7 @@ func testAccCheckDefaultVPCDHCPOptionsDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccDefaultVPCDHCPOptionsBasicConfig = `
+const testAccVPCDefaultVPCDHCPOptionsConfig_basic = `
 resource "aws_default_vpc_dhcp_options" "test" {
   tags = {
     Name = "Default DHCP Option Set"
@@ -76,7 +76,7 @@ resource "aws_default_vpc_dhcp_options" "test" {
 }
 `
 
-const testAccDefaultVPCDHCPOptionsOwnerConfig = `
+const testAccVPCDefaultVPCDHCPOptionsConfig_owner = `
 data "aws_caller_identity" "current" {}
 
 resource "aws_default_vpc_dhcp_options" "test" {

--- a/internal/service/ec2/vpc_default_vpc_test.go
+++ b/internal/service/ec2/vpc_default_vpc_test.go
@@ -93,7 +93,7 @@ func testAccDefaultVPC_Existing_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCConfig,
+				Config: testAccVPCDefaultVPCConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -140,7 +140,7 @@ func testAccDefaultVPC_Existing_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCAssignGeneratedIPv6CIDRBlockConfig(rName),
+				Config: testAccVPCDefaultVPCConfig_assignGeneratedIPv6CIDRBlock(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -187,7 +187,7 @@ func testAccDefaultVPC_Existing_forceDestroy(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDestroyNotFound,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCForceDestroyConfig,
+				Config: testAccVPCDefaultVPCConfig_forceDestroy,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "existing_default_vpc", "true"),
@@ -214,7 +214,7 @@ func testAccDefaultVPC_NotFound_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCConfig,
+				Config: testAccVPCDefaultVPCConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -261,7 +261,7 @@ func testAccDefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDestroyExists,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCAssignGeneratedIPv6CIDRBlockConfig(rName),
+				Config: testAccVPCDefaultVPCConfig_assignGeneratedIPv6CIDRBlock(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -308,7 +308,7 @@ func testAccDefaultVPC_NotFound_forceDestroy(t *testing.T) {
 		CheckDestroy:      testAccCheckDefaultVPCDestroyNotFound,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultVPCForceDestroyConfig,
+				Config: testAccVPCDefaultVPCConfig_forceDestroy,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "existing_default_vpc", "false"),
@@ -437,17 +437,17 @@ func testAccEmptyDefaultVPC(vpcID string) error {
 	return nil
 }
 
-const testAccDefaultVPCConfig = `
+const testAccVPCDefaultVPCConfig_basic = `
 resource "aws_default_vpc" "test" {}
 `
 
-const testAccDefaultVPCForceDestroyConfig = `
+const testAccVPCDefaultVPCConfig_forceDestroy = `
 resource "aws_default_vpc" "test" {
   force_destroy = true
 }
 `
 
-func testAccDefaultVPCAssignGeneratedIPv6CIDRBlockConfig(rName string) string {
+func testAccVPCDefaultVPCConfig_assignGeneratedIPv6CIDRBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_default_vpc" "test" {
   assign_generated_ipv6_cidr_block = true

--- a/internal/service/ec2/vpc_dhcp_options_association_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_association_test.go
@@ -25,7 +25,7 @@ func TestAccVPCDHCPOptionsAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDHCPOptionsAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDHCPOptionsAssociationConfig(rName),
+				Config: testAccVPCDHCPOptionsAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCDHCPOptionsAssociationExist(resourceName),
 				),
@@ -51,7 +51,7 @@ func TestAccVPCDHCPOptionsAssociation_Disappears_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDHCPOptionsAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDHCPOptionsAssociationConfig(rName),
+				Config: testAccVPCDHCPOptionsAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCDHCPOptionsAssociationExist(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPC(), "aws_vpc.test"),
@@ -73,7 +73,7 @@ func TestAccVPCDHCPOptionsAssociation_Disappears_dhcp(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDHCPOptionsAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDHCPOptionsAssociationConfig(rName),
+				Config: testAccVPCDHCPOptionsAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCDHCPOptionsAssociationExist(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPCDHCPOptions(), "aws_vpc_dhcp_options.test"),
@@ -95,7 +95,7 @@ func TestAccVPCDHCPOptionsAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDHCPOptionsAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDHCPOptionsAssociationConfig(rName),
+				Config: testAccVPCDHCPOptionsAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCDHCPOptionsAssociationExist(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPCDHCPOptionsAssociation(), resourceName),
@@ -117,7 +117,7 @@ func TestAccVPCDHCPOptionsAssociation_default(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDHCPOptionsAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDHCPOptionsAssociationDefaultConfig(rName),
+				Config: testAccVPCDHCPOptionsAssociationConfig_default(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCDHCPOptionsAssociationExist(resourceName),
 				),
@@ -202,7 +202,7 @@ func testAccCheckVPCDHCPOptionsAssociationExist(n string) resource.TestCheckFunc
 	}
 }
 
-func testAccVPCDHCPOptionsAssociationConfig(rName string) string {
+func testAccVPCDHCPOptionsAssociationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -231,7 +231,7 @@ resource "aws_vpc_dhcp_options_association" "test" {
 `, rName)
 }
 
-func testAccVPCDHCPOptionsAssociationDefaultConfig(rName string) string {
+func testAccVPCDHCPOptionsAssociationConfig_default(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_dhcp_options_data_source_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_data_source_test.go
@@ -84,7 +84,7 @@ func TestAccVPCDHCPOptionsDataSource_filter(t *testing.T) {
 				// test case with resources in the state and an erroneous config, and
 				// thus the automatic destroy step will fail. This ensures we end with
 				// both an empty state and a valid config.
-				Config: `/* this config intentionally left blank */`,
+				Config: `/* this config intentionally left blank */`, // nosemgrep:config-funcs-correct-form
 			},
 		},
 	})

--- a/internal/service/ec2/vpc_dhcp_options_data_source_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_data_source_test.go
@@ -21,11 +21,11 @@ func TestAccVPCDHCPOptionsDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVPCDHCPOptionsDataSourceConfig_Missing,
+				Config:      testAccVPCDHCPOptionsDataSourceConfig_missing,
 				ExpectError: regexp.MustCompile(`no matching EC2 DHCP Options Set found`),
 			},
 			{
-				Config: testAccVPCDHCPOptionsDataSourceConfig_dhcpOptionsID,
+				Config: testAccVPCDHCPOptionsDataSourceConfig_id,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "dhcp_options_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "domain_name", resourceName, "domain_name"),
@@ -58,7 +58,7 @@ func TestAccVPCDHCPOptionsDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCDHCPOptionsDataSourceConfig_Filter(rInt, 1),
+				Config: testAccVPCDHCPOptionsDataSourceConfig_filter(rInt, 1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "dhcp_options_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "domain_name", resourceName, "domain_name"),
@@ -76,7 +76,7 @@ func TestAccVPCDHCPOptionsDataSource_filter(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccVPCDHCPOptionsDataSourceConfig_Filter(rInt, 2),
+				Config:      testAccVPCDHCPOptionsDataSourceConfig_filter(rInt, 2),
 				ExpectError: regexp.MustCompile(`multiple EC2 DHCP Options Sets matched`),
 			},
 			{
@@ -90,13 +90,13 @@ func TestAccVPCDHCPOptionsDataSource_filter(t *testing.T) {
 	})
 }
 
-const testAccVPCDHCPOptionsDataSourceConfig_Missing = `
+const testAccVPCDHCPOptionsDataSourceConfig_missing = `
 data "aws_vpc_dhcp_options" "test" {
   dhcp_options_id = "does-not-exist"
 }
 `
 
-const testAccVPCDHCPOptionsDataSourceConfig_dhcpOptionsID = `
+const testAccVPCDHCPOptionsDataSourceConfig_id = `
 resource "aws_vpc_dhcp_options" "incorrect" {
   domain_name = "tf-acc-test-incorrect.example.com"
 }
@@ -118,7 +118,7 @@ data "aws_vpc_dhcp_options" "test" {
 }
 `
 
-func testAccVPCDHCPOptionsDataSourceConfig_Filter(rInt, count int) string {
+func testAccVPCDHCPOptionsDataSourceConfig_filter(rInt, count int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "incorrect" {
   domain_name = "tf-acc-test-incorrect.example.com"

--- a/internal/service/ec2/vpc_dhcp_options_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_test.go
@@ -27,7 +27,7 @@ func TestAccVPCDHCPOptions_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDHCPOptionsConfig(rName),
+				Config: testAccVPCDHCPOptionsConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dhcp-options/dopt-.+`)),
@@ -62,7 +62,7 @@ func TestAccVPCDHCPOptions_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDHCPOptionsConfigTags1(rName, "key1", "value1"),
+				Config: testAccVPCDHCPOptionsConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -75,7 +75,7 @@ func TestAccVPCDHCPOptions_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDHCPOptionsConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCDHCPOptionsConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -84,7 +84,7 @@ func TestAccVPCDHCPOptions_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDHCPOptionsConfigTags1(rName, "key2", "value2"),
+				Config: testAccVPCDHCPOptionsConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -107,7 +107,7 @@ func TestAccVPCDHCPOptions_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDHCPOptionsConfig(rName),
+				Config: testAccVPCDHCPOptionsConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPCDHCPOptions(), resourceName),
@@ -167,7 +167,7 @@ func testAccCheckDHCPOptionsExists(n string, v *ec2.DhcpOptions) resource.TestCh
 	}
 }
 
-func testAccDHCPOptionsConfig(rName string) string {
+func testAccVPCDHCPOptionsConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
   domain_name          = "service.%[1]s"
@@ -179,7 +179,7 @@ resource "aws_vpc_dhcp_options" "test" {
 `, rName)
 }
 
-func testAccDHCPOptionsConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCDHCPOptionsConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
   domain_name          = "service.%[1]s"
@@ -195,7 +195,7 @@ resource "aws_vpc_dhcp_options" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDHCPOptionsConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCDHCPOptionsConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
   domain_name          = "service.%[1]s"

--- a/internal/service/ec2/vpc_egress_only_internet_gateway_test.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway_test.go
@@ -26,7 +26,7 @@ func TestAccVPCEgressOnlyInternetGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEgressOnlyInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEgressOnlyInternetGatewayConfig(rName),
+				Config: testAccVPCEgressOnlyInternetGatewayConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEgressOnlyInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -53,7 +53,7 @@ func TestAccVPCEgressOnlyInternetGateway_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEgressOnlyInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEgressOnlyInternetGatewayTags1Config(rName, "key1", "value1"),
+				Config: testAccVPCEgressOnlyInternetGatewayConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEgressOnlyInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -66,7 +66,7 @@ func TestAccVPCEgressOnlyInternetGateway_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEgressOnlyInternetGatewayTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCEgressOnlyInternetGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEgressOnlyInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -75,7 +75,7 @@ func TestAccVPCEgressOnlyInternetGateway_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEgressOnlyInternetGatewayTags1Config(rName, "key2", "value2"),
+				Config: testAccVPCEgressOnlyInternetGatewayConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEgressOnlyInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -135,7 +135,7 @@ func testAccCheckEgressOnlyInternetGatewayExists(n string, v *ec2.EgressOnlyInte
 	}
 }
 
-func testAccEgressOnlyInternetGatewayConfig(rName string) string {
+func testAccVPCEgressOnlyInternetGatewayConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -152,7 +152,7 @@ resource "aws_egress_only_internet_gateway" "test" {
 `, rName)
 }
 
-func testAccEgressOnlyInternetGatewayTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCEgressOnlyInternetGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -172,7 +172,7 @@ resource "aws_egress_only_internet_gateway" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccEgressOnlyInternetGatewayTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCEgressOnlyInternetGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoint_data_source_test.go
@@ -141,7 +141,7 @@ func TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointDataSourceConfig_gatewayWithRouteTableAndTags(rName),
+				Config: testAccVPCEndpointDataSourceConfig_gatewayRouteTableAndTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Gateway"),
 					resource.TestCheckResourceAttrSet(datasourceName, "prefix_list_id"),
@@ -302,7 +302,7 @@ data "aws_vpc_endpoint" "test" {
 `, rName)
 }
 
-func testAccVPCEndpointDataSourceConfig_gatewayWithRouteTableAndTags(rName string) string {
+func testAccVPCEndpointDataSourceConfig_gatewayRouteTableAndTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_endpoint_security_group_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_security_group_association_test.go
@@ -97,7 +97,7 @@ func TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation(t *tes
 		CheckDestroy:      testAccCheckVPCEndpointSecurityGroupAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointSecurityGroupAssociationConfig_replaceDefaultAssociation(rName),
+				Config: testAccVPCEndpointSecurityGroupAssociationConfig_replaceDefault(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointSecurityGroupAssociationExists(resourceName, &v),
 					testAccCheckVPCEndpointSecurityGroupAssociationNumAssociations(&v, 1),
@@ -230,7 +230,7 @@ resource "aws_vpc_endpoint_security_group_association" "test" {
 `)
 }
 
-func testAccVPCEndpointSecurityGroupAssociationConfig_replaceDefaultAssociation(rName string) string {
+func testAccVPCEndpointSecurityGroupAssociationConfig_replaceDefault(rName string) string {
 	return acctest.ConfigCompose(
 		testAccVPCEndpointSecurityGroupAssociationConfig_base(rName),
 		`

--- a/internal/service/ec2/vpc_endpoint_service_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccVPCEndpointServiceDataSource_gateway(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceGatewayDataSourceConfig,
+				Config: testAccVPCEndpointServiceDataSourceConfig_gateway,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceAttrRegionalReverseDNSService(datasourceName, "service_name", "dynamodb"),
 					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "false"),
@@ -49,7 +49,7 @@ func TestAccVPCEndpointServiceDataSource_interface(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceInterfaceDataSourceConfig,
+				Config: testAccVPCEndpointServiceDataSourceConfig_interface,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceAttrRegionalReverseDNSService(datasourceName, "service_name", "ec2"),
 					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "false"),
@@ -77,7 +77,7 @@ func TestAccVPCEndpointServiceDataSource_custom(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceCustomDataSourceConfig(rName),
+				Config: testAccVPCEndpointServiceDataSourceConfig_custom(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "availability_zones.#", "2"),
@@ -104,7 +104,7 @@ func TestAccVPCEndpointServiceDataSource_Custom_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceCustomFilterDataSourceConfig(rName),
+				Config: testAccVPCEndpointServiceDataSourceConfig_customFilter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "availability_zones.#", "2"),
@@ -131,7 +131,7 @@ func TestAccVPCEndpointServiceDataSource_CustomFilter_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceCustomFilterTagsDataSourceConfig(rName),
+				Config: testAccVPCEndpointServiceDataSourceConfig_customFilterTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "availability_zones.#", "2"),
@@ -157,7 +157,7 @@ func TestAccVPCEndpointServiceDataSource_ServiceType_gateway(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceDataSourceConfig_ServiceType("s3", "Gateway"),
+				Config: testAccVPCEndpointServiceDataSourceConfig_type("s3", "Gateway"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceAttrRegionalReverseDNSService(datasourceName, "service_name", "s3"),
 					resource.TestCheckResourceAttr(datasourceName, "service_type", "Gateway"),
@@ -176,7 +176,7 @@ func TestAccVPCEndpointServiceDataSource_ServiceType_interface(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointServiceDataSourceConfig_ServiceType("ec2", "Interface"),
+				Config: testAccVPCEndpointServiceDataSourceConfig_type("ec2", "Interface"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceAttrRegionalReverseDNSService(datasourceName, "service_name", "ec2"),
 					resource.TestCheckResourceAttr(datasourceName, "service_type", "Interface"),
@@ -197,7 +197,7 @@ func testAccCheckResourceAttrRegionalReverseDNSService(resourceName, attributeNa
 	}
 }
 
-const testAccVPCEndpointServiceGatewayDataSourceConfig = `
+const testAccVPCEndpointServiceDataSourceConfig_gateway = `
 data "aws_availability_zones" "available" {}
 
 data "aws_vpc_endpoint_service" "test" {
@@ -205,13 +205,13 @@ data "aws_vpc_endpoint_service" "test" {
 }
 `
 
-const testAccVPCEndpointServiceInterfaceDataSourceConfig = `
+const testAccVPCEndpointServiceDataSourceConfig_interface = `
 data "aws_vpc_endpoint_service" "test" {
   service = "ec2"
 }
 `
 
-func testAccVPCEndpointServiceDataSourceConfig_ServiceType(service string, serviceType string) string {
+func testAccVPCEndpointServiceDataSourceConfig_type(service string, serviceType string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
   service      = %[1]q
@@ -291,7 +291,7 @@ resource "aws_vpc_endpoint_service" "test" {
 `, rName)
 }
 
-func testAccVPCEndpointServiceCustomDataSourceConfig(rName string) string {
+func testAccVPCEndpointServiceDataSourceConfig_custom(rName string) string {
 	return testAccVPCEndpointServiceCustomBaseDataSourceConfig(rName) + `
 data "aws_vpc_endpoint_service" "test" {
   service_name = aws_vpc_endpoint_service.test.service_name
@@ -299,7 +299,7 @@ data "aws_vpc_endpoint_service" "test" {
 `
 }
 
-func testAccVPCEndpointServiceCustomFilterDataSourceConfig(rName string) string {
+func testAccVPCEndpointServiceDataSourceConfig_customFilter(rName string) string {
 	return testAccVPCEndpointServiceCustomBaseDataSourceConfig(rName) + `
 data "aws_vpc_endpoint_service" "test" {
   filter {
@@ -310,7 +310,7 @@ data "aws_vpc_endpoint_service" "test" {
 `
 }
 
-func testAccVPCEndpointServiceCustomFilterTagsDataSourceConfig(rName string) string {
+func testAccVPCEndpointServiceDataSourceConfig_customFilterTags(rName string) string {
 	return testAccVPCEndpointServiceCustomBaseDataSourceConfig(rName) + `
 data "aws_vpc_endpoint_service" "test" {
   tags = {

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -68,7 +68,7 @@ func TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointConfig_gatewayWithRouteTableAndPolicy(rName),
+				Config: testAccVPCEndpointConfig_gatewayRouteTableAndPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointExists(resourceName, &endpoint),
 					testAccCheckRouteTableExists(routeTableResourceName, &routeTable),
@@ -87,7 +87,7 @@ func TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCEndpointConfig_gatewayWithRouteTableAndPolicyModified(rName),
+				Config: testAccVPCEndpointConfig_gatewayRouteTableAndPolicyModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointExists(resourceName, &endpoint),
 					testAccCheckRouteTableExists(routeTableResourceName, &routeTable),
@@ -257,7 +257,7 @@ func TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointConfig_interfaceWithSubnet(rName),
+				Config: testAccVPCEndpointConfig_interfaceSubnet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointExists(resourceName, &endpoint),
 					resource.TestCheckNoResourceAttr(resourceName, "prefix_list_id"),
@@ -276,7 +276,7 @@ func TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCEndpointConfig_interfaceWithSubnetModified(rName),
+				Config: testAccVPCEndpointConfig_interfaceSubnetModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointExists(resourceName, &endpoint),
 					resource.TestCheckNoResourceAttr(resourceName, "prefix_list_id"),
@@ -598,7 +598,7 @@ resource "aws_vpc_endpoint" "test" {
 `, rName)
 }
 
-func testAccVPCEndpointConfig_gatewayWithRouteTableAndPolicy(rName string) string {
+func testAccVPCEndpointConfig_gatewayRouteTableAndPolicy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -664,7 +664,7 @@ resource "aws_route_table_association" "test" {
 `, rName)
 }
 
-func testAccVPCEndpointConfig_gatewayWithRouteTableAndPolicyModified(rName string) string {
+func testAccVPCEndpointConfig_gatewayRouteTableAndPolicyModified(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -812,7 +812,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccVPCEndpointConfig_interfaceWithSubnet(rName string) string {
+func testAccVPCEndpointConfig_interfaceSubnet(rName string) string {
 	return acctest.ConfigCompose(
 		testAccVPCEndpointConfig_vpcBase(rName),
 		fmt.Sprintf(`
@@ -838,7 +838,7 @@ resource "aws_vpc_endpoint" "test" {
 `, rName))
 }
 
-func testAccVPCEndpointConfig_interfaceWithSubnetModified(rName string) string {
+func testAccVPCEndpointConfig_interfaceSubnetModified(rName string) string {
 	return acctest.ConfigCompose(
 		testAccVPCEndpointConfig_vpcBase(rName),
 		fmt.Sprintf(`

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -30,7 +30,7 @@ func TestAccVPCFlowLog_vpcID(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_VPCID(rName),
+				Config: testAccVPCFlowLogConfig_id(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpc-flow-log/fl-.+`)),
@@ -49,7 +49,7 @@ func TestAccVPCFlowLog_vpcID(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:             testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName),
+				Config:             testAccVPCFlowLogConfig_destinationTypeCloudWatchLogs(rName),
 				ExpectNonEmptyPlan: false,
 			},
 		},
@@ -69,7 +69,7 @@ func TestAccVPCFlowLog_logFormat(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogFormat(rName),
+				Config: testAccVPCFlowLogConfig_format(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttr(resourceName, "log_format", logFormat),
@@ -81,7 +81,7 @@ func TestAccVPCFlowLog_logFormat(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:             testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName),
+				Config:             testAccVPCFlowLogConfig_destinationTypeCloudWatchLogs(rName),
 				ExpectNonEmptyPlan: false,
 			},
 		},
@@ -103,7 +103,7 @@ func TestAccVPCFlowLog_subnetID(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_SubnetID(rName),
+				Config: testAccVPCFlowLogConfig_subnetID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "iam_role_arn", iamRoleResourceName, "arn"),
@@ -137,7 +137,7 @@ func TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeCloudWatchLogs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					// We automatically trim :* from ARNs if present
@@ -168,7 +168,7 @@ func TestAccVPCFlowLog_LogDestinationType_s3(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_S3(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeS3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
@@ -195,7 +195,7 @@ func TestAccVPCFlowLog_LogDestinationTypeS3_invalid(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccFlowLogConfig_LogDestinationType_S3_Invalid(rName),
+				Config:      testAccVPCFlowLogConfig_destinationTypeS3Invalid(rName),
 				ExpectError: regexp.MustCompile(`(Access Denied for LogDestination|does not exist)`),
 			},
 		},
@@ -215,7 +215,7 @@ func TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_S3_DO_PlainText(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeS3DOPlainText(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
@@ -246,7 +246,7 @@ func TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible(t *testing
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_S3_DO_PlainText_HiveCompatible_PerHour(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeS3DOPlainTextHiveCompatiblePerHour(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
@@ -279,7 +279,7 @@ func TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_S3_DO_Parquet(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeS3DOParquet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
@@ -310,7 +310,7 @@ func TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible(t *testing.T
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_S3_DO_Parquet_HiveCompatible(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeS3DOParquetHiveCompatible(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
@@ -342,7 +342,7 @@ func TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour(t *te
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_LogDestinationType_S3_DO_Parquet_HiveCompatible_PerHour(rName),
+				Config: testAccVPCFlowLogConfig_destinationTypeS3DOParquetHiveCompatiblePerHour(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
@@ -374,7 +374,7 @@ func TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_MaxAggregationInterval(rName),
+				Config: testAccVPCFlowLogConfig_maxAggregationInterval(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttr(resourceName, "max_aggregation_interval", "60"),
@@ -401,7 +401,7 @@ func TestAccVPCFlowLog_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfigTags1(rName, "key1", "value1"),
+				Config: testAccVPCFlowLogConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -414,7 +414,7 @@ func TestAccVPCFlowLog_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFlowLogConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCFlowLogConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -423,7 +423,7 @@ func TestAccVPCFlowLog_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFlowLogConfigTags1(rName, "key2", "value2"),
+				Config: testAccVPCFlowLogConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -446,7 +446,7 @@ func TestAccVPCFlowLog_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_VPCID(rName),
+				Config: testAccVPCFlowLogConfig_id(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceFlowLog(), resourceName),
@@ -518,7 +518,7 @@ resource "aws_vpc" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeCloudWatchLogs(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -559,7 +559,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -575,7 +575,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3_Invalid(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3Invalid(rName string) string {
 	return testAccFlowLogConfigBase(rName) + `
 data "aws_partition" "current" {}
 
@@ -588,7 +588,7 @@ resource "aws_flow_log" "test" {
 `
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3_DO_PlainText(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3DOPlainText(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -607,7 +607,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3_DO_PlainText_HiveCompatible_PerHour(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3DOPlainTextHiveCompatiblePerHour(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -628,7 +628,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3_DO_Parquet(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3DOParquet(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -647,7 +647,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3_DO_Parquet_HiveCompatible(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3DOParquetHiveCompatible(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -667,7 +667,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogDestinationType_S3_DO_Parquet_HiveCompatible_PerHour(rName string) string {
+func testAccVPCFlowLogConfig_destinationTypeS3DOParquetHiveCompatiblePerHour(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -688,7 +688,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_SubnetID(rName string) string {
+func testAccVPCFlowLogConfig_subnetID(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_subnet" "test" {
   cidr_block = "10.0.1.0/24"
@@ -737,7 +737,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_VPCID(rName string) string {
+func testAccVPCFlowLogConfig_id(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -777,7 +777,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfig_LogFormat(rName string) string {
+func testAccVPCFlowLogConfig_format(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -823,7 +823,7 @@ resource "aws_flow_log" "test" {
 `, rName)
 }
 
-func testAccFlowLogConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCFlowLogConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -867,7 +867,7 @@ resource "aws_flow_log" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccFlowLogConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCFlowLogConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -912,7 +912,7 @@ resource "aws_flow_log" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccFlowLogConfig_MaxAggregationInterval(rName string) string {
+func testAccVPCFlowLogConfig_maxAggregationInterval(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/ec2/vpc_internet_gateway_attachment_test.go
+++ b/internal/service/ec2/vpc_internet_gateway_attachment_test.go
@@ -28,7 +28,7 @@ func TestAccVPCInternetGatewayAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckInternetGatewayAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayAttachmentAttachmentConfig(rName),
+				Config: testAccVPCInternetGatewayAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayAttachmentExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "internet_gateway_id", igwResourceName, "id"),
@@ -56,7 +56,7 @@ func TestAccVPCInternetGatewayAttachment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckInternetGatewayAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayAttachmentAttachmentConfig(rName),
+				Config: testAccVPCInternetGatewayAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayAttachmentExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceInternetGatewayAttachment(), resourceName),
@@ -128,7 +128,7 @@ func testAccCheckInternetGatewayAttachmentExists(n string, v *ec2.InternetGatewa
 	}
 }
 
-func testAccInternetGatewayAttachmentAttachmentConfig(rName string) string {
+func testAccVPCInternetGatewayAttachmentConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_internet_gateway_data_source_test.go
+++ b/internal/service/ec2/vpc_internet_gateway_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccVPCInternetGatewayDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayDataSourceConfig(rName),
+				Config: testAccVPCInternetGatewayDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "internet_gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", igwResourceName, "owner_id"),
@@ -44,7 +44,7 @@ func TestAccVPCInternetGatewayDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccInternetGatewayDataSourceConfig(rName string) string {
+func testAccVPCInternetGatewayDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"

--- a/internal/service/ec2/vpc_internet_gateway_test.go
+++ b/internal/service/ec2/vpc_internet_gateway_test.go
@@ -26,7 +26,7 @@ func TestAccVPCInternetGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayBasicConfig,
+				Config: testAccVPCInternetGatewayConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`internet-gateway/igw-.+`)),
@@ -55,7 +55,7 @@ func TestAccVPCInternetGateway_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayBasicConfig,
+				Config: testAccVPCInternetGatewayConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceInternetGateway(), resourceName),
@@ -80,7 +80,7 @@ func TestAccVPCInternetGateway_Attachment(t *testing.T) {
 		CheckDestroy:      testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayAttachmentConfig(rName),
+				Config: testAccVPCInternetGatewayConfig_attachment(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpc1ResourceName, "id"),
@@ -92,7 +92,7 @@ func TestAccVPCInternetGateway_Attachment(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInternetGatewayAttachmentUpdatedConfig(rName),
+				Config: testAccVPCInternetGatewayConfig_attachmentUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpc2ResourceName, "id"),
@@ -114,7 +114,7 @@ func TestAccVPCInternetGateway_Tags(t *testing.T) {
 		CheckDestroy:      testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayTags1Config(rName, "key1", "value1"),
+				Config: testAccVPCInternetGatewayConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -127,7 +127,7 @@ func TestAccVPCInternetGateway_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInternetGatewayTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCInternetGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -136,7 +136,7 @@ func TestAccVPCInternetGateway_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInternetGatewayTags1Config(rName, "key2", "value2"),
+				Config: testAccVPCInternetGatewayConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -196,11 +196,11 @@ func testAccCheckInternetGatewayExists(n string, v *ec2.InternetGateway) resourc
 	}
 }
 
-const testAccInternetGatewayBasicConfig = `
+const testAccVPCInternetGatewayConfig_basic = `
 resource "aws_internet_gateway" "test" {}
 `
 
-func testAccInternetGatewayAttachmentConfig(rName string) string {
+func testAccVPCInternetGatewayConfig_attachment(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -228,7 +228,7 @@ resource "aws_internet_gateway" "test" {
 `, rName)
 }
 
-func testAccInternetGatewayAttachmentUpdatedConfig(rName string) string {
+func testAccVPCInternetGatewayConfig_attachmentUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -256,7 +256,7 @@ resource "aws_internet_gateway" "test" {
 `, rName)
 }
 
-func testAccInternetGatewayTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCInternetGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   tags = {
@@ -266,7 +266,7 @@ resource "aws_internet_gateway" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccInternetGatewayTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCInternetGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   tags = {

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
@@ -29,7 +29,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCIPv4CIDRBlockAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCIPv4CIDRBlockAssociationConfig(rName),
+				Config: testAccVPCIPv4CIDRBlockAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCIPv4CIDRBlockAssociationExists(resource1Name, &associationSecondary),
 					testAccCheckAdditionalVPCIPv4CIDRBlock(&associationSecondary, "172.2.0.0/16"),
@@ -64,7 +64,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCIPv4CIDRBlockAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCIPv4CIDRBlockAssociationConfig(rName),
+				Config: testAccVPCIPv4CIDRBlockAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCIPv4CIDRBlockAssociationExists(resource1Name, &associationSecondary),
 					testAccCheckVPCIPv4CIDRBlockAssociationExists(resource2Name, &associationTertiary),
@@ -117,7 +117,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_ipamBasicExplicitCIDR(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCIPv4CIDRBlockAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCIPv4CIDRBlockAssociationConfig_ipamExplicitCIDR(rName, cidr),
+				Config: testAccVPCIPv4CIDRBlockAssociationConfig_ipamExplicit(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCIPv4CIDRBlockAssociationExists("aws_vpc_ipv4_cidr_block_association.secondary_cidr", &associationSecondary),
 					testAccCheckAdditionalVPCIPv4CIDRBlock(&associationSecondary, cidr)),
@@ -196,7 +196,7 @@ func testAccCheckVPCIPv4CIDRBlockAssociationExists(n string, v *ec2.VpcCidrBlock
 	}
 }
 
-func testAccVPCIPv4CIDRBlockAssociationConfig(rName string) string {
+func testAccVPCIPv4CIDRBlockAssociationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -238,7 +238,7 @@ resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
 `, rName, netmaskLength))
 }
 
-func testAccVPCIPv4CIDRBlockAssociationConfig_ipamExplicitCIDR(rName, cidr string) string {
+func testAccVPCIPv4CIDRBlockAssociationConfig_ipamExplicit(rName, cidr string) string {
 	return acctest.ConfigCompose(testAccIPAMIPv4Config_base(rName), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/vpc_main_route_table_association_test.go
+++ b/internal/service/ec2/vpc_main_route_table_association_test.go
@@ -26,13 +26,13 @@ func TestAccVPCMainRouteTableAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMainRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMainRouteTableAssociationConfig(rName),
+				Config: testAccVPCMainRouteTableAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMainRouteTableAssociationExists(resourceName, &rta),
 				),
 			},
 			{
-				Config: testAccMainRouteTableAssociationConfigUpdated(rName),
+				Config: testAccVPCMainRouteTableAssociationConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMainRouteTableAssociationExists(resourceName, &rta),
 				),
@@ -119,7 +119,7 @@ resource "aws_internet_gateway" "test" {
 `, rName)
 }
 
-func testAccMainRouteTableAssociationConfig(rName string) string {
+func testAccVPCMainRouteTableAssociationConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccMainRouteTableAssociationConfigBaseVPC(rName), fmt.Sprintf(`
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
@@ -141,7 +141,7 @@ resource "aws_main_route_table_association" "test" {
 `, rName))
 }
 
-func testAccMainRouteTableAssociationConfigUpdated(rName string) string {
+func testAccVPCMainRouteTableAssociationConfig_updated(rName string) string {
 	return acctest.ConfigCompose(testAccMainRouteTableAssociationConfigBaseVPC(rName), fmt.Sprintf(`
 # Need to keep the old route table around when we update the
 # main_route_table_association, otherwise Terraform will try to destroy the

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
@@ -51,7 +51,7 @@ func TestAccVPCManagedPrefixListDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListDataSourceConfig_basic,
+				Config: testAccVPCManagedPrefixListDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccManagedPrefixListGetIdByNameDataSource(prefixListName, &prefixListId, &prefixListArn),
 
@@ -76,7 +76,7 @@ func TestAccVPCManagedPrefixListDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccManagedPrefixListDataSourceConfig_basic = `
+const testAccVPCManagedPrefixListDataSourceConfig_basic = `
 data "aws_region" "current" {}
 
 data "aws_ec2_managed_prefix_list" "s3_by_name" {
@@ -106,7 +106,7 @@ func TestAccVPCManagedPrefixListDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListDataSourceConfig_filter,
+				Config: testAccVPCManagedPrefixListDataSourceConfig_filter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccManagedPrefixListGetIdByNameDataSource(prefixListName, &prefixListId, &prefixListArn),
 					resource.TestCheckResourceAttrPtr(resourceByName, "id", &prefixListId),
@@ -133,7 +133,7 @@ func TestAccVPCManagedPrefixListDataSource_filter(t *testing.T) {
 	})
 }
 
-const testAccManagedPrefixListDataSourceConfig_filter = `
+const testAccVPCManagedPrefixListDataSourceConfig_filter = `
 data "aws_region" "current" {}
 
 data "aws_ec2_managed_prefix_list" "s3_by_name" {
@@ -158,13 +158,13 @@ func TestAccVPCManagedPrefixListDataSource_matchesTooMany(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccPrefixListDataSourceConfig_matchesTooMany,
+				Config:      testAccVPCManagedPrefixListDataSourceConfig_matchesTooMany,
 				ExpectError: regexp.MustCompile(`more than 1 prefix list matched the given criteria`),
 			},
 		},
 	})
 }
 
-const testAccPrefixListDataSourceConfig_matchesTooMany = `
+const testAccVPCManagedPrefixListDataSourceConfig_matchesTooMany = `
 data "aws_ec2_managed_prefix_list" "test" {}
 `

--- a/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
@@ -28,7 +28,7 @@ func TestAccVPCManagedPrefixListEntry_ipv4(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListEntryIPv4Config(rName),
+				Config: testAccVPCManagedPrefixListEntryConfig_ipv4(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckManagedPrefixListEntryExists(resourceName, &entry),
 					resource.TestCheckResourceAttrPair(resourceName, "prefix_list_id", plResourceName, "id"),
@@ -59,7 +59,7 @@ func TestAccVPCManagedPrefixListEntry_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListEntryIPv6Config(rName),
+				Config: testAccVPCManagedPrefixListEntryConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckManagedPrefixListEntryExists(resourceName, &entry),
 					resource.TestCheckResourceAttrPair(resourceName, "prefix_list_id", plResourceName, "id"),
@@ -87,7 +87,7 @@ func TestAccVPCManagedPrefixListEntry_expectInvalidTypeError(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccManagedPrefixListEntryExpectInvalidType(rName),
+				Config:      testAccVPCManagedPrefixListEntryConfig_expectInvalidType(rName),
 				ExpectError: regexp.MustCompile(`invalid CIDR address: ::/244`),
 			},
 		},
@@ -104,11 +104,11 @@ func TestAccVPCManagedPrefixListEntry_expectInvalidCIDR(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccManagedPrefixListEntryInvalidIPv4CIDR(rName),
+				Config:      testAccVPCManagedPrefixListEntryConfig_invalidIPv4CIDR(rName),
 				ExpectError: regexp.MustCompile("invalid CIDR address: 1.2.3.4/33"),
 			},
 			{
-				Config:      testAccManagedPrefixListEntryInvalidIPv6CIDR(rName),
+				Config:      testAccVPCManagedPrefixListEntryConfig_invalidIPv6CIDR(rName),
 				ExpectError: regexp.MustCompile("invalid CIDR address: ::/244"),
 			},
 		},
@@ -128,7 +128,7 @@ func TestAccVPCManagedPrefixListEntry_description(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListEntryDescriptionConfig(rName),
+				Config: testAccVPCManagedPrefixListEntryConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckManagedPrefixListEntryExists(resourceName, &entry),
 					resource.TestCheckResourceAttrPair(resourceName, "prefix_list_id", plResourceName, "id"),
@@ -158,7 +158,7 @@ func TestAccVPCManagedPrefixListEntry_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListEntryIPv4Config(rName),
+				Config: testAccVPCManagedPrefixListEntryConfig_ipv4(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckManagedPrefixListEntryExists(resourceName, &entry),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceManagedPrefixListEntry(), resourceName),
@@ -244,7 +244,7 @@ func testAccManagedPrefixListEntryImportStateIdFunc(resourceName string) resourc
 	}
 }
 
-func testAccManagedPrefixListEntryIPv4Config(rName string) string {
+func testAccVPCManagedPrefixListEntryConfig_ipv4(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
@@ -259,7 +259,7 @@ resource "aws_ec2_managed_prefix_list_entry" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListEntryIPv6Config(rName string) string {
+func testAccVPCManagedPrefixListEntryConfig_ipv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
@@ -274,7 +274,7 @@ resource "aws_ec2_managed_prefix_list_entry" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListEntryDescriptionConfig(rName string) string {
+func testAccVPCManagedPrefixListEntryConfig_description(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
@@ -290,7 +290,7 @@ resource "aws_ec2_managed_prefix_list_entry" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListEntryExpectInvalidType(rName string) string {
+func testAccVPCManagedPrefixListEntryConfig_expectInvalidType(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
@@ -305,7 +305,7 @@ resource "aws_ec2_managed_prefix_list_entry" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListEntryInvalidIPv4CIDR(rName string) string {
+func testAccVPCManagedPrefixListEntryConfig_invalidIPv4CIDR(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
@@ -320,7 +320,7 @@ resource "aws_ec2_managed_prefix_list_entry" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListEntryInvalidIPv6CIDR(rName string) string {
+func testAccVPCManagedPrefixListEntryConfig_invalidIPv6CIDR(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -26,7 +26,7 @@ func TestAccVPCManagedPrefixList_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:       testAccManagedPrefixListConfig_Name(rName),
+				Config:       testAccVPCManagedPrefixListConfig_name(rName),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -46,7 +46,7 @@ func TestAccVPCManagedPrefixList_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:       testAccManagedPrefixListUpdatedConfig(rName),
+				Config:       testAccVPCManagedPrefixListConfig_updated(rName),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -68,7 +68,7 @@ func TestAccVPCManagedPrefixList_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListConfig_Name(rName),
+				Config: testAccVPCManagedPrefixListConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceManagedPrefixList(), resourceName),
@@ -90,7 +90,7 @@ func TestAccVPCManagedPrefixList_AddressFamily_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:       testAccManagedPrefixListConfig_AddressFamily(rName, "IPv6"),
+				Config:       testAccVPCManagedPrefixListConfig_addressFamily(rName, "IPv6"),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -117,7 +117,7 @@ func TestAccVPCManagedPrefixList_Entry_cidr(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:       testAccManagedPrefixListConfig_Entry_CIDR1(rName),
+				Config:       testAccVPCManagedPrefixListConfig_entryCIDR1(rName),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -139,7 +139,7 @@ func TestAccVPCManagedPrefixList_Entry_cidr(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:       testAccManagedPrefixListConfig_Entry_CIDR2(rName),
+				Config:       testAccVPCManagedPrefixListConfig_entryCIDR2(rName),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -175,7 +175,7 @@ func TestAccVPCManagedPrefixList_Entry_description(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:       testAccManagedPrefixListConfig_Entry_Description(rName, "description1"),
+				Config:       testAccVPCManagedPrefixListConfig_entryDescription(rName, "description1"),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -197,7 +197,7 @@ func TestAccVPCManagedPrefixList_Entry_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:       testAccManagedPrefixListConfig_Entry_Description(rName, "description2"),
+				Config:       testAccVPCManagedPrefixListConfig_entryDescription(rName, "description2"),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -229,7 +229,7 @@ func TestAccVPCManagedPrefixList_name(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:       testAccManagedPrefixListConfig_Name(rName1),
+				Config:       testAccVPCManagedPrefixListConfig_name(rName1),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -243,7 +243,7 @@ func TestAccVPCManagedPrefixList_name(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:       testAccManagedPrefixListConfig_Name(rName2),
+				Config:       testAccVPCManagedPrefixListConfig_name(rName2),
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
@@ -266,7 +266,7 @@ func TestAccVPCManagedPrefixList_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccManagedPrefixListConfig_Tags1(rName, "key1", "value1"),
+				Config: testAccVPCManagedPrefixListConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -280,7 +280,7 @@ func TestAccVPCManagedPrefixList_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccManagedPrefixListConfig_Tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCManagedPrefixListConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -290,7 +290,7 @@ func TestAccVPCManagedPrefixList_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccManagedPrefixListConfig_Tags1(rName, "key2", "value2"),
+				Config: testAccVPCManagedPrefixListConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccManagedPrefixListExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -365,7 +365,7 @@ func testAccPreCheckManagedPrefixList(t *testing.T) {
 	}
 }
 
-func testAccManagedPrefixListConfig_AddressFamily(rName string, addressFamily string) string {
+func testAccVPCManagedPrefixListConfig_addressFamily(rName string, addressFamily string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = %[2]q
@@ -375,7 +375,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName, addressFamily)
 }
 
-func testAccManagedPrefixListConfig_Entry_CIDR1(rName string) string {
+func testAccVPCManagedPrefixListConfig_entryCIDR1(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
@@ -395,7 +395,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListConfig_Entry_CIDR2(rName string) string {
+func testAccVPCManagedPrefixListConfig_entryCIDR2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
@@ -415,7 +415,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListConfig_Entry_Description(rName string, description string) string {
+func testAccVPCManagedPrefixListConfig_entryDescription(rName string, description string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
@@ -435,7 +435,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName, description)
 }
 
-func testAccManagedPrefixListConfig_Name(rName string) string {
+func testAccVPCManagedPrefixListConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
@@ -445,7 +445,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListUpdatedConfig(rName string) string {
+func testAccVPCManagedPrefixListConfig_updated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
@@ -455,7 +455,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName)
 }
 
-func testAccManagedPrefixListConfig_Tags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccVPCManagedPrefixListConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
@@ -469,7 +469,7 @@ resource "aws_ec2_managed_prefix_list" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccManagedPrefixListConfig_Tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccVPCManagedPrefixListConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q

--- a/internal/service/ec2/vpc_nat_gateway_data_source_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccVPCNATGatewayDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNATGatewayDataSourceConfig(rName),
+				Config: testAccVPCNATGatewayDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceNameById, "connectivity_type", resourceName, "connectivity_type"),
 					resource.TestCheckResourceAttrPair(dataSourceNameById, "id", resourceName, "id"),
@@ -42,7 +42,7 @@ func TestAccVPCNATGatewayDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccNATGatewayDataSourceConfig(rName string) string {
+func testAccVPCNATGatewayDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.5.0.0/16"

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -26,7 +26,7 @@ func TestAccVPCNATGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNATGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNATGatewayConfig(rName),
+				Config: testAccVPCNATGatewayConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNATGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttrSet(resourceName, "allocation_id"),
@@ -58,7 +58,7 @@ func TestAccVPCNATGateway_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNATGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNATGatewayConfig(rName),
+				Config: testAccVPCNATGatewayConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNATGatewayExists(resourceName, &natGateway),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNATGateway(), resourceName),
@@ -81,7 +81,7 @@ func TestAccVPCNATGateway_ConnectivityType_private(t *testing.T) {
 		CheckDestroy:      testAccCheckNATGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNATGatewayConfigConnectivityType(rName, "private"),
+				Config: testAccVPCNATGatewayConfig_connectivityType(rName, "private"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNATGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
@@ -114,7 +114,7 @@ func TestAccVPCNATGateway_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckNATGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNATGatewayConfigTags1(rName, "key1", "value1"),
+				Config: testAccVPCNATGatewayConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNATGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -127,7 +127,7 @@ func TestAccVPCNATGateway_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNATGatewayConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCNATGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNATGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -136,7 +136,7 @@ func TestAccVPCNATGateway_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNATGatewayConfigTags1(rName, "key2", "value2"),
+				Config: testAccVPCNATGatewayConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNATGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -244,7 +244,7 @@ resource "aws_eip" "test" {
 `, rName)
 }
 
-func testAccNATGatewayConfig(rName string) string {
+func testAccVPCNATGatewayConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccNATGatewayConfigBase(rName), `
 resource "aws_nat_gateway" "test" {
   allocation_id = aws_eip.test.id
@@ -255,7 +255,7 @@ resource "aws_nat_gateway" "test" {
 `)
 }
 
-func testAccNATGatewayConfigConnectivityType(rName, connectivityType string) string {
+func testAccVPCNATGatewayConfig_connectivityType(rName, connectivityType string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -285,7 +285,7 @@ resource "aws_nat_gateway" "test" {
 `, rName, connectivityType)
 }
 
-func testAccNATGatewayConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCNATGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccNATGatewayConfigBase(rName), fmt.Sprintf(`
 resource "aws_nat_gateway" "test" {
   allocation_id = aws_eip.test.id
@@ -300,7 +300,7 @@ resource "aws_nat_gateway" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccNATGatewayConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCNATGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccNATGatewayConfigBase(rName), fmt.Sprintf(`
 resource "aws_nat_gateway" "test" {
   allocation_id = aws_eip.test.id

--- a/internal/service/ec2/vpc_nat_gateways_data_source_test.go
+++ b/internal/service/ec2/vpc_nat_gateways_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccVPCNATGatewaysDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNATGatewaysDataSourceConfig(rName),
+				Config: testAccVPCNATGatewaysDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_nat_gateways.by_vpc_id", "ids.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_nat_gateways.by_tags", "ids.#", "1"),
@@ -31,7 +31,7 @@ func TestAccVPCNATGatewaysDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccNATGatewaysDataSourceConfig(rName string) string {
+func testAccVPCNATGatewaysDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "172.5.0.0/16"

--- a/internal/service/ec2/vpc_network_acl_association_test.go
+++ b/internal/service/ec2/vpc_network_acl_association_test.go
@@ -28,7 +28,7 @@ func TestAccVPCNetworkACLAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLAssociationConfig(rName),
+				Config: testAccVPCNetworkACLAssociationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLAssociationExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "network_acl_id", naclResourceName, "id"),
@@ -56,7 +56,7 @@ func TestAccVPCNetworkACLAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLAssociationConfig(rName),
+				Config: testAccVPCNetworkACLAssociationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLAssociationExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkACLAssociation(), resourceName),
@@ -80,7 +80,7 @@ func TestAccVPCNetworkACLAssociation_disappears_NACL(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLAssociationConfig(rName),
+				Config: testAccVPCNetworkACLAssociationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLAssociationExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkACL(), naclResourceName),
@@ -104,7 +104,7 @@ func TestAccVPCNetworkACLAssociation_disappears_Subnet(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLAssociationConfig(rName),
+				Config: testAccVPCNetworkACLAssociationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLAssociationExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSubnet(), subnetResourceName),
@@ -131,7 +131,7 @@ func TestAccVPCNetworkACLAssociation_twoAssociations(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLAssociationTwoAssociationsConfig(rName),
+				Config: testAccVPCNetworkACLAssociationConfig_twoAssociations(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLAssociationExists(resource1Name, &v1),
 					testAccCheckNetworkACLAssociationExists(resource1Name, &v2),
@@ -168,7 +168,7 @@ func TestAccVPCNetworkACLAssociation_associateWithDefaultNACL(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLAssociationDefaultNACLConfig(rName),
+				Config: testAccVPCNetworkACLAssociationConfig_default(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLAssociationExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", subnetResourceName, "id"),
@@ -231,7 +231,7 @@ func testAccCheckNetworkACLAssociationExists(n string, v *ec2.NetworkAclAssociat
 	}
 }
 
-func testAccNetworkACLAssociationConfig(rName string) string {
+func testAccVPCNetworkACLAssociationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -266,7 +266,7 @@ resource "aws_network_acl_association" "test" {
 `, rName)
 }
 
-func testAccNetworkACLAssociationTwoAssociationsConfig(rName string) string {
+func testAccVPCNetworkACLAssociationConfig_twoAssociations(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -316,7 +316,7 @@ resource "aws_network_acl_association" "test2" {
 `, rName)
 }
 
-func testAccNetworkACLAssociationDefaultNACLConfig(rName string) string {
+func testAccVPCNetworkACLAssociationConfig_default(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_network_acl_rule_test.go
+++ b/internal/service/ec2/vpc_network_acl_rule_test.go
@@ -30,7 +30,7 @@ func TestAccVPCNetworkACLRule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resource1Name),
 					testAccCheckNetworkACLRuleExists(resource2Name),
@@ -97,7 +97,7 @@ func TestAccVPCNetworkACLRule_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkACLRule(), resourceName),
@@ -119,7 +119,7 @@ func TestAccVPCNetworkACLRule_Disappears_networkACL(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkACL(), "aws_network_acl.test"),
@@ -141,7 +141,7 @@ func TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleIngressEgressSameNumberMissingConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_ingressEgressSameNumberMissing(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkACLRule(), resourceName),
@@ -163,7 +163,7 @@ func TestAccVPCNetworkACLRule_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleIPv6Config(rName),
+				Config: testAccVPCNetworkACLRuleConfig_ipv6(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", ""),
@@ -197,7 +197,7 @@ func TestAccVPCNetworkACLRule_ipv6ICMP(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleIPv6ICMPConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_ipv6ICMP(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", ""),
@@ -234,7 +234,7 @@ func TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(t *testi
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleConfig_ipv6VPCNotAssignGeneratedIPv6CIDRBlockUpdate(rName),
+				Config: testAccVPCNetworkACLRuleConfig_ipv6NotAssignGeneratedIPv6CIDRBlockUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(vpcResourceName, &v),
 					resource.TestCheckResourceAttr(vpcResourceName, "assign_generated_ipv6_cidr_block", "false"),
@@ -242,7 +242,7 @@ func TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(t *testi
 				),
 			},
 			{
-				Config: testAccNetworkACLRuleConfig_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(rName),
+				Config: testAccVPCNetworkACLRuleConfig_ipv6AssignGeneratedIPv6CIDRBlockUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(vpcResourceName, &v),
 					testAccCheckNetworkACLRuleExists(resourceName),
@@ -271,7 +271,7 @@ func TestAccVPCNetworkACLRule_allProtocol(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleAllProtocolConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_allProtocol(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", "0.0.0.0/0"),
@@ -285,7 +285,7 @@ func TestAccVPCNetworkACLRule_allProtocol(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccNetworkACLRuleAllProtocolNoRealUpdateConfig(rName),
+				Config:   testAccVPCNetworkACLRuleConfig_allProtocolNoRealUpdate(rName),
 				PlanOnly: true,
 			},
 		},
@@ -303,7 +303,7 @@ func TestAccVPCNetworkACLRule_tcpProtocol(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRuleTCPProtocolConfig(rName),
+				Config: testAccVPCNetworkACLRuleConfig_tcpProtocol(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", "0.0.0.0/0"),
@@ -317,7 +317,7 @@ func TestAccVPCNetworkACLRule_tcpProtocol(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccNetworkACLRuleTCPProtocolNoRealUpdateConfig(rName),
+				Config:   testAccVPCNetworkACLRuleConfig_tcpProtocolNoRealUpdate(rName),
 				PlanOnly: true,
 			},
 		},
@@ -398,7 +398,7 @@ func testAccCheckNetworkACLRuleExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccNetworkACLRuleConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -449,7 +449,7 @@ resource "aws_network_acl_rule" "test3" {
 `, rName)
 }
 
-func testAccNetworkACLRuleAllProtocolNoRealUpdateConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_allProtocolNoRealUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -480,7 +480,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName)
 }
 
-func testAccNetworkACLRuleTCPProtocolNoRealUpdateConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_tcpProtocolNoRealUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -511,7 +511,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName)
 }
 
-func testAccNetworkACLRuleAllProtocolConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_allProtocol(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -542,7 +542,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName)
 }
 
-func testAccNetworkACLRuleTCPProtocolConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_tcpProtocol(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -573,7 +573,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName)
 }
 
-func testAccNetworkACLRuleIPv6Config(rName string) string {
+func testAccVPCNetworkACLRuleConfig_ipv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -604,7 +604,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName)
 }
 
-func testAccNetworkACLRuleIngressEgressSameNumberMissingConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_ingressEgressSameNumberMissing(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -646,7 +646,7 @@ resource "aws_network_acl_rule" "test2" {
 `, rName)
 }
 
-func testAccNetworkACLRuleIPv6ICMPConfig(rName string) string {
+func testAccVPCNetworkACLRuleConfig_ipv6ICMP(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -676,7 +676,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName, rName)
 }
 
-func testAccNetworkACLRuleConfig_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate(rName string) string {
+func testAccVPCNetworkACLRuleConfig_ipv6AssignGeneratedIPv6CIDRBlockUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
@@ -707,7 +707,7 @@ resource "aws_network_acl_rule" "test" {
 `, rName)
 }
 
-func testAccNetworkACLRuleConfig_ipv6VPCNotAssignGeneratedIPv6CIDRBlockUpdate(rName string) string {
+func testAccVPCNetworkACLRuleConfig_ipv6NotAssignGeneratedIPv6CIDRBlockUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = false

--- a/internal/service/ec2/vpc_network_acl_test.go
+++ b/internal/service/ec2/vpc_network_acl_test.go
@@ -28,7 +28,7 @@ func TestAccVPCNetworkACL_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLConfig(rName),
+				Config: testAccVPCNetworkACLConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`network-acl/acl-.+`)),
@@ -61,7 +61,7 @@ func TestAccVPCNetworkACL_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLConfig(rName),
+				Config: testAccVPCNetworkACLConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkACL(), resourceName),
@@ -84,7 +84,7 @@ func TestAccVPCNetworkACL_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLTags1Config(rName, "key1", "value1"),
+				Config: testAccVPCNetworkACLConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -97,7 +97,7 @@ func TestAccVPCNetworkACL_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCNetworkACLConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -106,7 +106,7 @@ func TestAccVPCNetworkACL_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNetworkACLTags1Config(rName, "key2", "value2"),
+				Config: testAccVPCNetworkACLConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -129,7 +129,7 @@ func TestAccVPCNetworkACL_Egress_mode(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLEgressModeBlocksConfig(rName),
+				Config: testAccVPCNetworkACLConfig_egressModeBlocks(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
@@ -141,7 +141,7 @@ func TestAccVPCNetworkACL_Egress_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLEgressModeNoBlocksConfig(rName),
+				Config: testAccVPCNetworkACLConfig_egressModeNoBlocks(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
@@ -153,7 +153,7 @@ func TestAccVPCNetworkACL_Egress_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLEgressModeZeroedConfig(rName),
+				Config: testAccVPCNetworkACLConfig_egressModeZeroed(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
@@ -180,7 +180,7 @@ func TestAccVPCNetworkACL_Ingress_mode(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLIngressModeBlocksConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ingressModeBlocks(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
@@ -192,7 +192,7 @@ func TestAccVPCNetworkACL_Ingress_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLIngressModeNoBlocksConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ingressModeNoBlocks(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
@@ -204,7 +204,7 @@ func TestAccVPCNetworkACL_Ingress_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLIngressModeZeroedConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ingressModeZeroed(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
@@ -231,7 +231,7 @@ func TestAccVPCNetworkACL_egressAndIngressRules(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLEgressNIngressConfig(rName),
+				Config: testAccVPCNetworkACLConfig_egressNIngress(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
@@ -273,7 +273,7 @@ func TestAccVPCNetworkACL_OnlyIngressRules_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLIngressConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ingress(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
@@ -307,7 +307,7 @@ func TestAccVPCNetworkACL_OnlyIngressRules_update(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLIngressConfig(resourceName),
+				Config: testAccVPCNetworkACLConfig_ingress(resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
@@ -331,7 +331,7 @@ func TestAccVPCNetworkACL_OnlyIngressRules_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLIngressChangeConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ingressChange(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "1"),
@@ -361,7 +361,7 @@ func TestAccVPCNetworkACL_caseSensitivityNoChanges(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLCaseSensitiveConfig(rName),
+				Config: testAccVPCNetworkACLConfig_caseSensitive(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 				),
@@ -387,7 +387,7 @@ func TestAccVPCNetworkACL_onlyEgressRules(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLEgressConfig(rName),
+				Config: testAccVPCNetworkACLConfig_egress(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 				),
@@ -413,7 +413,7 @@ func TestAccVPCNetworkACL_subnetChange(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLSubnetConfig(rName),
+				Config: testAccVPCNetworkACLConfig_subnet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -426,7 +426,7 @@ func TestAccVPCNetworkACL_subnetChange(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLSubnetChangeConfig(rName),
+				Config: testAccVPCNetworkACLConfig_subnetChange(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -450,7 +450,7 @@ func TestAccVPCNetworkACL_subnets(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLSubnet_SubnetIDs(rName),
+				Config: testAccVPCNetworkACLConfig_subnetSubnetIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -464,7 +464,7 @@ func TestAccVPCNetworkACL_subnets(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLSubnet_SubnetIDsUpdate(rName),
+				Config: testAccVPCNetworkACLConfig_subnetSubnetIDsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "3"),
@@ -489,7 +489,7 @@ func TestAccVPCNetworkACL_subnetsDelete(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLSubnet_SubnetIDs(resourceName),
+				Config: testAccVPCNetworkACLConfig_subnetSubnetIDs(resourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -503,7 +503,7 @@ func TestAccVPCNetworkACL_subnetsDelete(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkACLSubnet_SubnetIDsDeleteOne(rName),
+				Config: testAccVPCNetworkACLConfig_subnetSubnetIDsDeleteOne(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -526,7 +526,7 @@ func TestAccVPCNetworkACL_ipv6Rules(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLIPv6Config(rName),
+				Config: testAccVPCNetworkACLConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -562,7 +562,7 @@ func TestAccVPCNetworkACL_ipv6ICMPRules(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLIPv6ICMPConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ipv6ICMP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 				),
@@ -583,7 +583,7 @@ func TestAccVPCNetworkACL_ipv6VPCRules(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLIPv6VPCConfig(rName),
+				Config: testAccVPCNetworkACLConfig_ipv6VPC(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "1"),
@@ -613,7 +613,7 @@ func TestAccVPCNetworkACL_espProtocol(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLEsp(rName),
+				Config: testAccVPCNetworkACLConfig_esp(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &v),
 				),
@@ -676,7 +676,7 @@ func testAccCheckNetworkACLExists(n string, v *ec2.NetworkAcl) resource.TestChec
 	}
 }
 
-func testAccNetworkACLConfig(rName string) string {
+func testAccVPCNetworkACLConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -692,7 +692,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIPv6ICMPConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ipv6ICMP(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -723,7 +723,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIPv6Config(rName string) string {
+func testAccVPCNetworkACLConfig_ipv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -764,7 +764,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIPv6VPCConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ipv6VPC(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -794,7 +794,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIngressConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ingress(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -844,7 +844,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLCaseSensitiveConfig(rName string) string {
+func testAccVPCNetworkACLConfig_caseSensitive(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -885,7 +885,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIngressChangeConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ingressChange(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -926,7 +926,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLEgressConfig(rName string) string {
+func testAccVPCNetworkACLConfig_egress(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.2.0.0/16"
@@ -992,7 +992,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLEgressNIngressConfig(rName string) string {
+func testAccVPCNetworkACLConfig_egressNIngress(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
@@ -1040,7 +1040,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLSubnetConfig(rName string) string {
+func testAccVPCNetworkACLConfig_subnet(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1090,7 +1090,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLSubnetChangeConfig(rName string) string {
+func testAccVPCNetworkACLConfig_subnetChange(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1131,7 +1131,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLSubnet_SubnetIDs(rName string) string {
+func testAccVPCNetworkACLConfig_subnetSubnetIDs(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1170,7 +1170,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLSubnet_SubnetIDsUpdate(rName string) string {
+func testAccVPCNetworkACLConfig_subnetSubnetIDsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1231,7 +1231,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLSubnet_SubnetIDsDeleteOne(rName string) string {
+func testAccVPCNetworkACLConfig_subnetSubnetIDsDeleteOne(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1261,7 +1261,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLEsp(rName string) string {
+func testAccVPCNetworkACLConfig_esp(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1290,7 +1290,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLEgressModeBlocksConfig(rName string) string {
+func testAccVPCNetworkACLConfig_egressModeBlocks(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1328,7 +1328,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLEgressModeNoBlocksConfig(rName string) string {
+func testAccVPCNetworkACLConfig_egressModeNoBlocks(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1348,7 +1348,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLEgressModeZeroedConfig(rName string) string {
+func testAccVPCNetworkACLConfig_egressModeZeroed(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1370,7 +1370,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIngressModeBlocksConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ingressModeBlocks(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1408,7 +1408,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIngressModeNoBlocksConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ingressModeNoBlocks(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1428,7 +1428,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLIngressModeZeroedConfig(rName string) string {
+func testAccVPCNetworkACLConfig_ingressModeZeroed(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1450,7 +1450,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCNetworkACLConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1470,7 +1470,7 @@ resource "aws_network_acl" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccNetworkACLTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCNetworkACLConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_network_acls_data_source_test.go
+++ b/internal/service/ec2/vpc_network_acls_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccVPCNetworkACLsDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLsDataSourceConfig_basic(rName),
+				Config: testAccVPCNetworkACLsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ids.#", "1"),
 				),
@@ -41,7 +41,7 @@ func TestAccVPCNetworkACLsDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLsDataSourceConfig_Filter(rName),
+				Config: testAccVPCNetworkACLsDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 				),
@@ -61,7 +61,7 @@ func TestAccVPCNetworkACLsDataSource_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLsDataSourceConfig_Tags(rName),
+				Config: testAccVPCNetworkACLsDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
 				),
@@ -81,7 +81,7 @@ func TestAccVPCNetworkACLsDataSource_vpcID(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLsDataSourceConfig_VPCID(rName),
+				Config: testAccVPCNetworkACLsDataSourceConfig_id(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// The VPC will have a default network ACL
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "3"),
@@ -102,7 +102,7 @@ func TestAccVPCNetworkACLsDataSource_empty(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLsDataSourceConfig_Empty(rName),
+				Config: testAccVPCNetworkACLsDataSourceConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "0"),
 				),
@@ -133,7 +133,7 @@ resource "aws_network_acl" "test" {
 `, rName)
 }
 
-func testAccNetworkACLsDataSourceConfig_basic(rName string) string {
+func testAccVPCNetworkACLsDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccNetworkACLsDataSourceConfig_Base(rName), `
 data "aws_network_acls" "test" {
   depends_on = [aws_network_acl.test[0], aws_network_acl.test[1]]
@@ -141,7 +141,7 @@ data "aws_network_acls" "test" {
 `)
 }
 
-func testAccNetworkACLsDataSourceConfig_Filter(rName string) string {
+func testAccVPCNetworkACLsDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(testAccNetworkACLsDataSourceConfig_Base(rName), `
 data "aws_network_acls" "test" {
   filter {
@@ -154,7 +154,7 @@ data "aws_network_acls" "test" {
 `)
 }
 
-func testAccNetworkACLsDataSourceConfig_Tags(rName string) string {
+func testAccVPCNetworkACLsDataSourceConfig_tags(rName string) string {
 	return acctest.ConfigCompose(testAccNetworkACLsDataSourceConfig_Base(rName), `
 data "aws_network_acls" "test" {
   tags = {
@@ -166,7 +166,7 @@ data "aws_network_acls" "test" {
 `)
 }
 
-func testAccNetworkACLsDataSourceConfig_VPCID(rName string) string {
+func testAccVPCNetworkACLsDataSourceConfig_id(rName string) string {
 	return acctest.ConfigCompose(testAccNetworkACLsDataSourceConfig_Base(rName), `
 data "aws_network_acls" "test" {
   vpc_id = aws_network_acl.test[0].vpc_id
@@ -176,7 +176,7 @@ data "aws_network_acls" "test" {
 `)
 }
 
-func testAccNetworkACLsDataSourceConfig_Empty(rName string) string {
+func testAccVPCNetworkACLsDataSourceConfig_empty(rName string) string {
 	return fmt.Sprintf(`
 data "aws_network_acls" "test" {
   tags = {

--- a/internal/service/ec2/vpc_network_insights_path_test.go
+++ b/internal/service/ec2/vpc_network_insights_path_test.go
@@ -26,7 +26,7 @@ func TestAccVPCNetworkInsightsPath_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInsightsPathConfig_basic(rName, "tcp"),
+				Config: testAccVPCNetworkInsightsPathConfig_basic(rName, "tcp"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`network-insights-path/.+$`)),
@@ -59,7 +59,7 @@ func TestAccVPCNetworkInsightsPath_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInsightsPathConfig_basic(rName, "udp"),
+				Config: testAccVPCNetworkInsightsPathConfig_basic(rName, "udp"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkInsightsPath(), resourceName),
@@ -81,7 +81,7 @@ func TestAccVPCNetworkInsightsPath_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInsightsPathConfig_tags1(rName, "key1", "value1"),
+				Config: testAccVPCNetworkInsightsPathConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -94,7 +94,7 @@ func TestAccVPCNetworkInsightsPath_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkInsightsPathConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCNetworkInsightsPathConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -103,7 +103,7 @@ func TestAccVPCNetworkInsightsPath_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNetworkInsightsPathConfig_tags1(rName, "key2", "value2"),
+				Config: testAccVPCNetworkInsightsPathConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -125,7 +125,7 @@ func TestAccVPCNetworkInsightsPath_sourceIP(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInsightsPathConfig_sourceIP(rName, "1.1.1.1"),
+				Config: testAccVPCNetworkInsightsPathConfig_sourceIP(rName, "1.1.1.1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source_ip", "1.1.1.1"),
@@ -137,7 +137,7 @@ func TestAccVPCNetworkInsightsPath_sourceIP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkInsightsPathConfig_sourceIP(rName, "8.8.8.8"),
+				Config: testAccVPCNetworkInsightsPathConfig_sourceIP(rName, "8.8.8.8"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source_ip", "8.8.8.8"),
@@ -158,7 +158,7 @@ func TestAccVPCNetworkInsightsPath_destinationIP(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInsightsPathConfig_destinationIP(rName, "1.1.1.1"),
+				Config: testAccVPCNetworkInsightsPathConfig_destinationIP(rName, "1.1.1.1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_ip", "1.1.1.1"),
@@ -170,7 +170,7 @@ func TestAccVPCNetworkInsightsPath_destinationIP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkInsightsPathConfig_destinationIP(rName, "8.8.8.8"),
+				Config: testAccVPCNetworkInsightsPathConfig_destinationIP(rName, "8.8.8.8"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_ip", "8.8.8.8"),
@@ -191,7 +191,7 @@ func TestAccVPCNetworkInsightsPath_destinationPort(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInsightsPathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInsightsPathConfig_destinationPort(rName, 80),
+				Config: testAccVPCNetworkInsightsPathConfig_destinationPort(rName, 80),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_port", "80"),
@@ -203,7 +203,7 @@ func TestAccVPCNetworkInsightsPath_destinationPort(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkInsightsPathConfig_destinationPort(rName, 443),
+				Config: testAccVPCNetworkInsightsPathConfig_destinationPort(rName, 443),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInsightsPathExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "destination_port", "443"),
@@ -260,7 +260,7 @@ func testAccCheckNetworkInsightsPathDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccNetworkInsightsPathConfig_basic(rName, protocol string) string {
+func testAccVPCNetworkInsightsPathConfig_basic(rName, protocol string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -303,7 +303,7 @@ resource "aws_ec2_network_insights_path" "test" {
 `, rName, protocol)
 }
 
-func testAccNetworkInsightsPathConfig_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCNetworkInsightsPathConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -350,7 +350,7 @@ resource "aws_ec2_network_insights_path" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccNetworkInsightsPathConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCNetworkInsightsPathConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -398,7 +398,7 @@ resource "aws_ec2_network_insights_path" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccNetworkInsightsPathConfig_sourceIP(rName, sourceIP string) string {
+func testAccVPCNetworkInsightsPathConfig_sourceIP(rName, sourceIP string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -446,7 +446,7 @@ resource "aws_ec2_network_insights_path" "test" {
 `, rName, sourceIP)
 }
 
-func testAccNetworkInsightsPathConfig_destinationIP(rName, destinationIP string) string {
+func testAccVPCNetworkInsightsPathConfig_destinationIP(rName, destinationIP string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -494,7 +494,7 @@ resource "aws_ec2_network_insights_path" "test" {
 `, rName, destinationIP)
 }
 
-func testAccNetworkInsightsPathConfig_destinationPort(rName string, destinationPort int) string {
+func testAccVPCNetworkInsightsPathConfig_destinationPort(rName string, destinationPort int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/vpc_network_interface_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_attachment_test.go
@@ -22,7 +22,7 @@ func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceAttachmentConfig(rName),
+				Config: testAccVPCNetworkInterfaceAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists("aws_network_interface.test", &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "attachment_id"),
@@ -36,7 +36,7 @@ func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 	})
 }
 
-func testAccNetworkInterfaceAttachmentConfig(rName string) string {
+func testAccVPCNetworkInterfaceAttachmentConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),

--- a/internal/service/ec2/vpc_network_interface_data_source_test.go
+++ b/internal/service/ec2/vpc_network_interface_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccVPCNetworkInterfaceDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceBasicDataSourceConfig(rName),
+				Config: testAccVPCNetworkInterfaceDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "private_ips.#", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "security_groups.#", "1"),
@@ -51,7 +51,7 @@ func TestAccVPCNetworkInterfaceDataSource_filters(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceFiltersDataSourceConfig(rName),
+				Config: testAccVPCNetworkInterfaceDataSourceConfig_filters(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "private_ips.#", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "security_groups.#", "1"),
@@ -76,7 +76,7 @@ func TestAccVPCNetworkInterfaceDataSource_carrierIPAssociation(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceCarrierIPAssociationDataSourceConfig(rName),
+				Config: testAccVPCNetworkInterfaceDataSourceConfig_carrierIPAssociation(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "association.#", "1"),
 					resource.TestCheckResourceAttrPair(datasourceName, "association.0.allocation_id", eipResourceName, "id"),
@@ -124,7 +124,7 @@ func TestAccVPCNetworkInterfaceDataSource_publicIPAssociation(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfacePublicIPAssociationDataSourceConfig(rName),
+				Config: testAccVPCNetworkInterfaceDataSourceConfig_publicIPAssociation(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "association.#", "1"),
 					resource.TestCheckResourceAttrPair(datasourceName, "association.0.allocation_id", eipResourceName, "id"),
@@ -170,7 +170,7 @@ func TestAccVPCNetworkInterfaceDataSource_attachment(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceAttachmentDataSourceConfig(rName),
+				Config: testAccVPCNetworkInterfaceDataSourceConfig_attachment(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "association.#", "0"),
 					resource.TestCheckResourceAttr(datasourceName, "attachment.#", "1"),
@@ -240,7 +240,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccNetworkInterfaceBasicDataSourceConfig(rName string) string {
+func testAccVPCNetworkInterfaceDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccNetworkInterfaceBaseDataSourceConfig(rName),
 		`
@@ -250,7 +250,7 @@ data "aws_network_interface" "test" {
 `)
 }
 
-func testAccNetworkInterfaceCarrierIPAssociationDataSourceConfig(rName string) string {
+func testAccVPCNetworkInterfaceDataSourceConfig_carrierIPAssociation(rName string) string {
 	return acctest.ConfigCompose(
 		testAccAvailableAZsWavelengthZonesDefaultExcludeConfig(),
 		fmt.Sprintf(`
@@ -323,7 +323,7 @@ data "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccNetworkInterfacePublicIPAssociationDataSourceConfig(rName string) string {
+func testAccVPCNetworkInterfaceDataSourceConfig_publicIPAssociation(rName string) string {
 	return acctest.ConfigCompose(
 		testAccNetworkInterfaceBaseDataSourceConfig(rName),
 		fmt.Sprintf(`
@@ -354,7 +354,7 @@ data "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccNetworkInterfaceFiltersDataSourceConfig(rName string) string {
+func testAccVPCNetworkInterfaceDataSourceConfig_filters(rName string) string {
 	return acctest.ConfigCompose(
 		testAccNetworkInterfaceBaseDataSourceConfig(rName),
 		`
@@ -367,7 +367,7 @@ data "aws_network_interface" "test" {
 `)
 }
 
-func testAccNetworkInterfaceAttachmentDataSourceConfig(rName string) string {
+func testAccVPCNetworkInterfaceDataSourceConfig_attachment(rName string) string {
 	return acctest.ConfigCompose(
 		testAccNetworkInterfaceBaseDataSourceConfig(rName),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),

--- a/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
@@ -27,7 +27,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInterfaceSGAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceSGAttachmentConfig(rName),
+				Config: testAccVPCNetworkInterfaceSGAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceSGAttachmentExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", networkInterfaceResourceName, "id"),
@@ -49,7 +49,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInterfaceSGAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceSGAttachmentConfig(rName),
+				Config: testAccVPCNetworkInterfaceSGAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceSGAttachmentExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkInterfaceSGAttachment(), resourceName),
@@ -73,7 +73,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_instance(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInterfaceSGAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceSGAttachmentViaInstanceConfig(rName),
+				Config: testAccVPCNetworkInterfaceSGAttachmentConfig_viaInstance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceSGAttachmentExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
@@ -103,7 +103,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkInterfaceSGAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfaceSGAttachmentMultipleConfig(rName),
+				Config: testAccVPCNetworkInterfaceSGAttachmentConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceSGAttachmentExists(resourceName1),
 					resource.TestCheckResourceAttrPair(resourceName1, "network_interface_id", networkInterfaceResourceName, "id"),
@@ -170,7 +170,7 @@ func testAccCheckNetworkInterfaceSGAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccNetworkInterfaceSGAttachmentConfig(rName string) string {
+func testAccVPCNetworkInterfaceSGAttachmentConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
@@ -213,7 +213,7 @@ resource "aws_network_interface_sg_attachment" "test" {
 `, rName)
 }
 
-func testAccNetworkInterfaceSGAttachmentViaInstanceConfig(rName string) string {
+func testAccVPCNetworkInterfaceSGAttachmentConfig_viaInstance(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -264,7 +264,7 @@ resource "aws_network_interface_sg_attachment" "test" {
 `, rName))
 }
 
-func testAccNetworkInterfaceSGAttachmentMultipleConfig(rName string) string {
+func testAccVPCNetworkInterfaceSGAttachmentConfig_multiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -33,7 +33,7 @@ func TestAccVPCNetworkInterface_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`network-interface/.+$`)),
@@ -76,7 +76,7 @@ func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIIPV6Config(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
@@ -90,7 +90,7 @@ func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIIPV6MultipleConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"),
@@ -98,7 +98,7 @@ func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccENIIPV6Config(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
@@ -121,7 +121,7 @@ func TestAccVPCNetworkInterface_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENITags1Config(rName, "key1", "value1"),
+				Config: testAccVPCNetworkInterfaceConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -135,7 +135,7 @@ func TestAccVPCNetworkInterface_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENITags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCNetworkInterfaceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -144,7 +144,7 @@ func TestAccVPCNetworkInterface_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccENITags1Config(rName, "key2", "value2"),
+				Config: testAccVPCNetworkInterfaceConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -167,7 +167,7 @@ func TestAccVPCNetworkInterface_ipv6Count(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIIPV6CountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Count(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
@@ -180,21 +180,21 @@ func TestAccVPCNetworkInterface_ipv6Count(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIIPV6CountConfig(rName, 2),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Count(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"),
 				),
 			},
 			{
-				Config: testAccENIIPV6CountConfig(rName, 0),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Count(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "0"),
 				),
 			},
 			{
-				Config: testAccENIIPV6CountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Count(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
@@ -216,7 +216,7 @@ func TestAccVPCNetworkInterface_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceNetworkInterface(), resourceName),
@@ -241,7 +241,7 @@ func TestAccVPCNetworkInterface_description(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIDescriptionConfig(rName, "description 1"),
+				Config: testAccVPCNetworkInterfaceConfig_description(rName, "description 1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "attachment.#", "0"),
@@ -270,7 +270,7 @@ func TestAccVPCNetworkInterface_description(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIDescriptionConfig(rName, "description 2"),
+				Config: testAccVPCNetworkInterfaceConfig_description(rName, "description 2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "attachment.#", "0"),
@@ -312,7 +312,7 @@ func TestAccVPCNetworkInterface_attachment(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIAttachmentConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_attachment(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "attachment.#", "1"),
@@ -346,7 +346,7 @@ func TestAccVPCNetworkInterface_ignoreExternalAttachment(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIExternalAttachmentConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_externalAttachment(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					testAccCheckENIMakeExternalAttachment("aws_instance.test", &conf),
@@ -374,7 +374,7 @@ func TestAccVPCNetworkInterface_sourceDestCheck(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENISourceDestCheckConfig(rName, false),
+				Config: testAccVPCNetworkInterfaceConfig_sourceDestCheck(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "false"),
@@ -387,14 +387,14 @@ func TestAccVPCNetworkInterface_sourceDestCheck(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENISourceDestCheckConfig(rName, true),
+				Config: testAccVPCNetworkInterfaceConfig_sourceDestCheck(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "true"),
 				),
 			},
 			{
-				Config: testAccENISourceDestCheckConfig(rName, false),
+				Config: testAccVPCNetworkInterfaceConfig_sourceDestCheck(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "false"),
@@ -416,7 +416,7 @@ func TestAccVPCNetworkInterface_privateIPsCount(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIPrivateIPsCountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPsCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "1"),
@@ -429,7 +429,7 @@ func TestAccVPCNetworkInterface_privateIPsCount(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIPrivateIPsCountConfig(rName, 2),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPsCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "2"),
@@ -442,7 +442,7 @@ func TestAccVPCNetworkInterface_privateIPsCount(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIPrivateIPsCountConfig(rName, 0),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPsCount(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "0"),
@@ -455,7 +455,7 @@ func TestAccVPCNetworkInterface_privateIPsCount(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIPrivateIPsCountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPsCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "1"),
@@ -483,7 +483,7 @@ func TestAccVPCNetworkInterface_ENIInterfaceType_efa(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIInterfaceTypeConfig(rName, "efa"),
+				Config: testAccVPCNetworkInterfaceConfig_type(rName, "efa"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "interface_type", "efa"),
@@ -511,7 +511,7 @@ func TestAccVPCNetworkInterface_ENI_ipv4Prefix(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIIPV4PrefixConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4Prefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "1"),
@@ -525,7 +525,7 @@ func TestAccVPCNetworkInterface_ENI_ipv4Prefix(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIIPV4PrefixMultipleConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4PrefixMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "2"),
@@ -533,7 +533,7 @@ func TestAccVPCNetworkInterface_ENI_ipv4Prefix(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccENIIPV4PrefixConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4Prefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "1"),
@@ -556,7 +556,7 @@ func TestAccVPCNetworkInterface_ENI_ipv4PrefixCount(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIIPV4PrefixCountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4PrefixCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "1"),
@@ -569,21 +569,21 @@ func TestAccVPCNetworkInterface_ENI_ipv4PrefixCount(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIIPV4PrefixCountConfig(rName, 2),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4PrefixCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "2"),
 				),
 			},
 			{
-				Config: testAccENIIPV4PrefixCountConfig(rName, 0),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4PrefixCount(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "0"),
 				),
 			},
 			{
-				Config: testAccENIIPV4PrefixCountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_ipv4PrefixCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_prefix_count", "1"),
@@ -605,7 +605,7 @@ func TestAccVPCNetworkInterface_ENI_ipv6Prefix(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIIPV6PrefixConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Prefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "1"),
@@ -619,7 +619,7 @@ func TestAccVPCNetworkInterface_ENI_ipv6Prefix(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIIPV6PrefixMultipleConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6PrefixMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "2"),
@@ -627,7 +627,7 @@ func TestAccVPCNetworkInterface_ENI_ipv6Prefix(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccENIIPV6PrefixConfig(rName),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6Prefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "1"),
@@ -650,7 +650,7 @@ func TestAccVPCNetworkInterface_ENI_ipv6PrefixCount(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccENIIPV6PrefixCountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6PrefixCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "1"),
@@ -663,21 +663,21 @@ func TestAccVPCNetworkInterface_ENI_ipv6PrefixCount(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{
-				Config: testAccENIIPV6PrefixCountConfig(rName, 2),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6PrefixCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "2"),
 				),
 			},
 			{
-				Config: testAccENIIPV6PrefixCountConfig(rName, 0),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6PrefixCount(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "0"),
 				),
 			},
 			{
-				Config: testAccENIIPV6PrefixCountConfig(rName, 1),
+				Config: testAccVPCNetworkInterfaceConfig_ipv6PrefixCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_prefix_count", "1"),
@@ -699,7 +699,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{ // Configuration with three private_ips
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.44", "172.16.10.59", "172.16.10.123"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.44", "172.16.10.59", "172.16.10.123"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.44", "172.16.10.59", "172.16.10.123"}, &networkInterface),
@@ -713,7 +713,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{ // Change order of private_ips
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.44", "172.16.10.59"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.44", "172.16.10.59"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.44", "172.16.10.59", "172.16.10.123"}, &networkInterface),
@@ -722,7 +722,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				),
 			},
 			{ // Add secondaries to private_ips
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.12", "172.16.10.44", "172.16.10.59"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.12", "172.16.10.44", "172.16.10.59"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.44", "172.16.10.12", "172.16.10.59", "172.16.10.123"}, &networkInterface),
@@ -731,7 +731,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				),
 			},
 			{ // Remove secondary to private_ips
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.44", "172.16.10.59"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.44", "172.16.10.59"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.44", "172.16.10.59", "172.16.10.123"}, &networkInterface),
@@ -740,7 +740,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				),
 			},
 			{ // Remove primary
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.59", "172.16.10.57"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.59", "172.16.10.57"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.57", "172.16.10.59", "172.16.10.123"}, &networkInterface),
@@ -749,7 +749,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				),
 			},
 			{ // Use count to add IPs
-				Config: testAccENIConfig_privateIPSetCount(rName, 4),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSetCount(rName, 4),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENISame(&lastInterface, &networkInterface), // same
@@ -757,7 +757,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				),
 			},
 			{ // Change list, retain primary
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.44", "172.16.10.57"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.44", "172.16.10.57"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.44", "172.16.10.57"}, &networkInterface),
@@ -766,7 +766,7 @@ func TestAccVPCNetworkInterface_privateIPSet(t *testing.T) {
 				),
 			},
 			{ // New list
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.17"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.17"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.17"}, &networkInterface),
@@ -794,7 +794,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 		CheckDestroy:      testAccCheckENIDestroy,
 		Steps: []resource.TestStep{
 			{ // Build a set incrementally in order
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.17"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.17"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.17"}, &networkInterface),
@@ -808,7 +808,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
 			},
 			{ // Add to set
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.17", "172.16.10.45"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.17", "172.16.10.45"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.17", "172.16.10.45"}, &networkInterface),
@@ -817,7 +817,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Add to set
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.17", "172.16.10.45", "172.16.10.89"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.17", "172.16.10.45", "172.16.10.89"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.17", "172.16.10.45", "172.16.10.89"}, &networkInterface),
@@ -826,7 +826,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Add to set
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.17", "172.16.10.45", "172.16.10.89", "172.16.10.122"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.17", "172.16.10.45", "172.16.10.89", "172.16.10.122"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.17", "172.16.10.45", "172.16.10.89", "172.16.10.122"}, &networkInterface),
@@ -835,7 +835,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Change from set to list using same order
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.45", "172.16.10.89", "172.16.10.122"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.45", "172.16.10.89", "172.16.10.122"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.17", "172.16.10.45", "172.16.10.89", "172.16.10.122"}, &networkInterface),
@@ -844,7 +844,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Change order of private_ip_list
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.45", "172.16.10.122"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.45", "172.16.10.122"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.17", "172.16.10.89", "172.16.10.45", "172.16.10.122"}, &networkInterface),
@@ -853,7 +853,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Remove secondaries from end
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.45"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.45"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.17", "172.16.10.89", "172.16.10.45"}, &networkInterface),
@@ -862,7 +862,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Add secondaries to end
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.45", "172.16.10.123"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.45", "172.16.10.123"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.17", "172.16.10.89", "172.16.10.45", "172.16.10.123"}, &networkInterface),
@@ -871,7 +871,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Add secondaries to middle
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.77", "172.16.10.45", "172.16.10.123"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.77", "172.16.10.45", "172.16.10.123"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.17", "172.16.10.89", "172.16.10.77", "172.16.10.45", "172.16.10.123"}, &networkInterface),
@@ -880,7 +880,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Remove secondaries from middle
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.123"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.17", "172.16.10.89", "172.16.10.123"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.17", "172.16.10.89", "172.16.10.123"}, &networkInterface),
@@ -889,7 +889,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Use count to add IPs
-				Config: testAccENIConfig_privateIPSetCount(rName, 4),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSetCount(rName, 4),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENISame(&lastInterface, &networkInterface), // same
@@ -897,7 +897,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Change to specific list - forces new
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.59", "172.16.10.123", "172.16.10.38"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.59", "172.16.10.123", "172.16.10.38"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.59", "172.16.10.123", "172.16.10.38"}, &networkInterface),
@@ -906,7 +906,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Change first of private_ip_list - forces new
-				Config: testAccENIConfig_privateIPList(rName, []string{"172.16.10.123", "172.16.10.59", "172.16.10.38"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPList(rName, []string{"172.16.10.123", "172.16.10.59", "172.16.10.38"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPList([]string{"172.16.10.123", "172.16.10.59", "172.16.10.38"}, &networkInterface),
@@ -915,7 +915,7 @@ func TestAccVPCNetworkInterface_privateIPList(t *testing.T) {
 				),
 			},
 			{ // Change from list to set using same set
-				Config: testAccENIConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.59", "172.16.10.38"}),
+				Config: testAccVPCNetworkInterfaceConfig_privateIPSet(rName, []string{"172.16.10.123", "172.16.10.59", "172.16.10.38"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckENIExists(resourceName, &networkInterface),
 					testAccCheckENIPrivateIPSet([]string{"172.16.10.123", "172.16.10.59", "172.16.10.38"}, &networkInterface),
@@ -1162,7 +1162,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccENIConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), `
 resource "aws_network_interface" "test" {
   subnet_id = aws_subnet.test.id
@@ -1170,7 +1170,7 @@ resource "aws_network_interface" "test" {
 `)
 }
 
-func testAccENIIPV6Config(rName string) string {
+func testAccVPCNetworkInterfaceConfig_ipv6(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1185,7 +1185,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIIPV6MultipleConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_ipv6Multiple(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1200,7 +1200,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIIPV6CountConfig(rName string, ipv6Count int) string {
+func testAccVPCNetworkInterfaceConfig_ipv6Count(rName string, ipv6Count int) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id          = aws_subnet.test.id
@@ -1215,7 +1215,7 @@ resource "aws_network_interface" "test" {
 `, rName, ipv6Count))
 }
 
-func testAccENIDescriptionConfig(rName, description string) string {
+func testAccVPCNetworkInterfaceConfig_description(rName, description string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1230,7 +1230,7 @@ resource "aws_network_interface" "test" {
 `, rName, description))
 }
 
-func testAccENISourceDestCheckConfig(rName string, sourceDestCheck bool) string {
+func testAccVPCNetworkInterfaceConfig_sourceDestCheck(rName string, sourceDestCheck bool) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
@@ -1244,7 +1244,7 @@ resource "aws_network_interface" "test" {
 `, rName, sourceDestCheck))
 }
 
-func testAccENIAttachmentConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_attachment(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -1289,7 +1289,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIExternalAttachmentConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_externalAttachment(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
@@ -1329,7 +1329,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIPrivateIPsCountConfig(rName string, privateIpsCount int) string {
+func testAccVPCNetworkInterfaceConfig_privateIPsCount(rName string, privateIpsCount int) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   private_ips_count = %[2]d
@@ -1342,7 +1342,7 @@ resource "aws_network_interface" "test" {
 `, rName, privateIpsCount))
 }
 
-func testAccENITags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCNetworkInterfaceConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1356,7 +1356,7 @@ resource "aws_network_interface" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccENITags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCNetworkInterfaceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1371,7 +1371,7 @@ resource "aws_network_interface" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccENIInterfaceTypeConfig(rName, interfaceType string) string {
+func testAccVPCNetworkInterfaceConfig_type(rName, interfaceType string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1386,7 +1386,7 @@ resource "aws_network_interface" "test" {
 `, rName, interfaceType))
 }
 
-func testAccENIIPV4PrefixConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_ipv4Prefix(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1400,7 +1400,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIIPV4PrefixMultipleConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_ipv4PrefixMultiple(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1414,7 +1414,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIIPV4PrefixCountConfig(rName string, ipv4PrefixCount int) string {
+func testAccVPCNetworkInterfaceConfig_ipv4PrefixCount(rName string, ipv4PrefixCount int) string {
 	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
@@ -1428,7 +1428,7 @@ resource "aws_network_interface" "test" {
 `, rName, ipv4PrefixCount))
 }
 
-func testAccENIIPV6PrefixConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_ipv6Prefix(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1443,7 +1443,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIIPV6PrefixMultipleConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_ipv6PrefixMultiple(rName string) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1458,7 +1458,7 @@ resource "aws_network_interface" "test" {
 `, rName))
 }
 
-func testAccENIIPV6PrefixCountConfig(rName string, ipv6PrefixCount int) string {
+func testAccVPCNetworkInterfaceConfig_ipv6PrefixCount(rName string, ipv6PrefixCount int) string {
 	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
@@ -1473,7 +1473,7 @@ resource "aws_network_interface" "test" {
 `, rName, ipv6PrefixCount))
 }
 
-func testAccENIConfig_privateIPSet(rName string, privateIPs []string) string {
+func testAccVPCNetworkInterfaceConfig_privateIPSet(rName string, privateIPs []string) string {
 	return acctest.ConfigCompose(
 		testAccENIIPV6BaseConfig(rName),
 		fmt.Sprintf(`
@@ -1485,7 +1485,7 @@ resource "aws_network_interface" "test" {
 `, strings.Join(privateIPs, `", "`)))
 }
 
-func testAccENIConfig_privateIPSetCount(rName string, count int) string {
+func testAccVPCNetworkInterfaceConfig_privateIPSetCount(rName string, count int) string {
 	return acctest.ConfigCompose(
 		testAccENIIPV6BaseConfig(rName),
 		fmt.Sprintf(`
@@ -1497,7 +1497,7 @@ resource "aws_network_interface" "test" {
 `, count))
 }
 
-func testAccENIConfig_privateIPList(rName string, privateIPs []string) string {
+func testAccVPCNetworkInterfaceConfig_privateIPList(rName string, privateIPs []string) string {
 	return acctest.ConfigCompose(
 		testAccENIIPV6BaseConfig(rName),
 		fmt.Sprintf(`

--- a/internal/service/ec2/vpc_network_interfaces_data_source_test.go
+++ b/internal/service/ec2/vpc_network_interfaces_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccVPCNetworkInterfacesDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfacesDataSourceConfig_Filter(rName),
+				Config: testAccVPCNetworkInterfacesDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_network_interfaces.test", "ids.#", "2"),
 				),
@@ -39,7 +39,7 @@ func TestAccVPCNetworkInterfacesDataSource_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfacesDataSourceConfig_Tags(rName),
+				Config: testAccVPCNetworkInterfacesDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_network_interfaces.test", "ids.#", "1"),
 				),
@@ -58,7 +58,7 @@ func TestAccVPCNetworkInterfacesDataSource_empty(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkInterfacesDataSourceConfig_Empty(rName),
+				Config: testAccVPCNetworkInterfacesDataSourceConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_network_interfaces.test", "ids.#", "0"),
 				),
@@ -104,7 +104,7 @@ resource "aws_network_interface" "test2" {
 `, rName)
 }
 
-func testAccNetworkInterfacesDataSourceConfig_Filter(rName string) string {
+func testAccVPCNetworkInterfacesDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(testAccNetworkInterfacesDataSourceConfig_Base(rName), `
 data "aws_network_interfaces" "test" {
   filter {
@@ -115,7 +115,7 @@ data "aws_network_interfaces" "test" {
 `)
 }
 
-func testAccNetworkInterfacesDataSourceConfig_Tags(rName string) string {
+func testAccVPCNetworkInterfacesDataSourceConfig_tags(rName string) string {
 	return acctest.ConfigCompose(testAccNetworkInterfacesDataSourceConfig_Base(rName), `
 data "aws_network_interfaces" "test" {
   tags = {
@@ -125,7 +125,7 @@ data "aws_network_interfaces" "test" {
 `)
 }
 
-func testAccNetworkInterfacesDataSourceConfig_Empty(rName string) string {
+func testAccVPCNetworkInterfacesDataSourceConfig_empty(rName string) string {
 	return fmt.Sprintf(`
 data "aws_network_interfaces" "test" {
   tags = {

--- a/internal/service/ec2/vpc_peering_connection_accepter_test.go
+++ b/internal/service/ec2/vpc_peering_connection_accepter_test.go
@@ -27,7 +27,7 @@ func TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount(t *testing.T) {
 		CheckDestroy:      testAccVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAccepterSameRegionSameAccountConfig(rName),
+				Config: testAccVPCPeeringConnectionAccepterConfig_sameRegionSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceNameAccepter, &v),
 					// The aws_vpc_peering_connection documentation says:
@@ -55,7 +55,7 @@ func TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount(t *testing.T) {
 				),
 			},
 			{
-				Config:                  testAccVPCPeeringConnectionAccepterSameRegionSameAccountConfig(rName),
+				Config:                  testAccVPCPeeringConnectionAccepterConfig_sameRegionSameAccount(rName),
 				ResourceName:            resourceNameAccepter,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -84,7 +84,7 @@ func TestAccVPCPeeringConnectionAccepter_differentRegionSameAccount(t *testing.T
 		CheckDestroy:      testAccVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAccepterDifferentRegionSameAccountConfig(rName),
+				Config: testAccVPCPeeringConnectionAccepterConfig_differentRegionSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceNameConnection, &vMain),
 					testAccCheckVPCPeeringConnectionExistsWithProvider(resourceNameAccepter, &vPeer, acctest.RegionProviderFunc(acctest.AlternateRegion(), &providers)),
@@ -100,7 +100,7 @@ func TestAccVPCPeeringConnectionAccepter_differentRegionSameAccount(t *testing.T
 				),
 			},
 			{
-				Config:                  testAccVPCPeeringConnectionAccepterDifferentRegionSameAccountConfig(rName),
+				Config:                  testAccVPCPeeringConnectionAccepterConfig_differentRegionSameAccount(rName),
 				ResourceName:            resourceNameAccepter,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -129,7 +129,7 @@ func TestAccVPCPeeringConnectionAccepter_sameRegionDifferentAccount(t *testing.T
 		CheckDestroy:      testAccVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAccepterSameRegionDifferentAccountConfig(rName),
+				Config: testAccVPCPeeringConnectionAccepterConfig_sameRegionDifferentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceNameConnection, &v),
 					resource.TestCheckResourceAttrPair(resourceNameConnection, "vpc_id", resourceNameMainVpc, "id"),
@@ -167,7 +167,7 @@ func TestAccVPCPeeringConnectionAccepter_differentRegionDifferentAccount(t *test
 		CheckDestroy:      testAccVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAccepterDifferentRegionDifferentAccountConfig(rName),
+				Config: testAccVPCPeeringConnectionAccepterConfig_differentRegionDifferentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceNameConnection, &v),
 					resource.TestCheckResourceAttrPair(resourceNameConnection, "vpc_id", resourceNameMainVpc, "id"),
@@ -190,7 +190,7 @@ func testAccVPCPeeringConnectionAccepterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccVPCPeeringConnectionAccepterSameRegionSameAccountConfig(rName string) string {
+func testAccVPCPeeringConnectionAccepterConfig_sameRegionSameAccount(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
@@ -231,7 +231,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionAccepterDifferentRegionSameAccountConfig(rName string) string {
+func testAccVPCPeeringConnectionAccepterConfig_differentRegionSameAccount(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
@@ -277,7 +277,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 `, rName, acctest.AlternateRegion()))
 }
 
-func testAccVPCPeeringConnectionAccepterSameRegionDifferentAccountConfig(rName string) string {
+func testAccVPCPeeringConnectionAccepterConfig_sameRegionDifferentAccount(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
@@ -328,7 +328,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 `, rName, acctest.Region()))
 }
 
-func testAccVPCPeeringConnectionAccepterDifferentRegionDifferentAccountConfig(rName string) string {
+func testAccVPCPeeringConnectionAccepterConfig_differentRegionDifferentAccount(rName string) string {
 	return acctest.ConfigCompose(testAccAlternateAccountAlternateRegionProviderConfig(), fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/vpc_peering_connection_data_source_test.go
+++ b/internal/service/ec2/vpc_peering_connection_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccVPCPeeringConnectionDataSource_cidrBlock(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionDataSourceCIDRBlockConfig(rName),
+				Config: testAccVPCPeeringConnectionDataSourceConfig_cidrBlock(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cidr_block", requesterVpcResourceName, "cidr_block"),
@@ -45,7 +45,7 @@ func TestAccVPCPeeringConnectionDataSource_id(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionDataSourceIDConfig(rName),
+				Config: testAccVPCPeeringConnectionDataSourceConfig_id(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					// resource.TestCheckResourceAttrPair(dataSourceName, "cidr_block", resourceName, "cidr_block"), // not in resource
@@ -84,7 +84,7 @@ func TestAccVPCPeeringConnectionDataSource_peerCIDRBlock(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionDataSourcePeerCIDRBlockConfig(rName),
+				Config: testAccVPCPeeringConnectionDataSourceConfig_peerCIDRBlock(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_cidr_block", accepterVpcResourceName, "cidr_block"),
@@ -105,7 +105,7 @@ func TestAccVPCPeeringConnectionDataSource_peerVPCID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionDataSourcePeerVPCIDConfig(rName),
+				Config: testAccVPCPeeringConnectionDataSourceConfig_peerID(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_vpc_id", resourceName, "peer_vpc_id"),
@@ -126,7 +126,7 @@ func TestAccVPCPeeringConnectionDataSource_vpcID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionDataSourceVPCIDConfig(rName),
+				Config: testAccVPCPeeringConnectionDataSourceConfig_vpcID(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
@@ -136,7 +136,7 @@ func TestAccVPCPeeringConnectionDataSource_vpcID(t *testing.T) {
 	})
 }
 
-func testAccVPCPeeringConnectionDataSourceCIDRBlockConfig(rName string) string {
+func testAccVPCPeeringConnectionDataSourceConfig_cidrBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
   cidr_block = "10.250.0.0/16" # CIDR must be different than other tests
@@ -176,7 +176,7 @@ data "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionDataSourceIDConfig(rName string) string {
+func testAccVPCPeeringConnectionDataSourceConfig_id(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
   cidr_block = "10.1.0.0/16"
@@ -210,7 +210,7 @@ data "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionDataSourcePeerCIDRBlockConfig(rName string) string {
+func testAccVPCPeeringConnectionDataSourceConfig_peerCIDRBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
   cidr_block = "10.252.0.0/16" # CIDR must be different than other tests
@@ -250,7 +250,7 @@ data "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionDataSourcePeerVPCIDConfig(rName string) string {
+func testAccVPCPeeringConnectionDataSourceConfig_peerID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
   cidr_block = "10.1.0.0/16"
@@ -284,7 +284,7 @@ data "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionDataSourceVPCIDConfig(rName string) string {
+func testAccVPCPeeringConnectionDataSourceConfig_vpcID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_peering_connection_options_test.go
+++ b/internal/service/ec2/vpc_peering_connection_options_test.go
@@ -28,7 +28,7 @@ func TestAccVPCPeeringConnectionOptions_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionOptionsSameRegionSameAccountConfig(rName, true, true),
+				Config: testAccVPCPeeringConnectionOptionsConfig_sameRegionSameAccount(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
 					resource.TestCheckResourceAttr(resourceName, "requester.#", "1"),
@@ -66,7 +66,7 @@ func TestAccVPCPeeringConnectionOptions_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPCPeeringConnectionOptionsSameRegionSameAccountConfig(rName, false, false),
+				Config: testAccVPCPeeringConnectionOptionsConfig_sameRegionSameAccount(rName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
 					resource.TestCheckResourceAttr(
@@ -122,7 +122,7 @@ func TestAccVPCPeeringConnectionOptions_differentRegionSameAccount(t *testing.T)
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionOptionsDifferentRegionSameAccountConfig(rName, true, true),
+				Config: testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
 					resource.TestCheckResourceAttr(resourceName, "requester.#", "1"),
@@ -156,13 +156,13 @@ func TestAccVPCPeeringConnectionOptions_differentRegionSameAccount(t *testing.T)
 				),
 			},
 			{
-				Config:            testAccVPCPeeringConnectionOptionsDifferentRegionSameAccountConfig(rName, true, true),
+				Config:            testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName, true, true),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPCPeeringConnectionOptionsDifferentRegionSameAccountConfig(rName, false, false),
+				Config: testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
 					resource.TestCheckResourceAttr(
@@ -218,7 +218,7 @@ func TestAccVPCPeeringConnectionOptions_sameRegionDifferentAccount(t *testing.T)
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionOptionsSameRegionDifferentAccountConfig(rName),
+				Config: testAccVPCPeeringConnectionOptionsConfig_sameRegionDifferentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
 					resource.TestCheckResourceAttr(resourceName, "requester.#", "1"),
@@ -242,7 +242,7 @@ func TestAccVPCPeeringConnectionOptions_sameRegionDifferentAccount(t *testing.T)
 				),
 			},
 			{
-				Config:            testAccVPCPeeringConnectionOptionsSameRegionDifferentAccountConfig(rName),
+				Config:            testAccVPCPeeringConnectionOptionsConfig_sameRegionDifferentAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -287,7 +287,7 @@ func testAccCheckVPCPeeringConnectionOptionsWithProvider(n, block string, option
 	}
 }
 
-func testAccVPCPeeringConnectionOptionsSameRegionSameAccountConfig(rName string, accepterDnsResolution, requesterRemoteClassicLink bool) string {
+func testAccVPCPeeringConnectionOptionsConfig_sameRegionSameAccount(rName string, accepterDnsResolution, requesterRemoteClassicLink bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -331,7 +331,7 @@ resource "aws_vpc_peering_connection_options" "test" {
 `, rName, accepterDnsResolution, requesterRemoteClassicLink)
 }
 
-func testAccVPCPeeringConnectionOptionsDifferentRegionSameAccountConfig(rName string, dnsResolution, dnsResolutionPeer bool) string {
+func testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName string, dnsResolution, dnsResolutionPeer bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
@@ -401,7 +401,7 @@ resource "aws_vpc_peering_connection_options" "peer" {
 `, rName, acctest.AlternateRegion(), dnsResolution, dnsResolutionPeer))
 }
 
-func testAccVPCPeeringConnectionOptionsSameRegionDifferentAccountConfig(rName string) string {
+func testAccVPCPeeringConnectionOptionsConfig_sameRegionDifferentAccount(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"

--- a/internal/service/ec2/vpc_peering_connection_test.go
+++ b/internal/service/ec2/vpc_peering_connection_test.go
@@ -30,7 +30,7 @@ func TestAccVPCPeeringConnection_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionConfig(rName),
+				Config: testAccVPCPeeringConnectionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -60,7 +60,7 @@ func TestAccVPCPeeringConnection_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionConfig(rName),
+				Config: testAccVPCPeeringConnectionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPCPeeringConnection(), resourceName),
@@ -83,7 +83,7 @@ func TestAccVPCPeeringConnection_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionConfigTags1(rName, "key1", "value1"),
+				Config: testAccVPCPeeringConnectionConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -99,7 +99,7 @@ func TestAccVPCPeeringConnection_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccVPCPeeringConnectionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCPeeringConnectionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -108,7 +108,7 @@ func TestAccVPCPeeringConnection_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCPeeringConnectionConfigTags1(rName, "key2", "value2"),
+				Config: testAccVPCPeeringConnectionConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -146,7 +146,7 @@ func TestAccVPCPeeringConnection_options(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAccepterRequesterOptionsConfig(rName),
+				Config: testAccVPCPeeringConnectionConfig_accepterRequesterOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(
 						resourceName,
@@ -207,7 +207,7 @@ func TestAccVPCPeeringConnection_options(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccVPCPeeringConnectionAccepterRequesterOptionsConfig(rName),
+				Config: testAccVPCPeeringConnectionConfig_accepterRequesterOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(
 						resourceName,
@@ -271,7 +271,7 @@ func TestAccVPCPeeringConnection_failedState(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVPCPeeringConnectionFailedStateConfig(rName),
+				Config:      testAccVPCPeeringConnectionConfig_failedState(rName),
 				ExpectError: regexp.MustCompile(`unexpected state 'failed'`),
 			},
 		},
@@ -292,7 +292,7 @@ func TestAccVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVPCPeeringConnectionAlternateRegionAutoAcceptConfig(rName, true),
+				Config:      testAccVPCPeeringConnectionConfig_alternateRegionAutoAccept(rName, true),
 				ExpectError: regexp.MustCompile("`peer_region` cannot be set whilst `auto_accept` is `true` when creating an EC2 VPC Peering Connection"),
 			},
 		},
@@ -315,7 +315,7 @@ func TestAccVPCPeeringConnection_region(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAlternateRegionAutoAcceptConfig(rName, false),
+				Config: testAccVPCPeeringConnectionConfig_alternateRegionAutoAccept(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(
 						resourceName,
@@ -345,7 +345,7 @@ func TestAccVPCPeeringConnection_accept(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionAutoAcceptConfig(rName, false),
+				Config: testAccVPCPeeringConnectionConfig_autoAccept(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(
 						resourceName,
@@ -359,7 +359,7 @@ func TestAccVPCPeeringConnection_accept(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCPeeringConnectionAutoAcceptConfig(rName, true),
+				Config: testAccVPCPeeringConnectionConfig_autoAccept(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(
 						resourceName,
@@ -374,7 +374,7 @@ func TestAccVPCPeeringConnection_accept(t *testing.T) {
 			},
 			// Tests that changing 'auto_accept' back to false keeps the connection active.
 			{
-				Config: testAccVPCPeeringConnectionAutoAcceptConfig(rName, false),
+				Config: testAccVPCPeeringConnectionConfig_autoAccept(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCPeeringConnectionExists(
 						resourceName,
@@ -410,7 +410,7 @@ func TestAccVPCPeeringConnection_optionsNoAutoAccept(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVPCPeeringConnectionAccepterRequesterOptionsNoAutoAcceptConfig(rName),
+				Config:      testAccVPCPeeringConnectionConfig_accepterRequesterOptionsNoAutoAccept(rName),
 				ExpectError: regexp.MustCompile(`is not active`),
 			},
 		},
@@ -470,7 +470,7 @@ func testAccCheckVPCPeeringConnectionExistsWithProvider(n string, v *ec2.VpcPeer
 	}
 }
 
-func testAccVPCPeeringConnectionConfig(rName string) string {
+func testAccVPCPeeringConnectionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -496,7 +496,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCPeeringConnectionConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -525,7 +525,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccVPCPeeringConnectionConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCPeeringConnectionConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -556,7 +556,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccVPCPeeringConnectionAccepterRequesterOptionsConfig(rName string) string {
+func testAccVPCPeeringConnectionConfig_accepterRequesterOptions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -596,7 +596,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionFailedStateConfig(rName string) string {
+func testAccVPCPeeringConnectionConfig_failedState(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -625,7 +625,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionAlternateRegionAutoAcceptConfig(rName string, autoAccept bool) string {
+func testAccVPCPeeringConnectionConfig_alternateRegionAutoAccept(rName string, autoAccept bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -658,7 +658,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName, autoAccept, acctest.AlternateRegion()))
 }
 
-func testAccVPCPeeringConnectionAutoAcceptConfig(rName string, autoAccept bool) string {
+func testAccVPCPeeringConnectionConfig_autoAccept(rName string, autoAccept bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -688,7 +688,7 @@ resource "aws_vpc_peering_connection" "test" {
 `, rName, autoAccept)
 }
 
-func testAccVPCPeeringConnectionAccepterRequesterOptionsNoAutoAcceptConfig(rName string) string {
+func testAccVPCPeeringConnectionConfig_accepterRequesterOptionsNoAutoAccept(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/vpc_peering_connections_data_source_test.go
+++ b/internal/service/ec2/vpc_peering_connections_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccVPCPeeringConnectionsDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionsDataSourceConfig(rName),
+				Config: testAccVPCPeeringConnectionsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_vpc_peering_connections.test_by_filters", "ids.#", "2"),
 				),
@@ -37,7 +37,7 @@ func TestAccVPCPeeringConnectionsDataSource_NoMatches(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCPeeringConnectionsDataSourceConfig_NoMatches(rName),
+				Config: testAccVPCPeeringConnectionsDataSourceConfig_noMatches(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_vpc_peering_connections.test", "ids.#", "0"),
 				),
@@ -46,7 +46,7 @@ func TestAccVPCPeeringConnectionsDataSource_NoMatches(t *testing.T) {
 	})
 }
 
-func testAccVPCPeeringConnectionsDataSourceConfig(rName string) string {
+func testAccVPCPeeringConnectionsDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -101,7 +101,7 @@ data "aws_vpc_peering_connections" "test_by_filters" {
 `, rName)
 }
 
-func testAccVPCPeeringConnectionsDataSourceConfig_NoMatches(rName string) string {
+func testAccVPCPeeringConnectionsDataSourceConfig_noMatches(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_peering_connections" "test" {
   tags = {

--- a/internal/service/ec2/vpc_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_prefix_list_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccVPCPrefixListDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrefixListDataSourceConfig,
+				Config: testAccVPCPrefixListDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccPrefixListCheckDataSource("data.aws_prefix_list.s3_by_id"),
 					testAccPrefixListCheckDataSource("data.aws_prefix_list.s3_by_name"),
@@ -39,7 +39,7 @@ func TestAccVPCPrefixListDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrefixListFilterDataSourceConfig,
+				Config: testAccVPCPrefixListDataSourceConfig_filter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccPrefixListCheckDataSource("data.aws_prefix_list.s3_by_id"),
 					testAccPrefixListCheckDataSource("data.aws_prefix_list.s3_by_name"),
@@ -56,7 +56,7 @@ func TestAccVPCPrefixListDataSource_nameDoesNotOverrideFilter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccPrefixListDataSourceConfig_nameDoesNotOverrideFilter,
+				Config:      testAccVPCPrefixListDataSourceConfig_nameDoesNotOverrideFilter,
 				ExpectError: regexp.MustCompile(`no matching prefix list found`),
 			},
 		},
@@ -120,7 +120,7 @@ func testAccPrefixListCheckDataSource(name string) resource.TestCheckFunc {
 	}
 }
 
-const testAccPrefixListDataSourceConfig = `
+const testAccVPCPrefixListDataSourceConfig_basic = `
 data "aws_region" "current" {}
 
 data "aws_prefix_list" "s3_by_id" {
@@ -132,7 +132,7 @@ data "aws_prefix_list" "s3_by_name" {
 }
 `
 
-const testAccPrefixListFilterDataSourceConfig = `
+const testAccVPCPrefixListDataSourceConfig_filter = `
 data "aws_region" "current" {}
 
 data "aws_prefix_list" "s3_by_name" {
@@ -150,7 +150,7 @@ data "aws_prefix_list" "s3_by_id" {
 }
 `
 
-const testAccPrefixListDataSourceConfig_nameDoesNotOverrideFilter = `
+const testAccVPCPrefixListDataSourceConfig_nameDoesNotOverrideFilter = `
 data "aws_region" "current" {}
 
 data "aws_prefix_list" "test" {

--- a/internal/service/ec2/vpc_route_data_source_test.go
+++ b/internal/service/ec2/vpc_route_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccVPCRouteDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteBasicDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// By destination CIDR.
 					resource.TestCheckResourceAttrPair(datasource1Name, "destination_cidr_block", instanceRouteResourceName, "destination_cidr_block"),
@@ -65,7 +65,7 @@ func TestAccVPCRouteDataSource_transitGatewayID(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4TransitGatewayDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_ipv4TransitGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
@@ -88,7 +88,7 @@ func TestAccVPCRouteDataSource_ipv6DestinationCIDR(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6EgressOnlyInternetGatewayDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_ipv6EgressOnlyInternetGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "destination_ipv6_cidr_block", dataSourceName, "destination_ipv6_cidr_block"),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
@@ -110,7 +110,7 @@ func TestAccVPCRouteDataSource_localGatewayID(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4LocalGatewayDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_ipv4LocalGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
@@ -133,7 +133,7 @@ func TestAccVPCRouteDataSource_carrierGatewayID(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4CarrierGatewayDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_ipv4CarrierGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
@@ -156,7 +156,7 @@ func TestAccVPCRouteDataSource_destinationPrefixListID(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListNatGatewayDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_prefixListNATGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", dataSourceName, "destination_prefix_list_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", dataSourceName, "nat_gateway_id"),
@@ -181,7 +181,7 @@ func TestAccVPCRouteDataSource_gatewayVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteGatewayVPCEndpointNoDataSourceDataSourceConfig(rName),
+				Config: testAccVPCRouteDataSourceConfig_gatewayEndpointNo(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckVPCEndpointExists(vpceResourceName, &vpce),
@@ -189,14 +189,14 @@ func TestAccVPCRouteDataSource_gatewayVPCEndpoint(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccRouteGatewayVPCEndpointWithDataSourceDataSourceConfig(rName),
+				Config:      testAccVPCRouteDataSourceConfig_gatewayEndpoint(rName),
 				ExpectError: regexp.MustCompile(`No routes matching supplied arguments found in Route Table`),
 			},
 		},
 	})
 }
 
-func testAccRouteBasicDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
@@ -290,7 +290,7 @@ data "aws_route" "by_instance_id" {
 `, rName))
 }
 
-func testAccRouteIPv4TransitGatewayDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_ipv4TransitGateway(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
@@ -341,7 +341,7 @@ data "aws_route" "test" {
 `, rName))
 }
 
-func testAccRouteIPv6EgressOnlyInternetGatewayDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_ipv6EgressOnlyInternetGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -380,7 +380,7 @@ data "aws_route" "test" {
 `, rName)
 }
 
-func testAccRouteIPv4LocalGatewayDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_ipv4LocalGateway(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 
@@ -434,7 +434,7 @@ data "aws_route" "by_local_gateway_id" {
 `, rName)
 }
 
-func testAccRouteIPv4CarrierGatewayDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_ipv4CarrierGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -473,7 +473,7 @@ data "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListNatGatewayDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_prefixListNATGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -549,7 +549,7 @@ data "aws_route" "test" {
 `, rName)
 }
 
-func testAccRouteGatewayVPCEndpointNoDataSourceDataSourceConfig(rName string) string {
+func testAccVPCRouteDataSourceConfig_gatewayEndpointNo(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -577,8 +577,8 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteGatewayVPCEndpointWithDataSourceDataSourceConfig(rName string) string {
-	return acctest.ConfigCompose(testAccRouteGatewayVPCEndpointNoDataSourceDataSourceConfig(rName), `
+func testAccVPCRouteDataSourceConfig_gatewayEndpoint(rName string) string {
+	return acctest.ConfigCompose(testAccVPCRouteDataSourceConfig_gatewayEndpointNo(rName), `
 data "aws_prefix_list" "test" {
   name = aws_vpc_endpoint.test.service_name
 }

--- a/internal/service/ec2/vpc_route_table_association_test.go
+++ b/internal/service/ec2/vpc_route_table_association_test.go
@@ -28,7 +28,7 @@ func TestAccVPCRouteTableAssociation_Subnet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableAssociationConfigSubnet(rName),
+				Config: testAccVPCRouteTableAssociationConfig_subnet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", resourceNameRouteTable, "id"),
@@ -60,7 +60,7 @@ func TestAccVPCRouteTableAssociation_Subnet_changeRouteTable(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableAssociationConfigSubnet(rName),
+				Config: testAccVPCRouteTableAssociationConfig_subnet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", resourceNameRouteTable1, "id"),
@@ -68,7 +68,7 @@ func TestAccVPCRouteTableAssociation_Subnet_changeRouteTable(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableAssociationConfigSubnetChangeRouteTable(rName),
+				Config: testAccVPCRouteTableAssociationConfig_subnetChange(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", resourceNameRouteTable2, "id"),
@@ -93,7 +93,7 @@ func TestAccVPCRouteTableAssociation_Gateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableAssociationConfigGateway(rName),
+				Config: testAccVPCRouteTableAssociationConfig_gateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", resourceNameRouteTable, "id"),
@@ -125,7 +125,7 @@ func TestAccVPCRouteTableAssociation_Gateway_changeRouteTable(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableAssociationConfigGateway(rName),
+				Config: testAccVPCRouteTableAssociationConfig_gateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", resourceNameRouteTable1, "id"),
@@ -133,7 +133,7 @@ func TestAccVPCRouteTableAssociation_Gateway_changeRouteTable(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableAssociationConfigGatewayChangeRouteTable(rName),
+				Config: testAccVPCRouteTableAssociationConfig_gatewayChange(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", resourceNameRouteTable2, "id"),
@@ -156,7 +156,7 @@ func TestAccVPCRouteTableAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableAssociationConfigSubnet(rName),
+				Config: testAccVPCRouteTableAssociationConfig_subnet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &rta),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceRouteTableAssociation(), resourceName),
@@ -261,7 +261,7 @@ resource "aws_internet_gateway" "test" {
 `, rName)
 }
 
-func testAccRouteTableAssociationConfigSubnet(rName string) string {
+func testAccVPCRouteTableAssociationConfig_subnet(rName string) string {
 	return acctest.ConfigCompose(testAccRouteTableAssociationConfigBaseVPC(rName), fmt.Sprintf(`
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
@@ -283,7 +283,7 @@ resource "aws_route_table_association" "test" {
 `, rName))
 }
 
-func testAccRouteTableAssociationConfigSubnetChangeRouteTable(rName string) string {
+func testAccVPCRouteTableAssociationConfig_subnetChange(rName string) string {
 	return acctest.ConfigCompose(testAccRouteTableAssociationConfigBaseVPC(rName), fmt.Sprintf(`
 resource "aws_route_table" "test2" {
   vpc_id = aws_vpc.test.id
@@ -305,7 +305,7 @@ resource "aws_route_table_association" "test" {
 `, rName))
 }
 
-func testAccRouteTableAssociationConfigGateway(rName string) string {
+func testAccVPCRouteTableAssociationConfig_gateway(rName string) string {
 	return acctest.ConfigCompose(testAccRouteTableAssociationConfigBaseVPC(rName), fmt.Sprintf(`
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
@@ -335,7 +335,7 @@ resource "aws_route_table_association" "test" {
 `, rName))
 }
 
-func testAccRouteTableAssociationConfigGatewayChangeRouteTable(rName string) string {
+func testAccVPCRouteTableAssociationConfig_gatewayChange(rName string) string {
 	return acctest.ConfigCompose(testAccRouteTableAssociationConfigBaseVPC(rName), fmt.Sprintf(`
 resource "aws_route_table" "test2" {
   vpc_id = aws_vpc.test.id

--- a/internal/service/ec2/vpc_route_table_data_source_test.go
+++ b/internal/service/ec2/vpc_route_table_data_source_test.go
@@ -30,7 +30,7 @@ func TestAccVPCRouteTableDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableBasicDataSourceConfig(rName),
+				Config: testAccVPCRouteTableDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// By tags.
 					acctest.MatchResourceAttrRegionalARN(datasource1Name, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
@@ -108,7 +108,7 @@ func TestAccVPCRouteTableDataSource_main(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableMainDataSourceConfig(rName),
+				Config: testAccVPCRouteTableDataSourceConfig_main(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "vpc_id"),
@@ -165,7 +165,7 @@ func testAccCheckListHasSomeElementAttrPair(nameFirst string, resourceAttr strin
 	}
 }
 
-func testAccRouteTableBasicDataSourceConfig(rName string) string {
+func testAccVPCRouteTableDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
@@ -247,7 +247,7 @@ data "aws_route_table" "by_id" {
 `, rName)
 }
 
-func testAccRouteTableMainDataSourceConfig(rName string) string {
+func testAccVPCRouteTableDataSourceConfig_main(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"

--- a/internal/service/ec2/vpc_route_table_test.go
+++ b/internal/service/ec2/vpc_route_table_test.go
@@ -29,7 +29,7 @@ func TestAccVPCRouteTable_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableBasicConfig(rName),
+				Config: testAccVPCRouteTableConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -61,7 +61,7 @@ func TestAccVPCRouteTable_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableBasicConfig(rName),
+				Config: testAccVPCRouteTableConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceRouteTable(), resourceName),
@@ -84,7 +84,7 @@ func TestAccVPCRouteTable_Disappears_subnetAssociation(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableSubnetAssociationConfig(rName),
+				Config: testAccVPCRouteTableConfig_subnetAssociation(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceRouteTable(), resourceName),
@@ -111,7 +111,7 @@ func TestAccVPCRouteTable_ipv4ToInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4InternetGatewayConfig(rName, destinationCidr1, destinationCidr2),
+				Config: testAccVPCRouteTableConfig_ipv4InternetGateway(rName, destinationCidr1, destinationCidr2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -126,7 +126,7 @@ func TestAccVPCRouteTable_ipv4ToInternetGateway(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableIPv4InternetGatewayConfig(rName, destinationCidr2, destinationCidr3),
+				Config: testAccVPCRouteTableConfig_ipv4InternetGateway(rName, destinationCidr2, destinationCidr3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -163,7 +163,7 @@ func TestAccVPCRouteTable_ipv4ToInstance(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4InstanceConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4Instance(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -199,7 +199,7 @@ func TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv6EgressOnlyInternetGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv6EgressOnlyInternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -219,7 +219,7 @@ func TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 			},
 			{
 				// Verify that expanded form of the destination CIDR causes no diff.
-				Config:   testAccRouteTableIPv6EgressOnlyInternetGatewayConfig(rName, "::0/0"),
+				Config:   testAccVPCRouteTableConfig_ipv6EgressOnlyInternetGateway(rName, "::0/0"),
 				PlanOnly: true,
 			},
 		},
@@ -238,7 +238,7 @@ func TestAccVPCRouteTable_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableTags1Config(rName, "key1", "value1"),
+				Config: testAccVPCRouteTableConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -251,7 +251,7 @@ func TestAccVPCRouteTable_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRouteTableTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCRouteTableConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -260,7 +260,7 @@ func TestAccVPCRouteTable_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableTags1Config(rName, "key2", "value2"),
+				Config: testAccVPCRouteTableConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -285,7 +285,7 @@ func TestAccVPCRouteTable_requireRouteDestination(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccRouteTableConfigNoDestination(rName),
+				Config:      testAccVPCRouteTableConfig_noDestination(rName),
 				ExpectError: regexp.MustCompile("error creating route: one of `cidr_block"),
 			},
 		},
@@ -302,7 +302,7 @@ func TestAccVPCRouteTable_requireRouteTarget(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccRouteTableConfigNoTarget(rName),
+				Config:      testAccVPCRouteTableConfig_noTarget(rName),
 				ExpectError: regexp.MustCompile(`error creating route: one of .*\begress_only_gateway_id\b`),
 			},
 		},
@@ -324,7 +324,7 @@ func TestAccVPCRouteTable_Route_mode(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4InternetGatewayConfig(rName, destinationCidr1, destinationCidr2),
+				Config: testAccVPCRouteTableConfig_ipv4InternetGateway(rName, destinationCidr1, destinationCidr2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -344,7 +344,7 @@ func TestAccVPCRouteTable_Route_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRouteTableRouteModeNoBlocksConfig(rName),
+				Config: testAccVPCRouteTableConfig_modeNoBlocks(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -364,7 +364,7 @@ func TestAccVPCRouteTable_Route_mode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRouteTableRouteModeZeroedConfig(rName),
+				Config: testAccVPCRouteTableConfig_modeZeroed(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -403,7 +403,7 @@ func TestAccVPCRouteTable_ipv4ToTransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4TransitGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -443,7 +443,7 @@ func TestAccVPCRouteTable_ipv4ToVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableRouteIPv4VPCEndpointIDConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4EndpointID(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -479,7 +479,7 @@ func TestAccVPCRouteTable_ipv4ToCarrierGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4CarrierGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4CarrierGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -515,7 +515,7 @@ func TestAccVPCRouteTable_ipv4ToLocalGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableRouteIPv4LocalGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4LocalGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -551,7 +551,7 @@ func TestAccVPCRouteTable_ipv4ToVPCPeeringConnection(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4VPCPeeringConnectionConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4PeeringConnection(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -587,7 +587,7 @@ func TestAccVPCRouteTable_vgwRoutePropagation(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableConfig_vgwRoutePropagation(rName, vgwResourceName1),
+				Config: testAccVPCRouteTableConfig_vgwPropagation(rName, vgwResourceName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -601,7 +601,7 @@ func TestAccVPCRouteTable_vgwRoutePropagation(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableConfig_vgwRoutePropagation(rName, vgwResourceName2),
+				Config: testAccVPCRouteTableConfig_vgwPropagation(rName, vgwResourceName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -638,14 +638,14 @@ func TestAccVPCRouteTable_conditionalCIDRBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, false),
+				Config: testAccVPCRouteTableConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableRoute(resourceName, "cidr_block", destinationCidr, "gateway_id", igwResourceName, "id"),
 				),
 			},
 			{
-				Config: testAccRouteTableConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, true),
+				Config: testAccVPCRouteTableConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableRoute(resourceName, "ipv6_cidr_block", destinationIpv6Cidr, "gateway_id", igwResourceName, "id"),
@@ -674,7 +674,7 @@ func TestAccVPCRouteTable_ipv4ToNatGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv4NatGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv4NATGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -710,7 +710,7 @@ func TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableIPv6NetworkInterfaceUnattachedConfig(rName, destinationCidr),
+				Config: testAccVPCRouteTableConfig_ipv6NetworkInterfaceUnattached(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -748,7 +748,7 @@ func TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableBasicConfig(rName),
+				Config: testAccVPCRouteTableConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -760,7 +760,7 @@ func TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableIPv4TwoNetworkInterfacesUnattachedConfig(rName, destinationCidr1, destinationCidr2),
+				Config: testAccVPCRouteTableConfig_ipv4TwoNetworkInterfacesUnattached(rName, destinationCidr1, destinationCidr2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -780,7 +780,7 @@ func TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRouteTableIPv4TwoNetworkInterfacesUnattachedConfig(rName, destinationCidr2, destinationCidr1),
+				Config: testAccVPCRouteTableConfig_ipv4TwoNetworkInterfacesUnattached(rName, destinationCidr2, destinationCidr1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -795,7 +795,7 @@ func TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableRouteModeZeroedConfig(rName),
+				Config: testAccVPCRouteTableConfig_modeZeroed(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
@@ -823,7 +823,7 @@ func TestAccVPCRouteTable_vpcMultipleCIDRs(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableVPCMultipleCIDRsConfig(rName),
+				Config: testAccVPCRouteTableConfig_multipleCIDRs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -856,7 +856,7 @@ func TestAccVPCRouteTable_vpcClassicLink(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableVPCClassicLinkConfig(rName),
+				Config: testAccVPCRouteTableConfig_classicLink(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -891,7 +891,7 @@ func TestAccVPCRouteTable_gatewayVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableGatewayVPCEndpointConfig(rName),
+				Config: testAccVPCRouteTableConfig_gatewayEndpoint(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckVPCEndpointExists(vpceResourceName, &vpce),
@@ -936,7 +936,7 @@ func TestAccVPCRouteTable_multipleRoutes(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTableMultipleRoutesConfig(rName,
+				Config: testAccVPCRouteTableConfig_multiples(rName,
 					"cidr_block", destinationCidr1, "gateway_id", igwResourceName,
 					"cidr_block", destinationCidr2, "instance_id", instanceResourceName,
 					"ipv6_cidr_block", destinationCidr4, "egress_only_gateway_id", eoigwResourceName),
@@ -955,7 +955,7 @@ func TestAccVPCRouteTable_multipleRoutes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableMultipleRoutesConfig(rName,
+				Config: testAccVPCRouteTableConfig_multiples(rName,
 					"cidr_block", destinationCidr1, "vpc_peering_connection_id", pcxResourceName,
 					"cidr_block", destinationCidr3, "instance_id", instanceResourceName,
 					"ipv6_cidr_block", destinationCidr4, "egress_only_gateway_id", eoigwResourceName),
@@ -974,7 +974,7 @@ func TestAccVPCRouteTable_multipleRoutes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteTableMultipleRoutesConfig(rName,
+				Config: testAccVPCRouteTableConfig_multiples(rName,
 					"ipv6_cidr_block", destinationCidr4, "vpc_peering_connection_id", pcxResourceName,
 					"cidr_block", destinationCidr3, "gateway_id", igwResourceName,
 					"cidr_block", destinationCidr2, "instance_id", instanceResourceName),
@@ -1015,7 +1015,7 @@ func TestAccVPCRouteTable_prefixListToInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTablePrefixListInternetGatewayConfig(rName),
+				Config: testAccVPCRouteTableConfig_prefixListInternetGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -1189,7 +1189,7 @@ func testAccCheckRouteTableWaitForVPCEndpointRoute(routeTable *ec2.RouteTable, v
 	}
 }
 
-func testAccRouteTableBasicConfig(rName string) string {
+func testAccVPCRouteTableConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1205,7 +1205,7 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteTableSubnetAssociationConfig(rName string) string {
+func testAccVPCRouteTableConfig_subnetAssociation(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1240,7 +1240,7 @@ resource "aws_route_table_association" "test" {
 `, rName))
 }
 
-func testAccRouteTableIPv4InternetGatewayConfig(rName, destinationCidr1, destinationCidr2 string) string {
+func testAccVPCRouteTableConfig_ipv4InternetGateway(rName, destinationCidr1, destinationCidr2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1278,7 +1278,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr1, destinationCidr2)
 }
 
-func testAccRouteTableIPv6EgressOnlyInternetGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv6EgressOnlyInternetGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -1312,7 +1312,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteTableIPv4InstanceConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4Instance(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -1361,7 +1361,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteTableTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCRouteTableConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1381,7 +1381,7 @@ resource "aws_route_table" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccRouteTableTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCRouteTableConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1402,7 +1402,7 @@ resource "aws_route_table" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccRouteTableIPv4VPCPeeringConnectionConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4PeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1445,7 +1445,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteTableConfig_vgwRoutePropagation(rName, vgwResourceName string) string {
+func testAccVPCRouteTableConfig_vgwPropagation(rName, vgwResourceName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1484,7 +1484,7 @@ resource "aws_route_table" "test" {
 `, rName, vgwResourceName)
 }
 
-func testAccRouteTableConfigNoDestination(rName string) string {
+func testAccVPCRouteTableConfig_noDestination(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
@@ -1532,7 +1532,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccRouteTableConfigNoTarget(rName string) string {
+func testAccVPCRouteTableConfig_noTarget(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
@@ -1556,7 +1556,7 @@ resource "aws_vpc" "test" {
 `, rName)
 }
 
-func testAccRouteTableRouteModeNoBlocksConfig(rName string) string {
+func testAccVPCRouteTableConfig_modeNoBlocks(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1584,7 +1584,7 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteTableRouteModeZeroedConfig(rName string) string {
+func testAccVPCRouteTableConfig_modeZeroed(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1614,7 +1614,7 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteTableIPv4TransitGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4TransitGateway(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInDefaultExclude(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1665,7 +1665,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteTableRouteIPv4VPCEndpointIDConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4EndpointID(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -1734,7 +1734,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteTableIPv4CarrierGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4CarrierGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1767,7 +1767,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteTableRouteIPv4LocalGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4LocalGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 
@@ -1824,7 +1824,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteTableConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
+func testAccVPCRouteTableConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1866,7 +1866,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr, destinationIpv6Cidr, ipv6Route)
 }
 
-func testAccRouteTableIPv4NatGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv4NATGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1929,7 +1929,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteTableIPv6NetworkInterfaceUnattachedConfig(rName, destinationCidr string) string {
+func testAccVPCRouteTableConfig_ipv6NetworkInterfaceUnattached(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -1973,7 +1973,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteTableIPv4TwoNetworkInterfacesUnattachedConfig(rName, destinationCidr1, destinationCidr2 string) string {
+func testAccVPCRouteTableConfig_ipv4TwoNetworkInterfacesUnattached(rName, destinationCidr1, destinationCidr2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2028,7 +2028,7 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr1, destinationCidr2)
 }
 
-func testAccRouteTableVPCMultipleCIDRsConfig(rName string) string {
+func testAccVPCRouteTableConfig_multipleCIDRs(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2053,7 +2053,7 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteTableVPCClassicLinkConfig(rName string) string {
+func testAccVPCRouteTableConfig_classicLink(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block         = "10.1.0.0/16"
@@ -2074,7 +2074,7 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteTableGatewayVPCEndpointConfig(rName string) string {
+func testAccVPCRouteTableConfig_gatewayEndpoint(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2102,7 +2102,7 @@ resource "aws_vpc_endpoint" "test" {
 `, rName)
 }
 
-func testAccRouteTableMultipleRoutesConfig(rName,
+func testAccVPCRouteTableConfig_multiples(rName,
 	destinationAttr1, destinationValue1, targetAttribute1, targetValue1,
 	destinationAttr2, destinationValue2, targetAttribute2, targetValue2,
 	destinationAttr3, destinationValue3, targetAttribute3, targetValue3 string) string {
@@ -2246,7 +2246,7 @@ data "aws_ami" "amzn-ami-nat-instance" {
 `
 }
 
-func testAccRouteTablePrefixListInternetGatewayConfig(rName string) string {
+func testAccVPCRouteTableConfig_prefixListInternetGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_route_tables_data_source_test.go
+++ b/internal/service/ec2/vpc_route_tables_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccVPCRouteTablesDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTablesDataSourceConfig(rName),
+				Config: testAccVPCRouteTablesDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_route_tables.by_vpc_id", "ids.#", "2"), // Add the default route table.
 					resource.TestCheckResourceAttr("data.aws_route_tables.by_tags", "ids.#", "2"),
@@ -32,7 +32,7 @@ func TestAccVPCRouteTablesDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccRouteTablesDataSourceConfig(rName string) string {
+func testAccVPCRouteTablesDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "172.16.0.0/16"

--- a/internal/service/ec2/vpc_route_test.go
+++ b/internal/service/ec2/vpc_route_test.go
@@ -32,7 +32,7 @@ func TestAccVPCRoute_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4InternetGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 2),
@@ -79,7 +79,7 @@ func TestAccVPCRoute_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4InternetGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceRoute(), resourceName),
@@ -104,7 +104,7 @@ func TestAccVPCRoute_Disappears_routeTable(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4InternetGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceRouteTable(), rtResourceName),
@@ -129,7 +129,7 @@ func TestAccVPCRoute_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6EgressOnlyInternetGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6EgressOnlyInternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -159,7 +159,7 @@ func TestAccVPCRoute_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 			},
 			{
 				// Verify that expanded form of the destination CIDR causes no diff.
-				Config:   testAccRouteIPv6EgressOnlyInternetGatewayConfig(rName, "::0/0"),
+				Config:   testAccVPCRouteConfig_ipv6EgressOnlyInternetGateway(rName, "::0/0"),
 				PlanOnly: true,
 			},
 		},
@@ -180,7 +180,7 @@ func TestAccVPCRoute_ipv6ToInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6InternetGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -226,7 +226,7 @@ func TestAccVPCRoute_ipv6ToInstance(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6InstanceConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6Instance(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -272,7 +272,7 @@ func TestAccVPCRoute_IPv6ToNetworkInterface_unattached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6NetworkInterfaceUnattachedConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6NetworkInterfaceUnattached(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -318,7 +318,7 @@ func TestAccVPCRoute_ipv6ToVPCPeeringConnection(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6VPCPeeringConnectionConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6PeeringConnection(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -364,7 +364,7 @@ func TestAccVPCRoute_ipv6ToVPNGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6VPNGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6VPNGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -410,7 +410,7 @@ func TestAccVPCRoute_ipv4ToVPNGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4VPNGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4VPNGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -456,7 +456,7 @@ func TestAccVPCRoute_ipv4ToInstance(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4InstanceConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4Instance(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -502,7 +502,7 @@ func TestAccVPCRoute_IPv4ToNetworkInterface_unattached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4NetworkInterfaceUnattachedConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4NetworkInterfaceUnattached(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -549,7 +549,7 @@ func TestAccVPCRoute_IPv4ToNetworkInterface_attached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4NetworkInterfaceAttachedConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4NetworkInterfaceAttached(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -597,7 +597,7 @@ func TestAccVPCRoute_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4NetworkInterfaceTwoAttachmentsConfig(rName, destinationCidr, eni1ResourceName),
+				Config: testAccVPCRouteConfig_ipv4NetworkInterfaceTwoAttachments(rName, destinationCidr, eni1ResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -620,7 +620,7 @@ func TestAccVPCRoute_IPv4ToNetworkInterface_twoAttachments(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4NetworkInterfaceTwoAttachmentsConfig(rName, destinationCidr, eni2ResourceName),
+				Config: testAccVPCRouteConfig_ipv4NetworkInterfaceTwoAttachments(rName, destinationCidr, eni2ResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -666,7 +666,7 @@ func TestAccVPCRoute_ipv4ToVPCPeeringConnection(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4VPCPeeringConnectionConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4PeeringConnection(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -712,7 +712,7 @@ func TestAccVPCRoute_ipv4ToNatGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4NatGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4NATGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -758,7 +758,7 @@ func TestAccVPCRoute_ipv6ToNatGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6NatGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6NATGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -804,7 +804,7 @@ func TestAccVPCRoute_doesNotCrashWithVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteWithVPCEndpointConfig(rName),
+				Config: testAccVPCRouteConfig_endpoint(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckRouteTableNumberOfRoutes(&routeTable, 3),
@@ -839,7 +839,7 @@ func TestAccVPCRoute_ipv4ToTransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4TransitGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -889,7 +889,7 @@ func TestAccVPCRoute_ipv6ToTransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6TransitGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv6TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -935,7 +935,7 @@ func TestAccVPCRoute_ipv4ToCarrierGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4CarrierGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_ipv4CarrierGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "carrier_gateway_id", cgwResourceName, "id"),
@@ -981,7 +981,7 @@ func TestAccVPCRoute_ipv4ToLocalGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteResourceIPv4LocalGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_resourceIPv4LocalGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1027,7 +1027,7 @@ func TestAccVPCRoute_ipv6ToLocalGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteResourceIPv6LocalGatewayConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_resourceIPv6LocalGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1073,7 +1073,7 @@ func TestAccVPCRoute_conditionalCIDRBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, false),
+				Config: testAccVPCRouteConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
@@ -1081,7 +1081,7 @@ func TestAccVPCRoute_conditionalCIDRBlock(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, true),
+				Config: testAccVPCRouteConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
@@ -1123,7 +1123,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "instance_id", instanceResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1146,7 +1146,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1169,7 +1169,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "gateway_id", igwResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1192,7 +1192,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "nat_gateway_id", ngwResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "nat_gateway_id", ngwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1215,7 +1215,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1239,7 +1239,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "transit_gateway_id", tgwResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "transit_gateway_id", tgwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1262,7 +1262,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "vpc_endpoint_id", vpcEndpointResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "vpc_endpoint_id", vpcEndpointResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1285,7 +1285,7 @@ func TestAccVPCRoute_IPv4Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Config: testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1340,7 +1340,7 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, "instance_id", instanceResourceName),
+				Config: testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1363,7 +1363,7 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Config: testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1386,7 +1386,7 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, "gateway_id", igwResourceName),
+				Config: testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1409,7 +1409,7 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, "egress_only_gateway_id", eoigwResourceName),
+				Config: testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, "egress_only_gateway_id", eoigwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1432,7 +1432,7 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Config: testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1455,7 +1455,7 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Config: testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1505,7 +1505,7 @@ func TestAccVPCRoute_ipv4ToVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteResourceIPv4VPCEndpointConfig(rName, destinationCidr),
+				Config: testAccVPCRouteConfig_resourceIPv4Endpoint(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1553,7 +1553,7 @@ func TestAccVPCRoute_localRoute(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteIPv4NoRouteConfig(rName),
+				Config: testAccVPCRouteConfig_ipv4NoRoute(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(vpcResourceName, &vpc),
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
@@ -1561,7 +1561,7 @@ func TestAccVPCRoute_localRoute(t *testing.T) {
 				),
 			},
 			{
-				Config:       testAccRouteIPv4LocalRouteConfig(rName),
+				Config:       testAccVPCRouteConfig_ipv4Local(rName),
 				ResourceName: resourceName,
 				ImportState:  true,
 				ImportStateIdFunc: func(rt *ec2.RouteTable, v *ec2.Vpc) resource.ImportStateIdFunc {
@@ -1591,7 +1591,7 @@ func TestAccVPCRoute_prefixListToInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListInternetGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListInternetGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1637,7 +1637,7 @@ func TestAccVPCRoute_prefixListToVPNGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListVPNGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListVPNGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1683,7 +1683,7 @@ func TestAccVPCRoute_prefixListToInstance(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListInstanceConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListInstance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1729,7 +1729,7 @@ func TestAccVPCRoute_PrefixListToNetworkInterface_unattached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListNetworkInterfaceUnattachedConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListNetworkInterfaceUnattached(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1776,7 +1776,7 @@ func TestAccVPCRoute_PrefixListToNetworkInterface_attached(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListNetworkInterfaceAttachedConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListNetworkInterfaceAttached(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1822,7 +1822,7 @@ func TestAccVPCRoute_prefixListToVPCPeeringConnection(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListVPCPeeringConnectionConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListPeeringConnection(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1868,7 +1868,7 @@ func TestAccVPCRoute_prefixListToNatGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListNatGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListNATGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1918,7 +1918,7 @@ func TestAccVPCRoute_prefixListToTransitGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListTransitGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListTransitGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -1968,7 +1968,7 @@ func TestAccVPCRoute_prefixListToCarrierGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListCarrierGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListCarrierGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "carrier_gateway_id", cgwResourceName, "id"),
@@ -2018,7 +2018,7 @@ func TestAccVPCRoute_prefixListToLocalGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListLocalGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListLocalGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -2064,7 +2064,7 @@ func TestAccVPCRoute_prefixListToEgressOnlyInternetGateway(t *testing.T) {
 		CheckDestroy:      testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoutePrefixListEgressOnlyInternetGatewayConfig(rName),
+				Config: testAccVPCRouteConfig_prefixListEgressOnlyInternetGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
@@ -2179,7 +2179,7 @@ func testAccRouteImportStateIdFunc(resourceName string) resource.ImportStateIdFu
 	}
 }
 
-func testAccRouteIPv4InternetGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4InternetGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2213,7 +2213,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv6InternetGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6InternetGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -2256,7 +2256,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv6NetworkInterfaceUnattachedConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6NetworkInterfaceUnattached(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -2304,7 +2304,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteIPv6InstanceConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6Instance(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -2358,7 +2358,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteIPv6VPCPeeringConnectionConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6PeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -2404,7 +2404,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv6EgressOnlyInternetGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6EgressOnlyInternetGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -2439,7 +2439,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteWithVPCEndpointConfig(rName string) string {
+func testAccVPCRouteConfig_endpoint(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -2484,7 +2484,7 @@ resource "aws_vpc_endpoint" "test" {
 `, rName)
 }
 
-func testAccRouteIPv4TransitGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4TransitGateway(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
@@ -2538,7 +2538,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteIPv6TransitGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6TransitGateway(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -2593,7 +2593,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
+func testAccVPCRouteConfig_conditionalIPv4IPv6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -2636,7 +2636,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr, destinationIpv6Cidr, ipv6Route)
 }
 
-func testAccRouteIPv4InstanceConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4Instance(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -2686,7 +2686,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteIPv4NetworkInterfaceUnattachedConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4NetworkInterfaceUnattached(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -2732,7 +2732,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteResourceIPv4LocalGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_resourceIPv4LocalGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 
@@ -2781,7 +2781,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteResourceIPv6LocalGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_resourceIPv6LocalGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 
@@ -2831,7 +2831,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv4NetworkInterfaceAttachedConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4NetworkInterfaceAttached(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -2896,7 +2896,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteIPv4NetworkInterfaceTwoAttachmentsConfig(rName, destinationCidr, targetResourceName string) string {
+func testAccVPCRouteConfig_ipv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -2974,7 +2974,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr, targetResourceName))
 }
 
-func testAccRouteIPv4VPCPeeringConnectionConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4PeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3018,7 +3018,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv4NatGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4NATGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3082,7 +3082,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv6NatGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6NATGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -3131,7 +3131,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv4VPNGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4VPNGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3165,7 +3165,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteIPv6VPNGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv6VPNGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -3200,7 +3200,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccRouteResourceIPv4VPCEndpointConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_resourceIPv4Endpoint(rName, destinationCidr string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -3270,7 +3270,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-func testAccRouteIPv4FlexiTargetConfig(rName, destinationCidr, targetAttribute, targetValue string) string {
+func testAccVPCRouteConfig_ipv4FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
@@ -3445,7 +3445,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr, targetAttribute, targetValue))
 }
 
-func testAccRouteIPv6FlexiTargetConfig(rName, destinationCidr, targetAttribute, targetValue string) string {
+func testAccVPCRouteConfig_ipv6FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3566,7 +3566,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr, targetAttribute, targetValue))
 }
 
-func testAccRouteIPv4NoRouteConfig(rName string) string {
+func testAccVPCRouteConfig_ipv4NoRoute(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3586,9 +3586,9 @@ resource "aws_route_table" "test" {
 `, rName)
 }
 
-func testAccRouteIPv4LocalRouteConfig(rName string) string {
+func testAccVPCRouteConfig_ipv4Local(rName string) string {
 	return acctest.ConfigCompose(
-		testAccRouteIPv4NoRouteConfig(rName),
+		testAccVPCRouteConfig_ipv4NoRoute(rName),
 		`
 resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
@@ -3598,7 +3598,7 @@ resource "aws_route" "test" {
 `)
 }
 
-func testAccRoutePrefixListInternetGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListInternetGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3638,7 +3638,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListVPNGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListVPNGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3678,7 +3678,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListInstanceConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListInstance(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3734,7 +3734,7 @@ resource "aws_route" "test" {
 `, rName))
 }
 
-func testAccRoutePrefixListNetworkInterfaceUnattachedConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListNetworkInterfaceUnattached(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -3786,7 +3786,7 @@ resource "aws_route" "test" {
 `, rName))
 }
 
-func testAccRoutePrefixListNetworkInterfaceAttachedConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListNetworkInterfaceAttached(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLatestAmazonNatInstanceAMIConfig(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -3857,7 +3857,7 @@ resource "aws_route" "test" {
 `, rName))
 }
 
-func testAccRoutePrefixListVPCPeeringConnectionConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListPeeringConnection(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3907,7 +3907,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListNatGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListNATGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3977,7 +3977,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListTransitGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListTransitGateway(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
@@ -4037,7 +4037,7 @@ resource "aws_route" "test" {
 `, rName))
 }
 
-func testAccRoutePrefixListCarrierGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListCarrierGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -4077,7 +4077,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListLocalGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListLocalGateway(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 
@@ -4132,7 +4132,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRoutePrefixListEgressOnlyInternetGatewayConfig(rName string) string {
+func testAccVPCRouteConfig_prefixListEgressOnlyInternetGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -4173,7 +4173,7 @@ resource "aws_route" "test" {
 `, rName)
 }
 
-func testAccRouteIPv4CarrierGatewayConfig(rName, destinationCidr string) string {
+func testAccVPCRouteConfig_ipv4CarrierGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_security_group_data_source_test.go
+++ b/internal/service/ec2/vpc_security_group_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccVPCSecurityGroupDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupDataSourceConfig(rInt),
+				Config: testAccVPCSecurityGroupDataSourceConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecurityGroupCheckDataSource("data.aws_security_group.by_id"),
 					resource.TestCheckResourceAttr("data.aws_security_group.by_id", "description", "sg description"),
@@ -104,7 +104,7 @@ func testAccSecurityGroupCheckDefaultDataSource(name string) resource.TestCheckF
 	}
 }
 
-func testAccSecurityGroupDataSourceConfig(rInt int) string {
+func testAccVPCSecurityGroupDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -139,7 +139,7 @@ func TestAccVPCSecurityGroupRule_Ingress_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngressConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_ingress(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -172,7 +172,7 @@ func TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRule_Ingress_Source_with_AccountID(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_ingressSourceAccountID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					resource.TestCheckResourceAttrPair(
@@ -218,7 +218,7 @@ func TestAccVPCSecurityGroupRule_Ingress_protocol(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngress_protocolConfig,
+				Config: testAccVPCSecurityGroupRuleConfig_ingressProtocol,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -249,7 +249,7 @@ func TestAccVPCSecurityGroupRule_Ingress_icmpv6(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngress_icmpv6Config,
+				Config: testAccVPCSecurityGroupRuleConfig_ingressIcmpv6,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists(sgResourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "from_port", "-1"),
@@ -301,7 +301,7 @@ func TestAccVPCSecurityGroupRule_Ingress_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngress_ipv6Config,
+				Config: testAccVPCSecurityGroupRuleConfig_ingressIPv6,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testRuleCount,
@@ -343,7 +343,7 @@ func TestAccVPCSecurityGroupRule_Ingress_classic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngressClassicConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_ingressClassic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -393,7 +393,7 @@ func TestAccVPCSecurityGroupRule_multiIngress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleMultiIngressConfig,
+				Config: testAccVPCSecurityGroupRuleConfig_multiIngress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testMultiRuleCount,
@@ -420,7 +420,7 @@ func TestAccVPCSecurityGroupRule_egress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleEgressConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_egress(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
@@ -446,7 +446,7 @@ func TestAccVPCSecurityGroupRule_selfReference(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleSelfReferenceConfig,
+				Config: testAccVPCSecurityGroupRuleConfig_selfReference,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 				),
@@ -470,7 +470,7 @@ func TestAccVPCSecurityGroupRule_expectInvalidTypeError(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecurityGroupRuleExpectInvalidType(rInt),
+				Config:      testAccVPCSecurityGroupRuleConfig_expectInvalidType(rInt),
 				ExpectError: regexp.MustCompile(`expected type to be one of \[ingress egress\]`),
 			},
 		},
@@ -486,11 +486,11 @@ func TestAccVPCSecurityGroupRule_expectInvalidCIDR(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecurityGroupRuleInvalidIPv4CIDR(rInt),
+				Config:      testAccVPCSecurityGroupRuleConfig_invalidIPv4CIDR(rInt),
 				ExpectError: regexp.MustCompile("invalid CIDR address: 1.2.3.4/33"),
 			},
 			{
-				Config:      testAccSecurityGroupRuleInvalidIPv6CIDR(rInt),
+				Config:      testAccVPCSecurityGroupRuleConfig_invalidIPv6CIDR(rInt),
 				ExpectError: regexp.MustCompile("invalid CIDR address: ::/244"),
 			},
 		},
@@ -529,7 +529,7 @@ func TestAccVPCSecurityGroupRule_PartialMatching_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRulePartialMatchingConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_partialMatching(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress", &group, &p, "ingress"),
@@ -592,7 +592,7 @@ func TestAccVPCSecurityGroupRule_PartialMatching_source(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRulePartialMatching_SourceConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_partialMatchingSource(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleExists("aws_security_group.nat", &nat),
@@ -620,7 +620,7 @@ func TestAccVPCSecurityGroupRule_issue5310(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIssue5310,
+				Config: testAccVPCSecurityGroupRuleConfig_issue5310,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.issue_5310", &group),
 				),
@@ -645,7 +645,7 @@ func TestAccVPCSecurityGroupRule_race(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleRace,
+				Config: testAccVPCSecurityGroupRuleConfig_race,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.race", &group),
 				),
@@ -665,7 +665,7 @@ func TestAccVPCSecurityGroupRule_selfSource(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleSelfInSource(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_selfInSource(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 				),
@@ -723,7 +723,7 @@ func TestAccVPCSecurityGroupRule_prefixListEgress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRulePrefixListEgressConfig,
+				Config: testAccVPCSecurityGroupRuleConfig_prefixListEgress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.egress", &group),
 					// lookup info on the VPC Endpoint created, to populate the expected
@@ -754,7 +754,7 @@ func TestAccVPCSecurityGroupRule_ingressDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngressDescriptionConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_ingressDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -782,7 +782,7 @@ func TestAccVPCSecurityGroupRule_egressDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleEgressDescriptionConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_egressDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
@@ -810,7 +810,7 @@ func TestAccVPCSecurityGroupRule_IngressDescription_updates(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleIngressDescriptionConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_ingressDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -819,7 +819,7 @@ func TestAccVPCSecurityGroupRule_IngressDescription_updates(t *testing.T) {
 			},
 
 			{
-				Config: testAccSecurityGroupRuleIngress_updateDescriptionConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_ingressUpdateDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -847,7 +847,7 @@ func TestAccVPCSecurityGroupRule_EgressDescription_updates(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleEgressDescriptionConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_egressDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
@@ -856,7 +856,7 @@ func TestAccVPCSecurityGroupRule_EgressDescription_updates(t *testing.T) {
 			},
 
 			{
-				Config: testAccSecurityGroupRuleEgress_updateDescriptionConfig(rInt),
+				Config: testAccVPCSecurityGroupRuleConfig_egressUpdateDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
@@ -900,7 +900,7 @@ func TestAccVPCSecurityGroupRule_Description_allPorts(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleDescriptionAllPortsConfig(rName, "description1"),
+				Config: testAccVPCSecurityGroupRuleConfig_descriptionAllPorts(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists(securityGroupResourceName, &group),
 					testAccCheckSecurityGroupRuleAttributes(resourceName, &group, &rule1, "ingress"),
@@ -917,7 +917,7 @@ func TestAccVPCSecurityGroupRule_Description_allPorts(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSecurityGroupRuleDescriptionAllPortsConfig(rName, "description2"),
+				Config: testAccVPCSecurityGroupRuleConfig_descriptionAllPorts(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists(securityGroupResourceName, &group),
 					testAccCheckSecurityGroupRuleAttributes(resourceName, &group, &rule2, "ingress"),
@@ -958,7 +958,7 @@ func TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts(t *testing.T) 
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleDescriptionAllPortsNonZeroPortsConfig(rName, "description1"),
+				Config: testAccVPCSecurityGroupRuleConfig_descriptionAllPortsNonZeroPorts(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists(securityGroupResourceName, &group),
 					testAccCheckSecurityGroupRuleAttributes(resourceName, &group, &rule1, "ingress"),
@@ -975,7 +975,7 @@ func TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSecurityGroupRuleDescriptionAllPortsNonZeroPortsConfig(rName, "description2"),
+				Config: testAccVPCSecurityGroupRuleConfig_descriptionAllPortsNonZeroPorts(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists(securityGroupResourceName, &group),
 					testAccCheckSecurityGroupRuleAttributes(resourceName, &group, &rule2, "ingress"),
@@ -1020,7 +1020,7 @@ func TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash(t *testi
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleMultipleRuleSearchingAllProtocolCrashConfig(rName),
+				Config: testAccVPCSecurityGroupRuleConfig_multipleSearchingAllProtocolCrash(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists(securityGroupResourceName, &group),
 					testAccCheckSecurityGroupRuleAttributes(resourceName1, &group, &rule1, "ingress"),
@@ -1125,7 +1125,7 @@ func TestAccVPCSecurityGroupRule_multiDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleMultiDescription(rInt, "ingress"),
+				Config: testAccVPCSecurityGroupRuleConfig_multidescription(rInt, "ingress"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.worker", &group),
 					testAccCheckSecurityGroupRuleExists("aws_security_group.nat", &nat),
@@ -1161,7 +1161,7 @@ func TestAccVPCSecurityGroupRule_multiDescription(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSecurityGroupRuleMultiDescription(rInt, "egress"),
+				Config: testAccVPCSecurityGroupRuleConfig_multidescription(rInt, "egress"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupRuleExists("aws_security_group.worker", &group),
 					testAccCheckSecurityGroupRuleExists("aws_security_group.nat", &nat),
@@ -1441,7 +1441,7 @@ func testAccSecurityGroupRuleImportGetAttrs(attrs map[string]string, key string)
 	return &values, nil
 }
 
-func testAccSecurityGroupRuleIngressConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_ingress(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -1464,7 +1464,7 @@ resource "aws_security_group_rule" "ingress_1" {
 `, rInt)
 }
 
-const testAccSecurityGroupRuleIngress_icmpv6Config = `
+const testAccVPCSecurityGroupRuleConfig_ingressIcmpv6 = `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -1483,7 +1483,7 @@ resource "aws_security_group_rule" "test" {
 }
 `
 
-const testAccSecurityGroupRuleIngress_ipv6Config = `
+const testAccVPCSecurityGroupRuleConfig_ingressIPv6 = `
 resource "aws_vpc" "tftest" {
   cidr_block = "10.0.0.0/16"
 
@@ -1511,7 +1511,7 @@ resource "aws_security_group_rule" "ingress_1" {
 }
 `
 
-const testAccSecurityGroupRuleIngress_protocolConfig = `
+const testAccVPCSecurityGroupRuleConfig_ingressProtocol = `
 resource "aws_vpc" "tftest" {
   cidr_block = "10.0.0.0/16"
 
@@ -1539,7 +1539,7 @@ resource "aws_security_group_rule" "ingress_1" {
 }
 `
 
-const testAccSecurityGroupRuleIssue5310 = `
+const testAccVPCSecurityGroupRuleConfig_issue5310 = `
 resource "aws_security_group" "issue_5310" {
   name        = "terraform-test-issue_5310"
   description = "SG for test of issue 5310"
@@ -1555,7 +1555,7 @@ resource "aws_security_group_rule" "issue_5310" {
 }
 `
 
-func testAccSecurityGroupRuleIngressClassicConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_ingressClassic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -1578,7 +1578,7 @@ resource "aws_security_group_rule" "ingress_1" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleEgressConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_egress(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -1601,7 +1601,7 @@ resource "aws_security_group_rule" "egress_1" {
 `, rInt)
 }
 
-const testAccSecurityGroupRuleMultiIngressConfig = `
+const testAccVPCSecurityGroupRuleConfig_multiIngress = `
 resource "aws_security_group" "web" {
   name        = "terraform_acceptance_test_example_2"
   description = "Used in the terraform acceptance tests"
@@ -1633,7 +1633,7 @@ resource "aws_security_group_rule" "ingress_2" {
 }
 `
 
-func testAccSecurityGroupRuleMultiDescription(rInt int, rType string) string {
+func testAccVPCSecurityGroupRuleConfig_multidescription(rInt int, rType string) string {
 	var b bytes.Buffer
 	b.WriteString(fmt.Sprintf(`
 resource "aws_vpc" "tf_sgrule_description_test" {
@@ -1716,7 +1716,7 @@ resource "aws_security_group_rule" "rule_4" {
 }
 
 // check for GH-1985 regression
-const testAccSecurityGroupRuleSelfReferenceConfig = `
+const testAccVPCSecurityGroupRuleConfig_selfReference = `
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
@@ -1744,7 +1744,7 @@ resource "aws_security_group_rule" "self" {
 }
 `
 
-func testAccSecurityGroupRulePartialMatchingConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_partialMatching(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
@@ -1805,7 +1805,7 @@ resource "aws_security_group_rule" "nat_ingress" {
 `, rInt, rInt)
 }
 
-func testAccSecurityGroupRulePartialMatching_SourceConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_partialMatchingSource(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
@@ -1855,7 +1855,7 @@ resource "aws_security_group_rule" "other_ingress" {
 `, rInt, rInt)
 }
 
-const testAccSecurityGroupRulePrefixListEgressConfig = `
+const testAccVPCSecurityGroupRuleConfig_prefixListEgress = `
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1907,7 +1907,7 @@ resource "aws_security_group_rule" "egress_1" {
 }
 `
 
-func testAccSecurityGroupRuleIngressDescriptionConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_ingressDescription(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -1931,7 +1931,7 @@ resource "aws_security_group_rule" "ingress_1" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleIngress_updateDescriptionConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_ingressUpdateDescription(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -1955,7 +1955,7 @@ resource "aws_security_group_rule" "ingress_1" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleEgressDescriptionConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_egressDescription(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -1979,7 +1979,7 @@ resource "aws_security_group_rule" "egress_1" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleEgress_updateDescriptionConfig(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_egressUpdateDescription(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "web" {
   name        = "terraform_test_%d"
@@ -2003,7 +2003,7 @@ resource "aws_security_group_rule" "egress_1" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleDescriptionAllPortsConfig(rName, description string) string {
+func testAccVPCSecurityGroupRuleConfig_descriptionAllPorts(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %q
@@ -2025,7 +2025,7 @@ resource "aws_security_group_rule" "test" {
 `, rName, description)
 }
 
-func testAccSecurityGroupRuleDescriptionAllPortsNonZeroPortsConfig(rName, description string) string {
+func testAccVPCSecurityGroupRuleConfig_descriptionAllPortsNonZeroPorts(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %q
@@ -2047,7 +2047,7 @@ resource "aws_security_group_rule" "test" {
 `, rName, description)
 }
 
-func testAccSecurityGroupRuleMultipleRuleSearchingAllProtocolCrashConfig(rName string) string {
+func testAccVPCSecurityGroupRuleConfig_multipleSearchingAllProtocolCrash(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %q
@@ -2077,7 +2077,7 @@ resource "aws_security_group_rule" "test2" {
 `, rName)
 }
 
-var testAccSecurityGroupRuleRace = func() string {
+var testAccVPCSecurityGroupRuleConfig_race = func() string {
 	var b bytes.Buffer
 	iterations := 50
 	b.WriteString(fmt.Sprintf(`
@@ -2118,7 +2118,7 @@ resource "aws_security_group_rule" "egress%d" {
 	return b.String()
 }()
 
-func testAccSecurityGroupRuleSelfInSource(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_selfInSource(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
@@ -2145,7 +2145,7 @@ resource "aws_security_group_rule" "allow_self" {
 `, rInt)
 }
 
-func testAccSecurityGroupRule_Ingress_Source_with_AccountID(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_ingressSourceAccountID(rInt int) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -2175,7 +2175,7 @@ resource "aws_security_group_rule" "allow_self" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleExpectInvalidType(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_expectInvalidType(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
@@ -2202,7 +2202,7 @@ resource "aws_security_group_rule" "allow_self" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleInvalidIPv4CIDR(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_invalidIPv4CIDR(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "foo" {
   name = "testing-failure-%d"
@@ -2219,7 +2219,7 @@ resource "aws_security_group_rule" "ing" {
 `, rInt)
 }
 
-func testAccSecurityGroupRuleInvalidIPv6CIDR(rInt int) string {
+func testAccVPCSecurityGroupRuleConfig_invalidIPv6CIDR(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "foo" {
   name = "testing-failure-%d"

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -507,7 +507,7 @@ func TestAccVPCSecurityGroup_allowAll(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_allowAll,
+				Config: testAccVPCSecurityGroupConfig_allowAll,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
@@ -533,7 +533,7 @@ func TestAccVPCSecurityGroup_sourceSecurityGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_sourceSecurityGroup,
+				Config: testAccVPCSecurityGroupConfig_source,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
@@ -559,7 +559,7 @@ func TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules(t *testing.T) 
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_IPRangeAndSecurityGroupWithSameRules,
+				Config: testAccVPCSecurityGroupConfig_ipRangeSGSameRules,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
@@ -585,7 +585,7 @@ func TestAccVPCSecurityGroup_ipRangesWithSameRules(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_IPRangesWithSameRules,
+				Config: testAccVPCSecurityGroupConfig_ipRangesSameRules,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
@@ -611,7 +611,7 @@ func TestAccVPCSecurityGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig,
+				Config: testAccVPCSecurityGroupConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupAttributes(&group),
@@ -654,7 +654,7 @@ func TestAccVPCSecurityGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig,
+				Config: testAccVPCSecurityGroupConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSecurityGroup(), resourceName),
@@ -676,7 +676,7 @@ func TestAccVPCSecurityGroup_egressMode(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupEgressModeBlocksConfig(),
+				Config: testAccVPCSecurityGroupConfig_egressModeBlocks(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &securityGroup1),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
@@ -689,14 +689,14 @@ func TestAccVPCSecurityGroup_egressMode(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 			{
-				Config: testAccSecurityGroupEgressModeNoBlocksConfig(),
+				Config: testAccVPCSecurityGroupConfig_egressModeNoBlocks(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &securityGroup2),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
 				),
 			},
 			{
-				Config: testAccSecurityGroupEgressModeZeroedConfig(),
+				Config: testAccVPCSecurityGroupConfig_egressModeZeroed(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &securityGroup3),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
@@ -717,7 +717,7 @@ func TestAccVPCSecurityGroup_ingressMode(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupIngressModeBlocksConfig(),
+				Config: testAccVPCSecurityGroupConfig_ingressModeBlocks(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &securityGroup1),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
@@ -730,14 +730,14 @@ func TestAccVPCSecurityGroup_ingressMode(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 			{
-				Config: testAccSecurityGroupIngressModeNoBlocksConfig(),
+				Config: testAccVPCSecurityGroupConfig_ingressModeNoBlocks(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &securityGroup2),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
 				),
 			},
 			{
-				Config: testAccSecurityGroupIngressModeZeroedConfig(),
+				Config: testAccVPCSecurityGroupConfig_ingressModeZeroed(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &securityGroup3),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
@@ -759,7 +759,7 @@ func TestAccVPCSecurityGroup_ruleGathering(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_ruleGathering(sgName),
+				Config: testAccVPCSecurityGroupConfig_ruleGathering(sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", sgName),
@@ -873,7 +873,7 @@ func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 			// create the configuration with 2 security groups, then create a
 			// dependency cycle such that they cannot be deleted
 			{
-				Config: testAccSecurityGroupConfig_revoke_base,
+				Config: testAccVPCSecurityGroupConfig_revokeBase,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &primary),
 					testAccCheckSecurityGroupExists(resourceName2, &secondary),
@@ -890,13 +890,13 @@ func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 			// groups removed. Terraform tries to destroy them but cannot. Expect a
 			// DependencyViolation error
 			{
-				Config:      testAccSecurityGroupConfig_revoke_base_removed,
+				Config:      testAccVPCSecurityGroupConfig_revokeBaseRemoved,
 				ExpectError: regexp.MustCompile("DependencyViolation"),
 			},
 			// Restore the config (a no-op plan) but also remove the dependencies
 			// between the groups with testRemoveCycle
 			{
-				Config: testAccSecurityGroupConfig_revoke_base,
+				Config: testAccVPCSecurityGroupConfig_revokeBase,
 				// ExpectError: regexp.MustCompile("DependencyViolation"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &primary),
@@ -906,7 +906,7 @@ func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 			},
 			// Again try to apply the config with the sgs removed; it should work
 			{
-				Config: testAccSecurityGroupConfig_revoke_base_removed,
+				Config: testAccVPCSecurityGroupConfig_revokeBaseRemoved,
 			},
 			////
 			// now test with revoke_rules_on_delete
@@ -916,7 +916,7 @@ func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 			// configuration, each Security Group has `revoke_rules_on_delete`
 			// specified, and should delete with no issue
 			{
-				Config: testAccSecurityGroupConfig_revoke_true,
+				Config: testAccVPCSecurityGroupConfig_revokeTrue,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &primary),
 					testAccCheckSecurityGroupExists(resourceName2, &secondary),
@@ -926,7 +926,7 @@ func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 			// Again try to apply the config with the sgs removed; it should work,
 			// because we've told the SGs to forcefully revoke their rules first
 			{
-				Config: testAccSecurityGroupConfig_revoke_base_removed,
+				Config: testAccVPCSecurityGroupConfig_revokeBaseRemoved,
 			},
 		},
 	})
@@ -955,7 +955,7 @@ func TestAccVPCSecurityGroup_forceRevokeRulesFalse(t *testing.T) {
 			// Groups are configured to explicitly not revoke rules on delete,
 			// `revoke_rules_on_delete = false`
 			{
-				Config: testAccSecurityGroupConfig_revoke_false,
+				Config: testAccVPCSecurityGroupConfig_revokeFalse,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &primary),
 					testAccCheckSecurityGroupExists(resourceName2, &secondary),
@@ -973,13 +973,13 @@ func TestAccVPCSecurityGroup_forceRevokeRulesFalse(t *testing.T) {
 			// Terraform tries to destroy them but cannot. Expect a
 			// DependencyViolation error
 			{
-				Config:      testAccSecurityGroupConfig_revoke_base_removed,
+				Config:      testAccVPCSecurityGroupConfig_revokeBaseRemoved,
 				ExpectError: regexp.MustCompile("DependencyViolation"),
 			},
 			// Restore the config (a no-op plan) but also remove the dependencies
 			// between the groups with testRemoveCycle
 			{
-				Config: testAccSecurityGroupConfig_revoke_false,
+				Config: testAccVPCSecurityGroupConfig_revokeFalse,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &primary),
 					testAccCheckSecurityGroupExists(resourceName2, &secondary),
@@ -988,7 +988,7 @@ func TestAccVPCSecurityGroup_forceRevokeRulesFalse(t *testing.T) {
 			},
 			// Again try to apply the config with the sgs removed; it should work
 			{
-				Config: testAccSecurityGroupConfig_revoke_base_removed,
+				Config: testAccVPCSecurityGroupConfig_revokeBaseRemoved,
 			},
 		},
 	})
@@ -1005,7 +1005,7 @@ func TestAccVPCSecurityGroup_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupIPv6Config,
+				Config: testAccVPCSecurityGroupConfig_ipv6,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "terraform_acceptance_test_example"),
@@ -1057,7 +1057,7 @@ func TestAccVPCSecurityGroup_Name_generated(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_generatedName,
+				Config: testAccVPCSecurityGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -1086,7 +1086,7 @@ func TestAccVPCSecurityGroup_Name_terraformPrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupNameConfig("terraform-test"),
+				Config: testAccVPCSecurityGroupConfig_name("terraform-test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "terraform-test"),
@@ -1114,7 +1114,7 @@ func TestAccVPCSecurityGroup_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupNamePrefixConfig("tf-acc-test-prefix-"),
+				Config: testAccVPCSecurityGroupConfig_namePrefix("tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
@@ -1143,7 +1143,7 @@ func TestAccVPCSecurityGroup_NamePrefix_terraformPrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupNamePrefixConfig("terraform-test"),
+				Config: testAccVPCSecurityGroupConfig_namePrefix("terraform-test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "terraform-test"),
@@ -1192,7 +1192,7 @@ func TestAccVPCSecurityGroup_name_change(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupAndInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupNameConfigChange("terraform-test"),
+				Config: testAccVPCSecurityGroupConfig_nameChange("terraform-test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(sgResourceName, &group),
 					testAccCheckInstanceExists(instanceResourceName, &instance),
@@ -1201,7 +1201,7 @@ func TestAccVPCSecurityGroup_name_change(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecurityGroupNameConfigChange("terraform-test-2"),
+				Config: testAccVPCSecurityGroupConfig_nameChange("terraform-test-2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(sgResourceName, &group),
 					testAccCheckInstanceExists(instanceResourceName, &instance),
@@ -1238,7 +1238,7 @@ func TestAccVPCSecurityGroup_self(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupSelfConfig,
+				Config: testAccVPCSecurityGroupConfig_self,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "terraform_acceptance_test_example"),
@@ -1273,7 +1273,7 @@ func TestAccVPCSecurityGroup_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupVPCConfig,
+				Config: testAccVPCSecurityGroupConfig_vpc,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupAttributes(&group),
@@ -1317,7 +1317,7 @@ func TestAccVPCSecurityGroup_vpcNegOneIngress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupVPCNegOneIngressConfig,
+				Config: testAccVPCSecurityGroupConfig_negOneIngress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupAttributesNegOneProtocol(&group),
@@ -1354,7 +1354,7 @@ func TestAccVPCSecurityGroup_vpcProtoNumIngress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupVPCProtoNumIngressConfig,
+				Config: testAccVPCSecurityGroupConfig_protoNumIngress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "terraform_acceptance_test_example"),
@@ -1390,7 +1390,7 @@ func TestAccVPCSecurityGroup_multiIngress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupMultiIngressConfig,
+				Config: testAccVPCSecurityGroupConfig_multiIngress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
@@ -1416,7 +1416,7 @@ func TestAccVPCSecurityGroup_change(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig,
+				Config: testAccVPCSecurityGroupConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
@@ -1428,7 +1428,7 @@ func TestAccVPCSecurityGroup_change(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 			{
-				Config: testAccSecurityGroupChangeConfig,
+				Config: testAccVPCSecurityGroupConfig_change,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupAttributesChanged(&group),
@@ -1449,7 +1449,7 @@ func TestAccVPCSecurityGroup_ruleDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupRuleDescriptionConfig("Egress description", "Ingress description"),
+				Config: testAccVPCSecurityGroupConfig_ruleDescription("Egress description", "Ingress description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "1"),
@@ -1487,7 +1487,7 @@ func TestAccVPCSecurityGroup_ruleDescription(t *testing.T) {
 			},
 			// Change just the rule descriptions.
 			{
-				Config: testAccSecurityGroupRuleDescriptionConfig("New egress description", "New ingress description"),
+				Config: testAccVPCSecurityGroupConfig_ruleDescription("New egress description", "New ingress description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "1"),
@@ -1519,7 +1519,7 @@ func TestAccVPCSecurityGroup_ruleDescription(t *testing.T) {
 			},
 			// Remove just the rule descriptions.
 			{
-				Config: testAccSecurityGroupEmptyRuleDescriptionConfig,
+				Config: testAccVPCSecurityGroupConfig_emptyRuleDescription,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "1"),
@@ -1561,7 +1561,7 @@ func TestAccVPCSecurityGroup_defaultEgressVPC(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupDefaultEgressConfig,
+				Config: testAccVPCSecurityGroupConfig_defaultEgress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExistsWithoutDefault(resourceName),
 				),
@@ -1588,13 +1588,13 @@ func TestAccVPCSecurityGroup_defaultEgressClassic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupClassicDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupClassicConfig(rName),
+				Config: testAccVPCSecurityGroupConfig_classic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupClassicExists(resourceName, &group),
 				),
 			},
 			{
-				Config:                  testAccSecurityGroupClassicConfig(rName),
+				Config:                  testAccVPCSecurityGroupConfig_classic(rName),
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1616,7 +1616,7 @@ func TestAccVPCSecurityGroup_drift(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_drift(),
+				Config: testAccVPCSecurityGroupConfig_drift(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "description", "Used in the terraform acceptance tests"),
@@ -1670,7 +1670,7 @@ func TestAccVPCSecurityGroup_driftComplex(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_drift_complex(),
+				Config: testAccVPCSecurityGroupConfig_driftComplex(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "description", "Used in the terraform acceptance tests"),
@@ -1745,19 +1745,19 @@ func TestAccVPCSecurityGroup_invalidCIDRBlock(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecurityGroupInvalidIngressCIDR,
+				Config:      testAccVPCSecurityGroupConfig_invalidIngressCIDR,
 				ExpectError: regexp.MustCompile("invalid CIDR address: 1.2.3.4/33"),
 			},
 			{
-				Config:      testAccSecurityGroupInvalidEgressCIDR,
+				Config:      testAccVPCSecurityGroupConfig_invalidEgressCIDR,
 				ExpectError: regexp.MustCompile("invalid CIDR address: 1.2.3.4/33"),
 			},
 			{
-				Config:      testAccSecurityGroupInvalidIPv6IngressCIDR,
+				Config:      testAccVPCSecurityGroupConfig_invalidIPv6IngressCIDR,
 				ExpectError: regexp.MustCompile("invalid CIDR address: ::/244"),
 			},
 			{
-				Config:      testAccSecurityGroupInvalidIPv6EgressCIDR,
+				Config:      testAccVPCSecurityGroupConfig_invalidIPv6EgressCIDR,
 				ExpectError: regexp.MustCompile("invalid CIDR address: ::/244"),
 			},
 		},
@@ -1776,7 +1776,7 @@ func TestAccVPCSecurityGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupTags1Config(rName, "key1", "value1"),
+				Config: testAccVPCSecurityGroupConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -1790,7 +1790,7 @@ func TestAccVPCSecurityGroup_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 			{
-				Config: testAccSecurityGroupTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCSecurityGroupConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -1799,7 +1799,7 @@ func TestAccVPCSecurityGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecurityGroupTags1Config(rName, "key2", "value2"),
+				Config: testAccVPCSecurityGroupConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -1821,7 +1821,7 @@ func TestAccVPCSecurityGroup_cidrAndGroups(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupCombindCIDRandGroups,
+				Config: testAccVPCSecurityGroupConfig_combinedCIDRAndGroups,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					// testAccCheckSecurityGroupAttributes(&group),
@@ -1848,7 +1848,7 @@ func TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_ingressWithCIDRAndSGs,
+				Config: testAccVPCSecurityGroupConfig_ingressCIDRAndSGs,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupSGandCIDRAttributes(&group),
@@ -1901,7 +1901,7 @@ func TestAccVPCSecurityGroup_ingressWithCIDRAndSGsClassic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupClassicDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_ingressWithCIDRAndSGs_classic(rName),
+				Config: testAccVPCSecurityGroupConfig_ingressCIDRAndSGsClassic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupClassicExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
@@ -1920,7 +1920,7 @@ func TestAccVPCSecurityGroup_ingressWithCIDRAndSGsClassic(t *testing.T) {
 				),
 			},
 			{
-				Config:                  testAccSecurityGroupConfig_ingressWithCIDRAndSGs_classic(rName),
+				Config:                  testAccVPCSecurityGroupConfig_ingressCIDRAndSGsClassic(rName),
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1941,7 +1941,7 @@ func TestAccVPCSecurityGroup_egressWithPrefixList(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupPrefixListEgressConfig,
+				Config: testAccVPCSecurityGroupConfig_prefixListEgress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupEgressPrefixListAttributes(&group),
@@ -1969,7 +1969,7 @@ func TestAccVPCSecurityGroup_ingressWithPrefixList(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupPrefixListIngressConfig,
+				Config: testAccVPCSecurityGroupConfig_prefixListIngress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupIngressPrefixListAttributes(&group),
@@ -1997,7 +1997,7 @@ func TestAccVPCSecurityGroup_ipv4AndIPv6Egress(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_ipv4andIPv6Egress,
+				Config: testAccVPCSecurityGroupConfig_ipv4andIPv6Egress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
@@ -2527,7 +2527,7 @@ func TestAccVPCSecurityGroup_failWithDiffMismatch(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupConfig_failWithDiffMismatch,
+				Config: testAccVPCSecurityGroupConfig_failDiffMismatch,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
@@ -2553,7 +2553,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededAppend(t *testing.T) {
 		Steps: []resource.TestStep{
 			// create a valid SG just under the limit
 			{
-				Config: testAccSecurityGroupRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, ruleLimit),
@@ -2562,7 +2562,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededAppend(t *testing.T) {
 			},
 			// append a rule to step over the limit
 			{
-				Config:      testAccSecurityGroupRuleLimitConfig(0, ruleLimit+1),
+				Config:      testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit+1),
 				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
 			},
 			{
@@ -2574,7 +2574,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededAppend(t *testing.T) {
 					}
 				},
 				// running the original config again now should restore the rules
-				Config: testAccSecurityGroupRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, ruleLimit),
@@ -2600,7 +2600,7 @@ func TestAccVPCSecurityGroup_ruleLimitCIDRBlockExceededAppend(t *testing.T) {
 		Steps: []resource.TestStep{
 			// create a valid SG just under the limit
 			{
-				Config: testAccSecurityGroupCIDRBlockRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_cidrBlockRuleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, 1),
@@ -2608,7 +2608,7 @@ func TestAccVPCSecurityGroup_ruleLimitCIDRBlockExceededAppend(t *testing.T) {
 			},
 			// append a rule to step over the limit
 			{
-				Config:      testAccSecurityGroupCIDRBlockRuleLimitConfig(0, ruleLimit+1),
+				Config:      testAccVPCSecurityGroupConfig_cidrBlockRuleLimit(0, ruleLimit+1),
 				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
 			},
 			{
@@ -2636,7 +2636,7 @@ func TestAccVPCSecurityGroup_ruleLimitCIDRBlockExceededAppend(t *testing.T) {
 					}
 				},
 				// running the original config again now should restore the rules
-				Config: testAccSecurityGroupCIDRBlockRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_cidrBlockRuleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, 1),
@@ -2661,7 +2661,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
 		Steps: []resource.TestStep{
 			// create a valid SG just under the limit
 			{
-				Config: testAccSecurityGroupRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, ruleLimit),
@@ -2669,7 +2669,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
 			},
 			// prepend a rule to step over the limit
 			{
-				Config:      testAccSecurityGroupRuleLimitConfig(1, ruleLimit+1),
+				Config:      testAccVPCSecurityGroupConfig_ruleLimit(1, ruleLimit+1),
 				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
 			},
 			{
@@ -2681,7 +2681,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
 					}
 				},
 				// running the original config again now should restore the rules
-				Config: testAccSecurityGroupRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, ruleLimit),
@@ -2706,7 +2706,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
 		Steps: []resource.TestStep{
 			// create a valid SG just under the limit
 			{
-				Config: testAccSecurityGroupRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, ruleLimit),
@@ -2714,7 +2714,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
 			},
 			// add a rule to step over the limit with entirely new rules
 			{
-				Config:      testAccSecurityGroupRuleLimitConfig(100, ruleLimit+1),
+				Config:      testAccVPCSecurityGroupConfig_ruleLimit(100, ruleLimit+1),
 				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
 			},
 			{
@@ -2726,7 +2726,7 @@ func TestAccVPCSecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
 					}
 				},
 				// running the original config again now should restore the rules
-				Config: testAccSecurityGroupRuleLimitConfig(0, ruleLimit),
+				Config: testAccVPCSecurityGroupConfig_ruleLimit(0, ruleLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 					testAccCheckSecurityGroupRuleCount(&group, 0, ruleLimit),
@@ -2749,19 +2749,19 @@ func TestAccVPCSecurityGroup_rulesDropOnError(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a valid security group with some rules and make sure it exists
 			{
-				Config: testAccSecurityGroupConfig_rulesDropOnError_Init,
+				Config: testAccVPCSecurityGroupConfig_rulesDropOnErrorInit,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupExists(resourceName, &group),
 				),
 			},
 			// Add a bad rule to trigger API error
 			{
-				Config:      testAccSecurityGroupConfig_rulesDropOnError_AddBadRule,
+				Config:      testAccVPCSecurityGroupConfig_rulesDropOnErrorAddBadRule,
 				ExpectError: regexp.MustCompile("InvalidGroupId.Malformed"),
 			},
 			// All originally added rules must survive. This will return non-empty plan if anything changed.
 			{
-				Config:   testAccSecurityGroupConfig_rulesDropOnError_Init,
+				Config:   testAccVPCSecurityGroupConfig_rulesDropOnErrorInit,
 				PlanOnly: true,
 			},
 		},
@@ -2797,7 +2797,7 @@ func testSecurityGroupRuleCount(id string, expectedIngressCount, expectedEgressC
 	return nil
 }
 
-func testAccSecurityGroupRuleLimitConfig(egressStartIndex, egressRulesCount int) string {
+func testAccVPCSecurityGroupConfig_ruleLimit(egressStartIndex, egressRulesCount int) string {
 	var egressRules strings.Builder
 	for i := egressStartIndex; i < egressRulesCount+egressStartIndex; i++ {
 		fmt.Fprintf(&egressRules, `
@@ -2834,7 +2834,7 @@ resource "aws_security_group" "test" {
 `, egressRules.String())
 }
 
-func testAccSecurityGroupCIDRBlockRuleLimitConfig(egressStartIndex, egressRulesCount int) string {
+func testAccVPCSecurityGroupConfig_cidrBlockRuleLimit(egressStartIndex, egressRulesCount int) string {
 	var cidrBlocks strings.Builder
 	for i := egressStartIndex; i < egressRulesCount+egressStartIndex; i++ {
 		fmt.Fprintf(&cidrBlocks, `
@@ -2873,7 +2873,7 @@ resource "aws_security_group" "test" {
 `, cidrBlocks.String())
 }
 
-const testAccSecurityGroupEmptyRuleDescriptionConfig = `
+const testAccVPCSecurityGroupConfig_emptyRuleDescription = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -2909,7 +2909,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupIPv6Config = `
+const testAccVPCSecurityGroupConfig_ipv6 = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -2943,7 +2943,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupConfig = `
+const testAccVPCSecurityGroupConfig_basic = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -2966,7 +2966,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupConfig_revoke_base_removed = `
+const testAccVPCSecurityGroupConfig_revokeBaseRemoved = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 
@@ -2976,7 +2976,7 @@ resource "aws_vpc" "sg-race-revoke" {
 }
 `
 
-const testAccSecurityGroupConfig_revoke_base = `
+const testAccVPCSecurityGroupConfig_revokeBase = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 
@@ -3006,7 +3006,7 @@ resource "aws_security_group" "secondary" {
 }
 `
 
-const testAccSecurityGroupConfig_revoke_false = `
+const testAccVPCSecurityGroupConfig_revokeFalse = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 
@@ -3040,7 +3040,7 @@ resource "aws_security_group" "secondary" {
 }
 `
 
-const testAccSecurityGroupConfig_revoke_true = `
+const testAccVPCSecurityGroupConfig_revokeTrue = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 
@@ -3074,7 +3074,7 @@ resource "aws_security_group" "secondary" {
 }
 `
 
-const testAccSecurityGroupChangeConfig = `
+const testAccVPCSecurityGroupConfig_change = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3111,7 +3111,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-func testAccSecurityGroupRuleDescriptionConfig(egressDescription, ingressDescription string) string {
+func testAccVPCSecurityGroupConfig_ruleDescription(egressDescription, ingressDescription string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
@@ -3149,7 +3149,7 @@ resource "aws_security_group" "test" {
 `, ingressDescription, egressDescription)
 }
 
-const testAccSecurityGroupSelfConfig = `
+const testAccVPCSecurityGroupConfig_self = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3179,7 +3179,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupVPCConfig = `
+const testAccVPCSecurityGroupConfig_vpc = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3209,7 +3209,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupVPCNegOneIngressConfig = `
+const testAccVPCSecurityGroupConfig_negOneIngress = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3232,7 +3232,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupVPCProtoNumIngressConfig = `
+const testAccVPCSecurityGroupConfig_protoNumIngress = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3255,7 +3255,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupMultiIngressConfig = `
+const testAccVPCSecurityGroupConfig_multiIngress = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3319,7 +3319,7 @@ resource "aws_security_group" "test2" {
 }
 `
 
-func testAccSecurityGroupTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccVPCSecurityGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3341,7 +3341,7 @@ resource "aws_security_group" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccSecurityGroupTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCSecurityGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -3364,7 +3364,7 @@ resource "aws_security_group" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-const testAccSecurityGroupConfig_generatedName = `
+const testAccVPCSecurityGroupConfig_generatedName = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3382,7 +3382,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupDefaultEgressConfig = `
+const testAccVPCSecurityGroupConfig_defaultEgress = `
 resource "aws_vpc" "tf_sg_egress_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -3405,7 +3405,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-func testAccSecurityGroupClassicConfig(rName string) string {
+func testAccVPCSecurityGroupConfig_classic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		fmt.Sprintf(`
@@ -3416,7 +3416,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccSecurityGroupNameConfig(name string) string {
+func testAccVPCSecurityGroupConfig_name(name string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -3433,7 +3433,7 @@ resource "aws_security_group" "test" {
 `, name)
 }
 
-func testAccSecurityGroupNamePrefixConfig(namePrefix string) string {
+func testAccVPCSecurityGroupConfig_namePrefix(namePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -3450,7 +3450,7 @@ resource "aws_security_group" "test" {
 `, namePrefix)
 }
 
-func testAccSecurityGroupConfig_drift() string {
+func testAccVPCSecurityGroupConfig_drift() string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name        = "tf_acc_%d"
@@ -3477,7 +3477,7 @@ resource "aws_security_group" "test" {
 `, sdkacctest.RandInt())
 }
 
-func testAccSecurityGroupConfig_drift_complex() string {
+func testAccVPCSecurityGroupConfig_driftComplex() string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
@@ -3547,7 +3547,7 @@ resource "aws_security_group" "test" {
 `, sdkacctest.RandInt(), sdkacctest.RandInt())
 }
 
-const testAccSecurityGroupInvalidIngressCIDR = `
+const testAccVPCSecurityGroupConfig_invalidIngressCIDR = `
 resource "aws_security_group" "test" {
   name        = "testing-foo"
   description = "foo-testing"
@@ -3561,7 +3561,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupInvalidEgressCIDR = `
+const testAccVPCSecurityGroupConfig_invalidEgressCIDR = `
 resource "aws_security_group" "test" {
   name        = "testing-foo"
   description = "foo-testing"
@@ -3575,7 +3575,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupInvalidIPv6IngressCIDR = `
+const testAccVPCSecurityGroupConfig_invalidIPv6IngressCIDR = `
 resource "aws_security_group" "test" {
   name        = "testing-foo"
   description = "foo-testing"
@@ -3589,7 +3589,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupInvalidIPv6EgressCIDR = `
+const testAccVPCSecurityGroupConfig_invalidIPv6EgressCIDR = `
 resource "aws_security_group" "test" {
   name        = "testing-foo"
   description = "foo-testing"
@@ -3603,7 +3603,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupCombindCIDRandGroups = `
+const testAccVPCSecurityGroupConfig_combinedCIDRAndGroups = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3662,7 +3662,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupConfig_ingressWithCIDRAndSGs = `
+const testAccVPCSecurityGroupConfig_ingressCIDRAndSGs = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3717,7 +3717,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-func testAccSecurityGroupConfig_ingressWithCIDRAndSGs_classic(rName string) string {
+func testAccVPCSecurityGroupConfig_ingressCIDRAndSGsClassic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigEC2ClassicRegionProvider(),
 		fmt.Sprintf(`
@@ -3761,7 +3761,7 @@ resource "aws_security_group" "test" {
 
 // fails to apply in one pass with the error "diffs didn't match during apply"
 // GH-2027
-const testAccSecurityGroupConfig_failWithDiffMismatch = `
+const testAccVPCSecurityGroupConfig_failDiffMismatch = `
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
@@ -3806,7 +3806,7 @@ resource "aws_security_group" "nat" {
 }
 `
 
-const testAccSecurityGroupConfig_allowAll = `
+const testAccVPCSecurityGroupConfig_allowAll = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3842,7 +3842,7 @@ resource "aws_security_group_rule" "allow_all-1" {
 }
 `
 
-const testAccSecurityGroupConfig_sourceSecurityGroup = `
+const testAccVPCSecurityGroupConfig_source = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3887,7 +3887,7 @@ resource "aws_security_group_rule" "allow_test3" {
 }
 `
 
-const testAccSecurityGroupConfig_IPRangeAndSecurityGroupWithSameRules = `
+const testAccVPCSecurityGroupConfig_ipRangeSGSameRules = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3937,7 +3937,7 @@ resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
 }
 `
 
-const testAccSecurityGroupConfig_IPRangesWithSameRules = `
+const testAccVPCSecurityGroupConfig_ipRangesSameRules = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3972,7 +3972,7 @@ resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
 }
 `
 
-const testAccSecurityGroupConfig_ipv4andIPv6Egress = `
+const testAccVPCSecurityGroupConfig_ipv4andIPv6Egress = `
 resource "aws_vpc" "foo" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -4003,7 +4003,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupPrefixListEgressConfig = `
+const testAccVPCSecurityGroupConfig_prefixListEgress = `
 data "aws_region" "current" {}
 
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
@@ -4053,7 +4053,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupPrefixListIngressConfig = `
+const testAccVPCSecurityGroupConfig_prefixListIngress = `
 data "aws_region" "current" {}
 
 resource "aws_vpc" "tf_sg_prefix_list_ingress_test" {
@@ -4103,7 +4103,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-func testAccSecurityGroupConfig_ruleGathering(sgName string) string {
+func testAccVPCSecurityGroupConfig_ruleGathering(sgName string) string {
 	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
@@ -4228,7 +4228,7 @@ resource "aws_security_group" "test" {
 `, sgName)
 }
 
-const testAccSecurityGroupConfig_rulesDropOnError_Init = `
+const testAccVPCSecurityGroupConfig_rulesDropOnErrorInit = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -4268,7 +4268,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccSecurityGroupConfig_rulesDropOnError_AddBadRule = `
+const testAccVPCSecurityGroupConfig_rulesDropOnErrorAddBadRule = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -4309,7 +4309,7 @@ resource "aws_security_group" "test" {
 }
 `
 
-func testAccSecurityGroupEgressModeBlocksConfig() string {
+func testAccVPCSecurityGroupConfig_egressModeBlocks() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -4343,7 +4343,7 @@ resource "aws_security_group" "test" {
 `
 }
 
-func testAccSecurityGroupEgressModeNoBlocksConfig() string {
+func testAccVPCSecurityGroupConfig_egressModeNoBlocks() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -4363,7 +4363,7 @@ resource "aws_security_group" "test" {
 `
 }
 
-func testAccSecurityGroupEgressModeZeroedConfig() string {
+func testAccVPCSecurityGroupConfig_egressModeZeroed() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -4385,7 +4385,7 @@ resource "aws_security_group" "test" {
 `
 }
 
-func testAccSecurityGroupIngressModeBlocksConfig() string {
+func testAccVPCSecurityGroupConfig_ingressModeBlocks() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -4419,7 +4419,7 @@ resource "aws_security_group" "test" {
 `
 }
 
-func testAccSecurityGroupIngressModeNoBlocksConfig() string {
+func testAccVPCSecurityGroupConfig_ingressModeNoBlocks() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -4439,7 +4439,7 @@ resource "aws_security_group" "test" {
 `
 }
 
-func testAccSecurityGroupIngressModeZeroedConfig() string {
+func testAccVPCSecurityGroupConfig_ingressModeZeroed() string {
 	return `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -4461,7 +4461,7 @@ resource "aws_security_group" "test" {
 `
 }
 
-func testAccSecurityGroupNameConfigChange(sgName string) string {
+func testAccVPCSecurityGroupConfig_nameChange(sgName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),

--- a/internal/service/ec2/vpc_security_groups_data_source_test.go
+++ b/internal/service/ec2/vpc_security_groups_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccVPCSecurityGroupsDataSource_tag(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupsDataSourceConfig_tag(rName),
+				Config: testAccVPCSecurityGroupsDataSourceConfig_tag(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "3"),
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "3"),
@@ -41,7 +41,7 @@ func TestAccVPCSecurityGroupsDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupsDataSourceConfig_filter(rName),
+				Config: testAccVPCSecurityGroupsDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
@@ -62,7 +62,7 @@ func TestAccVPCSecurityGroupsDataSource_empty(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityGroupsDataSourceConfig_empty(rName),
+				Config: testAccVPCSecurityGroupsDataSourceConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "0"),
@@ -73,7 +73,7 @@ func TestAccVPCSecurityGroupsDataSource_empty(t *testing.T) {
 	})
 }
 
-func testAccSecurityGroupsDataSourceConfig_tag(rName string) string {
+func testAccVPCSecurityGroupsDataSourceConfig_tag(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
@@ -103,7 +103,7 @@ data "aws_security_groups" "test" {
 `, rName)
 }
 
-func testAccSecurityGroupsDataSourceConfig_filter(rName string) string {
+func testAccVPCSecurityGroupsDataSourceConfig_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
@@ -136,7 +136,7 @@ data "aws_security_groups" "test" {
 `, rName)
 }
 
-func testAccSecurityGroupsDataSourceConfig_empty(rName string) string {
+func testAccVPCSecurityGroupsDataSourceConfig_empty(rName string) string {
 	return fmt.Sprintf(`
 data "aws_security_groups" "test" {
   tags = {

--- a/internal/service/ec2/vpc_subnet_cidr_reservation_test.go
+++ b/internal/service/ec2/vpc_subnet_cidr_reservation_test.go
@@ -26,7 +26,7 @@ func TestAccVPCSubnetCIDRReservation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetCIDRReservationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testSubnetCIDRReservationConfig_ipv4(rName),
+				Config: testAccVPCSubnetCIDRReservationConfig_testIPv4(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetCIDRReservationExists(resourceName, &res),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.1.16/28"),
@@ -57,7 +57,7 @@ func TestAccVPCSubnetCIDRReservation_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetCIDRReservationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testSubnetCIDRReservationConfig_ipv6(rName),
+				Config: testAccVPCSubnetCIDRReservationConfig_testIPv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetCIDRReservationExists(resourceName, &res),
 					resource.TestCheckResourceAttr(resourceName, "reservation_type", "explicit"),
@@ -86,7 +86,7 @@ func TestAccVPCSubnetCIDRReservation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetCIDRReservationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testSubnetCIDRReservationConfig_ipv4(rName),
+				Config: testAccVPCSubnetCIDRReservationConfig_testIPv4(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetCIDRReservationExists(resourceName, &res),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSubnetCIDRReservation(), resourceName),
@@ -157,7 +157,7 @@ func testAccSubnetCIDRReservationImportStateIdFunc(resourceName string) resource
 	}
 }
 
-func testSubnetCIDRReservationConfig_ipv4(rName string) string {
+func testAccVPCSubnetCIDRReservationConfig_testIPv4(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -185,7 +185,7 @@ resource "aws_ec2_subnet_cidr_reservation" "test" {
 `, rName)
 }
 
-func testSubnetCIDRReservationConfig_ipv6(rName string) string {
+func testAccVPCSubnetCIDRReservationConfig_testIPv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"

--- a/internal/service/ec2/vpc_subnet_data_source_test.go
+++ b/internal/service/ec2/vpc_subnet_data_source_test.go
@@ -31,7 +31,7 @@ func TestAccVPCSubnetDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetDataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetDataSourceConfig_basic(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", snResourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", snResourceName, "owner_id"),
@@ -147,10 +147,10 @@ func TestAccVPCSubnetDataSource_ipv6ByIPv6Filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetIPv6DataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetDataSourceConfig_ipv6(rName, rInt),
 			},
 			{
-				Config: testAccSubnetIPv6WithDataSourceFilterDataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetDataSourceConfig_ipv6Filter(rName, rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
 					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block"),
@@ -170,10 +170,10 @@ func TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetIPv6DataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetDataSourceConfig_ipv6(rName, rInt),
 			},
 			{
-				Config: testAccSubnetIPv6WithDataSourceIPv6CIDRBlockDataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetDataSourceConfig_ipv6IPv6CIDRBlock(rName, rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
 				),
@@ -182,7 +182,7 @@ func TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock(t *testing.T) {
 	})
 }
 
-func testAccSubnetDataSourceConfig(rName string, rInt int) string {
+func testAccVPCSubnetDataSourceConfig_basic(rName string, rInt int) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -246,7 +246,7 @@ data "aws_subnet" "by_az_id" {
 `, rName, rInt)
 }
 
-func testAccSubnetIPv6DataSourceConfig(rName string, rInt int) string {
+func testAccVPCSubnetDataSourceConfig_ipv6(rName string, rInt int) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -279,7 +279,7 @@ resource "aws_subnet" "test" {
 `, rName, rInt)
 }
 
-func testAccSubnetIPv6WithDataSourceFilterDataSourceConfig(rName string, rInt int) string {
+func testAccVPCSubnetDataSourceConfig_ipv6Filter(rName string, rInt int) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -319,7 +319,7 @@ data "aws_subnet" "by_ipv6_cidr" {
 `, rName, rInt)
 }
 
-func testAccSubnetIPv6WithDataSourceIPv6CIDRBlockDataSourceConfig(rName string, rInt int) string {
+func testAccVPCSubnetDataSourceConfig_ipv6IPv6CIDRBlock(rName string, rInt int) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/ec2/vpc_subnet_ids_data_source_test.go
+++ b/internal/service/ec2/vpc_subnet_ids_data_source_test.go
@@ -21,10 +21,10 @@ func TestAccVPCSubnetIDsDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetIDsDataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetIDsDataSourceConfig_basic(rName, rInt),
 			},
 			{
-				Config: testAccSubnetIDsWithDataSourceDataSourceConfig(rName, rInt),
+				Config: testAccVPCSubnetIDsDataSourceConfig_dataSource(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_subnet_ids.selected", "ids.#", "3"),
 					resource.TestCheckResourceAttr("data.aws_subnet_ids.private", "ids.#", "2"),
@@ -45,7 +45,7 @@ func TestAccVPCSubnetIDsDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetIDsDataSource_filter(rName, rInt),
+				Config: testAccVPCSubnetIdsDataSourceConfig_filter(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_subnet_ids.test", "ids.#", "2"),
 				),
@@ -54,7 +54,7 @@ func TestAccVPCSubnetIDsDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccSubnetIDsWithDataSourceDataSourceConfig(rName string, rInt int) string {
+func testAccVPCSubnetIDsDataSourceConfig_dataSource(rName string, rInt int) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.%[2]d.0.0/16"
@@ -111,7 +111,7 @@ data "aws_subnet_ids" "private" {
 `, rName, rInt))
 }
 
-func testAccSubnetIDsDataSourceConfig(rName string, rInt int) string {
+func testAccVPCSubnetIDsDataSourceConfig_basic(rName string, rInt int) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.%[2]d.0.0/16"
@@ -156,7 +156,7 @@ resource "aws_subnet" "test_private_b" {
 `, rName, rInt))
 }
 
-func testAccSubnetIDsDataSource_filter(rName string, rInt int) string {
+func testAccVPCSubnetIdsDataSourceConfig_filter(rName string, rInt int) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.%[2]d.0.0/16"

--- a/internal/service/ec2/vpc_subnet_test.go
+++ b/internal/service/ec2/vpc_subnet_test.go
@@ -29,7 +29,7 @@ func TestAccVPCSubnet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig(rName),
+				Config: testAccVPCSubnetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
@@ -71,7 +71,7 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetTagsConfig1(rName, "key1", "value1"),
+				Config: testAccVPCSubnetConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -84,7 +84,7 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetTagsConfig2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCSubnetConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -93,7 +93,7 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSubnetTagsConfig1(rName, "key2", "value2"),
+				Config: testAccVPCSubnetConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -118,7 +118,7 @@ func TestAccVPCSubnet_DefaultTags_providerOnly(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey1", "providervalue1"),
-					testAccSubnetConfig(rName),
+					testAccVPCSubnetConfig_basic(rName),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -135,7 +135,7 @@ func TestAccVPCSubnet_DefaultTags_providerOnly(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags2("providerkey1", "providervalue1", "providerkey2", "providervalue2"),
-					testAccSubnetConfig(rName),
+					testAccVPCSubnetConfig_basic(rName),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -148,7 +148,7 @@ func TestAccVPCSubnet_DefaultTags_providerOnly(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey1", "value1"),
-					testAccSubnetConfig(rName),
+					testAccVPCSubnetConfig_basic(rName),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -174,7 +174,7 @@ func TestAccVPCSubnet_DefaultTags_updateToProviderOnly(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetTagsConfig1(rName, "key1", "value1"),
+				Config: testAccVPCSubnetConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -186,7 +186,7 @@ func TestAccVPCSubnet_DefaultTags_updateToProviderOnly(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("key1", "value1"),
-					testAccSubnetConfig(rName),
+					testAccVPCSubnetConfig_basic(rName),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -219,7 +219,7 @@ func TestAccVPCSubnet_DefaultTags_updateToResourceOnly(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("key1", "value1"),
-					testAccSubnetConfig(rName),
+					testAccVPCSubnetConfig_basic(rName),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -229,7 +229,7 @@ func TestAccVPCSubnet_DefaultTags_updateToResourceOnly(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSubnetTagsConfig1(rName, "key1", "value1"),
+				Config: testAccVPCSubnetConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -262,7 +262,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag(t *testin
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey1", "providervalue1"),
-					testAccSubnetTagsConfig1(rName, "resourcekey1", "resourcevalue1"),
+					testAccVPCSubnetConfig_tags1(rName, "resourcekey1", "resourcevalue1"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -281,7 +281,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag(t *testin
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey1", "providervalue1"),
-					testAccSubnetTagsConfig2(rName, "resourcekey1", "resourcevalue1", "resourcekey2", "resourcevalue2"),
+					testAccVPCSubnetConfig_tags2(rName, "resourcekey1", "resourcevalue1", "resourcekey2", "resourcevalue2"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -297,7 +297,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_nonOverlappingTag(t *testin
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey2", "providervalue2"),
-					testAccSubnetTagsConfig1(rName, "resourcekey3", "resourcevalue3"),
+					testAccVPCSubnetConfig_tags1(rName, "resourcekey3", "resourcevalue3"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -327,7 +327,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag(t *testing.T
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("overlapkey1", "providervalue1"),
-					testAccSubnetTagsConfig1(rName, "overlapkey1", "resourcevalue1"),
+					testAccVPCSubnetConfig_tags1(rName, "overlapkey1", "resourcevalue1"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -344,7 +344,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag(t *testing.T
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags2("overlapkey1", "providervalue1", "overlapkey2", "providervalue2"),
-					testAccSubnetTagsConfig2(rName, "overlapkey1", "resourcevalue1", "overlapkey2", "resourcevalue2"),
+					testAccVPCSubnetConfig_tags2(rName, "overlapkey1", "resourcevalue1", "overlapkey2", "resourcevalue2"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -359,7 +359,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_overlappingTag(t *testing.T
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("overlapkey1", "providervalue1"),
-					testAccSubnetTagsConfig1(rName, "overlapkey1", "resourcevalue2"),
+					testAccVPCSubnetConfig_tags1(rName, "overlapkey1", "resourcevalue2"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
@@ -386,7 +386,7 @@ func TestAccVPCSubnet_DefaultTagsProviderAndResource_duplicateTag(t *testing.T) 
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("overlapkey", "overlapvalue"),
-					testAccSubnetTagsConfig1(rName, "overlapkey", "overlapvalue"),
+					testAccVPCSubnetConfig_tags1(rName, "overlapkey", "overlapvalue"),
 				),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`"tags" are identical to those in the "default_tags" configuration block`),
@@ -408,7 +408,7 @@ func TestAccVPCSubnet_defaultAndIgnoreTags(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetTagsConfig1(rName, "key1", "value1"),
+				Config: testAccVPCSubnetConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					testAccCheckSubnetUpdateTags(&subnet, nil, map[string]string{"defaultkey1": "defaultvalue1"}),
@@ -418,14 +418,14 @@ func TestAccVPCSubnet_defaultAndIgnoreTags(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultAndIgnoreTagsKeyPrefixes1("defaultkey1", "defaultvalue1", "defaultkey"),
-					testAccSubnetTagsConfig1(rName, "key1", "value1"),
+					testAccVPCSubnetConfig_tags1(rName, "key1", "value1"),
 				),
 				PlanOnly: true,
 			},
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultAndIgnoreTagsKeys1("defaultkey1", "defaultvalue1"),
-					testAccSubnetTagsConfig1(rName, "key1", "value1"),
+					testAccVPCSubnetConfig_tags1(rName, "key1", "value1"),
 				),
 				PlanOnly: true,
 			},
@@ -450,7 +450,7 @@ func TestAccVPCSubnet_updateTagsKnownAtApply(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_tagsComputedFromVPCDataSource1("key1", "value1"),
+				Config: testAccVPCSubnetConfig_tagsComputedFromDataSource1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -458,7 +458,7 @@ func TestAccVPCSubnet_updateTagsKnownAtApply(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSubnetConfig_tagsComputedFromVPCDataSource2("key1", "value1", "key2", "value2"),
+				Config: testAccVPCSubnetConfig_tagsComputedFromDataSource2("key1", "value1", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -487,7 +487,7 @@ func TestAccVPCSubnet_ignoreTags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig(rName),
+				Config: testAccVPCSubnetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					testAccCheckSubnetUpdateTags(&subnet, nil, map[string]string{"ignorekey1": "ignorevalue1"}),
@@ -495,11 +495,11 @@ func TestAccVPCSubnet_ignoreTags(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config:   acctest.ConfigCompose(acctest.ConfigIgnoreTagsKeyPrefixes1("ignorekey"), testAccSubnetConfig(rName)),
+				Config:   acctest.ConfigCompose(acctest.ConfigIgnoreTagsKeyPrefixes1("ignorekey"), testAccVPCSubnetConfig_basic(rName)),
 				PlanOnly: true,
 			},
 			{
-				Config:   acctest.ConfigCompose(acctest.ConfigIgnoreTagsKeys("ignorekey1"), testAccSubnetConfig(rName)),
+				Config:   acctest.ConfigCompose(acctest.ConfigIgnoreTagsKeys("ignorekey1"), testAccVPCSubnetConfig_basic(rName)),
 				PlanOnly: true,
 			},
 		},
@@ -518,7 +518,7 @@ func TestAccVPCSubnet_ipv6(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_ipv6(rName),
+				Config: testAccVPCSubnetConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &before),
 					testAccCheckSubnetIPv6BeforeUpdate(&before),
@@ -530,14 +530,14 @@ func TestAccVPCSubnet_ipv6(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetConfig_ipv6UpdateAssignv6OnCreation(rName),
+				Config: testAccVPCSubnetConfig_ipv6UpdateAssignv6OnCreation(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &after),
 					testAccCheckSubnetIPv6AfterUpdate(&after),
 				),
 			},
 			{
-				Config: testAccSubnetConfig_ipv6UpdateV6CIDR(rName),
+				Config: testAccVPCSubnetConfig_ipv6UpdateV6CIDR(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &after),
 					testAccCheckSubnetNotRecreated(t, &before, &after),
@@ -559,7 +559,7 @@ func TestAccVPCSubnet_enableIPv6(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_prev6(rName),
+				Config: testAccVPCSubnetConfig_prev6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
@@ -572,7 +572,7 @@ func TestAccVPCSubnet_enableIPv6(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetConfig_ipv6(rName),
+				Config: testAccVPCSubnetConfig_ipv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttrSet(resourceName, "ipv6_cidr_block"),
@@ -580,7 +580,7 @@ func TestAccVPCSubnet_enableIPv6(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSubnetConfig_prev6(rName),
+				Config: testAccVPCSubnetConfig_prev6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
@@ -603,7 +603,7 @@ func TestAccVPCSubnet_availabilityZoneID(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfigAvailabilityZoneId(rName),
+				Config: testAccVPCSubnetConfig_availabilityZoneID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
@@ -631,7 +631,7 @@ func TestAccVPCSubnet_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig(rName),
+				Config: testAccVPCSubnetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSubnet(), resourceName),
@@ -655,7 +655,7 @@ func TestAccVPCSubnet_customerOwnedIPv4Pool(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_customerOwnedv4Pool(rName),
+				Config: testAccVPCSubnetConfig_customerOwnedv4Pool(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttrPair(resourceName, "customer_owned_ipv4_pool", coipDataSourceName, "pool_id"),
@@ -682,7 +682,7 @@ func TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_mapCustomerOwnedOnLaunch(rName, true),
+				Config: testAccVPCSubnetConfig_mapCustomerOwnedOnLaunch(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "map_customer_owned_ip_on_launch", "true"),
@@ -709,7 +709,7 @@ func TestAccVPCSubnet_mapPublicIPOnLaunch(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_mapPublicOnLaunch(rName, true),
+				Config: testAccVPCSubnetConfig_mapPublicOnLaunch(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "map_public_ip_on_launch", "true"),
@@ -721,14 +721,14 @@ func TestAccVPCSubnet_mapPublicIPOnLaunch(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetConfig_mapPublicOnLaunch(rName, false),
+				Config: testAccVPCSubnetConfig_mapPublicOnLaunch(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "map_public_ip_on_launch", "false"),
 				),
 			},
 			{
-				Config: testAccSubnetConfig_mapPublicOnLaunch(rName, true),
+				Config: testAccVPCSubnetConfig_mapPublicOnLaunch(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "map_public_ip_on_launch", "true"),
@@ -751,7 +751,7 @@ func TestAccVPCSubnet_outpost(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfigOutpost(rName),
+				Config: testAccVPCSubnetConfig_outpost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "outpost_arn", outpostDataSourceName, "arn"),
@@ -778,7 +778,7 @@ func TestAccVPCSubnet_enableDNS64(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_enableDNS64(rName, true),
+				Config: testAccVPCSubnetConfig_enableDNS64(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "enable_dns64", "true"),
@@ -790,14 +790,14 @@ func TestAccVPCSubnet_enableDNS64(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetConfig_enableDNS64(rName, false),
+				Config: testAccVPCSubnetConfig_enableDNS64(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "enable_dns64", "false"),
 				),
 			},
 			{
-				Config: testAccSubnetConfig_enableDNS64(rName, true),
+				Config: testAccVPCSubnetConfig_enableDNS64(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "enable_dns64", "true"),
@@ -819,7 +819,7 @@ func TestAccVPCSubnet_privateDNSNameOptionsOnLaunch(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfig_privateDNSNameOptionsOnLaunch(rName, true, true, "resource-name"),
+				Config: testAccVPCSubnetConfig_privateDNSNameOptionsOnLaunch(rName, true, true, "resource-name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "enable_resource_name_dns_aaaa_record_on_launch", "true"),
@@ -833,7 +833,7 @@ func TestAccVPCSubnet_privateDNSNameOptionsOnLaunch(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetConfig_privateDNSNameOptionsOnLaunch(rName, false, true, "ip-name"),
+				Config: testAccVPCSubnetConfig_privateDNSNameOptionsOnLaunch(rName, false, true, "ip-name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "enable_resource_name_dns_aaaa_record_on_launch", "false"),
@@ -842,7 +842,7 @@ func TestAccVPCSubnet_privateDNSNameOptionsOnLaunch(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSubnetConfig_privateDNSNameOptionsOnLaunch(rName, true, false, "resource-name"),
+				Config: testAccVPCSubnetConfig_privateDNSNameOptionsOnLaunch(rName, true, false, "resource-name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "enable_resource_name_dns_aaaa_record_on_launch", "true"),
@@ -866,7 +866,7 @@ func TestAccVPCSubnet_ipv6Native(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfigIPv6Native(rName),
+				Config: testAccVPCSubnetConfig_ipv6Native(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", ""),
@@ -974,7 +974,7 @@ func testAccCheckSubnetUpdateTags(subnet *ec2.Subnet, oldTags, newTags map[strin
 	}
 }
 
-func testAccSubnetConfig(rName string) string {
+func testAccVPCSubnetConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -991,7 +991,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetTagsConfig1(rName, tagKey1, tagValue1 string) string {
+func testAccVPCSubnetConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1012,7 +1012,7 @@ resource "aws_subnet" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccSubnetTagsConfig2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCSubnetConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1051,7 +1051,7 @@ resource "aws_subnet" "test" {
 }
 `
 
-func testAccSubnetConfig_tagsComputedFromVPCDataSource1(tagKey1, tagValue1 string) string {
+func testAccVPCSubnetConfig_tagsComputedFromDataSource1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		testAccSubnetComputedTagsBaseConfig,
 		fmt.Sprintf(`
@@ -1063,7 +1063,7 @@ locals {
 `, tagKey1, tagValue1))
 }
 
-func testAccSubnetConfig_tagsComputedFromVPCDataSource2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCSubnetConfig_tagsComputedFromDataSource2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		testAccSubnetComputedTagsBaseConfig,
 		fmt.Sprintf(`
@@ -1076,7 +1076,7 @@ locals {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccSubnetConfig_prev6(rName string) string {
+func testAccVPCSubnetConfig_prev6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1098,7 +1098,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetConfig_ipv6(rName string) string {
+func testAccVPCSubnetConfig_ipv6(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1122,7 +1122,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetConfig_ipv6UpdateAssignv6OnCreation(rName string) string {
+func testAccVPCSubnetConfig_ipv6UpdateAssignv6OnCreation(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1146,7 +1146,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetConfig_ipv6UpdateV6CIDR(rName string) string {
+func testAccVPCSubnetConfig_ipv6UpdateV6CIDR(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1170,7 +1170,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetConfigAvailabilityZoneId(rName string) string {
+func testAccVPCSubnetConfig_availabilityZoneID(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1192,7 +1192,7 @@ resource "aws_subnet" "test" {
 `, rName))
 }
 
-func testAccSubnetConfig_customerOwnedv4Pool(rName string) string {
+func testAccVPCSubnetConfig_customerOwnedv4Pool(rName string) string {
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -1245,7 +1245,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetConfig_mapCustomerOwnedOnLaunch(rName string, mapCustomerOwnedIpOnLaunch bool) string {
+func testAccVPCSubnetConfig_mapCustomerOwnedOnLaunch(rName string, mapCustomerOwnedIpOnLaunch bool) string {
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -1298,7 +1298,7 @@ resource "aws_subnet" "test" {
 `, rName, mapCustomerOwnedIpOnLaunch)
 }
 
-func testAccSubnetConfig_mapPublicOnLaunch(rName string, mapPublicIpOnLaunch bool) string {
+func testAccVPCSubnetConfig_mapPublicOnLaunch(rName string, mapPublicIpOnLaunch bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -1320,7 +1320,7 @@ resource "aws_subnet" "test" {
 `, rName, mapPublicIpOnLaunch)
 }
 
-func testAccSubnetConfig_enableDNS64(rName string, enableDns64 bool) string {
+func testAccVPCSubnetConfig_enableDNS64(rName string, enableDns64 bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1345,7 +1345,7 @@ resource "aws_subnet" "test" {
 `, rName, enableDns64)
 }
 
-func testAccSubnetConfig_privateDNSNameOptionsOnLaunch(rName string, enableDnsAAAA, enableDnsA bool, hostnameType string) string {
+func testAccVPCSubnetConfig_privateDNSNameOptionsOnLaunch(rName string, enableDnsAAAA, enableDnsA bool, hostnameType string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1373,7 +1373,7 @@ resource "aws_subnet" "test" {
 `, rName, enableDnsAAAA, enableDnsA, hostnameType)
 }
 
-func testAccSubnetConfigIPv6Native(rName string) string {
+func testAccVPCSubnetConfig_ipv6Native(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.10.0.0/16"
@@ -1399,7 +1399,7 @@ resource "aws_subnet" "test" {
 `, rName)
 }
 
-func testAccSubnetConfigOutpost(rName string) string {
+func testAccVPCSubnetConfig_outpost(rName string) string {
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/ec2/vpc_subnets_data_source_test.go
+++ b/internal/service/ec2/vpc_subnets_data_source_test.go
@@ -19,10 +19,10 @@ func TestAccVPCSubnetsDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetsDataSourceConfig(rName),
+				Config: testAccVPCSubnetsDataSourceConfig_basic(rName),
 			},
 			{
-				Config: testAccSubnetsWithDataSourceDataSourceConfig(rName),
+				Config: testAccVPCSubnetsDataSourceConfig_dataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_subnets.selected", "ids.#", "4"),
 					resource.TestCheckResourceAttr("data.aws_subnets.private", "ids.#", "2"),
@@ -43,7 +43,7 @@ func TestAccVPCSubnetsDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetsDataSource_filter(rName),
+				Config: testAccVPCSubnetsDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_subnets.test", "ids.#", "2"),
 				),
@@ -52,7 +52,7 @@ func TestAccVPCSubnetsDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccSubnetsDataSourceConfig(rName string) string {
+func testAccVPCSubnetsDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
@@ -108,8 +108,8 @@ resource "aws_subnet" "test_private_b" {
 `, rName))
 }
 
-func testAccSubnetsWithDataSourceDataSourceConfig(rName string) string {
-	return acctest.ConfigCompose(testAccSubnetsDataSourceConfig(rName), `
+func testAccVPCSubnetsDataSourceConfig_dataSource(rName string) string {
+	return acctest.ConfigCompose(testAccVPCSubnetsDataSourceConfig_basic(rName), `
 data "aws_subnets" "selected" {
   filter {
     name   = "vpc-id"
@@ -144,7 +144,7 @@ data "aws_subnets" "none" {
 `)
 }
 
-func testAccSubnetsDataSource_filter(rName string) string {
+func testAccVPCSubnetsDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -98,7 +98,7 @@ func TestAccVPC_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCTags1Config("key1", "value1"),
+				Config: testAccVPCConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -111,7 +111,7 @@ func TestAccVPC_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPCTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -120,7 +120,7 @@ func TestAccVPC_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCTags1Config("key2", "value2"),
+				Config: testAccVPCConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -200,7 +200,7 @@ func TestAccVPC_DefaultTags_updateToProviderOnly(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCTags1Config("key1", "value1"),
+				Config: testAccVPCConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -254,7 +254,7 @@ func TestAccVPC_DefaultTags_updateToResourceOnly(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCTags1Config("key1", "value1"),
+				Config: testAccVPCConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -286,7 +286,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey1", "providervalue1"),
-					testAccVPCTags1Config("resourcekey1", "resourcevalue1"),
+					testAccVPCConfig_tags1("resourcekey1", "resourcevalue1"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -305,7 +305,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey1", "providervalue1"),
-					testAccVPCTags2Config("resourcekey1", "resourcevalue1", "resourcekey2", "resourcevalue2"),
+					testAccVPCConfig_tags2("resourcekey1", "resourcevalue1", "resourcekey2", "resourcevalue2"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -321,7 +321,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("providerkey2", "providervalue2"),
-					testAccVPCTags1Config("resourcekey3", "resourcevalue3"),
+					testAccVPCConfig_tags1("resourcekey3", "resourcevalue3"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -350,7 +350,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_overlappingTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("overlapkey1", "providervalue1"),
-					testAccVPCTags1Config("overlapkey1", "resourcevalue1"),
+					testAccVPCConfig_tags1("overlapkey1", "resourcevalue1"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -367,7 +367,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_overlappingTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags2("overlapkey1", "providervalue1", "overlapkey2", "providervalue2"),
-					testAccVPCTags2Config("overlapkey1", "resourcevalue1", "overlapkey2", "resourcevalue2"),
+					testAccVPCConfig_tags2("overlapkey1", "resourcevalue1", "overlapkey2", "resourcevalue2"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -382,7 +382,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_overlappingTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("overlapkey1", "providervalue1"),
-					testAccVPCTags1Config("overlapkey1", "resourcevalue2"),
+					testAccVPCConfig_tags1("overlapkey1", "resourcevalue2"),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
@@ -408,7 +408,7 @@ func TestAccVPC_DefaultTagsProviderAndResource_duplicateTag(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultTags_Tags1("overlapkey", "overlapvalue"),
-					testAccVPCTags1Config("overlapkey", "overlapvalue"),
+					testAccVPCConfig_tags1("overlapkey", "overlapvalue"),
 				),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`"tags" are identical to those in the "default_tags" configuration block`),
@@ -435,7 +435,7 @@ func TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges(t *testing.T) 
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCWithIgnoreChangesConfig_DynamicTagsMergedWithLocals("localkey", "localvalue"),
+				Config: testAccVPCConfig_ignoreChangesDynamicTagsMergedLocals("localkey", "localvalue"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -453,7 +453,7 @@ func TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges(t *testing.T) 
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccVPCWithIgnoreChangesConfig_DynamicTagsMergedWithLocals("localkey", "localvalue"),
+				Config: testAccVPCConfig_ignoreChangesDynamicTagsMergedLocals("localkey", "localvalue"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -491,7 +491,7 @@ func TestAccVPC_DynamicResourceTags_ignoreChanges(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCWithIgnoreChangesConfig_DynamicTags,
+				Config: testAccVPCConfig_ignoreChangesDynamicTags,
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -507,7 +507,7 @@ func TestAccVPC_DynamicResourceTags_ignoreChanges(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccVPCWithIgnoreChangesConfig_DynamicTags,
+				Config: testAccVPCConfig_ignoreChangesDynamicTags,
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -537,7 +537,7 @@ func TestAccVPC_defaultAndIgnoreTags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCTags1Config("key1", "value1"),
+				Config: testAccVPCConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					testAccCheckVPCUpdateTags(&vpc, nil, map[string]string{"defaultkey1": "defaultvalue1"}),
@@ -547,14 +547,14 @@ func TestAccVPC_defaultAndIgnoreTags(t *testing.T) {
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultAndIgnoreTagsKeyPrefixes1("defaultkey1", "defaultvalue1", "defaultkey"),
-					testAccVPCTags1Config("key1", "value1"),
+					testAccVPCConfig_tags1("key1", "value1"),
 				),
 				PlanOnly: true,
 			},
 			{
 				Config: acctest.ConfigCompose(
 					acctest.ConfigDefaultAndIgnoreTagsKeys1("defaultkey1", "defaultvalue1"),
-					testAccVPCTags1Config("key1", "value1"),
+					testAccVPCConfig_tags1("key1", "value1"),
 				),
 				PlanOnly: true,
 			},
@@ -574,7 +574,7 @@ func TestAccVPC_ignoreTags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCTags1Config("key1", "value1"),
+				Config: testAccVPCConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					testAccCheckVPCUpdateTags(&vpc, nil, map[string]string{"ignorekey1": "ignorevalue1"}),
@@ -582,11 +582,11 @@ func TestAccVPC_ignoreTags(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config:   acctest.ConfigIgnoreTagsKeyPrefixes1("ignorekey") + testAccVPCTags1Config("key1", "value1"),
+				Config:   acctest.ConfigIgnoreTagsKeyPrefixes1("ignorekey") + testAccVPCConfig_tags1("key1", "value1"),
 				PlanOnly: true,
 			},
 			{
-				Config:   acctest.ConfigIgnoreTagsKeys("ignorekey1") + testAccVPCTags1Config("key1", "value1"),
+				Config:   acctest.ConfigIgnoreTagsKeys("ignorekey1") + testAccVPCConfig_tags1("key1", "value1"),
 				PlanOnly: true,
 			},
 		},
@@ -840,7 +840,7 @@ func TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup(t *testing.T)
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCConfig_assignGeneratedIPv6CIDRBlockWithOptionalNetworkBorderGroup(rName, true),
+				Config: testAccVPCConfig_assignGeneratedIPv6CIDRBlockOptionalNetworkBorderGroup(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "assign_generated_ipv6_cidr_block", "true"),
@@ -857,7 +857,7 @@ func TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup(t *testing.T)
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPCConfig_assignGeneratedIPv6CIDRBlockWithOptionalNetworkBorderGroup(rName, false),
+				Config: testAccVPCConfig_assignGeneratedIPv6CIDRBlockOptionalNetworkBorderGroup(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "assign_generated_ipv6_cidr_block", "true"),
@@ -888,7 +888,7 @@ func TestAccVPC_IPAMIPv4BasicNetmask(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMIPv4(rName, 28),
+				Config: testAccVPCConfig_ipamIPv4(rName, 28),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					testAccCheckVPCCIDRPrefix(&vpc, "28"),
@@ -915,7 +915,7 @@ func TestAccVPC_IPAMIPv4BasicExplicitCIDR(t *testing.T) {
 		CheckDestroy:      testAccCheckVPCDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMIPv4Config_explicitCIDR(rName, cidr),
+				Config: testAccVPCConfig_ipamIPv4ExplicitCIDR(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidr),
@@ -993,7 +993,7 @@ resource "aws_vpc" "test" {
 }
 `
 
-func testAccVPCTags1Config(tagKey1, tagValue1 string) string {
+func testAccVPCConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1005,7 +1005,7 @@ resource "aws_vpc" "test" {
 `, tagKey1, tagValue1)
 }
 
-func testAccVPCTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -1018,7 +1018,7 @@ resource "aws_vpc" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccVPCWithIgnoreChangesConfig_DynamicTagsMergedWithLocals(localTagKey1, localTagValue1 string) string {
+func testAccVPCConfig_ignoreChangesDynamicTagsMergedLocals(localTagKey1, localTagValue1 string) string {
 	return fmt.Sprintf(`
 locals {
   tags = {
@@ -1043,7 +1043,7 @@ resource "aws_vpc" "test" {
 `, localTagKey1, localTagValue1)
 }
 
-const testAccVPCWithIgnoreChangesConfig_DynamicTags = `
+const testAccVPCConfig_ignoreChangesDynamicTags = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -1073,7 +1073,7 @@ resource "aws_vpc" "test" {
 `, rName, assignGeneratedIpv6CidrBlock)
 }
 
-func testAccVPCConfig_assignGeneratedIPv6CIDRBlockWithOptionalNetworkBorderGroup(rName string, localZoneNetworkBorderGroup bool) string {
+func testAccVPCConfig_assignGeneratedIPv6CIDRBlockOptionalNetworkBorderGroup(rName string, localZoneNetworkBorderGroup bool) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -1230,7 +1230,7 @@ resource "aws_vpc_ipam_pool_cidr" "test" {
 `, rName)
 }
 
-func testAccIPAMIPv4(rName string, netmaskLength int) string {
+func testAccVPCConfig_ipamIPv4(rName string, netmaskLength int) string {
 	return acctest.ConfigCompose(testAccIPAMIPv4Config_base(rName), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   ipv4_ipam_pool_id   = aws_vpc_ipam_pool.test.id
@@ -1245,7 +1245,7 @@ resource "aws_vpc" "test" {
 `, rName, netmaskLength))
 }
 
-func testAccIPAMIPv4Config_explicitCIDR(rName, cidr string) string {
+func testAccVPCConfig_ipamIPv4ExplicitCIDR(rName, cidr string) string {
 	return acctest.ConfigCompose(testAccIPAMIPv4Config_base(rName), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   ipv4_ipam_pool_id = aws_vpc_ipam_pool.test.id

--- a/internal/service/ec2/vpc_traffic_mirror_filter_rule_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_rule_test.go
@@ -41,7 +41,7 @@ func TestAccVPCTrafficMirrorFilterRule_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			//create
 			{
-				Config: testAccTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, direction, ruleNum),
+				Config: testAccVPCTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, direction, ruleNum),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterRuleExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", ec2.ServiceName, regexp.MustCompile(`traffic-mirror-filter-rule/tmfr-.+`)),
@@ -59,7 +59,7 @@ func TestAccVPCTrafficMirrorFilterRule_basic(t *testing.T) {
 			},
 			// Add all optionals
 			{
-				Config: testAccTrafficMirrorFilterRuleConfig_full(dstCidr, srcCidr, action, direction, description, ruleNum, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo, protocol),
+				Config: testAccVPCTrafficMirrorFilterRuleConfig_full(dstCidr, srcCidr, action, direction, description, ruleNum, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo, protocol),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterRuleExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "traffic_mirror_filter_id", regexp.MustCompile("tmf-.*")),
@@ -80,7 +80,7 @@ func TestAccVPCTrafficMirrorFilterRule_basic(t *testing.T) {
 			},
 			// remove optionals
 			{
-				Config: testAccTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, direction, ruleNum),
+				Config: testAccVPCTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, direction, ruleNum),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterRuleExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "traffic_mirror_filter_id", regexp.MustCompile("tmf-.*")),
@@ -123,7 +123,7 @@ func TestAccVPCTrafficMirrorFilterRule_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorFilterRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, direction, ruleNum),
+				Config: testAccVPCTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, direction, ruleNum),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterRuleExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTrafficMirrorFilterRule(), resourceName),
@@ -183,7 +183,7 @@ func testAccCheckTrafficMirrorFilterRuleExists(name string) resource.TestCheckFu
 	}
 }
 
-func testAccTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, dir string, num int) string {
+func testAccVPCTrafficMirrorFilterRuleConfig_basic(dstCidr, srcCidr, action, dir string, num int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {
 }
@@ -199,7 +199,7 @@ resource "aws_ec2_traffic_mirror_filter_rule" "test" {
 `, dstCidr, action, num, srcCidr, dir)
 }
 
-func testAccTrafficMirrorFilterRuleConfig_full(dstCidr, srcCidr, action, dir, description string, ruleNum, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo, protocol int) string {
+func testAccVPCTrafficMirrorFilterRuleConfig_full(dstCidr, srcCidr, action, dir, description string, ruleNum, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo, protocol int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {}
 

--- a/internal/service/ec2/vpc_traffic_mirror_filter_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_test.go
@@ -31,7 +31,7 @@ func TestAccVPCTrafficMirrorFilter_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			//create
 			{
-				Config: testAccTrafficMirrorFilterConfig(description),
+				Config: testAccVPCTrafficMirrorFilterConfig_basic(description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-filter/tmf-.+`)),
@@ -42,7 +42,7 @@ func TestAccVPCTrafficMirrorFilter_basic(t *testing.T) {
 			},
 			// Test Disable DNS service
 			{
-				Config: testAccTrafficMirrorFilterConfigWithoutDNS(description),
+				Config: testAccVPCTrafficMirrorFilterConfig_noDNS(description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckNoResourceAttr(resourceName, "network_services"),
@@ -50,7 +50,7 @@ func TestAccVPCTrafficMirrorFilter_basic(t *testing.T) {
 			},
 			// Test Enable DNS service
 			{
-				Config: testAccTrafficMirrorFilterConfig(description),
+				Config: testAccVPCTrafficMirrorFilterConfig_basic(description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -80,7 +80,7 @@ func TestAccVPCTrafficMirrorFilter_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorFilterConfigTags1("key1", "value1"),
+				Config: testAccVPCTrafficMirrorFilterConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -93,7 +93,7 @@ func TestAccVPCTrafficMirrorFilter_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTrafficMirrorFilterConfigTags2("key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCTrafficMirrorFilterConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -102,7 +102,7 @@ func TestAccVPCTrafficMirrorFilter_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTrafficMirrorFilterConfigTags1("key2", "value2"),
+				Config: testAccVPCTrafficMirrorFilterConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -128,7 +128,7 @@ func TestAccVPCTrafficMirrorFilter_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorFilterConfig(description),
+				Config: testAccVPCTrafficMirrorFilterConfig_basic(description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorFilterExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTrafficMirrorFilter(), resourceName),
@@ -170,7 +170,7 @@ func testAccCheckTrafficMirrorFilterExists(name string, traffic *ec2.TrafficMirr
 	}
 }
 
-func testAccTrafficMirrorFilterConfig(description string) string {
+func testAccVPCTrafficMirrorFilterConfig_basic(description string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {
   description = "%s"
@@ -180,7 +180,7 @@ resource "aws_ec2_traffic_mirror_filter" "test" {
 `, description)
 }
 
-func testAccTrafficMirrorFilterConfigWithoutDNS(description string) string {
+func testAccVPCTrafficMirrorFilterConfig_noDNS(description string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {
   description = "%s"
@@ -188,7 +188,7 @@ resource "aws_ec2_traffic_mirror_filter" "test" {
 `, description)
 }
 
-func testAccTrafficMirrorFilterConfigTags1(tagKey1, tagValue1 string) string {
+func testAccVPCTrafficMirrorFilterConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {
   tags = {
@@ -198,7 +198,7 @@ resource "aws_ec2_traffic_mirror_filter" "test" {
 `, tagKey1, tagValue1)
 }
 
-func testAccTrafficMirrorFilterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCTrafficMirrorFilterConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {
   tags = {

--- a/internal/service/ec2/vpc_traffic_mirror_session_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session_test.go
@@ -37,7 +37,7 @@ func TestAccVPCTrafficMirrorSession_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			//create
 			{
-				Config: testAccTrafficMirrorSessionConfig(rName, session),
+				Config: testAccVPCTrafficMirrorSessionConfig_basic(rName, session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -51,7 +51,7 @@ func TestAccVPCTrafficMirrorSession_basic(t *testing.T) {
 			},
 			// update of description, packet length and VNI
 			{
-				Config: testAccTrafficMirrorSessionConfigWithOptionals(description, rName, session, pLen, vni),
+				Config: testAccVPCTrafficMirrorSessionConfig_optionals(description, rName, session, pLen, vni),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -62,7 +62,7 @@ func TestAccVPCTrafficMirrorSession_basic(t *testing.T) {
 			},
 			// removal of description, packet length and VNI
 			{
-				Config: testAccTrafficMirrorSessionConfig(rName, session),
+				Config: testAccVPCTrafficMirrorSessionConfig_basic(rName, session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -97,7 +97,7 @@ func TestAccVPCTrafficMirrorSession_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorSessionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorSessionConfigTags1(rName, "key1", "value1", session),
+				Config: testAccVPCTrafficMirrorSessionConfig_tags1(rName, "key1", "value1", session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -110,7 +110,7 @@ func TestAccVPCTrafficMirrorSession_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTrafficMirrorSessionConfigTags2(rName, "key1", "value1updated", "key2", "value2", session),
+				Config: testAccVPCTrafficMirrorSessionConfig_tags2(rName, "key1", "value1updated", "key2", "value2", session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -119,7 +119,7 @@ func TestAccVPCTrafficMirrorSession_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTrafficMirrorSessionConfigTags1(rName, "key2", "value2", session),
+				Config: testAccVPCTrafficMirrorSessionConfig_tags1(rName, "key2", "value2", session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -146,7 +146,7 @@ func TestAccVPCTrafficMirrorSession_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorSessionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorSessionConfig(rName, session),
+				Config: testAccVPCTrafficMirrorSessionConfig_basic(rName, session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorSessionExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTrafficMirrorSession(), resourceName),
@@ -260,7 +260,7 @@ resource "aws_ec2_traffic_mirror_target" "target" {
 `, rName))
 }
 
-func testAccTrafficMirrorSessionConfig(rName string, session int) string {
+func testAccVPCTrafficMirrorSessionConfig_basic(rName string, session int) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorSessionConfigBase(rName), fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_session" "test" {
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
@@ -271,7 +271,7 @@ resource "aws_ec2_traffic_mirror_session" "test" {
 `, session))
 }
 
-func testAccTrafficMirrorSessionConfigTags1(rName, tagKey1, tagValue1 string, session int) string {
+func testAccVPCTrafficMirrorSessionConfig_tags1(rName, tagKey1, tagValue1 string, session int) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorSessionConfigBase(rName), fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_session" "test" {
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
@@ -286,7 +286,7 @@ resource "aws_ec2_traffic_mirror_session" "test" {
 `, tagKey1, tagValue1, session))
 }
 
-func testAccTrafficMirrorSessionConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string, session int) string {
+func testAccVPCTrafficMirrorSessionConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string, session int) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorSessionConfigBase(rName), fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_session" "test" {
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
@@ -302,7 +302,7 @@ resource "aws_ec2_traffic_mirror_session" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2, session))
 }
 
-func testAccTrafficMirrorSessionConfigWithOptionals(description string, rName string, session, pLen, vni int) string {
+func testAccVPCTrafficMirrorSessionConfig_optionals(description string, rName string, session, pLen, vni int) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorSessionConfigBase(rName), fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_session" "test" {
   description              = "%s"

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -32,7 +32,7 @@ func TestAccVPCTrafficMirrorTarget_nlb(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorTargetConfigNlb(rName, description),
+				Config: testAccVPCTrafficMirrorTargetConfig_nlb(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorTargetExists(resourceName, &v),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
@@ -67,7 +67,7 @@ func TestAccVPCTrafficMirrorTarget_eni(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorTargetConfigEni(rName, description),
+				Config: testAccVPCTrafficMirrorTargetConfig_eni(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -100,7 +100,7 @@ func TestAccVPCTrafficMirrorTarget_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorTargetConfigTags1(rName, description, "key1", "value1"),
+				Config: testAccVPCTrafficMirrorTargetConfig_tags1(rName, description, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -113,7 +113,7 @@ func TestAccVPCTrafficMirrorTarget_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTrafficMirrorTargetConfigTags2(rName, description, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVPCTrafficMirrorTargetConfig_tags2(rName, description, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -122,7 +122,7 @@ func TestAccVPCTrafficMirrorTarget_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTrafficMirrorTargetConfigTags1(rName, description, "key2", "value2"),
+				Config: testAccVPCTrafficMirrorTargetConfig_tags1(rName, description, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -149,7 +149,7 @@ func TestAccVPCTrafficMirrorTarget_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTrafficMirrorTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficMirrorTargetConfigNlb(rName, description),
+				Config: testAccVPCTrafficMirrorTargetConfig_nlb(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficMirrorTargetExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceTrafficMirrorTarget(), resourceName),
@@ -232,7 +232,7 @@ resource "aws_subnet" "sub2" {
 `, rName)
 }
 
-func testAccTrafficMirrorTargetConfigNlb(rName, description string) string {
+func testAccVPCTrafficMirrorTargetConfig_nlb(rName, description string) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
 resource "aws_lb" "lb" {
   name               = %[1]q
@@ -255,7 +255,7 @@ resource "aws_ec2_traffic_mirror_target" "test" {
 `, rName, description))
 }
 
-func testAccTrafficMirrorTargetConfigEni(rName, description string) string {
+func testAccVPCTrafficMirrorTargetConfig_eni(rName, description string) string {
 	return acctest.ConfigCompose(
 		testAccTrafficMirrorTargetConfigBase(rName),
 		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
@@ -277,7 +277,7 @@ resource "aws_ec2_traffic_mirror_target" "test" {
 `, rName, description))
 }
 
-func testAccTrafficMirrorTargetConfigTags1(rName, description, tagKey1, tagValue1 string) string {
+func testAccVPCTrafficMirrorTargetConfig_tags1(rName, description, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
 resource "aws_lb" "lb" {
   name               = %[1]q
@@ -304,7 +304,7 @@ resource "aws_ec2_traffic_mirror_target" "test" {
 `, rName, description, tagKey1, tagValue1))
 }
 
-func testAccTrafficMirrorTargetConfigTags2(rName, description, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVPCTrafficMirrorTargetConfig_tags2(rName, description, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
 resource "aws_lb" "lb" {
   name               = %[1]q

--- a/internal/service/ec2/vpc_vpcs_data_source_test.go
+++ b/internal/service/ec2/vpc_vpcs_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccVPCsDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCsDataSourceConfig(rName),
+				Config: testAccVPCVPCsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue("data.aws_vpcs.test", "ids.#", "0"),
 				),
@@ -37,7 +37,7 @@ func TestAccVPCsDataSource_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCsDataSourceConfig_tags(rName),
+				Config: testAccVPCVPCsDataSourceConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_vpcs.test", "ids.#", "1"),
 				),
@@ -55,7 +55,7 @@ func TestAccVPCsDataSource_filters(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCsDataSourceConfig_filters(rName),
+				Config: testAccVPCVPCsDataSourceConfig_filters(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue("data.aws_vpcs.test", "ids.#", "0"),
 				),
@@ -73,7 +73,7 @@ func TestAccVPCsDataSource_empty(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCsDataSourceConfig_empty(rName),
+				Config: testAccVPCVPCsDataSourceConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_vpcs.test", "ids.#", "0"),
 				),
@@ -82,7 +82,7 @@ func TestAccVPCsDataSource_empty(t *testing.T) {
 	})
 }
 
-func testAccVPCsDataSourceConfig(rName string) string {
+func testAccVPCVPCsDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
@@ -96,7 +96,7 @@ data "aws_vpcs" "test" {}
 `, rName)
 }
 
-func testAccVPCsDataSourceConfig_tags(rName string) string {
+func testAccVPCVPCsDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
@@ -116,7 +116,7 @@ data "aws_vpcs" "test" {
 `, rName)
 }
 
-func testAccVPCsDataSourceConfig_filters(rName string) string {
+func testAccVPCVPCsDataSourceConfig_filters(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/25"
@@ -135,7 +135,7 @@ data "aws_vpcs" "test" {
 `, rName)
 }
 
-func testAccVPCsDataSourceConfig_empty(rName string) string {
+func testAccVPCVPCsDataSourceConfig_empty(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpcs" "test" {
   tags = {

--- a/internal/service/ec2/vpnclient_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source_test.go
@@ -23,7 +23,7 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointDataSourceConfig_basic(rName),
+				Config: testAccClientVPNEndpointDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasource1Name, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasource1Name, "authentication_options.#", resourceName, "authentication_options.#"),
@@ -90,7 +90,7 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccEndpointDataSourceConfig_basic(rName string) string {
+func testAccClientVPNEndpointDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_basic(rName), `
 data "aws_ec2_client_vpn_endpoint" "by_id" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -329,7 +329,7 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T)
 		CheckDestroy:      testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSamlProvider(rName, idpEntityID),
+				Config: testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSAMLProvider(rName, idpEntityID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
@@ -1135,7 +1135,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, idpEntityID))
 }
 
-func testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSamlProvider(rName, idpEntityID string) string {
+func testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSAMLProvider(rName, idpEntityID string) string {
 	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test1" {
   name                   = %[1]q

--- a/internal/service/ec2/vpnsite_connection_route_test.go
+++ b/internal/service/ec2/vpnsite_connection_route_test.go
@@ -26,7 +26,7 @@ func TestAccSiteVPNConnectionRoute_basic(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionRouteConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionRouteConfig_basic(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionRouteExists(resourceName),
 				),
@@ -47,7 +47,7 @@ func TestAccSiteVPNConnectionRoute_disappears(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionRouteConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionRouteConfig_basic(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionRouteExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPNConnectionRoute(), resourceName),
@@ -117,7 +117,7 @@ func testAccVPNConnectionRouteExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccVPNConnectionRouteConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionRouteConfig_basic(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {

--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -159,7 +159,7 @@ func TestAccSiteVPNConnection_basic(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_basic(rName, rBgpAsn),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpn-connection/vpn-.+`)),
@@ -248,7 +248,7 @@ func TestAccSiteVPNConnection_transitGatewayID(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTransitGatewayConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_transitGateway(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestMatchResourceAttr(resourceName, "transit_gateway_attachment_id", regexp.MustCompile(`tgw-attach-.+`)),
@@ -277,7 +277,7 @@ func TestAccSiteVPNConnection_tunnel1InsideCIDR(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTunnel1InsideCIDRConfig(rName, rBgpAsn, "169.254.8.0/30", "169.254.9.0/30"),
+				Config: testAccSiteVPNConnectionConfig_tunnel1InsideCIDR(rName, rBgpAsn, "169.254.8.0/30", "169.254.9.0/30"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_inside_cidr", "169.254.8.0/30"),
@@ -306,7 +306,7 @@ func TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTunnel1InsideIPv6CIDRConfig(rName, rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
+				Config: testAccSiteVPNConnectionConfig_tunnel1InsideIPv6CIDR(rName, rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_inside_ipv6_cidr", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126"),
@@ -335,7 +335,7 @@ func TestAccSiteVPNConnection_tunnel1PreSharedKey(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTunnel1PresharedKeyConfig(rName, rBgpAsn, "tunnel1presharedkey", "tunnel2presharedkey"),
+				Config: testAccSiteVPNConnectionConfig_tunnel1PresharedKey(rName, rBgpAsn, "tunnel1presharedkey", "tunnel2presharedkey"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_preshared_key", "tunnel1presharedkey"),
@@ -405,63 +405,63 @@ func TestAccSiteVPNConnection_tunnelOptions(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "not-a-cidr"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "not-a-cidr"),
 				ExpectError: regexp.MustCompile(`invalid CIDR address: not-a-cidr`),
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.254.0/31"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.254.0/31"),
 				ExpectError: regexp.MustCompile(`expected "\w+" to contain a network Value with between 30 and 30 significant bits`),
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "172.16.0.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "172.16.0.0/30"),
 				ExpectError: regexp.MustCompile(`must be within 169.254.0.0/16`),
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.0.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.0.0/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.1.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.1.0/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.2.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.2.0/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.3.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.3.0/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.4.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.4.0/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.5.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.5.0/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "12345678", "169.254.169.252/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "12345678", "169.254.169.252/30"),
 				ExpectError: badCidrRangeErr,
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "1234567", "169.254.254.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "1234567", "169.254.254.0/30"),
 				ExpectError: regexp.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, sdkacctest.RandStringFromCharSet(65, sdkacctest.CharSetAlpha), "169.254.254.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, sdkacctest.RandStringFromCharSet(65, sdkacctest.CharSetAlpha), "169.254.254.0/30"),
 				ExpectError: regexp.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "01234567", "169.254.254.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "01234567", "169.254.254.0/30"),
 				ExpectError: regexp.MustCompile(`cannot start with zero character`),
 			},
 			{
-				Config:      testAccVPNConnectionSingleTunnelOptionsConfig(rName, rBgpAsn, "1234567!", "169.254.254.0/30"),
+				Config:      testAccSiteVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, "1234567!", "169.254.254.0/30"),
 				ExpectError: regexp.MustCompile(`can only contain alphanumeric, period and underscore characters`),
 			},
 			{
-				Config: testAccVPNConnectionTunnelOptionsConfig(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1, tunnel2),
+				Config: testAccSiteVPNConnectionConfig_tunnelOptions(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1, tunnel2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "static_routes_only", "false"),
@@ -543,7 +543,7 @@ func TestAccSiteVPNConnection_tunnelOptionsLesser(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTunnelOptionsConfig(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1, tunnel2),
+				Config: testAccSiteVPNConnectionConfig_tunnelOptions(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1, tunnel2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn1),
 					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_address"),
@@ -649,7 +649,7 @@ func TestAccSiteVPNConnection_tunnelOptionsLesser(t *testing.T) {
 			},
 			// Update just tunnel1.
 			{
-				Config: testAccVPNConnectionTunnelOptionsConfig(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1Updated, tunnel2),
+				Config: testAccSiteVPNConnectionConfig_tunnelOptions(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1Updated, tunnel2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn2),
 					testAccCheckVPNConnectionNotRecreated(&vpn1, &vpn2),
@@ -756,7 +756,7 @@ func TestAccSiteVPNConnection_tunnelOptionsLesser(t *testing.T) {
 			},
 			// Update just tunnel2.
 			{
-				Config: testAccVPNConnectionTunnelOptionsConfig(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1Updated, tunnel2Updated),
+				Config: testAccSiteVPNConnectionConfig_tunnelOptions(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1Updated, tunnel2Updated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn3),
 					testAccCheckVPNConnectionNotRecreated(&vpn2, &vpn3),
@@ -863,7 +863,7 @@ func TestAccSiteVPNConnection_tunnelOptionsLesser(t *testing.T) {
 			},
 			// Update tunnel1 and tunnel2.
 			{
-				Config: testAccVPNConnectionTunnelOptionsConfig(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1, tunnel2),
+				Config: testAccSiteVPNConnectionConfig_tunnelOptions(rName, rBgpAsn, "192.168.1.1/32", "192.168.1.2/32", tunnel1, tunnel2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn4),
 					testAccCheckVPNConnectionNotRecreated(&vpn3, &vpn4),
@@ -971,7 +971,7 @@ func TestAccSiteVPNConnection_tunnelOptionsLesser(t *testing.T) {
 			// Test resetting to defaults.
 			// [local|remote]_ipv[4|6]_network_cidr, tunnel[1|2]_inside_[ipv6_]cidr and tunnel[1|2]_preshared_key are Computed so no diffs will be detected.
 			{
-				Config: testAccVPNConnectionConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_basic(rName, rBgpAsn),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn5),
 					testAccCheckVPNConnectionNotRecreated(&vpn4, &vpn5),
@@ -1045,7 +1045,7 @@ func TestAccSiteVPNConnection_staticRoutes(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionWithStaticRoutesConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_staticRoutes(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "static_routes_only", "true"),
@@ -1073,7 +1073,7 @@ func TestAccSiteVPNConnection_enableAcceleration(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionEnableAccelerationConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_enableAcceleration(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "enable_acceleration", "true"),
@@ -1101,7 +1101,7 @@ func TestAccSiteVPNConnection_ipv6(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionIPv6Config(rName, rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d201/128", "fd00:2001:db8:2:2d1:81ff:fe41:d202/128", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
+				Config: testAccSiteVPNConnectionConfig_ipv6(rName, rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d201/128", "fd00:2001:db8:2:2d1:81ff:fe41:d202/128", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 				),
@@ -1128,7 +1128,7 @@ func TestAccSiteVPNConnection_tags(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTags1Config(rName, rBgpAsn, "key1", "value1"),
+				Config: testAccSiteVPNConnectionConfig_tags1(rName, rBgpAsn, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -1141,7 +1141,7 @@ func TestAccSiteVPNConnection_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionTags2Config(rName, rBgpAsn, "key1", "value1updated", "key2", "value2"),
+				Config: testAccSiteVPNConnectionConfig_tags2(rName, rBgpAsn, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -1150,7 +1150,7 @@ func TestAccSiteVPNConnection_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPNConnectionTags1Config(rName, rBgpAsn, "key2", "value2"),
+				Config: testAccSiteVPNConnectionConfig_tags1(rName, rBgpAsn, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -1174,7 +1174,7 @@ func TestAccSiteVPNConnection_specifyIPv4(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionLocalRemoteIPv4CIDRsConfig(rName, rBgpAsn, "10.111.0.0/16", "10.222.33.0/24"),
+				Config: testAccSiteVPNConnectionConfig_localRemoteIPv4CIDRs(rName, rBgpAsn, "10.111.0.0/16", "10.222.33.0/24"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "local_ipv4_network_cidr", "10.111.0.0/16"),
@@ -1187,7 +1187,7 @@ func TestAccSiteVPNConnection_specifyIPv4(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionLocalRemoteIPv4CIDRsConfig(rName, rBgpAsn, "10.112.0.0/16", "10.222.32.0/24"),
+				Config: testAccSiteVPNConnectionConfig_localRemoteIPv4CIDRs(rName, rBgpAsn, "10.112.0.0/16", "10.222.32.0/24"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "local_ipv4_network_cidr", "10.112.0.0/16"),
@@ -1211,7 +1211,7 @@ func TestAccSiteVPNConnection_specifyIPv6(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionIPv6Config(rName, rBgpAsn, "1111:2222:3333:4444::/64", "5555:6666:7777::/48", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
+				Config: testAccSiteVPNConnectionConfig_ipv6(rName, rBgpAsn, "1111:2222:3333:4444::/64", "5555:6666:7777::/48", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "local_ipv6_network_cidr", "1111:2222:3333:4444::/64"),
@@ -1235,7 +1235,7 @@ func TestAccSiteVPNConnection_disappears(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_basic(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPNConnection(), resourceName),
@@ -1260,7 +1260,7 @@ func TestAccSiteVPNConnection_updateCustomerGatewayID(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionCustomerGatewayIDConfig(rName, rBgpAsn1, rBgpAsn2),
+				Config: testAccSiteVPNConnectionConfig_customerGatewayID(rName, rBgpAsn1, rBgpAsn2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn1),
 					resource.TestCheckResourceAttrPair(resourceName, "customer_gateway_id", "aws_customer_gateway.test1", "id"),
@@ -1272,7 +1272,7 @@ func TestAccSiteVPNConnection_updateCustomerGatewayID(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionCustomerGatewayIDUpdatedConfig(rName, rBgpAsn1, rBgpAsn2),
+				Config: testAccSiteVPNConnectionConfig_customerGatewayIDUpdated(rName, rBgpAsn1, rBgpAsn2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn2),
 					testAccCheckVPNConnectionNotRecreated(&vpn1, &vpn2),
@@ -1296,7 +1296,7 @@ func TestAccSiteVPNConnection_updateVPNGatewayID(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionVPNGatewayIDConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_vpnGatewayID(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn1),
 					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", "aws_vpn_gateway.test1", "id"),
@@ -1308,7 +1308,7 @@ func TestAccSiteVPNConnection_updateVPNGatewayID(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionVPNGatewayIDUpdatedConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_vpnGatewayIDUpdated(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn2),
 					testAccCheckVPNConnectionNotRecreated(&vpn1, &vpn2),
@@ -1332,7 +1332,7 @@ func TestAccSiteVPNConnection_updateTransitGatewayID(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTransitGatewayIDConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_transitGatewayID(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn1),
 					resource.TestCheckResourceAttrSet(resourceName, "transit_gateway_attachment_id"),
@@ -1345,7 +1345,7 @@ func TestAccSiteVPNConnection_updateTransitGatewayID(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionTransitGatewayIDUpdatedConfig(rName, rBgpAsn),
+				Config: testAccSiteVPNConnectionConfig_transitGatewayIDUpdated(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn2),
 					testAccCheckVPNConnectionNotRecreated(&vpn1, &vpn2),
@@ -1370,7 +1370,7 @@ func TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTransitGatewayIDOrVPNGatewayIDConfig(rName, rBgpAsn, false),
+				Config: testAccSiteVPNConnectionConfig_transitGatewayIDOrVPNGatewayID(rName, rBgpAsn, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn1),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
@@ -1383,7 +1383,7 @@ func TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionTransitGatewayIDOrVPNGatewayIDConfig(rName, rBgpAsn, true),
+				Config: testAccSiteVPNConnectionConfig_transitGatewayIDOrVPNGatewayID(rName, rBgpAsn, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn2),
 					testAccCheckVPNConnectionNotRecreated(&vpn1, &vpn2),
@@ -1408,7 +1408,7 @@ func TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID(t *testing.T) {
 		CheckDestroy:      testAccVPNConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNConnectionTransitGatewayIDOrVPNGatewayIDConfig(rName, rBgpAsn, true),
+				Config: testAccSiteVPNConnectionConfig_transitGatewayIDOrVPNGatewayID(rName, rBgpAsn, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn1),
 					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", "aws_ec2_transit_gateway.test", "id"),
@@ -1421,7 +1421,7 @@ func TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNConnectionTransitGatewayIDOrVPNGatewayIDConfig(rName, rBgpAsn, false),
+				Config: testAccSiteVPNConnectionConfig_transitGatewayIDOrVPNGatewayID(rName, rBgpAsn, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVPNConnectionExists(resourceName, &vpn2),
 					testAccCheckVPNConnectionNotRecreated(&vpn1, &vpn2),
@@ -1492,7 +1492,7 @@ func testAccCheckVPNConnectionNotRecreated(before, after *ec2.VpnConnection) res
 	}
 }
 
-func testAccVPNConnectionConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_basic(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1518,7 +1518,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionCustomerGatewayIDConfig(rName string, rBgpAsn1, rBgpAsn2 int) string {
+func testAccSiteVPNConnectionConfig_customerGatewayID(rName string, rBgpAsn1, rBgpAsn2 int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1554,7 +1554,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn1, rBgpAsn2)
 }
 
-func testAccVPNConnectionCustomerGatewayIDUpdatedConfig(rName string, rBgpAsn1, rBgpAsn2 int) string {
+func testAccSiteVPNConnectionConfig_customerGatewayIDUpdated(rName string, rBgpAsn1, rBgpAsn2 int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1590,7 +1590,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn1, rBgpAsn2)
 }
 
-func testAccVPNConnectionVPNGatewayIDConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_vpnGatewayID(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test1" {
   tags = {
@@ -1622,7 +1622,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionVPNGatewayIDUpdatedConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_vpnGatewayIDUpdated(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test1" {
   tags = {
@@ -1654,7 +1654,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionWithStaticRoutesConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_staticRoutes(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1685,7 +1685,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionEnableAccelerationConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_enableAcceleration(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   description = %[1]q
@@ -1715,7 +1715,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionIPv6Config(rName string, rBgpAsn int, localIpv6NetworkCidr string, remoteIpv6NetworkCidr string, tunnel1InsideIpv6Cidr string, tunnel2InsideIpv6Cidr string) string {
+func testAccSiteVPNConnectionConfig_ipv6(rName string, rBgpAsn int, localIpv6NetworkCidr string, remoteIpv6NetworkCidr string, tunnel1InsideIpv6Cidr string, tunnel2InsideIpv6Cidr string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   description = %[1]q
@@ -1752,7 +1752,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, localIpv6NetworkCidr, remoteIpv6NetworkCidr, tunnel1InsideIpv6Cidr, tunnel2InsideIpv6Cidr)
 }
 
-func testAccVPNConnectionSingleTunnelOptionsConfig(rName string, rBgpAsn int, psk string, tunnelCidr string) string {
+func testAccSiteVPNConnectionConfig_singleTunnelOptions(rName string, rBgpAsn int, psk string, tunnelCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1786,7 +1786,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, tunnelCidr, psk)
 }
 
-func testAccVPNConnectionTransitGatewayConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_transitGateway(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   description = %[1]q
@@ -1814,7 +1814,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionTransitGatewayIDConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_transitGatewayID(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test1" {
   description = "%[1]s-1"
@@ -1846,7 +1846,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionTransitGatewayIDUpdatedConfig(rName string, rBgpAsn int) string {
+func testAccSiteVPNConnectionConfig_transitGatewayIDUpdated(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test1" {
   description = "%[1]s-1"
@@ -1878,7 +1878,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccVPNConnectionTunnel1InsideCIDRConfig(rName string, rBgpAsn int, tunnel1InsideCidr string, tunnel2InsideCidr string) string {
+func testAccSiteVPNConnectionConfig_tunnel1InsideCIDR(rName string, rBgpAsn int, tunnel1InsideCidr string, tunnel2InsideCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1910,7 +1910,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, tunnel1InsideCidr, tunnel2InsideCidr)
 }
 
-func testAccVPNConnectionTunnel1InsideIPv6CIDRConfig(rName string, rBgpAsn int, tunnel1InsideIpv6Cidr string, tunnel2InsideIpv6Cidr string) string {
+func testAccSiteVPNConnectionConfig_tunnel1InsideIPv6CIDR(rName string, rBgpAsn int, tunnel1InsideIpv6Cidr string, tunnel2InsideIpv6Cidr string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   description = %[1]q
@@ -1941,7 +1941,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, tunnel1InsideIpv6Cidr, tunnel2InsideIpv6Cidr)
 }
 
-func testAccVPNConnectionTunnel1PresharedKeyConfig(rName string, rBgpAsn int, tunnel1PresharedKey string, tunnel2PresharedKey string) string {
+func testAccSiteVPNConnectionConfig_tunnel1PresharedKey(rName string, rBgpAsn int, tunnel1PresharedKey string, tunnel2PresharedKey string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -1973,7 +1973,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, tunnel1PresharedKey, tunnel2PresharedKey)
 }
 
-func testAccVPNConnectionTunnelOptionsConfig(
+func testAccSiteVPNConnectionConfig_tunnelOptions(
 	rName string,
 	rBgpAsn int,
 	localIpv4NetworkCidr string,
@@ -2087,7 +2087,7 @@ resource "aws_vpn_connection" "test" {
 		tunnel2.startupAction)
 }
 
-func testAccVPNConnectionTags1Config(rName string, rBgpAsn int, tagKey1, tagValue1 string) string {
+func testAccSiteVPNConnectionConfig_tags1(rName string, rBgpAsn int, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -2118,7 +2118,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, tagKey1, tagValue1)
 }
 
-func testAccVPNConnectionTags2Config(rName string, rBgpAsn int, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccSiteVPNConnectionConfig_tags2(rName string, rBgpAsn int, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -2150,7 +2150,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccVPNConnectionLocalRemoteIPv4CIDRsConfig(rName string, rBgpAsn int, localIpv4Cidr string, remoteIpv4Cidr string) string {
+func testAccSiteVPNConnectionConfig_localRemoteIPv4CIDRs(rName string, rBgpAsn int, localIpv4Cidr string, remoteIpv4Cidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -2184,7 +2184,7 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn, localIpv4Cidr, remoteIpv4Cidr)
 }
 
-func testAccVPNConnectionTransitGatewayIDOrVPNGatewayIDConfig(rName string, rBgpAsn int, useTransitGateway bool) string {
+func testAccSiteVPNConnectionConfig_transitGatewayIDOrVPNGatewayID(rName string, rBgpAsn int, useTransitGateway bool) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {

--- a/internal/service/ec2/vpnsite_customer_gateway_data_source_test.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccSiteVPNCustomerGatewayDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayFilterDataSourceConfig(rName, asn, hostOctet),
+				Config: testAccSiteVPNCustomerGatewayDataSourceConfig_filter(rName, asn, hostOctet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "bgp_asn", dataSourceName, "bgp_asn"),
@@ -53,7 +53,7 @@ func TestAccSiteVPNCustomerGatewayDataSource_id(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayIDDataSourceConfig(rName, asn, hostOctet),
+				Config: testAccSiteVPNCustomerGatewayDataSourceConfig_id(rName, asn, hostOctet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "bgp_asn", dataSourceName, "bgp_asn"),
@@ -68,7 +68,7 @@ func TestAccSiteVPNCustomerGatewayDataSource_id(t *testing.T) {
 	})
 }
 
-func testAccCustomerGatewayFilterDataSourceConfig(rName string, asn, hostOctet int) string {
+func testAccSiteVPNCustomerGatewayDataSourceConfig_filter(rName string, asn, hostOctet int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %[2]d
@@ -89,7 +89,7 @@ data "aws_customer_gateway" "test" {
 `, rName, asn, hostOctet)
 }
 
-func testAccCustomerGatewayIDDataSourceConfig(rName string, asn, hostOctet int) string {
+func testAccSiteVPNCustomerGatewayDataSourceConfig_id(rName string, asn, hostOctet int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn     = %[2]d

--- a/internal/service/ec2/vpnsite_customer_gateway_test.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_test.go
@@ -29,7 +29,7 @@ func TestAccSiteVPNCustomerGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig(rBgpAsn),
+				Config: testAccSiteVPNCustomerGatewayConfig_basic(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`customer-gateway/cgw-.+`)),
@@ -61,7 +61,7 @@ func TestAccSiteVPNCustomerGateway_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig(rBgpAsn),
+				Config: testAccSiteVPNCustomerGatewayConfig_basic(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceCustomerGateway(), resourceName),
@@ -84,7 +84,7 @@ func TestAccSiteVPNCustomerGateway_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfigTags1(rBgpAsn, "key1", "value1"),
+				Config: testAccSiteVPNCustomerGatewayConfig_tags1(rBgpAsn, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -96,7 +96,7 @@ func TestAccSiteVPNCustomerGateway_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCustomerGatewayConfigTags2(rBgpAsn, "key1", "value1updated", "key2", "value2"),
+				Config: testAccSiteVPNCustomerGatewayConfig_tags2(rBgpAsn, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -104,7 +104,7 @@ func TestAccSiteVPNCustomerGateway_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2")),
 			},
 			{
-				Config: testAccCustomerGatewayConfigTags1(rBgpAsn, "key2", "value2"),
+				Config: testAccSiteVPNCustomerGatewayConfig_tags1(rBgpAsn, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -127,7 +127,7 @@ func TestAccSiteVPNCustomerGateway_deviceName(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfigDeviceName(rName, rBgpAsn),
+				Config: testAccSiteVPNCustomerGatewayConfig_deviceName(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					resource.TestCheckResourceAttr(resourceName, "device_name", "test"),
@@ -155,7 +155,7 @@ func TestAccSiteVPNCustomerGateway_4ByteASN(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSiteVPNCustomerGatewayConfig_4ByteASN(rName, rBgpAsn),
+				Config: testAccSiteVPNCustomerGatewayConfig_siteVPN4ByteASN(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					resource.TestCheckResourceAttr(resourceName, "bgp_asn", rBgpAsn),
@@ -190,7 +190,7 @@ func TestAccSiteVPNCustomerGateway_certificate(t *testing.T) {
 		Steps: []resource.TestStep{
 			// We need to create and activate the CAs before issuing a certificate.
 			{
-				Config: testAccCustomerGatewayConfigCAs(domain),
+				Config: testAccSiteVPNCustomerGatewayConfig_cas(domain),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckACMPCACertificateAuthorityExists(acmRootCAResourceName, &caRoot),
 					acctest.CheckACMPCACertificateAuthorityExists(acmSubordinateCAResourceName, &caSubordinate),
@@ -199,7 +199,7 @@ func TestAccSiteVPNCustomerGateway_certificate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCustomerGatewayConfigCertificate(rName, rBgpAsn, domain),
+				Config: testAccSiteVPNCustomerGatewayConfig_certificate(rName, rBgpAsn, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGatewayExists(resourceName, &gateway),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", acmCertificateResourceName, "arn"),
@@ -211,7 +211,7 @@ func TestAccSiteVPNCustomerGateway_certificate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCustomerGatewayConfigCertificate(rName, rBgpAsn, domain),
+				Config: testAccSiteVPNCustomerGatewayConfig_certificate(rName, rBgpAsn, domain),
 				Check: resource.ComposeTestCheckFunc(
 					// CAs must be DISABLED for deletion.
 					acctest.CheckACMPCACertificateAuthorityDisableCA(&caSubordinate),
@@ -272,7 +272,7 @@ func testAccCheckCustomerGatewayExists(n string, v *ec2.CustomerGateway) resourc
 	}
 }
 
-func testAccCustomerGatewayConfig(rBgpAsn int) string {
+func testAccSiteVPNCustomerGatewayConfig_basic(rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %[1]d
@@ -282,7 +282,7 @@ resource "aws_customer_gateway" "test" {
 `, rBgpAsn)
 }
 
-func testAccCustomerGatewayConfigTags1(rBgpAsn int, tagKey1, tagValue1 string) string {
+func testAccSiteVPNCustomerGatewayConfig_tags1(rBgpAsn int, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %[1]d
@@ -296,7 +296,7 @@ resource "aws_customer_gateway" "test" {
 `, rBgpAsn, tagKey1, tagValue1)
 }
 
-func testAccCustomerGatewayConfigTags2(rBgpAsn int, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccSiteVPNCustomerGatewayConfig_tags2(rBgpAsn int, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %[1]d
@@ -311,7 +311,7 @@ resource "aws_customer_gateway" "test" {
 `, rBgpAsn, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccCustomerGatewayConfigDeviceName(rName string, rBgpAsn int) string {
+func testAccSiteVPNCustomerGatewayConfig_deviceName(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn     = %[2]d
@@ -326,7 +326,7 @@ resource "aws_customer_gateway" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccSiteVPNCustomerGatewayConfig_4ByteASN(rName, rBgpAsn string) string {
+func testAccSiteVPNCustomerGatewayConfig_siteVPN4ByteASN(rName, rBgpAsn string) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %[2]q
@@ -340,7 +340,7 @@ resource "aws_customer_gateway" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccCustomerGatewayConfigCAs(domain string) string {
+func testAccSiteVPNCustomerGatewayConfig_cas(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "root" {
   permanent_deletion_time_in_days = 7
@@ -372,9 +372,9 @@ resource "aws_acmpca_certificate_authority" "test" {
 `, domain)
 }
 
-func testAccCustomerGatewayConfigCertificate(rName string, rBgpAsn int, domain string) string {
+func testAccSiteVPNCustomerGatewayConfig_certificate(rName string, rBgpAsn int, domain string) string {
 	return acctest.ConfigCompose(
-		testAccCustomerGatewayConfigCAs(domain),
+		testAccSiteVPNCustomerGatewayConfig_cas(domain),
 		fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   domain_name               = "test.sub.%[3]s"

--- a/internal/service/ec2/vpnsite_gateway_attachment_test.go
+++ b/internal/service/ec2/vpnsite_gateway_attachment_test.go
@@ -26,7 +26,7 @@ func TestAccSiteVPNGatewayAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayAttachmentConfig_basic(rName),
+				Config: testAccSiteVPNGatewayAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayAttachmentExists(resourceName, &v),
 				),
@@ -47,7 +47,7 @@ func TestAccSiteVPNGatewayAttachment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayAttachmentConfig_basic(rName),
+				Config: testAccSiteVPNGatewayAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayAttachmentExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPNGatewayAttachment(), resourceName),
@@ -107,7 +107,7 @@ func testAccCheckVPNGatewayAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccVPNGatewayAttachmentConfig_basic(rName string) string {
+func testAccSiteVPNGatewayAttachmentConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/ec2/vpnsite_gateway_data_source_test.go
+++ b/internal/service/ec2/vpnsite_gateway_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccSiteVPNGatewayDataSource_unattached(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayUnattachedDataSourceConfig(rName),
+				Config: testAccSiteVPNGatewayDataSourceConfig_unattached(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceNameById, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceNameById, "arn", resourceName, "arn"),
@@ -50,7 +50,7 @@ func TestAccSiteVPNGatewayDataSource_attached(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayAttachedDataSourceConfig(rName),
+				Config: testAccSiteVPNGatewayDataSourceConfig_attached(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", "aws_vpn_gateway.test", "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "attached_vpc_id", "aws_vpc.test", "id"),
@@ -61,7 +61,7 @@ func TestAccSiteVPNGatewayDataSource_attached(t *testing.T) {
 	})
 }
 
-func testAccVPNGatewayUnattachedDataSourceConfig(rName string) string {
+func testAccSiteVPNGatewayDataSourceConfig_unattached(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
   tags = {
@@ -88,7 +88,7 @@ data "aws_vpn_gateway" "test_by_amazon_side_asn" {
 `, rName)
 }
 
-func testAccVPNGatewayAttachedDataSourceConfig(rName string) string {
+func testAccSiteVPNGatewayDataSourceConfig_attached(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpnsite_gateway_route_propagation_test.go
+++ b/internal/service/ec2/vpnsite_gateway_route_propagation_test.go
@@ -25,7 +25,7 @@ func TestAccSiteVPNGatewayRoutePropagation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayRoutePropagationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayRoutePropagationBasicConfig(rName),
+				Config: testAccSiteVPNGatewayRoutePropagationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayRoutePropagationExists(resourceName),
 				),
@@ -45,7 +45,7 @@ func TestAccSiteVPNGatewayRoutePropagation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayRoutePropagationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayRoutePropagationBasicConfig(rName),
+				Config: testAccSiteVPNGatewayRoutePropagationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayRoutePropagationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPNGatewayRoutePropagation(), resourceName),
@@ -115,7 +115,7 @@ func testAccCheckVPNGatewayRoutePropagationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccVPNGatewayRoutePropagationBasicConfig(rName string) string {
+func testAccSiteVPNGatewayRoutePropagationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/vpnsite_gateway_test.go
+++ b/internal/service/ec2/vpnsite_gateway_test.go
@@ -45,7 +45,7 @@ func TestAccSiteVPNGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayConfig_basic(rName),
+				Config: testAccSiteVPNGatewayConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v1),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpn-gateway/vgw-.+`)),
@@ -58,7 +58,7 @@ func TestAccSiteVPNGateway_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNGatewayConfig_changeVPC(rName),
+				Config: testAccSiteVPNGatewayConfig_changeVPC(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v2),
 					testNotEqual,
@@ -81,7 +81,7 @@ func TestAccSiteVPNGateway_withAvailabilityZoneSetToState(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayConfig_az(rName),
+				Config: testAccSiteVPNGatewayConfig_az(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", azDataSourceName, "names.0"),
@@ -109,7 +109,7 @@ func TestAccSiteVPNGateway_amazonSideASN(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayConfig_asn(rName),
+				Config: testAccSiteVPNGatewayConfig_asn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -137,7 +137,7 @@ func TestAccSiteVPNGateway_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayConfig_basic(rName),
+				Config: testAccSiteVPNGatewayConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceVPNGateway(), resourceName),
@@ -196,7 +196,7 @@ func TestAccSiteVPNGateway_reattach(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayConfig_reattach(rName),
+				Config: testAccSiteVPNGatewayConfig_reattach(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckVPCExists(vpcResourceName1, &vpc1),
 					acctest.CheckVPCExists(vpcResourceName2, &vpc2),
@@ -217,7 +217,7 @@ func TestAccSiteVPNGateway_reattach(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNGatewayConfig_reattachChange(rName),
+				Config: testAccSiteVPNGatewayConfig_reattachChange(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName1, &vgw1),
 					testAccCheckVPNGatewayExists(resourceName2, &vgw2),
@@ -226,7 +226,7 @@ func TestAccSiteVPNGateway_reattach(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPNGatewayConfig_reattach(rName),
+				Config: testAccSiteVPNGatewayConfig_reattach(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName1, &vgw1),
 					testAccCheckVPNGatewayExists(resourceName2, &vgw2),
@@ -250,7 +250,7 @@ func TestAccSiteVPNGateway_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNGatewayConfig_tags1(rName, "key1", "value1"),
+				Config: testAccSiteVPNGatewayConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -263,7 +263,7 @@ func TestAccSiteVPNGateway_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPNGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccSiteVPNGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -272,7 +272,7 @@ func TestAccSiteVPNGateway_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPNGatewayConfig_tags1(rName, "key2", "value2"),
+				Config: testAccSiteVPNGatewayConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPNGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -332,7 +332,7 @@ func testAccCheckVPNGatewayExists(n string, v *ec2.VpnGateway) resource.TestChec
 	}
 }
 
-func testAccVPNGatewayConfig_basic(rName string) string {
+func testAccSiteVPNGatewayConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -348,7 +348,7 @@ resource "aws_vpn_gateway" "test" {
 `, rName)
 }
 
-func testAccVPNGatewayConfig_changeVPC(rName string) string {
+func testAccSiteVPNGatewayConfig_changeVPC(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -372,7 +372,7 @@ resource "aws_vpn_gateway" "test" {
 `, rName)
 }
 
-func testAccVPNGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccSiteVPNGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -392,7 +392,7 @@ resource "aws_vpn_gateway" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccVPNGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccSiteVPNGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -413,7 +413,7 @@ resource "aws_vpn_gateway" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccVPNGatewayConfig_reattach(rName string) string {
+func testAccSiteVPNGatewayConfig_reattach(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -449,7 +449,7 @@ resource "aws_vpn_gateway" "test2" {
 `, rName)
 }
 
-func testAccVPNGatewayConfig_reattachChange(rName string) string {
+func testAccSiteVPNGatewayConfig_reattachChange(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
@@ -485,7 +485,7 @@ resource "aws_vpn_gateway" "test2" {
 `, rName)
 }
 
-func testAccVPNGatewayConfig_az(rName string) string {
+func testAccSiteVPNGatewayConfig_az(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -506,7 +506,7 @@ resource "aws_vpn_gateway" "test" {
 `, rName))
 }
 
-func testAccVPNGatewayConfig_asn(rName string) string {
+func testAccSiteVPNGatewayConfig_asn(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/ec2/wavelength_carrier_gateway_test.go
+++ b/internal/service/ec2/wavelength_carrier_gateway_test.go
@@ -29,7 +29,7 @@ func TestAccWavelengthCarrierGateway_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCarrierGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCarrierGatewayConfig_basic(rName),
+				Config: testAccWavelengthCarrierGatewayConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCarrierGatewayExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`carrier-gateway/cagw-.+`)),
@@ -59,7 +59,7 @@ func TestAccWavelengthCarrierGateway_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckCarrierGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCarrierGatewayConfig_basic(rName),
+				Config: testAccWavelengthCarrierGatewayConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCarrierGatewayExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceCarrierGateway(), resourceName),
@@ -82,7 +82,7 @@ func TestAccWavelengthCarrierGateway_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckCarrierGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCarrierGatewayConfig_tags1(rName, "key1", "value1"),
+				Config: testAccWavelengthCarrierGatewayConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCarrierGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -95,7 +95,7 @@ func TestAccWavelengthCarrierGateway_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCarrierGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccWavelengthCarrierGatewayConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCarrierGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -104,7 +104,7 @@ func TestAccWavelengthCarrierGateway_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCarrierGatewayConfig_tags1(rName, "key2", "value2"),
+				Config: testAccWavelengthCarrierGatewayConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCarrierGatewayExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -197,7 +197,7 @@ func testAccPreCheckWavelengthZoneAvailable(t *testing.T) {
 	}
 }
 
-func testAccCarrierGatewayConfig_basic(rName string) string {
+func testAccWavelengthCarrierGatewayConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -213,7 +213,7 @@ resource "aws_ec2_carrier_gateway" "test" {
 `, rName)
 }
 
-func testAccCarrierGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccWavelengthCarrierGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -233,7 +233,7 @@ resource "aws_ec2_carrier_gateway" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccCarrierGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccWavelengthCarrierGatewayConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
