### PR TITLE
github/workflows: reinstate goreleaser check and build for a single 32-bit arch

### DIFF
--- a/.github/goreleaser-cross-compiler-test.yml
+++ b/.github/goreleaser-cross-compiler-test.yml
@@ -1,0 +1,27 @@
+archives:
+  - files:
+      # Ensure only built binary is archived
+      - 'none*'
+    format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+before:
+  hooks:
+    - 'go mod download'
+builds:
+  # Check and build binary for 32-bit architecture (FreeBSD/ARM)
+  - id: 32-bit-arch
+    # Binary naming only required for Terraform CLI 0.12
+    binary: '{{ .ProjectName }}_v{{ .Version }}_x5'
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - freebsd
+    goarch:
+      - arm
+    ldflags:
+      - -s -w -X version.ProviderVersion={{.Version}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+snapshot:
+  name_template: "{{ .Tag }}-next"

--- a/.github/workflows/goreleaser-ci.yml
+++ b/.github/workflows/goreleaser-ci.yml
@@ -1,0 +1,73 @@
+# Continuous integration handling for GoReleaser
+name: GoReleaser CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+  pull_request:
+    paths:
+      - .github/workflows/goreleaser-ci.yml
+      - .goreleaser.yml
+      - .go-version
+      - go.sum
+      - main.go
+      - internal/**
+      - names/**
+      - providerlint/**
+      - skaff/**
+      - tools/**
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      goreleaser: ${{ steps.filter.outputs.goreleaser }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            goreleaser:
+              - '.github/workflows/goreleaser-ci.yml'
+              - '.goreleaser.yml'
+  check:
+    needs: changes
+    if: ${{ needs.changes.outputs.goreleaser == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@v2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - name: goreleaser check
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: check
+  build-32-bit:
+    # Run a single compiler check for 32-bit architecture (FreeBSD/ARM)
+    # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/8988
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@v2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - name: goreleaser build
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: build --config .github/goreleaser-cross-compiler-test.yml --id 32-bit-arch --snapshot


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/8988
Relates #24937 
Relates https://github.com/hashicorp/terraform-provider-aws/pull/24890

Output from goreleaser is using the 614939c70bfa212bc105cf0b9f4e8762fbd431a1 commit for testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ goreleaser build --config .github/goreleaser-cross-compiler-test.yml --id 32-bit-arch --snapshot --rm-dist
   • building...
   • loading config file       file=.github/goreleaser-cross-compiler-test.yml
   • single build in config, '--id' ignored
   • loading environment variables
   • getting and validating git state
      • building...               commit=614939c70bfa212bc105cf0b9f4e8762fbd431a1 latest tag=v4.14.0
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag
   • running before hooks
      • running                   hook=go mod download
   • setting defaults
   • snapshotting
      • building snapshot...      version=v4.14.0-next
   • checking distribution directory
      • --rm-dist is set, cleaning it up
   • loading go mod information
   • build prerequisites
   • writing effective config file
      • writing                   config=dist/config.yaml
   • building binaries
      • building                  binary=dist/32-bit-arch_freebsd_arm_6/terraform-provider-aws_vv4.14.0-next_x5
   ⨯ build failed after 4.58s error=failed to build for freebsd_arm_6: exit status 2: # github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager
internal/service/networkmanager/core_network_policy_document_data_source.go:167:34: cannot use 4200000000 (untyped int constant) as int value in argument to validation.IntBetween (overflows)
internal/service/networkmanager/core_network_policy_document_data_source.go:167:46: cannot use 4294967294 (untyped int constant) as int value in argument to validation.IntBetween (overflows)
```
