### PR TITLE
Add 'Context' as an optional parameter for Auto Scaling 'CreateAutoScalingGroup'

### DIFF
--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -235,6 +235,11 @@ func ResourceGroup() *schema.Resource {
 				ExactlyOneOf: []string{"launch_configuration", "launch_template", "mixed_instances_policy"},
 			},
 
+			"context": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"capacity_rebalance": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -732,6 +737,10 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		createOpts.Tags = Tags(KeyValueTags(v, asgName, TagResourceTypeGroup).IgnoreAWS())
 	}
 
+	if v, ok := d.GetOk("context"); ok {
+		createOpts.Context = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("capacity_rebalance"); ok {
 		createOpts.CapacityRebalance = aws.Bool(v.(bool))
 	}
@@ -874,6 +883,7 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("arn", g.AutoScalingGroupARN)
+	d.Set("context", g.Context)
 	d.Set("capacity_rebalance", g.CapacityRebalance)
 	d.Set("default_cooldown", g.DefaultCooldown)
 	d.Set("desired_capacity", g.DesiredCapacity)
@@ -1060,6 +1070,10 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("default_cooldown") {
 		opts.DefaultCooldown = aws.Int64(int64(d.Get("default_cooldown").(int)))
+	}
+
+	if d.HasChange("context") {
+		opts.Context = aws.String(d.Get("context").(string))
 	}
 
 	if d.HasChange("capacity_rebalance") {

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -69,6 +69,7 @@ func TestAccAutoScalingGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "min_size", "2"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "mixed_instances_policy.#", "0"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "name", randName),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "context", ""),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "placement_group", ""),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "protect_from_scale_in", "false"),
 					acctest.CheckResourceAttrGlobalARN("aws_autoscaling_group.bar", "service_linked_role_arn", "iam", "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"),

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -347,6 +347,7 @@ The following arguments are supported:
 * `min_size` - (Required) The minimum size of the Auto Scaling Group.
     (See also [Waiting for Capacity](#waiting-for-capacity) below.)
 * `availability_zones` - (Optional) A list of one or more availability zones for the group. Used for EC2-Classic, attaching a network interface via id from a launch template and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier`.
+* `context` - (Optional) Reserved.
 * `capacity_rebalance` - (Optional) Indicates whether capacity rebalance is enabled. Otherwise, capacity rebalance is disabled.
 * `default_cooldown` - (Optional) The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
 * `launch_configuration` - (Optional) The name of the launch configuration to use.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24943

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAutoScalingGroup_basic PKG=autoscaling
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 5 -run='TestAccAutoScalingGroup_basic'  -timeout 180m
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_basic
--- PASS: TestAccAutoScalingGroup_basic (264.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling268.769s
...
```
