### PR TITLE
serverlessrepo: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -363,7 +363,6 @@ rules:
         - internal/service/schemas
         - internal/service/secretsmanager
         - internal/service/securityhub
-        - internal/service/serverlessrepo
         - internal/service/servicecatalog
         - internal/service/servicediscovery
         - internal/service/servicequotas

--- a/internal/service/serverlessrepo/application_data_source_test.go
+++ b/internal/service/serverlessrepo/application_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccServerlessRepoApplicationDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckApplicationDataSourceConfig(appARN),
+				Config: testAccApplicationDataSourceConfig_basic(appARN),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplicationIDDataSource(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -32,7 +32,7 @@ func TestAccServerlessRepoApplicationDataSource_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccCheckApplicationDataSourceConfig_NonExistent(),
+				Config:      testAccApplicationDataSourceConfig_nonExistent(),
 				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
 			},
 		},
@@ -54,7 +54,7 @@ func TestAccServerlessRepoApplicationDataSource_versioned(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckApplicationDataSourceConfig_Versioned(appARN, version1),
+				Config: testAccApplicationDataSourceConfig_versioned(appARN, version1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplicationIDDataSource(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -65,7 +65,7 @@ func TestAccServerlessRepoApplicationDataSource_versioned(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckApplicationDataSourceConfig_Versioned(appARN, version2),
+				Config: testAccApplicationDataSourceConfig_versioned(appARN, version2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplicationIDDataSource(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -78,7 +78,7 @@ func TestAccServerlessRepoApplicationDataSource_versioned(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccCheckApplicationDataSourceConfig_Versioned_NonExistent(appARN),
+				Config:      testAccApplicationDataSourceConfig_versionedNonExistent(appARN),
 				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
 			},
 		},
@@ -99,7 +99,7 @@ func testAccCheckApplicationIDDataSource(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckApplicationDataSourceConfig(appARN string) string {
+func testAccApplicationDataSourceConfig_basic(appARN string) string {
 	return fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id = %[1]q
@@ -107,7 +107,7 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
 `, appARN)
 }
 
-func testAccCheckApplicationDataSourceConfig_NonExistent() string {
+func testAccApplicationDataSourceConfig_nonExistent() string {
 	return `
 data "aws_caller_identity" "current" {}
 
@@ -121,7 +121,7 @@ data "aws_serverlessapplicationrepository_application" "no_such_function" {
 `
 }
 
-func testAccCheckApplicationDataSourceConfig_Versioned(appARN, version string) string {
+func testAccApplicationDataSourceConfig_versioned(appARN, version string) string {
 	return fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id   = %[1]q
@@ -130,7 +130,7 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
 `, appARN, version)
 }
 
-func testAccCheckApplicationDataSourceConfig_Versioned_NonExistent(appARN string) string {
+func testAccApplicationDataSourceConfig_versionedNonExistent(appARN string) string {
 	return fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id   = %[1]q

--- a/internal/service/serverlessrepo/cloudformation_stack_test.go
+++ b/internal/service/serverlessrepo/cloudformation_stack_test.go
@@ -36,7 +36,7 @@ func TestAccServerlessRepoCloudFormationStack_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFormationStackConfig(stackName, appARN),
+				Config: testAccCloudFormationStackConfig_basic(stackName, appARN),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "name", stackName),
@@ -87,7 +87,7 @@ func TestAccServerlessRepoCloudFormationStack_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAMIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFormationStackConfig(stackName, appARN),
+				Config: testAccCloudFormationStackConfig_basic(stackName, appARN),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					acctest.CheckResourceDisappears(acctest.Provider, tfserverlessrepo.ResourceCloudFormationStack(), resourceName),
@@ -198,7 +198,7 @@ func TestAccServerlessRepoCloudFormationStack_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFormationStackTags1Config(stackName, appARN, "key1", "value1"),
+				Config: testAccCloudFormationStackConfig_tags1(stackName, appARN, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -211,7 +211,7 @@ func TestAccServerlessRepoCloudFormationStack_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCloudFormationStackTags2Config(stackName, appARN, "key1", "value1updated", "key2", "value2"),
+				Config: testAccCloudFormationStackConfig_tags2(stackName, appARN, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -219,7 +219,7 @@ func TestAccServerlessRepoCloudFormationStack_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCloudFormationStackTags1Config(stackName, appARN, "key2", "value2"),
+				Config: testAccCloudFormationStackConfig_tags1(stackName, appARN, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -331,7 +331,7 @@ func testAccCloudFormationApplicationID() string {
 	}.String()
 }
 
-func testAccCloudFormationStackConfig(stackName, appARN string) string {
+func testAccCloudFormationStackConfig_basic(stackName, appARN string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -482,7 +482,7 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
 `, stackName, appARN, version)
 }
 
-func testAccCloudFormationStackTags1Config(rName, appARN, tagKey1, tagValue1 string) string {
+func testAccCloudFormationStackConfig_tags1(rName, appARN, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -509,7 +509,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 `, rName, appARN, tagKey1, tagValue1)
 }
 
-func testAccCloudFormationStackTags2Config(rName, appARN, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccCloudFormationStackConfig_tags2(rName, appARN, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
