### PR TITLE
d/aws_location_place_index - new data source

### DIFF
--- a/.changelog/24980.txt
+++ b/.changelog/24980.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_location_place_index
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -732,7 +732,8 @@ func Provider() *schema.Provider {
 			"aws_lex_intent":    lexmodels.DataSourceIntent(),
 			"aws_lex_slot_type": lexmodels.DataSourceSlotType(),
 
-			"aws_location_map": location.DataSourceMap(),
+			"aws_location_map":         location.DataSourceMap(),
+			"aws_location_place_index": location.DataSourcePlaceIndex(),
 
 			"aws_arn":                     meta.DataSourceARN(),
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),

--- a/internal/service/location/place_index_data_source.go
+++ b/internal/service/location/place_index_data_source.go
@@ -1,0 +1,97 @@
+package location
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourcePlaceIndex() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePlaceIndexRead,
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"intended_use": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"index_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"index_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePlaceIndexRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.DescribePlaceIndexInput{}
+
+	if v, ok := d.GetOk("index_name"); ok {
+		input.IndexName = aws.String(v.(string))
+	}
+
+	output, err := conn.DescribePlaceIndex(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Location Service Place Index: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Location Service Place Index: empty response")
+	}
+
+	d.SetId(aws.StringValue(output.IndexName))
+	d.Set("create_time", aws.TimeValue(output.CreateTime).Format(time.RFC3339))
+	d.Set("data_source", output.DataSource)
+
+	if output.DataSourceConfiguration != nil {
+		d.Set("data_source_configuration", []interface{}{flattenDataSourceConfiguration(output.DataSourceConfiguration)})
+	} else {
+		d.Set("data_source_configuration", nil)
+	}
+
+	d.Set("description", output.Description)
+	d.Set("index_arn", output.IndexArn)
+	d.Set("index_name", output.IndexName)
+	d.Set("tags", KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(meta.(*conns.AWSClient).IgnoreTagsConfig).Map())
+	d.Set("update_time", aws.TimeValue(output.UpdateTime).Format(time.RFC3339))
+
+	return nil
+}

--- a/internal/service/location/place_index_data_source_test.go
+++ b/internal/service/location/place_index_data_source_test.go
@@ -1,0 +1,53 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationPlaceIndexDataSource_indexName(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_place_index.test"
+	resourceName := "aws_location_place_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckPlaceIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigPlaceIndexDataSource_indexName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_time", resourceName, "create_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "data_source", resourceName, "data_source"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "data_source_configuration.#", resourceName, "data_source_configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "data_source_configuration.0.intended_use", resourceName, "data_source_configuration.0.intended_use"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "index_arn", resourceName, "index_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "index_name", resourceName, "index_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "update_time", resourceName, "update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigPlaceIndexDataSource_indexName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_place_index" "test" {
+  data_source = "Here"
+  index_name  = %[1]q
+}
+
+data "aws_location_place_index" "test" {
+  index_name = aws_location_place_index.test.index_name
+}
+`, rName)
+}

--- a/website/docs/d/location_place_index.html.markdown
+++ b/website/docs/d/location_place_index.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_place_index"
+description: |-
+    Retrieve information about a Location Service Place Index.
+---
+
+# Data Source: aws_location_place_index
+
+Retrieve information about a Location Service Place Index.
+
+## Example Usage
+
+```terraform
+data "aws_location_place_index" "example" {
+  index_name = "example"
+}
+```
+
+## Argument Reference
+
+* `index_name` - (Required) The name of the place index resource.
+
+## Attribute Reference
+
+* `create_time` - The timestamp for when the place index resource was created in ISO 8601 format.
+* `data_source` - The data provider of geospatial data.
+* `data_source_configuration` - List of configurations that specify data storage option for requesting Places.
+* `description` - The optional description for the place index resource.
+* `index_arn` - The Amazon Resource Name (ARN) for the place index resource.
+* `tags` - Key-value map of resource tags for the map.
+* `update_time` - The timestamp for when the place index resource was last update in ISO 8601.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationPlaceIndexDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationPlaceIndexDataSource_'  -timeout 180m
=== RUN   TestAccLocationPlaceIndexDataSource_indexName
=== PAUSE TestAccLocationPlaceIndexDataSource_indexName
=== CONT  TestAccLocationPlaceIndexDataSource_indexName
--- PASS: TestAccLocationPlaceIndexDataSource_indexName (25.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   26.919s
```
