### PR TITLE
r/aws_cloudfront_response_headers_policy added server_timing_headers_config option to resource

### DIFF
--- a/.changelog/24917.txt
+++ b/.changelog/24917.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_response_headers_policy: Add `server_timing_headers_config` argument
+```

--- a/internal/service/cloudfront/response_headers_policy.go
+++ b/internal/service/cloudfront/response_headers_policy.go
@@ -273,16 +273,18 @@ func ResourceResponseHeadersPolicy() *schema.Resource {
 			},
 			"server_timing_headers_config": {
 				Type:     schema.TypeList,
+				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 						"sampling_rate": {
 							Type:         schema.TypeFloat,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.FloatBetween(0.0, 100.0),
 						},
 					},

--- a/internal/service/cloudfront/response_headers_policy_data_source.go
+++ b/internal/service/cloudfront/response_headers_policy_data_source.go
@@ -253,6 +253,8 @@ func DataSourceResponseHeadersPolicy() *schema.Resource {
 			},
 			"server_timing_headers_config": {
 				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/cloudfront/response_headers_policy_data_source.go
+++ b/internal/service/cloudfront/response_headers_policy_data_source.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
@@ -250,6 +251,23 @@ func DataSourceResponseHeadersPolicy() *schema.Resource {
 					},
 				},
 			},
+			"server_timing_headers_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"sampling_rate": {
+							Type:         schema.TypeFloat,
+							Required:     true,
+							ValidateFunc: validation.FloatBetween(0.0000, 100.0000),
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -322,6 +340,13 @@ func dataSourceResponseHeadersPolicyRead(d *schema.ResourceData, meta interface{
 		}
 	} else {
 		d.Set("security_headers_config", nil)
+	}
+	if apiObject.ServerTimingHeadersConfig != nil {
+		if err := d.Set("server_timing_headers_config", []interface{}{flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject.ServerTimingHeadersConfig)}); err != nil {
+			return fmt.Errorf("error setting server_timing_headers_config: %w", err)
+		}
+	} else {
+		d.Set("server_timing_headers_config", nil)
 	}
 
 	return nil

--- a/internal/service/cloudfront/response_headers_policy_data_source_test.go
+++ b/internal/service/cloudfront/response_headers_policy_data_source_test.go
@@ -49,7 +49,9 @@ func TestAccCloudFrontResponseHeadersPolicyDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.referrer_policy.#", resourceName, "security_headers_config.0.referrer_policy.#"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.strict_transport_security.#", resourceName, "security_headers_config.0.strict_transport_security.#"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.xss_protection.#", resourceName, "security_headers_config.0.xss_protection.#"),
-
+					resource.TestCheckResourceAttrPair(dataSource1Name, "server_timing_headers_config.#", resourceName, "server_timing_headers_config.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "server_timing_headers_config.0.enabled.#", resourceName, "server_timing_headers_config.0.enabled.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "server_timing_headers_config.0.sampling_rate.#", resourceName, "server_timing_headers_config.0.sampling_rate.#"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "comment", resourceName, "comment"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "cors_config.#", resourceName, "cors_config.#"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "cors_config.0.access_control_allow_credentials", resourceName, "cors_config.0.access_control_allow_credentials"),
@@ -74,6 +76,9 @@ func TestAccCloudFrontResponseHeadersPolicyDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.referrer_policy.#", resourceName, "security_headers_config.0.referrer_policy.#"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.strict_transport_security.#", resourceName, "security_headers_config.0.strict_transport_security.#"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.xss_protection.#", resourceName, "security_headers_config.0.xss_protection.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "server_timing_headers_config.#", resourceName, "server_timing_headers_config.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "server_timing_headers_config.0.enabled.#", resourceName, "server_timing_headers_config.0.enabled.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "server_timing_headers_config.0.sampling_rate.#", resourceName, "server_timing_headers_config.0.sampling_rate.#"),
 				),
 			},
 		},
@@ -142,6 +147,11 @@ resource "aws_cloudfront_response_headers_policy" "test" {
       override                   = true
       preload                    = true
     }
+  }
+
+  server_timing_headers_config {
+	  enabled       = true
+	  sampling_rate = 10.1 
   }
 }
 `, rName)

