### PR TITLE
r/aws_appintegrations_data_integration

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -967,6 +967,7 @@ func Provider() *schema.Provider {
 			"aws_appflow_connector_profile": appflow.ResourceConnectorProfile(),
 			"aws_appflow_flow":              appflow.ResourceFlow(),
 
+			"aws_appintegrations_data_integration":  appintegrations.ResourceDataIntegration(),
 			"aws_appintegrations_event_integration": appintegrations.ResourceEventIntegration(),
 
 			"aws_appmesh_gateway_route":   appmesh.ResourceGatewayRoute(),

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -1,0 +1,86 @@
+package appintegrations
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceDataIntegration() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1000),
+			},
+			"kms_key": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\/\._\-]+$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+				),
+			},
+			"schedule_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"first_execution_from": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+						"object": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 255),
+								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\/\._\-]+$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+							),
+						},
+						"schedule_expression": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
+				},
+			},
+			"source_uri": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 1000),
+					validation.StringMatch(regexp.MustCompile(`^\w+\:\/\/\w+\/[\w/!@#+=.-]+$`), "should be a valid source uri"),
+				),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -1,16 +1,25 @@
 package appintegrations
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appintegrationsservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceDataIntegration() *schema.Resource {
 	return &schema.Resource{
+		ReadContext: resourceDataIntegrationRead,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -83,4 +92,67 @@ func ResourceDataIntegration() *schema.Resource {
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}
+}
+
+func resourceDataIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppIntegrationsConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	id := d.Id()
+
+	resp, err := conn.GetDataIntegrationWithContext(ctx, &appintegrationsservice.GetDataIntegrationInput{
+		Identifier: aws.String(id),
+	})
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, appintegrationsservice.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] AppIntegrations Data Integration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting AppIntegrations Data Integration (%s): %w", d.Id(), err))
+	}
+
+	if resp == nil {
+		return diag.FromErr(fmt.Errorf("error getting AppIntegrations Data Integration (%s): empty response", d.Id()))
+	}
+
+	d.Set("arn", resp.Arn)
+	d.Set("description", resp.Description)
+	d.Set("kms_key", resp.KmsKey)
+	d.Set("name", resp.Name)
+	d.Set("source_uri", resp.SourceURI)
+
+	if err := d.Set("schedule_config", flattenScheduleConfig(resp.ScheduleConfiguration)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting schedule_config: %w", err))
+	}
+
+	tags := KeyValueTags(resp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+	}
+
+	return nil
+}
+
+func flattenScheduleConfig(scheduleConfig *appintegrationsservice.ScheduleConfiguration) []interface{} {
+	if scheduleConfig == nil {
+		return []interface{}{}
+	}
+
+	values := map[string]interface{}{
+		"first_execution_from": aws.StringValue(scheduleConfig.FirstExecutionFrom),
+		"object":               aws.StringValue(scheduleConfig.Object),
+		"schedule_expression":  aws.StringValue(scheduleConfig.ScheduleExpression),
+	}
+
+	return []interface{}{values}
 }

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -23,6 +23,7 @@ func ResourceDataIntegration() *schema.Resource {
 		CreateContext: resourceDataIntegrationCreate,
 		ReadContext:   resourceDataIntegrationRead,
 		UpdateContext: resourceDataIntegrationUpdate,
+		DeleteContext: resourceDataIntegrationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -211,6 +212,22 @@ func resourceDataIntegrationUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	return resourceDataIntegrationRead(ctx, d, meta)
+}
+
+func resourceDataIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppIntegrationsConn
+
+	id := d.Id()
+
+	_, err := conn.DeleteDataIntegrationWithContext(ctx, &appintegrationsservice.DeleteDataIntegrationInput{
+		DataIntegrationIdentifier: aws.String(id),
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting DataIntegration (%s): %w", d.Id(), err))
+	}
+
+	return nil
 }
 
 func expandScheduleConfig(scheduleConfig []interface{}) *appintegrationsservice.ScheduleConfiguration {

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+func testAccCheckDataIntegrationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AppIntegrationsConn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_appintegrations_data_integration" {
+			continue
+		}
+
+		input := &appintegrationsservice.GetDataIntegrationInput{
+			Identifier: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.GetDataIntegration(input)
+
+		if err == nil {
+			if aws.StringValue(resp.Id) == rs.Primary.ID {
+				return fmt.Errorf("Data Integration '%s' was not deleted properly", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
 func testAccCheckDataIntegrationExists(name string, dataIntegration *appintegrationsservice.GetDataIntegrationOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -25,10 +25,11 @@ func TestAccDataIntegration_basic(t *testing.T) {
 	resourceName := "aws_appintegrations_data_integration.test"
 
 	key := "DATA_INTEGRATION_SOURCE_URI"
-	var sourceUri string
-	sourceUri = os.Getenv(key)
+	sourceUri := os.Getenv(key)
 	if sourceUri == "" {
-		sourceUri = "Salesforce://AppFlow/test"
+		t.Skip("Environment variable DATA_INTEGRATION_SOURCE_URI is not set")
+		// sourceUri of the form Salesforce://AppFlow/<NameOfSalesforceConnectorProfile>
+		// sourceUri = "Salesforce://AppFlow/test"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -88,10 +89,11 @@ func TestAccDataIntegration_updateTags(t *testing.T) {
 	resourceName := "aws_appintegrations_data_integration.test"
 
 	key := "DATA_INTEGRATION_SOURCE_URI"
-	var sourceUri string
-	sourceUri = os.Getenv(key)
+	sourceUri := os.Getenv(key)
 	if sourceUri == "" {
-		sourceUri = "Salesforce://AppFlow/test"
+		t.Skip("Environment variable DATA_INTEGRATION_SOURCE_URI is not set")
+		// sourceUri of the form Salesforce://AppFlow/<NameOfSalesforceConnectorProfile>
+		// sourceUri = "Salesforce://AppFlow/test"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -18,6 +18,7 @@ func TestAccDataIntegration_basic(t *testing.T) {
 	var dataIntegration appintegrationsservice.GetDataIntegrationOutput
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	originalDescription := "original description"
 	updatedDescription := "updated description"
 	firstExecutionFrom := "1439788442681"
@@ -45,6 +46,7 @@ func TestAccDataIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "source_uri", sourceUri),
 					resource.TestCheckResourceAttr(resourceName, "schedule_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.first_execution_from", firstExecutionFrom),
@@ -65,6 +67,24 @@ func TestAccDataIntegration_basic(t *testing.T) {
 					testAccCheckDataIntegrationExists(resourceName, &dataIntegration),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "source_uri", sourceUri),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.first_execution_from", firstExecutionFrom),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.object", "Account"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.schedule_expression", "rate(1 hour)"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+				),
+			},
+			{
+				Config: testAccDataIntegrationConfig_basic(rName2, updatedDescription, sourceUri, firstExecutionFrom),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataIntegrationExists(resourceName, &dataIntegration),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key", "aws_kms_key.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "source_uri", sourceUri),
 					resource.TestCheckResourceAttr(resourceName, "schedule_config.#", "1"),

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -2,14 +2,81 @@ package appintegrations_test
 
 import (
 	"fmt"
+	"os"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appintegrationsservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
+
+func TestAccDataIntegration_basic(t *testing.T) {
+	var dataIntegration appintegrationsservice.GetDataIntegrationOutput
+
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	originalDescription := "original description"
+	updatedDescription := "updated description"
+	firstExecutionFrom := "1439788442681"
+
+	resourceName := "aws_appintegrations_data_integration.test"
+
+	key := "DATA_INTEGRATION_SOURCE_URI"
+	var sourceUri string
+	sourceUri = os.Getenv(key)
+	if sourceUri == "" {
+		sourceUri = "Salesforce://AppFlow/test"
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, appintegrationsservice.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataIntegrationConfig_basic(rName, originalDescription, sourceUri, firstExecutionFrom),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataIntegrationExists(resourceName, &dataIntegration),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "source_uri", sourceUri),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.first_execution_from", firstExecutionFrom),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.object", "Account"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.schedule_expression", "rate(1 hour)"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataIntegrationConfig_basic(rName, updatedDescription, sourceUri, firstExecutionFrom),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataIntegrationExists(resourceName, &dataIntegration),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "source_uri", sourceUri),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.first_execution_from", firstExecutionFrom),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.object", "Account"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.0.schedule_expression", "rate(1 hour)"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckDataIntegrationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AppIntegrationsConn
@@ -56,4 +123,53 @@ func testAccCheckDataIntegrationExists(name string, dataIntegration *appintegrat
 
 		return nil
 	}
+}
+
+func testAccDataIntegrationBaseConfig() string {
+	return `
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+`
+}
+
+func testAccDataIntegrationConfig_basic(rName, description, sourceUri, firstExecutionFrom string) string {
+	return acctest.ConfigCompose(
+		testAccDataIntegrationBaseConfig(),
+		fmt.Sprintf(`
+resource "aws_appintegrations_data_integration" "test" {
+  name        = %[1]q
+  description = %[2]q
+  kms_key     = aws_kms_key.test.arn
+  source_uri  = %[3]q
+
+  schedule_config {
+    first_execution_from = %[4]q
+    object               = "Account"
+    schedule_expression  = "rate(1 hour)"
+  }
+
+  tags = {
+    "Key1" = "Value1"
+  }
+}
+`, rName, description, sourceUri, firstExecutionFrom))
 }

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -1,0 +1,36 @@
+package appintegrations_test
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appintegrationsservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func testAccCheckDataIntegrationExists(name string, dataIntegration *appintegrationsservice.GetDataIntegrationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppIntegrationsConn
+		input := &appintegrationsservice.GetDataIntegrationInput{
+			Identifier: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.GetDataIntegration(input)
+
+		if err != nil {
+			return err
+		}
+
+		*dataIntegration = *resp
+
+		return nil
+	}
+}

--- a/website/docs/r/appintegrations_data_integration.html.markdown
+++ b/website/docs/r/appintegrations_data_integration.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "AppIntegrations"
+layout: "aws"
+page_title: "AWS: aws_appintegrations_data_integration"
+description: |-
+  Provides details about a specific Amazon AppIntegrations Data Integration
+---
+
+# Resource: aws_appintegrations_data_integration
+
+Provides an Amazon AppIntegrations Data Integration resource.
+
+## Example Usage
+
+```terraform
+resource "aws_appintegrations_data_integration" "example" {
+  name        = "example"
+  description = "example"
+  kms_key     = aws_kms_key.test.arn
+  source_uri  = "Salesforce://AppFlow/example"
+
+  schedule_config {
+    first_execution_from = "1439788442681"
+    object               = "Account"
+    schedule_expression  = "rate(1 hour)"
+  }
+
+  tags = {
+    "Key1" = "Value1"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Specifies the description of the Data Integration.
+* `kms_key` - (Required) Specifies the KMS key Amazon Resource Name (ARN) for the Data Integration.
+* `name` - (Required) Specifies the name of the Data Integration.
+* `schedule_config` - (Required) A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
+* `source_uri` - (Required) Specifies the URI of the data source. Create an [AppFlow Connector Profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appflow_connector_profile) and reference the name of the profile in the URL. An example of this value for Salesforce is `Salesforce://AppFlow/example` where `example` is the name of the AppFlow Connector Profile.
+* `tags` - (Optional) Tags to apply to the Data Integration. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+A `schedule_config` block supports the following arguments:
+
+* `first_execution_from` - (Required) The start date for objects to import in the first flow run as an Unix/epoch timestamp in milliseconds or in ISO-8601 format. This needs to be a time in the past, meaning that the data created or updated before this given date will not be downloaded.
+* `object` - (Required) The name of the object to pull from the data source. Examples of objects in Salesforce include `Case`, `Account`, or `Lead`.
+* `schedule_expression` - (Required) How often the data should be pulled from data source. Examples include `rate(1 hour)`, `rate(3 hours)`, `rate(1 day)`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the Data Integration.
+* `id` - The identifier of the Data Integration.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Amazon AppIntegrations Data Integrations can be imported using the `id` e.g.,
+
+```
+$ terraform import aws_appintegrations_data_integration.example 12345678-1234-1234-1234-123456789123
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24939

Pre-reqs for testing

1. Create a Salesforce developer account: https://developer.salesforce.com/signup
2. Create an AppFlow ConnectorProfile and then reference the name of that profile in the DataIntegration `source_uri` like: `Salesforce://AppFlow/<NameOfSalesforceConnectorProfile>`. This is set in an environment variable called `DATA_INTEGRATION_SOURCE_URI`

Output from acceptance testing (if env variables are set):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataIntegration' PKG=appintegrations
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appintegrations/... -v -count 1 -parallel 20  -run=TestAccDataIntegration -timeout 180m
=== RUN   TestAccDataIntegration_basic
=== PAUSE TestAccDataIntegration_basic
=== RUN   TestAccDataIntegration_updateDescription
=== PAUSE TestAccDataIntegration_updateDescription
=== RUN   TestAccDataIntegration_updateName
=== PAUSE TestAccDataIntegration_updateName
=== RUN   TestAccDataIntegration_updateTags
=== PAUSE TestAccDataIntegration_updateTags
=== CONT  TestAccDataIntegration_basic
=== CONT  TestAccDataIntegration_updateName
=== CONT  TestAccDataIntegration_updateDescription
=== CONT  TestAccDataIntegration_updateTags
--- PASS: TestAccDataIntegration_basic (31.68s)
--- PASS: TestAccDataIntegration_updateDescription (48.53s)
--- PASS: TestAccDataIntegration_updateName (51.27s)
--- PASS: TestAccDataIntegration_updateTags (64.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appintegrations    64.795s

...
```