--- a/internal/service/cloudfront/response_headers_policy_test.go
+++ b/internal/service/cloudfront/response_headers_policy_test.go
@@ -239,8 +239,9 @@ func TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig(t *testing
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "security_headers_config.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.sampling_rate", "50.0"),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.sampling_rate", "50"),
 				),
 			},
 			{
@@ -255,10 +256,16 @@ func TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig(t *testing
 					testAccCheckResponseHeadersPolicyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "comment", ""),
 					resource.TestCheckResourceAttr(resourceName, "cors_config.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "custom_headers_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_headers_config.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "custom_headers_config.0.items.*", map[string]string{
+						"header":   "X-Header1",
+						"override": "true",
+						"value":    "value1",
+					}),
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "security_headers_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.enabled", "false"),
 				),
 			},
@@ -481,9 +488,17 @@ func testAccResponseHeadersPolicyServerTimingHeadersConfigConfig(rName string) s
 resource "aws_cloudfront_response_headers_policy" "test" {
   name = %[1]q
 
+  custom_headers_config {
+    items {
+      header   = "X-Header1"
+      override = true
+      value    = "value1"
+    }
+  }
+
   server_timing_headers_config {
 	enabled = true
-	sampling_rate = 50.0
+	sampling_rate = 50
   }
 }
 `, rName)
@@ -493,6 +508,14 @@ func testAccResponseHeadersPolicyServerTimingHeadersConfigUpdatedConfig(rName st
 	return fmt.Sprintf(`
 resource "aws_cloudfront_response_headers_policy" "test" {
   name = %[1]q
+
+  custom_headers_config {
+    items {
+      header   = "X-Header1"
+      override = true
+      value    = "value1"
+    }
+  }
 
   server_timing_headers_config {
 	enabled = false

--- a/website/docs/d/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/d/cloudfront_response_headers_policy.html.markdown
@@ -34,6 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cors_config` - A configuration for a set of HTTP response headers that are used for Cross-Origin Resource Sharing (CORS). See [Cors Config](#cors-config) for more information.
 * `custom_headers_config` - Object that contains an attribute `items` that contains a list of Custom Headers See [Custom Header](#custom-header) for more information.
 * `security_headers_config` - A configuration for a set of security-related HTTP response headers. See [Security Headers Config](#security-headers-config) for more information.
+* `server_timing_headers_config` - (Optional) A configuration for enabling the `Server-Timing` header in HTTP responses sent from CloudFront. See [Server Timing Headers Config](#server-timing-headers-config) for more information.
 
 ### Cors Config
 
@@ -58,6 +59,11 @@ In addition to all arguments above, the following attributes are exported:
 * `referrer_policy` - A setting that determines whether CloudFront includes the Referrer-Policy HTTP response header and the header’s value. See [Referrer Policy](#referrer-policy) for more information.
 * `strict_transport_security` - Settings that determine whether CloudFront includes the Strict-Transport-Security HTTP response header and the header’s value. See [Strict Transport Security](#strict-transport-security) for more information.
 * `xss_protection` - Settings that determine whether CloudFront includes the X-XSS-Protection HTTP response header and the header’s value. See [XSS Protection](#xss-protection) for more information.
+
+### Server Timing Headers Config
+
+* `enabled` - (Required) A Boolean that determines whether CloudFront adds the `Server-Timing` header to HTTP responses that it sends in response to requests that match a cache behavior that's associated with this response headers policy.
+* `sampling_rate` - (Required) A number 0–100 (inclusive) that specifies the percentage of responses that you want CloudFront to add the `Server-Timing` header to. When you set the sampling rate to 100, CloudFront adds the `Server-Timing` header to the HTTP response for every request that matches the cache behavior that this response headers policy is attached to. When you set it to 50, CloudFront adds the header to 50% of the responses for requests that match the cache behavior. You can set the sampling rate to any number 0–100 with up to four decimal places.
 
 ### Content Security Policy
 

--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -64,6 +64,19 @@ resource "aws_cloudfront_response_headers_policy" "example" {
 }
 ```
 
+The example below creates a CloudFront response headers policy with a server timing headers config.
+
+```terraform
+resource "aws_cloudfront_response_headers_policy" "example" {
+  name = "example-headers-policy"
+
+  server_timing_headers_config {
+    enabled       = true
+    sampling_rate = 50.0
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -73,6 +86,7 @@ The following arguments are supported:
 * `cors_config` - (Optional) A configuration for a set of HTTP response headers that are used for Cross-Origin Resource Sharing (CORS). See [Cors Config](#cors-config) for more information.
 * `custom_headers_config` - (Optional) Object that contains an attribute `items` that contains a list of custom headers. See [Custom Header](#custom-header) for more information.
 * `security_headers_config` - (Optional) A configuration for a set of security-related HTTP response headers. See [Security Headers Config](#security-headers-config) for more information.
+* `server_timing_headers_config` - (Optional) A configuration for enabling the `Server-Timing` header in HTTP responses sent from CloudFront. See [Server Timing Headers Config](#server-timing-headers-config) for more information.
 
 ### Cors Config
 
@@ -98,6 +112,11 @@ The following arguments are supported:
 * `referrer_policy` - (Optional) Determines whether CloudFront includes the `Referrer-Policy` HTTP response header and the header’s value. See [Referrer Policy](#referrer-policy) for more information.
 * `strict_transport_security` - (Optional) Determines whether CloudFront includes the `Strict-Transport-Security` HTTP response header and the header’s value. See [Strict Transport Security](#strict-transport-security) for more information.
 * `xss_protection` - (Optional) Determine whether CloudFront includes the `X-XSS-Protection` HTTP response header and the header’s value. See [XSS Protection](#xss-protection) for more information.
+
+### Server Timing Headers Config
+
+* `enabled` - (Required) A Boolean that determines whether CloudFront adds the `Server-Timing` header to HTTP responses that it sends in response to requests that match a cache behavior that's associated with this response headers policy.
+* `sampling_rate` - (Required) A number 0–100 (inclusive) that specifies the percentage of responses that you want CloudFront to add the `Server-Timing` header to. When you set the sampling rate to 100, CloudFront adds the `Server-Timing` header to the HTTP response for every request that matches the cache behavior that this response headers policy is attached to. When you set it to 50, CloudFront adds the header to 50% of the responses for requests that match the cache behavior. You can set the sampling rate to any number 0–100 with up to four decimal places.
 
 ### Content Security Policy
 


### PR DESCRIPTION
### Summary
This PR includes changes made to the [aws_cloudfront_response_headers_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) resource, to include the `server_timing_headers_config` argument. The following AWS SDK resources were used to inform the logic and descriptions for the argument attributes:
- https://raw.githubusercontent.com/aws/aws-sdk-go/v1.44.19/service/cloudfront/api.go
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24728

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCloudFrontResponseHeadersPolicy PKG=cloudfront 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontResponseHeadersPolicy'  -timeout 180m
=== RUN   TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== PAUSE TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== RUN   TestAccCloudFrontResponseHeadersPolicy_CorsConfig
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_CorsConfig
=== RUN   TestAccCloudFrontResponseHeadersPolicy_CustomHeadersConfig
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_CustomHeadersConfig
=== RUN   TestAccCloudFrontResponseHeadersPolicy_SecurityHeadersConfig
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_SecurityHeadersConfig
=== RUN   TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig
=== RUN   TestAccCloudFrontResponseHeadersPolicy_disappears
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_disappears
=== CONT  TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== CONT  TestAccCloudFrontResponseHeadersPolicy_SecurityHeadersConfig
=== CONT  TestAccCloudFrontResponseHeadersPolicy_disappears
=== CONT  TestAccCloudFrontResponseHeadersPolicy_CustomHeadersConfig
=== CONT  TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig
=== CONT  TestAccCloudFrontResponseHeadersPolicy_CorsConfig
--- PASS: TestAccCloudFrontResponseHeadersPolicy_disappears (16.36s)
--- PASS: TestAccCloudFrontResponseHeadersPolicyDataSource_basic (20.33s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_CustomHeadersConfig (21.88s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig (36.12s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_CorsConfig (36.25s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_SecurityHeadersConfig (36.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 38.268s
```
