### PR TITLE
sagemaker: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -359,7 +359,6 @@ rules:
         - internal/service/s3
         - internal/service/s3control
         - internal/service/s3outposts
-        - internal/service/sagemaker
         - internal/service/schemas
         - internal/service/secretsmanager
         - internal/service/securityhub

--- a/internal/service/apigateway/model_test.go
+++ b/internal/service/apigateway/model_test.go
@@ -29,7 +29,7 @@ func TestAccAPIGatewayModel_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelConfig(rName, modelName),
+				Config: testAccModelConfig_basic(rName, modelName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName, modelName, &conf),
 					testAccCheckModelAttributes(&conf, modelName),
@@ -65,7 +65,7 @@ func TestAccAPIGatewayModel_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelConfig(rName, modelName),
+				Config: testAccModelConfig_basic(rName, modelName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName, modelName, &conf),
 					acctest.CheckResourceDisappears(acctest.Provider, tfapigateway.ResourceModel(), resourceName),
@@ -168,7 +168,7 @@ func testAccModelImportStateIdFunc(resourceName string) resource.ImportStateIdFu
 	}
 }
 
-func testAccModelConfig(rName, modelName string) string {
+func testAccModelConfig_basic(rName, modelName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = "%s"

--- a/internal/service/codeartifact/domain_test.go
+++ b/internal/service/codeartifact/domain_test.go
@@ -27,7 +27,7 @@ func testAccDomain_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainBasicConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "codeartifact", fmt.Sprintf("domain/%s", rName)),
@@ -92,7 +92,7 @@ func testAccDomain_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainTags1Config(rName, "key1", "value1"),
+				Config: testAccDomainConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -105,7 +105,7 @@ func testAccDomain_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDomainTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccDomainConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -114,7 +114,7 @@ func testAccDomain_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainTags1Config(rName, "key2", "value2"),
+				Config: testAccDomainConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -207,7 +207,7 @@ func testAccCheckDomainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccDomainBasicConfig(rName string) string {
+func testAccDomainConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -221,7 +221,7 @@ resource "aws_codeartifact_domain" "test" {
 `, rName)
 }
 
-func testAccDomainTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccDomainConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_codeartifact_domain" "test" {
   domain = %[1]q
@@ -233,7 +233,7 @@ resource "aws_codeartifact_domain" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDomainTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_codeartifact_domain" "test" {
   domain = %[1]q

--- a/internal/service/imagebuilder/image_test.go
+++ b/internal/service/imagebuilder/image_test.go
@@ -199,7 +199,7 @@ func TestAccImageBuilderImage_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageTags1Config(rName, "key1", "value1"),
+				Config: testAccImageConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -212,7 +212,7 @@ func TestAccImageBuilderImage_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccImageTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccImageConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -221,7 +221,7 @@ func TestAccImageBuilderImage_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccImageTags1Config(rName, "key2", "value2"),
+				Config: testAccImageConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -491,7 +491,7 @@ resource "aws_imagebuilder_image" "test" {
 `)
 }
 
-func testAccImageTags1Config(rName string, tagKey1 string, tagValue1 string) string {
+func testAccImageConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		testAccImageBaseConfig(rName),
 		fmt.Sprintf(`
@@ -506,7 +506,7 @@ resource "aws_imagebuilder_image" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccImageTags2Config(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccImageConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		testAccImageBaseConfig(rName),
 		fmt.Sprintf(`

--- a/internal/service/iot/endpoint_data_source_test.go
+++ b/internal/service/iot/endpoint_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccIoTEndpointDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig,
+				Config: testAccEndpointConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "endpoint_address", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]+(-ats)?.iot.%s.amazonaws.com$", acctest.Region()))),
 				),
@@ -100,7 +100,7 @@ func TestAccIoTEndpointDataSource_EndpointType_iotJobs(t *testing.T) {
 	})
 }
 
-const testAccEndpointConfig = `
+const testAccEndpointConfig_basic = `
 data "aws_iot_endpoint" "test" {}
 `
 

--- a/internal/service/s3outposts/endpoint_test.go
+++ b/internal/service/s3outposts/endpoint_test.go
@@ -25,7 +25,7 @@ func TestAccS3OutpostsEndpoint_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig(rInt),
+				Config: testAccEndpointConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "s3-outposts", regexp.MustCompile(`outpost/[^/]+/endpoint/[a-z0-9]+`)),
@@ -58,7 +58,7 @@ func TestAccS3OutpostsEndpoint_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig(rInt),
+				Config: testAccEndpointConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfs3outposts.ResourceEndpoint(), resourceName),
@@ -129,7 +129,7 @@ func testAccEndpointImportStateIdFunc(resourceName string) resource.ImportStateI
 	}
 }
 
-func testAccEndpointConfig(rInt int) string {
+func testAccEndpointConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/sagemaker/app_image_config_test.go
+++ b/internal/service/sagemaker/app_image_config_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerAppImageConfig_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAppImageDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppImageBasicConfig(rName),
+				Config: testAccAppImageConfigConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "app_image_config_name", rName),
@@ -57,7 +57,7 @@ func TestAccSageMakerAppImageConfig_KernelGatewayImage_kernelSpecs(t *testing.T)
 		CheckDestroy:      testAccCheckAppImageDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppImageKernelGatewayImageKernalSpecs1Config(rName),
+				Config: testAccAppImageConfigConfig_kernelGatewayKernalSpecs1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "app_image_config_name", rName),
@@ -73,7 +73,7 @@ func TestAccSageMakerAppImageConfig_KernelGatewayImage_kernelSpecs(t *testing.T)
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppImageKernelGatewayImageKernalSpecs2Config(rName),
+				Config: testAccAppImageConfigConfig_kernelGatewayKernalSpecs2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "app_image_config_name", rName),
@@ -100,7 +100,7 @@ func TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystem(t *testing.T) 
 		CheckDestroy:      testAccCheckAppImageDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppImageKernelGatewayImageFileSystem1Config(rName),
+				Config: testAccAppImageConfigConfig_kernelGatewayFileSystem1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "app_image_config_name", rName),
@@ -118,7 +118,7 @@ func TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystem(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppImageKernelGatewayImageFileSystem2Config(rName),
+				Config: testAccAppImageConfigConfig_kernelGatewayFileSystem2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "app_image_config_name", rName),
@@ -146,7 +146,7 @@ func TestAccSageMakerAppImageConfig_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppImageTags1Config(rName, "key1", "value1"),
+				Config: testAccAppImageConfigConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -159,7 +159,7 @@ func TestAccSageMakerAppImageConfig_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppImageTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAppImageConfigConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -168,7 +168,7 @@ func TestAccSageMakerAppImageConfig_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppImageTags1Config(rName, "key2", "value2"),
+				Config: testAccAppImageConfigConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -191,7 +191,7 @@ func TestAccSageMakerAppImageConfig_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAppImageDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppImageBasicConfig(rName),
+				Config: testAccAppImageConfigConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppImageExistsConfig(resourceName, &config),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceAppImageConfig(), resourceName),
@@ -251,7 +251,7 @@ func testAccCheckAppImageExistsConfig(n string, config *sagemaker.DescribeAppIma
 	}
 }
 
-func testAccAppImageBasicConfig(rName string) string {
+func testAccAppImageConfigConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q
@@ -259,7 +259,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 `, rName)
 }
 
-func testAccAppImageKernelGatewayImageKernalSpecs1Config(rName string) string {
+func testAccAppImageConfigConfig_kernelGatewayKernalSpecs1(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q
@@ -273,7 +273,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 `, rName)
 }
 
-func testAccAppImageKernelGatewayImageKernalSpecs2Config(rName string) string {
+func testAccAppImageConfigConfig_kernelGatewayKernalSpecs2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q
@@ -288,7 +288,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 `, rName)
 }
 
-func testAccAppImageKernelGatewayImageFileSystem1Config(rName string) string {
+func testAccAppImageConfigConfig_kernelGatewayFileSystem1(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q
@@ -304,7 +304,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 `, rName)
 }
 
-func testAccAppImageKernelGatewayImageFileSystem2Config(rName string) string {
+func testAccAppImageConfigConfig_kernelGatewayFileSystem2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q
@@ -324,7 +324,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 `, rName)
 }
 
-func testAccAppImageTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccAppImageConfigConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q
@@ -336,7 +336,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAppImageTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAppImageConfigConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_app_image_config" "test" {
   app_image_config_name = %[1]q

--- a/internal/service/sagemaker/app_test.go
+++ b/internal/service/sagemaker/app_test.go
@@ -32,7 +32,7 @@ func testAccApp_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppBasicConfig(rName),
+				Config: testAccAppConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
@@ -70,7 +70,7 @@ func testAccApp_resourceSpec(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppResourceSpecConfig(rName),
+				Config: testAccAppConfig_resourceSpec(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
@@ -105,7 +105,7 @@ func testAccApp_resourceSpecLifecycle(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppResourceSpecLifecycleConfig(rName, uName),
+				Config: testAccAppConfig_resourceSpecLifecycle(rName, uName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
@@ -140,7 +140,7 @@ func testAccApp_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppTags1Config(rName, "key1", "value1"),
+				Config: testAccAppConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -153,7 +153,7 @@ func testAccApp_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAppConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -162,7 +162,7 @@ func testAccApp_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppTags1Config(rName, "key2", "value2"),
+				Config: testAccAppConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -189,7 +189,7 @@ func testAccApp_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppBasicConfig(rName),
+				Config: testAccAppConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &app),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceApp(), resourceName),
@@ -330,7 +330,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccAppBasicConfig(rName string) string {
+func testAccAppConfig_basic(rName string) string {
 	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -341,7 +341,7 @@ resource "aws_sagemaker_app" "test" {
 `, rName)
 }
 
-func testAccAppTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccAppConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -356,7 +356,7 @@ resource "aws_sagemaker_app" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAppTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAppConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -372,7 +372,7 @@ resource "aws_sagemaker_app" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAppResourceSpecConfig(rName string) string {
+func testAccAppConfig_resourceSpec(rName string) string {
 	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -387,7 +387,7 @@ resource "aws_sagemaker_app" "test" {
 `, rName)
 }
 
-func testAccAppResourceSpecLifecycleConfig(rName, uName string) string {
+func testAccAppConfig_resourceSpecLifecycle(rName, uName string) string {
 	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q

--- a/internal/service/sagemaker/code_repository_test.go
+++ b/internal/service/sagemaker/code_repository_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerCodeRepository_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCodeRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodeRepositoryBasicConfig(rName),
+				Config: testAccCodeRepositoryConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "code_repository_name", rName),
@@ -58,7 +58,7 @@ func TestAccSageMakerCodeRepository_Git_branch(t *testing.T) {
 		CheckDestroy:      testAccCheckCodeRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodeRepositoryGitBranchConfig(rName),
+				Config: testAccCodeRepositoryConfig_gitBranch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "code_repository_name", rName),
@@ -89,7 +89,7 @@ func TestAccSageMakerCodeRepository_Git_secret(t *testing.T) {
 		CheckDestroy:      testAccCheckCodeRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodeRepositoryGitSecretConfig(rName),
+				Config: testAccCodeRepositoryConfig_gitSecret(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "code_repository_name", rName),
@@ -105,7 +105,7 @@ func TestAccSageMakerCodeRepository_Git_secret(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCodeRepositoryGitSecretUpdatedConfig(rName),
+				Config: testAccCodeRepositoryConfig_gitSecretUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "code_repository_name", rName),
@@ -131,7 +131,7 @@ func TestAccSageMakerCodeRepository_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodeRepositoryBasicConfigTags1(rName, "key1", "value1"),
+				Config: testAccCodeRepositoryConfig_basicTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -144,7 +144,7 @@ func TestAccSageMakerCodeRepository_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCodeRepositoryBasicConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccCodeRepositoryConfig_basicTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -153,7 +153,7 @@ func TestAccSageMakerCodeRepository_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCodeRepositoryBasicConfigTags1(rName, "key2", "value2"),
+				Config: testAccCodeRepositoryConfig_basicTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -176,7 +176,7 @@ func TestAccSageMakerCodeRepository_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckCodeRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodeRepositoryBasicConfig(rName),
+				Config: testAccCodeRepositoryConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeRepositoryExists(resourceName, &repo),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceCodeRepository(), resourceName),
@@ -237,7 +237,7 @@ func testAccCheckCodeRepositoryExists(n string, codeRepo *sagemaker.DescribeCode
 	}
 }
 
-func testAccCodeRepositoryBasicConfig(rName string) string {
+func testAccCodeRepositoryConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
@@ -249,7 +249,7 @@ resource "aws_sagemaker_code_repository" "test" {
 `, rName)
 }
 
-func testAccCodeRepositoryGitBranchConfig(rName string) string {
+func testAccCodeRepositoryConfig_gitBranch(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
@@ -262,7 +262,7 @@ resource "aws_sagemaker_code_repository" "test" {
 `, rName)
 }
 
-func testAccCodeRepositoryGitSecretConfig(rName string) string {
+func testAccCodeRepositoryConfig_gitSecret(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = %[1]q
@@ -286,7 +286,7 @@ resource "aws_sagemaker_code_repository" "test" {
 `, rName)
 }
 
-func testAccCodeRepositoryGitSecretUpdatedConfig(rName string) string {
+func testAccCodeRepositoryConfig_gitSecretUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test2" {
   name = "%[1]s-2"
@@ -310,7 +310,7 @@ resource "aws_sagemaker_code_repository" "test" {
 `, rName)
 }
 
-func testAccCodeRepositoryBasicConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccCodeRepositoryConfig_basicTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
@@ -326,7 +326,7 @@ resource "aws_sagemaker_code_repository" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccCodeRepositoryBasicConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccCodeRepositoryConfig_basicTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q

--- a/internal/service/sagemaker/device_fleet_test.go
+++ b/internal/service/sagemaker/device_fleet_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerDeviceFleet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceFleetBasicConfig(rName),
+				Config: testAccDeviceFleetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "device_fleet_name", rName),
@@ -61,7 +61,7 @@ func TestAccSageMakerDeviceFleet_description(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceFleetDescription(rName, rName),
+				Config: testAccDeviceFleetConfig_description(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
@@ -73,7 +73,7 @@ func TestAccSageMakerDeviceFleet_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDeviceFleetDescription(rName, "test"),
+				Config: testAccDeviceFleetConfig_description(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "description", "test"),
@@ -95,7 +95,7 @@ func TestAccSageMakerDeviceFleet_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceFleetTags1Config(rName, "key1", "value1"),
+				Config: testAccDeviceFleetConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -108,7 +108,7 @@ func TestAccSageMakerDeviceFleet_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDeviceFleetTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccDeviceFleetConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -117,7 +117,7 @@ func TestAccSageMakerDeviceFleet_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDeviceFleetTags1Config(rName, "key2", "value2"),
+				Config: testAccDeviceFleetConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -140,7 +140,7 @@ func TestAccSageMakerDeviceFleet_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceFleetBasicConfig(rName),
+				Config: testAccDeviceFleetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFleetExists(resourceName, &deviceFleet),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceDeviceFleet(), resourceName),
@@ -267,7 +267,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, rName)
 }
 
-func testAccDeviceFleetBasicConfig(rName string) string {
+func testAccDeviceFleetConfig_basic(rName string) string {
 	return testAccDeviceFleetBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device_fleet" "test" {
   device_fleet_name = %[1]q
@@ -280,7 +280,7 @@ resource "aws_sagemaker_device_fleet" "test" {
 `, rName)
 }
 
-func testAccDeviceFleetDescription(rName, desc string) string {
+func testAccDeviceFleetConfig_description(rName, desc string) string {
 	return testAccDeviceFleetBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device_fleet" "test" {
   device_fleet_name = %[1]q
@@ -294,7 +294,7 @@ resource "aws_sagemaker_device_fleet" "test" {
 `, rName, desc)
 }
 
-func testAccDeviceFleetTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccDeviceFleetConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccDeviceFleetBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device_fleet" "test" {
   device_fleet_name = %[1]q
@@ -311,7 +311,7 @@ resource "aws_sagemaker_device_fleet" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDeviceFleetTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccDeviceFleetConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccDeviceFleetBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device_fleet" "test" {
   device_fleet_name = %[1]q

--- a/internal/service/sagemaker/device_test.go
+++ b/internal/service/sagemaker/device_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerDevice_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceBasicConfig(rName),
+				Config: testAccDeviceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceExists(resourceName, &device),
 					resource.TestCheckResourceAttr(resourceName, "device_fleet_name", rName),
@@ -57,7 +57,7 @@ func TestAccSageMakerDevice_description(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceDescription(rName, rName),
+				Config: testAccDeviceConfig_description(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceExists(resourceName, &device),
 					resource.TestCheckResourceAttr(resourceName, "device.0.description", rName),
@@ -69,7 +69,7 @@ func TestAccSageMakerDevice_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDeviceDescription(rName, "test"),
+				Config: testAccDeviceConfig_description(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceExists(resourceName, &device),
 					resource.TestCheckResourceAttr(resourceName, "device.0.description", "test"),
@@ -91,7 +91,7 @@ func TestAccSageMakerDevice_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceBasicConfig(rName),
+				Config: testAccDeviceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceExists(resourceName, &device),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceDevice(), resourceName),
@@ -115,7 +115,7 @@ func TestAccSageMakerDevice_disappears_fleet(t *testing.T) {
 		CheckDestroy:      testAccCheckDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeviceBasicConfig(rName),
+				Config: testAccDeviceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceExists(resourceName, &device),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceDeviceFleet(), "aws_sagemaker_device_fleet.test"),
@@ -262,7 +262,7 @@ resource "aws_sagemaker_device_fleet" "test" {
 `, rName)
 }
 
-func testAccDeviceBasicConfig(rName string) string {
+func testAccDeviceConfig_basic(rName string) string {
 	return testAccDeviceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device" "test" {
   device_fleet_name = aws_sagemaker_device_fleet.test.device_fleet_name
@@ -274,7 +274,7 @@ resource "aws_sagemaker_device" "test" {
 `, rName)
 }
 
-func testAccDeviceDescription(rName, desc string) string {
+func testAccDeviceConfig_description(rName, desc string) string {
 	return testAccDeviceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device" "test" {
   device_fleet_name = aws_sagemaker_device_fleet.test.device_fleet_name

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -29,7 +29,7 @@ func testAccDomain_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainBasicConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
@@ -67,7 +67,7 @@ func testAccDomain_kms(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainKMSConfig(rName),
+				Config: testAccDomainConfig_kms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.test", "arn"),
@@ -95,7 +95,7 @@ func testAccDomain_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainTags1Config(rName, "key1", "value1"),
+				Config: testAccDomainConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -109,7 +109,7 @@ func testAccDomain_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 			{
-				Config: testAccDomainTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccDomainConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -118,7 +118,7 @@ func testAccDomain_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainTags1Config(rName, "key2", "value2"),
+				Config: testAccDomainConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -141,7 +141,7 @@ func testAccDomain_securityGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSecurityGroup1Config(rName),
+				Config: testAccDomainConfig_securityGroup1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -155,7 +155,7 @@ func testAccDomain_securityGroup(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 			{
-				Config: testAccDomainSecurityGroup2Config(rName),
+				Config: testAccDomainConfig_securityGroup2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -178,7 +178,7 @@ func testAccDomain_sharingSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSharingSettingsConfig(rName),
+				Config: testAccDomainConfig_sharingSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -210,7 +210,7 @@ func testAccDomain_tensorboardAppSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainTensorBoardAppSettingsConfig(rName),
+				Config: testAccDomainConfig_tensorBoardAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -241,7 +241,7 @@ func testAccDomain_tensorboardAppSettingsWithImage(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainTensorBoardAppSettingsWithImageConfig(rName),
+				Config: testAccDomainConfig_tensorBoardAppSettingsImage(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -273,7 +273,7 @@ func testAccDomain_kernelGatewayAppSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainKernelGatewayAppSettingsConfig(rName),
+				Config: testAccDomainConfig_kernelGatewayAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -304,7 +304,7 @@ func testAccDomain_kernelGatewayAppSettings_lifecycleConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainKernelGatewayAppSettingsLifecycleConfig(rName),
+				Config: testAccDomainConfig_kernelGatewayAppSettingsLifecycle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -343,7 +343,7 @@ func testAccDomain_kernelGatewayAppSettings_customImage(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainKernelGatewayAppSettingsCustomImageConfig(rName, baseImage),
+				Config: testAccDomainConfig_kernelGatewayAppSettingsCustomImage(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -382,7 +382,7 @@ func testAccDomain_kernelGatewayAppSettings_defaultResourceSpecAndCustomImage(t 
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainKernelGatewayAppSettingsDefaultResourceSpecAndCustomImageConfig(rName, baseImage),
+				Config: testAccDomainConfig_kernelGatewayAppSettingsDefaultResourceSpecAndCustomImage(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -416,7 +416,7 @@ func testAccDomain_jupyterServerAppSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainJupyterServerAppSettingsConfig(rName),
+				Config: testAccDomainConfig_jupyterServerAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
@@ -447,7 +447,7 @@ func testAccDomain_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainBasicConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceDomain(), resourceName),
@@ -558,7 +558,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, rName)
 }
 
-func testAccDomainBasicConfig(rName string) string {
+func testAccDomainConfig_basic(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
@@ -577,7 +577,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainKMSConfig(rName string) string {
+func testAccDomainConfig_kms(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = "Terraform acc test"
@@ -602,7 +602,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainSecurityGroup1Config(rName string) string {
+func testAccDomainConfig_securityGroup1(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = "%[1]s"
@@ -626,7 +626,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainSecurityGroup2Config(rName string) string {
+func testAccDomainConfig_securityGroup2(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -654,7 +654,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccDomainConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
@@ -677,7 +677,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDomainTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
@@ -701,7 +701,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccDomainSharingSettingsConfig(rName string) string {
+func testAccDomainConfig_sharingSettings(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -737,7 +737,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainTensorBoardAppSettingsConfig(rName string) string {
+func testAccDomainConfig_tensorBoardAppSettings(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
@@ -762,7 +762,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainTensorBoardAppSettingsWithImageConfig(rName string) string {
+func testAccDomainConfig_tensorBoardAppSettingsImage(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q
@@ -793,7 +793,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainJupyterServerAppSettingsConfig(rName string) string {
+func testAccDomainConfig_jupyterServerAppSettings(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
@@ -818,7 +818,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainKernelGatewayAppSettingsConfig(rName string) string {
+func testAccDomainConfig_kernelGatewayAppSettings(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
@@ -843,7 +843,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainKernelGatewayAppSettingsLifecycleConfig(rName string) string {
+func testAccDomainConfig_kernelGatewayAppSettingsLifecycle(rName string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q
@@ -877,7 +877,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccDomainKernelGatewayAppSettingsCustomImageConfig(rName, baseImage string) string {
+func testAccDomainConfig_kernelGatewayAppSettingsCustomImage(rName, baseImage string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q
@@ -925,7 +925,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName, baseImage)
 }
 
-func testAccDomainKernelGatewayAppSettingsDefaultResourceSpecAndCustomImageConfig(rName, baseImage string) string {
+func testAccDomainConfig_kernelGatewayAppSettingsDefaultResourceSpecAndCustomImage(rName, baseImage string) string {
 	return testAccDomainBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -25,7 +25,7 @@ func TestAccSageMakerEndpointConfiguration_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfig_Basic(rName),
+				Config: testAccEndpointConfigurationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -60,7 +60,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeig
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName),
+				Config: testAccEndpointConfigurationConfig_productionVariantsInitialVariantWeight(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(
@@ -87,7 +87,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType(t 
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName),
+				Config: testAccEndpointConfigurationConfig_productionVariantAcceleratorType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.accelerator_type", "ml.eia1.medium"),
@@ -113,7 +113,7 @@ func TestAccSageMakerEndpointConfiguration_kmsKeyID(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfig_kmsKeyId(rName),
+				Config: testAccEndpointConfigurationConfig_kmsKeyID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", "aws_kms_key.test", "arn"),
@@ -139,7 +139,7 @@ func TestAccSageMakerEndpointConfiguration_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfigTags1(rName, "key1", "value1"),
+				Config: testAccEndpointConfigurationConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -152,7 +152,7 @@ func TestAccSageMakerEndpointConfiguration_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEndpointConfigurationConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccEndpointConfigurationConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -161,7 +161,7 @@ func TestAccSageMakerEndpointConfiguration_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEndpointConfigurationConfigTags1(rName, "key2", "value2"),
+				Config: testAccEndpointConfigurationConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -183,7 +183,7 @@ func TestAccSageMakerEndpointConfiguration_dataCapture(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationDataCaptureConfig(rName),
+				Config: testAccEndpointConfigurationConfig_dataCapture(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.#", "1"),
@@ -216,7 +216,7 @@ func TestAccSageMakerEndpointConfiguration_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfig_Basic(rName),
+				Config: testAccEndpointConfigurationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceEndpointConfiguration(), resourceName),
@@ -239,7 +239,7 @@ func TestAccSageMakerEndpointConfiguration_async(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfigAsyncConfig(rName),
+				Config: testAccEndpointConfigurationConfig_async(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -271,7 +271,7 @@ func TestAccSageMakerEndpointConfiguration_async_kms(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfigAsyncKMSConfig(rName),
+				Config: testAccEndpointConfigurationConfig_asyncKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -303,7 +303,7 @@ func TestAccSageMakerEndpointConfiguration_Async_notif(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfigAsyncNotifConfig(rName),
+				Config: testAccEndpointConfigurationConfig_asyncNotif(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -336,7 +336,7 @@ func TestAccSageMakerEndpointConfiguration_Async_client(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigurationConfigAsyncClientConfig(rName),
+				Config: testAccEndpointConfigurationConfig_asyncClient(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -436,7 +436,7 @@ data "aws_iam_policy_document" "assume_role" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfig_Basic(rName string) string {
+func testAccEndpointConfigurationConfig_basic(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %q
@@ -452,7 +452,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName string) string {
+func testAccEndpointConfigurationConfig_productionVariantsInitialVariantWeight(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %q
@@ -475,7 +475,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName string) string {
+func testAccEndpointConfigurationConfig_productionVariantAcceleratorType(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %q
@@ -492,7 +492,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfig_kmsKeyId(rName string) string {
+func testAccEndpointConfigurationConfig_kmsKeyID(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name        = %[1]q
@@ -514,7 +514,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccEndpointConfigurationConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
@@ -534,7 +534,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccEndpointConfigurationConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccEndpointConfigurationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
@@ -555,7 +555,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccEndpointConfigurationDataCaptureConfig(rName string) string {
+func testAccEndpointConfigurationConfig_dataCapture(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -599,7 +599,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfigAsyncKMSConfig(rName string) string {
+func testAccEndpointConfigurationConfig_asyncKMS(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -637,7 +637,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfigAsyncConfig(rName string) string {
+func testAccEndpointConfigurationConfig_async(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -665,7 +665,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfigAsyncNotifConfig(rName string) string {
+func testAccEndpointConfigurationConfig_asyncNotif(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -712,7 +712,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigurationConfigAsyncClientConfig(rName string) string {
+func testAccEndpointConfigurationConfig_asyncClient(rName string) string {
 	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -25,7 +25,7 @@ func TestAccSageMakerEndpoint_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig(rName),
+				Config: testAccEndpointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -62,14 +62,14 @@ func TestAccSageMakerEndpoint_endpointName(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig(rName),
+				Config: testAccEndpointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName1, "name"),
 				),
 			},
 			{
-				Config: testAccEndpointConfigEndpointConfigNameUpdate(rName),
+				Config: testAccEndpointConfig_nameUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName2, "name"),
@@ -99,7 +99,7 @@ func TestAccSageMakerEndpoint_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfigTags(rName),
+				Config: testAccEndpointConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -107,7 +107,7 @@ func TestAccSageMakerEndpoint_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEndpointConfigTagsUpdate(rName),
+				Config: testAccEndpointConfig_tagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -138,7 +138,7 @@ func TestAccSageMakerEndpoint_deploymentConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointDeploymentBasicConfig(rName, "ALL_AT_ONCE", 60),
+				Config: testAccEndpointConfig_deploymentBasic(rName, "ALL_AT_ONCE", 60),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -178,7 +178,7 @@ func TestAccSageMakerEndpoint_deploymentConfig_full(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointDeploymentFullConfig(rName),
+				Config: testAccEndpointConfig_deploymentFull(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -217,7 +217,7 @@ func TestAccSageMakerEndpoint_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig(rName),
+				Config: testAccEndpointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceEndpoint(), resourceName),
@@ -365,7 +365,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccEndpointConfig(rName string) string {
+func testAccEndpointConfig_basic(rName string) string {
 	return testAccEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
@@ -374,7 +374,7 @@ resource "aws_sagemaker_endpoint" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigEndpointConfigNameUpdate(rName string) string {
+func testAccEndpointConfig_nameUpdate(rName string) string {
 	return testAccEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test2" {
   name = "%[1]s2"
@@ -395,7 +395,7 @@ resource "aws_sagemaker_endpoint" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigTags(rName string) string {
+func testAccEndpointConfig_tags(rName string) string {
 	return testAccEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
@@ -408,7 +408,7 @@ resource "aws_sagemaker_endpoint" "test" {
 `, rName)
 }
 
-func testAccEndpointConfigTagsUpdate(rName string) string {
+func testAccEndpointConfig_tagsUpdate(rName string) string {
 	return testAccEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
@@ -421,7 +421,7 @@ resource "aws_sagemaker_endpoint" "test" {
 `, rName)
 }
 
-func testAccEndpointDeploymentBasicConfig(rName, tType string, wait int) string {
+func testAccEndpointConfig_deploymentBasic(rName, tType string, wait int) string {
 	return testAccEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
@@ -439,7 +439,7 @@ resource "aws_sagemaker_endpoint" "test" {
 `, rName, tType, wait)
 }
 
-func testAccEndpointDeploymentFullConfig(rName string) string {
+func testAccEndpointConfig_deploymentFull(rName string) string {
 	return testAccEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = %[1]q

--- a/internal/service/sagemaker/feature_group_test.go
+++ b/internal/service/sagemaker/feature_group_test.go
@@ -48,7 +48,7 @@ func testAccFeatureGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupBasicConfig(rName),
+				Config: testAccFeatureGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -84,7 +84,7 @@ func testAccFeatureGroup_description(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupDescriptionConfig(rName),
+				Config: testAccFeatureGroupConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -112,7 +112,7 @@ func testAccFeatureGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupTags1(rName, "key1", "value1"),
+				Config: testAccFeatureGroupConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -126,7 +126,7 @@ func testAccFeatureGroup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFeatureGroupTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccFeatureGroupConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -136,7 +136,7 @@ func testAccFeatureGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFeatureGroupTags1(rName, "key2", "value2"),
+				Config: testAccFeatureGroupConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -160,7 +160,7 @@ func testAccFeatureGroup_multipleFeatures(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupMultiFeatureConfig(rName),
+				Config: testAccFeatureGroupConfig_multi(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -192,7 +192,7 @@ func testAccFeatureGroup_onlineConfigSecurityConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupOnlineSecurityConfig(rName),
+				Config: testAccFeatureGroupConfig_onlineSecurity(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -223,7 +223,7 @@ func testAccFeatureGroup_offlineConfig_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupOfflineBasicConfig(rName),
+				Config: testAccFeatureGroupConfig_offlineBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -255,7 +255,7 @@ func testAccFeatureGroup_offlineConfig_createCatalog(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupOfflineCreateGlueCatalogConfig(rName),
+				Config: testAccFeatureGroupConfig_offlineCreateGlueCatalog(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -291,7 +291,7 @@ func TestAccSageMakerFeatureGroup_Offline_providedCatalog(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupOfflineCreateGlueCatalogProvidedCatalogConfig(rName),
+				Config: testAccFeatureGroupConfig_offlineCreateGlueCatalogProvidedCatalog(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					resource.TestCheckResourceAttr(resourceName, "feature_group_name", rName),
@@ -326,7 +326,7 @@ func TestAccSageMakerFeatureGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckFeatureGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFeatureGroupBasicConfig(rName),
+				Config: testAccFeatureGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureGroupExists(resourceName, &featureGroup),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceFeatureGroup(), resourceName),
@@ -444,7 +444,7 @@ resource "aws_iam_policy" "test" {
 `, rName)
 }
 
-func testAccFeatureGroupBasicConfig(rName string) string {
+func testAccFeatureGroupConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
@@ -464,7 +464,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupDescriptionConfig(rName string) string {
+func testAccFeatureGroupConfig_description(rName string) string {
 	return acctest.ConfigCompose(testAccFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
@@ -485,7 +485,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupMultiFeatureConfig(rName string) string {
+func testAccFeatureGroupConfig_multi(rName string) string {
 	return acctest.ConfigCompose(testAccFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
@@ -510,7 +510,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupOnlineSecurityConfig(rName string) string {
+func testAccFeatureGroupConfig_onlineSecurity(rName string) string {
 	return acctest.ConfigCompose(testAccFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -539,7 +539,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupOfflineBasicConfig(rName string) string {
+func testAccFeatureGroupConfig_offlineBasic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccFeatureGroupBaseConfig(rName),
 		testAccFeatureGroupOfflineBaseConfig(rName),
@@ -568,7 +568,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupOfflineCreateGlueCatalogConfig(rName string) string {
+func testAccFeatureGroupConfig_offlineCreateGlueCatalog(rName string) string {
 	return acctest.ConfigCompose(
 		testAccFeatureGroupBaseConfig(rName),
 		testAccFeatureGroupOfflineBaseConfig(rName),
@@ -597,7 +597,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupOfflineCreateGlueCatalogProvidedCatalogConfig(rName string) string {
+func testAccFeatureGroupConfig_offlineCreateGlueCatalogProvidedCatalog(rName string) string {
 	return acctest.ConfigCompose(
 		testAccFeatureGroupBaseConfig(rName),
 		testAccFeatureGroupOfflineBaseConfig(rName),
@@ -641,7 +641,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName))
 }
 
-func testAccFeatureGroupTags1(rName, tag1Key, tag1Value string) string {
+func testAccFeatureGroupConfig_tags1(rName, tag1Key, tag1Value string) string {
 	return acctest.ConfigCompose(testAccFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
@@ -665,7 +665,7 @@ resource "aws_sagemaker_feature_group" "test" {
 `, rName, tag1Key, tag1Value))
 }
 
-func testAccFeatureGroupTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccFeatureGroupConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return acctest.ConfigCompose(testAccFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q

--- a/internal/service/sagemaker/flow_definition_test.go
+++ b/internal/service/sagemaker/flow_definition_test.go
@@ -26,7 +26,7 @@ func testAccFlowDefinition_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowDefinitionBasicConfig(rName),
+				Config: testAccFlowDefinitionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					resource.TestCheckResourceAttr(resourceName, "flow_definition_name", rName),
@@ -68,7 +68,7 @@ func testAccFlowDefinition_humanLoopConfig_publicWorkforce(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowDefinitionPublicWorkforceConfig(rName),
+				Config: testAccFlowDefinitionConfig_publicWorkforce(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					resource.TestCheckResourceAttr(resourceName, "flow_definition_name", rName),
@@ -100,7 +100,7 @@ func testAccFlowDefinition_humanLoopRequestSource(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowDefinitionHumanLoopRequestSourceConfig(rName),
+				Config: testAccFlowDefinitionConfig_humanLoopRequestSource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					resource.TestCheckResourceAttr(resourceName, "flow_definition_name", rName),
@@ -132,7 +132,7 @@ func testAccFlowDefinition_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowDefinitionTags1Config(rName, "key1", "value1"),
+				Config: testAccFlowDefinitionConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -145,7 +145,7 @@ func testAccFlowDefinition_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFlowDefinitionTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccFlowDefinitionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -154,7 +154,7 @@ func testAccFlowDefinition_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFlowDefinitionTags1Config(rName, "key2", "value2"),
+				Config: testAccFlowDefinitionConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -177,7 +177,7 @@ func testAccFlowDefinition_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckFlowDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowDefinitionBasicConfig(rName),
+				Config: testAccFlowDefinitionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowDefinitionExists(resourceName, &flowDefinition),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceFlowDefinition(), resourceName),
@@ -308,9 +308,9 @@ EOF
 `, rName)
 }
 
-func testAccFlowDefinitionBasicConfig(rName string) string {
+func testAccFlowDefinitionConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccFlowDefinitionBaseConfig(rName),
-		testAccWorkteamCognitoConfig(rName),
+		testAccWorkteamConfig_cognito(rName),
 		fmt.Sprintf(`
 resource "aws_sagemaker_flow_definition" "test" {
   flow_definition_name = %[1]q
@@ -332,7 +332,7 @@ resource "aws_sagemaker_flow_definition" "test" {
 `, rName))
 }
 
-func testAccFlowDefinitionPublicWorkforceConfig(rName string) string {
+func testAccFlowDefinitionConfig_publicWorkforce(rName string) string {
 	return acctest.ConfigCompose(testAccFlowDefinitionBaseConfig(rName),
 		fmt.Sprintf(`
 data "aws_region" "current" {}
@@ -366,9 +366,9 @@ resource "aws_sagemaker_flow_definition" "test" {
 `, rName))
 }
 
-func testAccFlowDefinitionHumanLoopRequestSourceConfig(rName string) string {
+func testAccFlowDefinitionConfig_humanLoopRequestSource(rName string) string {
 	return acctest.ConfigCompose(testAccFlowDefinitionBaseConfig(rName),
-		testAccWorkteamCognitoConfig(rName),
+		testAccWorkteamConfig_cognito(rName),
 		fmt.Sprintf(`
 resource "aws_sagemaker_flow_definition" "test" {
   flow_definition_name = %[1]q
@@ -411,9 +411,9 @@ resource "aws_sagemaker_flow_definition" "test" {
 `, rName))
 }
 
-func testAccFlowDefinitionTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccFlowDefinitionConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccFlowDefinitionBaseConfig(rName),
-		testAccWorkteamCognitoConfig(rName),
+		testAccWorkteamConfig_cognito(rName),
 		fmt.Sprintf(`
 resource "aws_sagemaker_flow_definition" "test" {
   flow_definition_name = %[1]q
@@ -439,9 +439,9 @@ resource "aws_sagemaker_flow_definition" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccFlowDefinitionTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccFlowDefinitionConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccFlowDefinitionBaseConfig(rName),
-		testAccWorkteamCognitoConfig(rName),
+		testAccWorkteamConfig_cognito(rName),
 		fmt.Sprintf(`
 resource "aws_sagemaker_flow_definition" "test" {
   flow_definition_name = %[1]q

--- a/internal/service/sagemaker/human_task_ui_test.go
+++ b/internal/service/sagemaker/human_task_ui_test.go
@@ -26,7 +26,7 @@ func TestAccSageMakerHumanTaskUI_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckHumanTaskUIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHumanTaskUICognitoBasicConfig(rName),
+				Config: testAccHumanTaskUIConfig_cognitoBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHumanTaskUIExists(resourceName, &humanTaskUi),
 					resource.TestCheckResourceAttr(resourceName, "human_task_ui_name", rName),
@@ -57,7 +57,7 @@ func TestAccSageMakerHumanTaskUI_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckHumanTaskUIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHumanTaskUITags1Config(rName, "key1", "value1"),
+				Config: testAccHumanTaskUIConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHumanTaskUIExists(resourceName, &humanTaskUi),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -71,7 +71,7 @@ func TestAccSageMakerHumanTaskUI_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ui_template.0.content", "ui_template.0.url"},
 			},
 			{
-				Config: testAccHumanTaskUITags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccHumanTaskUIConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHumanTaskUIExists(resourceName, &humanTaskUi),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -80,7 +80,7 @@ func TestAccSageMakerHumanTaskUI_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccHumanTaskUITags1Config(rName, "key2", "value2"),
+				Config: testAccHumanTaskUIConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHumanTaskUIExists(resourceName, &humanTaskUi),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -103,7 +103,7 @@ func TestAccSageMakerHumanTaskUI_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckHumanTaskUIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHumanTaskUICognitoBasicConfig(rName),
+				Config: testAccHumanTaskUIConfig_cognitoBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHumanTaskUIExists(resourceName, &humanTaskUi),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceHumanTaskUI(), resourceName),
@@ -163,7 +163,7 @@ func testAccCheckHumanTaskUIExists(n string, humanTaskUi *sagemaker.DescribeHuma
 	}
 }
 
-func testAccHumanTaskUICognitoBasicConfig(rName string) string {
+func testAccHumanTaskUIConfig_cognitoBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_human_task_ui" "test" {
   human_task_ui_name = %[1]q
@@ -175,7 +175,7 @@ resource "aws_sagemaker_human_task_ui" "test" {
 `, rName)
 }
 
-func testAccHumanTaskUITags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccHumanTaskUIConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_human_task_ui" "test" {
   human_task_ui_name = %[1]q
@@ -191,7 +191,7 @@ resource "aws_sagemaker_human_task_ui" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccHumanTaskUITags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccHumanTaskUIConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_human_task_ui" "test" {
   human_task_ui_name = %[1]q

--- a/internal/service/sagemaker/image_test.go
+++ b/internal/service/sagemaker/image_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerImage_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageBasicConfig(rName),
+				Config: testAccImageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
@@ -57,7 +57,7 @@ func TestAccSageMakerImage_description(t *testing.T) {
 		CheckDestroy:      testAccCheckImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageDescription(rName),
+				Config: testAccImageConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
@@ -69,14 +69,14 @@ func TestAccSageMakerImage_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccImageBasicConfig(rName),
+				Config: testAccImageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 			{
-				Config: testAccImageDescription(rName),
+				Config: testAccImageConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
@@ -98,7 +98,7 @@ func TestAccSageMakerImage_displayName(t *testing.T) {
 		CheckDestroy:      testAccCheckImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageDisplayName(rName),
+				Config: testAccImageConfig_displayName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "display_name", rName),
@@ -110,14 +110,14 @@ func TestAccSageMakerImage_displayName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccImageBasicConfig(rName),
+				Config: testAccImageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "display_name", ""),
 				),
 			},
 			{
-				Config: testAccImageDisplayName(rName),
+				Config: testAccImageConfig_displayName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "display_name", rName),
@@ -139,7 +139,7 @@ func TestAccSageMakerImage_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageTags1Config(rName, "key1", "value1"),
+				Config: testAccImageConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -152,7 +152,7 @@ func TestAccSageMakerImage_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccImageTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccImageConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -161,7 +161,7 @@ func TestAccSageMakerImage_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccImageTags1Config(rName, "key2", "value2"),
+				Config: testAccImageConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -184,7 +184,7 @@ func TestAccSageMakerImage_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageBasicConfig(rName),
+				Config: testAccImageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageExists(resourceName, &image),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceImage(), resourceName),
@@ -266,7 +266,7 @@ data "aws_iam_policy_document" "test" {
 `, rName)
 }
 
-func testAccImageBasicConfig(rName string) string {
+func testAccImageConfig_basic(rName string) string {
 	return testAccImageBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q
@@ -275,7 +275,7 @@ resource "aws_sagemaker_image" "test" {
 `, rName)
 }
 
-func testAccImageDescription(rName string) string {
+func testAccImageConfig_description(rName string) string {
 	return testAccImageBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name  = %[1]q
@@ -285,7 +285,7 @@ resource "aws_sagemaker_image" "test" {
 `, rName)
 }
 
-func testAccImageDisplayName(rName string) string {
+func testAccImageConfig_displayName(rName string) string {
 	return testAccImageBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name   = %[1]q
@@ -295,7 +295,7 @@ resource "aws_sagemaker_image" "test" {
 `, rName)
 }
 
-func testAccImageTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccImageConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccImageBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q
@@ -308,7 +308,7 @@ resource "aws_sagemaker_image" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccImageTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccImageConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccImageBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q

--- a/internal/service/sagemaker/image_version_test.go
+++ b/internal/service/sagemaker/image_version_test.go
@@ -34,7 +34,7 @@ func TestAccSageMakerImageVersion_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckImageVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageVersionBasicConfig(rName, baseImage),
+				Config: testAccImageVersionConfig_basic(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageVersionExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
@@ -72,7 +72,7 @@ func TestAccSageMakerImageVersion_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckImageVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageVersionBasicConfig(rName, baseImage),
+				Config: testAccImageVersionConfig_basic(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageVersionExists(resourceName, &image),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceImageVersion(), resourceName),
@@ -101,7 +101,7 @@ func TestAccSageMakerImageVersion_Disappears_image(t *testing.T) {
 		CheckDestroy:      testAccCheckImageVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageVersionBasicConfig(rName, baseImage),
+				Config: testAccImageVersionConfig_basic(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageVersionExists(resourceName, &image),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceImage(), "aws_sagemaker_image.test"),
@@ -161,7 +161,7 @@ func testAccCheckImageVersionExists(n string, image *sagemaker.DescribeImageVers
 	}
 }
 
-func testAccImageVersionBasicConfig(rName, baseImage string) string {
+func testAccImageVersionConfig_basic(rName, baseImage string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/sagemaker/model_package_group_policy_test.go
+++ b/internal/service/sagemaker/model_package_group_policy_test.go
@@ -26,7 +26,7 @@ func TestAccSageMakerModelPackageGroupPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckModelPackageGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupPolicyBasicConfig(rName),
+				Config: testAccModelPackageGroupPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupPolicyExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "model_package_group_name", rName),
@@ -53,7 +53,7 @@ func TestAccSageMakerModelPackageGroupPolicy_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckModelPackageGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupPolicyBasicConfig(rName),
+				Config: testAccModelPackageGroupPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupPolicyExists(resourceName, &mpg),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceModelPackageGroupPolicy(), resourceName),
@@ -77,7 +77,7 @@ func TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup(t *tes
 		CheckDestroy:      testAccCheckModelPackageGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupPolicyBasicConfig(rName),
+				Config: testAccModelPackageGroupPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupPolicyExists(resourceName, &mpg),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceModelPackageGroup(), "aws_sagemaker_model_package_group.test"),
@@ -133,7 +133,7 @@ func testAccCheckModelPackageGroupPolicyExists(n string, mpg *sagemaker.GetModel
 	}
 }
 
-func testAccModelPackageGroupPolicyBasicConfig(rName string) string {
+func testAccModelPackageGroupPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}

--- a/internal/service/sagemaker/model_package_group_test.go
+++ b/internal/service/sagemaker/model_package_group_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerModelPackageGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckModelPackageGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupBasicConfig(rName),
+				Config: testAccModelPackageGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "model_package_group_name", rName),
@@ -56,7 +56,7 @@ func TestAccSageMakerModelPackageGroup_description(t *testing.T) {
 		CheckDestroy:      testAccCheckModelPackageGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupDescription(rName),
+				Config: testAccModelPackageGroupConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "model_package_group_description", rName),
@@ -83,7 +83,7 @@ func TestAccSageMakerModelPackageGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckModelPackageGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupTags1Config(rName, "key1", "value1"),
+				Config: testAccModelPackageGroupConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -96,7 +96,7 @@ func TestAccSageMakerModelPackageGroup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccModelPackageGroupTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccModelPackageGroupConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -105,7 +105,7 @@ func TestAccSageMakerModelPackageGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccModelPackageGroupTags1Config(rName, "key2", "value2"),
+				Config: testAccModelPackageGroupConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -128,7 +128,7 @@ func TestAccSageMakerModelPackageGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckModelPackageGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelPackageGroupBasicConfig(rName),
+				Config: testAccModelPackageGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelPackageGroupExists(resourceName, &mpg),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceModelPackageGroup(), resourceName),
@@ -188,7 +188,7 @@ func testAccCheckModelPackageGroupExists(n string, mpg *sagemaker.DescribeModelP
 	}
 }
 
-func testAccModelPackageGroupBasicConfig(rName string) string {
+func testAccModelPackageGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model_package_group" "test" {
   model_package_group_name = %[1]q
@@ -196,7 +196,7 @@ resource "aws_sagemaker_model_package_group" "test" {
 `, rName)
 }
 
-func testAccModelPackageGroupDescription(rName string) string {
+func testAccModelPackageGroupConfig_description(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model_package_group" "test" {
   model_package_group_name        = %[1]q
@@ -205,7 +205,7 @@ resource "aws_sagemaker_model_package_group" "test" {
 `, rName)
 }
 
-func testAccModelPackageGroupTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccModelPackageGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model_package_group" "test" {
   model_package_group_name = %[1]q
@@ -217,7 +217,7 @@ resource "aws_sagemaker_model_package_group" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccModelPackageGroupTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccModelPackageGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model_package_group" "test" {
   model_package_group_name = %[1]q

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -26,7 +26,7 @@ func TestAccSageMakerModel_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelConfig(rName),
+				Config: testAccModelConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -61,7 +61,7 @@ func TestAccSageMakerModel_inferenceExecution(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelInferenceExecutionConfig(rName),
+				Config: testAccModelConfig_inferenceExecution(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "inference_execution_config.#", "1"),
@@ -88,7 +88,7 @@ func TestAccSageMakerModel_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelConfigTags1(rName, "key1", "value1"),
+				Config: testAccModelConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -96,7 +96,7 @@ func TestAccSageMakerModel_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccModelConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccModelConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -105,7 +105,7 @@ func TestAccSageMakerModel_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccModelConfigTags1(rName, "key2", "value2"),
+				Config: testAccModelConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -132,7 +132,7 @@ func TestAccSageMakerModel_primaryContainerModelDataURL(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrimaryContainerModelDataURLConfig(rName),
+				Config: testAccModelConfig_primaryContainerDataURL(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "primary_container.0.model_data_url"),
@@ -158,7 +158,7 @@ func TestAccSageMakerModel_primaryContainerHostname(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrimaryContainerHostnameConfig(rName),
+				Config: testAccModelConfig_primaryContainerHostname(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.container_hostname", "test"),
@@ -184,7 +184,7 @@ func TestAccSageMakerModel_primaryContainerImage(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrimaryContainerImageConfigConfig(rName),
+				Config: testAccModelConfig_primaryContainerImage(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image_config.#", "1"),
@@ -211,7 +211,7 @@ func TestAccSageMakerModel_primaryContainerEnvironment(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrimaryContainerEnvironmentConfig(rName),
+				Config: testAccModelConfig_primaryContainerEnvironment(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.%", "1"),
@@ -238,7 +238,7 @@ func TestAccSageMakerModel_primaryContainerModeSingle(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrimaryContainerModeSingle(rName),
+				Config: testAccModelConfig_primaryContainerModeSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.mode", "SingleModel"),
@@ -264,7 +264,7 @@ func TestAccSageMakerModel_containers(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelContainers(rName),
+				Config: testAccModelConfig_containers(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "container.#", "2"),
@@ -292,7 +292,7 @@ func TestAccSageMakerModel_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelVPCConfig_basic(rName),
+				Config: testAccModelConfig_vpcBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
@@ -320,7 +320,7 @@ func TestAccSageMakerModel_networkIsolation(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelNetworkIsolation(rName),
+				Config: testAccModelConfig_networkIsolation(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable_network_isolation", "true"),
@@ -346,7 +346,7 @@ func TestAccSageMakerModel_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccModelConfig(rName),
+				Config: testAccModelConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckModelExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceModel(), resourceName),
@@ -437,7 +437,7 @@ data "aws_sagemaker_prebuilt_ecr_image" "test" {
 `, rName)
 }
 
-func testAccModelConfig(rName string) string {
+func testAccModelConfig_basic(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -450,7 +450,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccModelInferenceExecutionConfig(rName string) string {
+func testAccModelConfig_inferenceExecution(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -471,7 +471,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccModelConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccModelConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -488,7 +488,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccModelConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccModelConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -506,7 +506,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccPrimaryContainerModelDataURLConfig(rName string) string {
+func testAccModelConfig_primaryContainerDataURL(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -581,7 +581,7 @@ resource "aws_s3_object" "test" {
 `, rName)
 }
 
-func testAccPrimaryContainerHostnameConfig(rName string) string {
+func testAccModelConfig_primaryContainerHostname(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -595,7 +595,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccPrimaryContainerImageConfigConfig(rName string) string {
+func testAccModelConfig_primaryContainerImage(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -612,7 +612,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccPrimaryContainerEnvironmentConfig(rName string) string {
+func testAccModelConfig_primaryContainerEnvironment(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -629,7 +629,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccPrimaryContainerModeSingle(rName string) string {
+func testAccModelConfig_primaryContainerModeSingle(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -643,7 +643,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccModelContainers(rName string) string {
+func testAccModelConfig_containers(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
@@ -660,7 +660,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccModelNetworkIsolation(rName string) string {
+func testAccModelConfig_networkIsolation(rName string) string {
 	return testAccModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name                     = %[1]q
@@ -674,7 +674,7 @@ resource "aws_sagemaker_model" "test" {
 `, rName)
 }
 
-func testAccModelVPCConfig_basic(rName string) string {
+func testAccModelConfig_vpcBasic(rName string) string {
 	return testAccModelConfigBase(rName) +
 		acctest.ConfigAvailableAZsNoOptIn() +
 		fmt.Sprintf(`

--- a/internal/service/sagemaker/notebook_instance_lifecycle_configuration_test.go
+++ b/internal/service/sagemaker/notebook_instance_lifecycle_configuration_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerNotebookInstanceLifecycleConfiguration_basic(t *testing.T) 
 		CheckDestroy:      testAccCheckNotebookInstanceLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceLifecycleConfigurationConfig_Basic(rName),
+				Config: testAccNotebookInstanceLifecycleConfigurationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceLifecycleConfigurationExists(resourceName, &lifecycleConfig),
 
@@ -58,7 +58,7 @@ func TestAccSageMakerNotebookInstanceLifecycleConfiguration_update(t *testing.T)
 		CheckDestroy:      testAccCheckNotebookInstanceLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceLifecycleConfigurationConfig_Basic(rName),
+				Config: testAccNotebookInstanceLifecycleConfigurationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceLifecycleConfigurationExists(resourceName, &lifecycleConfig),
 
@@ -66,7 +66,7 @@ func TestAccSageMakerNotebookInstanceLifecycleConfiguration_update(t *testing.T)
 				),
 			},
 			{
-				Config: testAccNotebookInstanceLifecycleConfigurationConfig_Update(rName),
+				Config: testAccNotebookInstanceLifecycleConfigurationConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceLifecycleConfigurationExists(resourceName, &lifecycleConfig),
 
@@ -138,7 +138,7 @@ func testAccCheckNotebookInstanceLifecycleConfigurationDestroy(s *terraform.Stat
 	return nil
 }
 
-func testAccNotebookInstanceLifecycleConfigurationConfig_Basic(rName string) string {
+func testAccNotebookInstanceLifecycleConfigurationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
   name = %q
@@ -146,7 +146,7 @@ resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
 `, rName)
 }
 
-func testAccNotebookInstanceLifecycleConfigurationConfig_Update(rName string) string {
+func testAccNotebookInstanceLifecycleConfigurationConfig_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
   name      = %q

--- a/internal/service/sagemaker/notebook_instance_test.go
+++ b/internal/service/sagemaker/notebook_instance_test.go
@@ -33,7 +33,7 @@ func TestAccSageMakerNotebookInstance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -75,7 +75,7 @@ func TestAccSageMakerNotebookInstance_update(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
@@ -83,7 +83,7 @@ func TestAccSageMakerNotebookInstance_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccNotebookInstanceUpdateConfig(rName),
+				Config: testAccNotebookInstanceConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.m4.xlarge"),
@@ -113,14 +113,14 @@ func TestAccSageMakerNotebookInstance_volumeSize(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook1),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "5"),
 				),
 			},
 			{
-				Config: testAccNotebookInstanceVolumeConfig(rName),
+				Config: testAccNotebookInstanceConfig_volume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook2),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "8"),
@@ -133,7 +133,7 @@ func TestAccSageMakerNotebookInstance_volumeSize(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook3),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "5"),
@@ -161,7 +161,7 @@ func TestAccSageMakerNotebookInstance_lifecycleName(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceLifecycleNameConfig(rName),
+				Config: testAccNotebookInstanceConfig_lifecycleName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttrPair(resourceName, "lifecycle_config_name", sagemakerLifecycleConfigResourceName, "name"),
@@ -173,14 +173,14 @@ func TestAccSageMakerNotebookInstance_lifecycleName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_config_name", ""),
 				),
 			},
 			{
-				Config: testAccNotebookInstanceLifecycleNameConfig(rName),
+				Config: testAccNotebookInstanceConfig_lifecycleName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttrPair(resourceName, "lifecycle_config_name", sagemakerLifecycleConfigResourceName, "name"),
@@ -206,7 +206,7 @@ func TestAccSageMakerNotebookInstance_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceTags1Config(rName, "key1", "value1"),
+				Config: testAccNotebookInstanceConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -219,7 +219,7 @@ func TestAccSageMakerNotebookInstance_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccNotebookInstanceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -228,7 +228,7 @@ func TestAccSageMakerNotebookInstance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNotebookInstanceTags1Config(rName, "key2", "value2"),
+				Config: testAccNotebookInstanceConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -255,7 +255,7 @@ func TestAccSageMakerNotebookInstance_kms(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceKMSConfig(rName),
+				Config: testAccNotebookInstanceConfig_kms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.test", "id"),
@@ -286,7 +286,7 @@ func TestAccSageMakerNotebookInstance_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceNotebookInstance(), resourceName),
@@ -388,7 +388,7 @@ func TestAccSageMakerNotebookInstance_Root_access(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceRootAccessConfig(rName, "Disabled"),
+				Config: testAccNotebookInstanceConfig_rootAccess(rName, "Disabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "root_access", "Disabled"),
@@ -400,7 +400,7 @@ func TestAccSageMakerNotebookInstance_Root_access(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceRootAccessConfig(rName, "Enabled"),
+				Config: testAccNotebookInstanceConfig_rootAccess(rName, "Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "root_access", "Enabled"),
@@ -426,7 +426,7 @@ func TestAccSageMakerNotebookInstance_Platform_identifier(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstancePlatformIdentifierConfig(rName, "notebook-al2-v1"),
+				Config: testAccNotebookInstanceConfig_platformIdentifier(rName, "notebook-al2-v1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "platform_identifier", "notebook-al2-v1"),
@@ -438,7 +438,7 @@ func TestAccSageMakerNotebookInstance_Platform_identifier(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstancePlatformIdentifierConfig(rName, "notebook-al1-v1"),
+				Config: testAccNotebookInstanceConfig_platformIdentifier(rName, "notebook-al1-v1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "platform_identifier", "notebook-al1-v1"),
@@ -464,7 +464,7 @@ func TestAccSageMakerNotebookInstance_DirectInternet_access(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceDirectInternetAccessConfig(rName, "Disabled"),
+				Config: testAccNotebookInstanceConfig_directInternetAccess(rName, "Disabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Disabled"),
@@ -479,7 +479,7 @@ func TestAccSageMakerNotebookInstance_DirectInternet_access(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceDirectInternetAccessConfig(rName, "Enabled"),
+				Config: testAccNotebookInstanceConfig_directInternetAccess(rName, "Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
@@ -507,7 +507,7 @@ func TestAccSageMakerNotebookInstance_DefaultCode_repository(t *testing.T) {
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceDefaultCodeRepositoryConfig(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
+				Config: testAccNotebookInstanceConfig_defaultCodeRepository(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "default_code_repository", "https://github.com/hashicorp/terraform-provider-aws.git"),
@@ -519,14 +519,14 @@ func TestAccSageMakerNotebookInstance_DefaultCode_repository(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "default_code_repository", ""),
 				),
 			},
 			{
-				Config: testAccNotebookInstanceDefaultCodeRepositoryConfig(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
+				Config: testAccNotebookInstanceConfig_defaultCodeRepository(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "default_code_repository", "https://github.com/hashicorp/terraform-provider-aws.git"),
@@ -551,7 +551,7 @@ func TestAccSageMakerNotebookInstance_AdditionalCode_repositories(t *testing.T) 
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceAdditionalCodeRepository1Config(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
+				Config: testAccNotebookInstanceConfig_additionalCodeRepository1(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "additional_code_repositories.#", "1"),
@@ -564,14 +564,14 @@ func TestAccSageMakerNotebookInstance_AdditionalCode_repositories(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "additional_code_repositories.#", "0"),
 				),
 			},
 			{
-				Config: testAccNotebookInstanceAdditionalCodeRepository2Config(rName, "https://github.com/hashicorp/terraform-provider-aws.git", "https://github.com/hashicorp/terraform.git"),
+				Config: testAccNotebookInstanceConfig_additionalCodeRepository2(rName, "https://github.com/hashicorp/terraform-provider-aws.git", "https://github.com/hashicorp/terraform.git"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "additional_code_repositories.#", "2"),
@@ -580,7 +580,7 @@ func TestAccSageMakerNotebookInstance_AdditionalCode_repositories(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccNotebookInstanceAdditionalCodeRepository1Config(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
+				Config: testAccNotebookInstanceConfig_additionalCodeRepository1(rName, "https://github.com/hashicorp/terraform-provider-aws.git"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "additional_code_repositories.#", "1"),
@@ -606,7 +606,7 @@ func TestAccSageMakerNotebookInstance_DefaultCodeRepository_sageMakerRepo(t *tes
 		CheckDestroy:      testAccCheckNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebookInstanceDefaultCodeRepositoryRepoConfig(rName),
+				Config: testAccNotebookInstanceConfig_defaultCodeRepositoryRepo(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttrPair(resourceName, "default_code_repository", "aws_sagemaker_code_repository.test", "code_repository_name"),
@@ -618,14 +618,14 @@ func TestAccSageMakerNotebookInstance_DefaultCodeRepository_sageMakerRepo(t *tes
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNotebookInstanceBasicConfig(rName),
+				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "default_code_repository", ""),
 				),
 			},
 			{
-				Config: testAccNotebookInstanceDefaultCodeRepositoryRepoConfig(rName),
+				Config: testAccNotebookInstanceConfig_defaultCodeRepositoryRepo(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttrPair(resourceName, "default_code_repository", "aws_sagemaker_code_repository.test", "code_repository_name")),
@@ -655,7 +655,7 @@ data "aws_iam_policy_document" "test" {
 `, rName)
 }
 
-func testAccNotebookInstanceBasicConfig(rName string) string {
+func testAccNotebookInstanceConfig_basic(rName string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
@@ -665,7 +665,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName)
 }
 
-func testAccNotebookInstanceUpdateConfig(rName string) string {
+func testAccNotebookInstanceConfig_update(rName string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
@@ -675,7 +675,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName)
 }
 
-func testAccNotebookInstanceLifecycleNameConfig(rName string) string {
+func testAccNotebookInstanceConfig_lifecycleName(rName string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
   name = %[1]q
@@ -690,7 +690,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName)
 }
 
-func testAccNotebookInstanceTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccNotebookInstanceConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
@@ -704,7 +704,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccNotebookInstanceTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccNotebookInstanceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
@@ -719,7 +719,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccNotebookInstanceRootAccessConfig(rName string, rootAccess string) string {
+func testAccNotebookInstanceConfig_rootAccess(rName string, rootAccess string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
@@ -730,7 +730,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName, rootAccess)
 }
 
-func testAccNotebookInstancePlatformIdentifierConfig(rName string, platformIdentifier string) string {
+func testAccNotebookInstanceConfig_platformIdentifier(rName string, platformIdentifier string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name                = %[1]q
@@ -740,7 +740,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 }
 `, rName, platformIdentifier)
 }
-func testAccNotebookInstanceDirectInternetAccessConfig(rName string, directInternetAccess string) string {
+func testAccNotebookInstanceConfig_directInternetAccess(rName string, directInternetAccess string) string {
 	return testAccNotebookInstanceBaseConfig(rName) +
 		fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
@@ -779,7 +779,7 @@ resource "aws_security_group" "test" {
 `, rName, directInternetAccess)
 }
 
-func testAccNotebookInstanceVolumeConfig(rName string) string {
+func testAccNotebookInstanceConfig_volume(rName string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
@@ -790,7 +790,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
   `, rName)
 }
 
-func testAccNotebookInstanceDefaultCodeRepositoryConfig(rName string, defaultCodeRepository string) string {
+func testAccNotebookInstanceConfig_defaultCodeRepository(rName string, defaultCodeRepository string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name                    = %[1]q
@@ -801,7 +801,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName, defaultCodeRepository)
 }
 
-func testAccNotebookInstanceAdditionalCodeRepository1Config(rName, repo1 string) string {
+func testAccNotebookInstanceConfig_additionalCodeRepository1(rName, repo1 string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name                         = %[1]q
@@ -812,7 +812,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName, repo1)
 }
 
-func testAccNotebookInstanceAdditionalCodeRepository2Config(rName, repo1, repo2 string) string {
+func testAccNotebookInstanceConfig_additionalCodeRepository2(rName, repo1, repo2 string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "test" {
   name                         = %[1]q
@@ -823,7 +823,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName, repo1, repo2)
 }
 
-func testAccNotebookInstanceDefaultCodeRepositoryRepoConfig(rName string) string {
+func testAccNotebookInstanceConfig_defaultCodeRepositoryRepo(rName string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
@@ -842,7 +842,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName)
 }
 
-func testAccNotebookInstanceKMSConfig(rName string) string {
+func testAccNotebookInstanceConfig_kms(rName string) string {
 	return testAccNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = "Terraform acc test %[1]s"

--- a/internal/service/sagemaker/prebuilt_ecr_image_data_source_test.go
+++ b/internal/service/sagemaker/prebuilt_ecr_image_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccSageMakerPrebuiltECRImageDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrebuiltECRImageConfig_basic,
+				Config: testAccPrebuiltECRImageDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", expectedID),
 					resource.TestCheckResourceAttr(dataSourceName, "registry_id", expectedID),
@@ -42,7 +42,7 @@ func TestAccSageMakerPrebuiltECRImageDataSource_region(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrebuiltECRImageConfig_explicitRegion,
+				Config: testAccPrebuiltECRImageDataSourceConfig_explicitRegion,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", expectedID),
 					resource.TestCheckResourceAttr(dataSourceName, "registry_id", expectedID),
@@ -53,13 +53,13 @@ func TestAccSageMakerPrebuiltECRImageDataSource_region(t *testing.T) {
 	})
 }
 
-const testAccPrebuiltECRImageConfig_basic = `
+const testAccPrebuiltECRImageDataSourceConfig_basic = `
 data "aws_sagemaker_prebuilt_ecr_image" "test" {
   repository_name = "kmeans"
 }
 `
 
-const testAccPrebuiltECRImageConfig_explicitRegion = `
+const testAccPrebuiltECRImageDataSourceConfig_explicitRegion = `
 data "aws_region" "current" {}
 
 data "aws_sagemaker_prebuilt_ecr_image" "test" {

--- a/internal/service/sagemaker/project_test.go
+++ b/internal/service/sagemaker/project_test.go
@@ -27,7 +27,7 @@ func TestAccSageMakerProject_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectBasicConfig(rName),
+				Config: testAccProjectConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "project_name", rName),
@@ -44,7 +44,7 @@ func TestAccSageMakerProject_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectBaseConfig(rName),
+				Config: testAccProjectConfig_base(rName),
 			},
 		},
 	})
@@ -63,7 +63,7 @@ func TestAccSageMakerProject_description(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectDescription(rName, rName),
+				Config: testAccProjectConfig_description(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "project_name", rName),
@@ -76,7 +76,7 @@ func TestAccSageMakerProject_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectDescription(rName, rNameUpdated),
+				Config: testAccProjectConfig_description(rName, rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "project_name", rName),
@@ -84,7 +84,7 @@ func TestAccSageMakerProject_description(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectBaseConfig(rName),
+				Config: testAccProjectConfig_base(rName),
 			},
 		},
 	})
@@ -102,7 +102,7 @@ func TestAccSageMakerProject_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectTagsConfig1(rName, "key1", "value1"),
+				Config: testAccProjectConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -115,7 +115,7 @@ func TestAccSageMakerProject_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectTagsConfig2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccProjectConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -124,7 +124,7 @@ func TestAccSageMakerProject_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectTagsConfig1(rName, "key2", "value2"),
+				Config: testAccProjectConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -132,7 +132,7 @@ func TestAccSageMakerProject_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectBaseConfig(rName),
+				Config: testAccProjectConfig_base(rName),
 			},
 		},
 	})
@@ -150,7 +150,7 @@ func TestAccSageMakerProject_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectBasicConfig(rName),
+				Config: testAccProjectConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &mpg),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceProject(), resourceName),
@@ -211,7 +211,7 @@ func testAccCheckProjectExists(n string, mpg *sagemaker.DescribeProjectOutput) r
 	}
 }
 
-func testAccProjectBaseConfig(rName string) string {
+func testAccProjectConfig_base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -355,8 +355,8 @@ resource "aws_servicecatalog_principal_portfolio_association" "test" {
 `, rName)
 }
 
-func testAccProjectBasicConfig(rName string) string {
-	return acctest.ConfigCompose(testAccProjectBaseConfig(rName), fmt.Sprintf(`
+func testAccProjectConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_project" "test" {
   project_name = %[1]q
 
@@ -367,8 +367,8 @@ resource "aws_sagemaker_project" "test" {
 `, rName))
 }
 
-func testAccProjectDescription(rName, desc string) string {
-	return acctest.ConfigCompose(testAccProjectBaseConfig(rName), fmt.Sprintf(`
+func testAccProjectConfig_description(rName, desc string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_project" "test" {
   project_name        = %[1]q
   project_description = %[2]q
@@ -380,8 +380,8 @@ resource "aws_sagemaker_project" "test" {
 `, rName, desc))
 }
 
-func testAccProjectTagsConfig1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccProjectBaseConfig(rName), fmt.Sprintf(`
+func testAccProjectConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_project" "test" {
   project_name = %[1]q
 
@@ -396,8 +396,8 @@ resource "aws_sagemaker_project" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccProjectTagsConfig2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccProjectBaseConfig(rName), fmt.Sprintf(`
+func testAccProjectConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_project" "test" {
   project_name = %[1]q
 

--- a/internal/service/sagemaker/studio_lifecycle_config_test.go
+++ b/internal/service/sagemaker/studio_lifecycle_config_test.go
@@ -26,7 +26,7 @@ func TestAccSageMakerStudioLifecycleConfig_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckStudioLifecycleDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStudioLifecycleBasicConfig(rName),
+				Config: testAccStudioLifecycleConfigConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStudioLifecycleExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "studio_lifecycle_config_name", rName),
@@ -57,7 +57,7 @@ func TestAccSageMakerStudioLifecycleConfig_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckStudioLifecycleDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStudioLifecycleTags1Config(rName, "key1", "value1"),
+				Config: testAccStudioLifecycleConfigConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStudioLifecycleExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -70,7 +70,7 @@ func TestAccSageMakerStudioLifecycleConfig_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStudioLifecycleTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccStudioLifecycleConfigConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStudioLifecycleExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -79,7 +79,7 @@ func TestAccSageMakerStudioLifecycleConfig_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStudioLifecycleTags1Config(rName, "key2", "value2"),
+				Config: testAccStudioLifecycleConfigConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStudioLifecycleExistsConfig(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -102,7 +102,7 @@ func TestAccSageMakerStudioLifecycleConfig_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckStudioLifecycleDestroyConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStudioLifecycleBasicConfig(rName),
+				Config: testAccStudioLifecycleConfigConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStudioLifecycleExistsConfig(resourceName, &config),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceStudioLifecycleConfig(), resourceName),
@@ -163,7 +163,7 @@ func testAccCheckStudioLifecycleExistsConfig(n string, config *sagemaker.Describ
 	}
 }
 
-func testAccStudioLifecycleBasicConfig(rName string) string {
+func testAccStudioLifecycleConfigConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q
@@ -173,7 +173,7 @@ resource "aws_sagemaker_studio_lifecycle_config" "test" {
 `, rName)
 }
 
-func testAccStudioLifecycleTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccStudioLifecycleConfigConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q
@@ -187,7 +187,7 @@ resource "aws_sagemaker_studio_lifecycle_config" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccStudioLifecycleTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccStudioLifecycleConfigConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q

--- a/internal/service/sagemaker/user_profile_test.go
+++ b/internal/service/sagemaker/user_profile_test.go
@@ -29,7 +29,7 @@ func testAccUserProfile_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileBasicConfig(rName),
+				Config: testAccUserProfileConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_profile_name", rName),
@@ -61,7 +61,7 @@ func testAccUserProfile_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileTags1Config(rName, "key1", "value1"),
+				Config: testAccUserProfileConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -74,7 +74,7 @@ func testAccUserProfile_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccUserProfileTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccUserProfileConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -83,7 +83,7 @@ func testAccUserProfile_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccUserProfileTags1Config(rName, "key2", "value2"),
+				Config: testAccUserProfileConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -106,7 +106,7 @@ func testAccUserProfile_tensorboardAppSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileTensorBoardAppSettingsConfig(rName),
+				Config: testAccUserProfileConfig_tensorBoardAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -136,7 +136,7 @@ func testAccUserProfile_tensorboardAppSettingsWithImage(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileTensorBoardAppSettingsWithImageConfig(rName),
+				Config: testAccUserProfileConfig_tensorBoardAppSettingsImage(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -167,7 +167,7 @@ func testAccUserProfile_kernelGatewayAppSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileKernelGatewayAppSettingsConfig(rName),
+				Config: testAccUserProfileConfig_kernelGatewayAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -197,7 +197,7 @@ func testAccUserProfile_kernelGatewayAppSettings_lifecycleconfig(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileKernelGatewayAppSettingsLifecycleConfig(rName),
+				Config: testAccUserProfileConfig_kernelGatewayAppSettingsLifecycle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -235,7 +235,7 @@ func testAccUserProfile_kernelGatewayAppSettings_imageconfig(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileKernelGatewayAppSettingsImageConfig(rName, baseImage),
+				Config: testAccUserProfileConfig_kernelGatewayAppSettingsImage(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -267,7 +267,7 @@ func testAccUserProfile_jupyterServerAppSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileJupyterServerAppSettingsConfig(rName),
+				Config: testAccUserProfileConfig_jupyterServerAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -297,7 +297,7 @@ func testAccUserProfile_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileBasicConfig(rName),
+				Config: testAccUserProfileConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceUserProfile(), resourceName),
@@ -418,7 +418,7 @@ resource "aws_sagemaker_domain" "test" {
 `, rName)
 }
 
-func testAccUserProfileBasicConfig(rName string) string {
+func testAccUserProfileConfig_basic(rName string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -427,7 +427,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccUserProfileTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccUserProfileConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -440,7 +440,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccUserProfileTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccUserProfileConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -454,7 +454,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccUserProfileTensorBoardAppSettingsConfig(rName string) string {
+func testAccUserProfileConfig_tensorBoardAppSettings(rName string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -473,7 +473,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccUserProfileTensorBoardAppSettingsWithImageConfig(rName string) string {
+func testAccUserProfileConfig_tensorBoardAppSettingsImage(rName string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q
@@ -498,7 +498,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccUserProfileJupyterServerAppSettingsConfig(rName string) string {
+func testAccUserProfileConfig_jupyterServerAppSettings(rName string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -517,7 +517,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccUserProfileKernelGatewayAppSettingsConfig(rName string) string {
+func testAccUserProfileConfig_kernelGatewayAppSettings(rName string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
@@ -536,7 +536,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccUserProfileKernelGatewayAppSettingsLifecycleConfig(rName string) string {
+func testAccUserProfileConfig_kernelGatewayAppSettingsLifecycle(rName string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q
@@ -564,7 +564,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName)
 }
 
-func testAccUserProfileKernelGatewayAppSettingsImageConfig(rName, baseImage string) string {
+func testAccUserProfileConfig_kernelGatewayAppSettingsImage(rName, baseImage string) string {
 	return testAccUserProfileBaseConfig(rName) + fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/sagemaker/workforce_test.go
+++ b/internal/service/sagemaker/workforce_test.go
@@ -27,7 +27,7 @@ func testAccWorkforce_cognitoConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkforceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkforceCognitoConfig(rName),
+				Config: testAccWorkforceConfig_cognito(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					resource.TestCheckResourceAttr(resourceName, "workforce_name", rName),
@@ -64,7 +64,7 @@ func testAccWorkforce_oidcConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkforceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkforceOIDCConfig(rName, endpoint1),
+				Config: testAccWorkforceConfig_oidc(rName, endpoint1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					resource.TestCheckResourceAttr(resourceName, "workforce_name", rName),
@@ -91,7 +91,7 @@ func testAccWorkforce_oidcConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"oidc_config.0.client_secret"},
 			},
 			{
-				Config: testAccWorkforceOIDCConfig(rName, endpoint2),
+				Config: testAccWorkforceConfig_oidc(rName, endpoint2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					resource.TestCheckResourceAttr(resourceName, "workforce_name", rName),
@@ -126,7 +126,7 @@ func testAccWorkforce_sourceIPConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkforceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkforceSourceIP1Config(rName, "1.1.1.1/32"),
+				Config: testAccWorkforceConfig_sourceIP1(rName, "1.1.1.1/32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					resource.TestCheckResourceAttr(resourceName, "source_ip_config.#", "1"),
@@ -140,7 +140,7 @@ func testAccWorkforce_sourceIPConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkforceSourceIP2Config(rName, "2.2.2.2/32", "3.3.3.3/32"),
+				Config: testAccWorkforceConfig_sourceIP2(rName, "2.2.2.2/32", "3.3.3.3/32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					resource.TestCheckResourceAttr(resourceName, "source_ip_config.#", "1"),
@@ -149,7 +149,7 @@ func testAccWorkforce_sourceIPConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkforceSourceIP1Config(rName, "2.2.2.2/32"),
+				Config: testAccWorkforceConfig_sourceIP1(rName, "2.2.2.2/32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					resource.TestCheckResourceAttr(resourceName, "source_ip_config.#", "1"),
@@ -173,7 +173,7 @@ func testAccWorkforce_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkforceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkforceCognitoConfig(rName),
+				Config: testAccWorkforceConfig_cognito(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkforceExists(resourceName, &workforce),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceWorkforce(), resourceName),
@@ -252,7 +252,7 @@ resource "aws_cognito_user_pool_domain" "test" {
 `, rName)
 }
 
-func testAccWorkforceCognitoConfig(rName string) string {
+func testAccWorkforceConfig_cognito(rName string) string {
 	return testAccWorkforceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_workforce" "test" {
   workforce_name = %[1]q
@@ -265,7 +265,7 @@ resource "aws_sagemaker_workforce" "test" {
 `, rName)
 }
 
-func testAccWorkforceSourceIP1Config(rName, cidr1 string) string {
+func testAccWorkforceConfig_sourceIP1(rName, cidr1 string) string {
 	return testAccWorkforceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_workforce" "test" {
   workforce_name = %[1]q
@@ -282,7 +282,7 @@ resource "aws_sagemaker_workforce" "test" {
 `, rName, cidr1)
 }
 
-func testAccWorkforceSourceIP2Config(rName, cidr1, cidr2 string) string {
+func testAccWorkforceConfig_sourceIP2(rName, cidr1, cidr2 string) string {
 	return testAccWorkforceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_workforce" "test" {
   workforce_name = %[1]q
@@ -299,7 +299,7 @@ resource "aws_sagemaker_workforce" "test" {
 `, rName, cidr1, cidr2)
 }
 
-func testAccWorkforceOIDCConfig(rName, endpoint string) string {
+func testAccWorkforceConfig_oidc(rName, endpoint string) string {
 	return testAccWorkforceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_workforce" "test" {
   workforce_name = %[1]q

--- a/internal/service/sagemaker/workteam_test.go
+++ b/internal/service/sagemaker/workteam_test.go
@@ -27,7 +27,7 @@ func testAccWorkteam_cognitoConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkteamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkteamCognitoConfig(rName),
+				Config: testAccWorkteamConfig_cognito(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -49,7 +49,7 @@ func testAccWorkteam_cognitoConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"workforce_name"},
 			},
 			{
-				Config: testAccWorkteamCognitoUpdatedConfig(rName),
+				Config: testAccWorkteamConfig_cognitoUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -68,7 +68,7 @@ func testAccWorkteam_cognitoConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkteamCognitoConfig(rName),
+				Config: testAccWorkteamConfig_cognito(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -98,7 +98,7 @@ func testAccWorkteam_oidcConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkteamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkteamOIDCConfig(rName),
+				Config: testAccWorkteamConfig_oidc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -116,7 +116,7 @@ func testAccWorkteam_oidcConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"workforce_name"},
 			},
 			{
-				Config: testAccWorkteamOIDC2Config(rName, "test"),
+				Config: testAccWorkteamConfig_oidc2(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -129,7 +129,7 @@ func testAccWorkteam_oidcConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkteamOIDCConfig(rName),
+				Config: testAccWorkteamConfig_oidc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -155,7 +155,7 @@ func testAccWorkteam_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkteamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkteamTags1Config(rName, "key1", "value1"),
+				Config: testAccWorkteamConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -169,7 +169,7 @@ func testAccWorkteam_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"workforce_name"},
 			},
 			{
-				Config: testAccWorkteamTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccWorkteamConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -178,7 +178,7 @@ func testAccWorkteam_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkteamTags1Config(rName, "key2", "value2"),
+				Config: testAccWorkteamConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -201,7 +201,7 @@ func testAccWorkteam_notificationConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkteamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkteamNotificationConfig(rName),
+				Config: testAccWorkteamConfig_notification(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -218,7 +218,7 @@ func testAccWorkteam_notificationConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"workforce_name"},
 			},
 			{
-				Config: testAccWorkteamOIDCConfig(rName),
+				Config: testAccWorkteamConfig_oidc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -228,7 +228,7 @@ func testAccWorkteam_notificationConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkteamNotificationConfig(rName),
+				Config: testAccWorkteamConfig_notification(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					resource.TestCheckResourceAttr(resourceName, "workteam_name", rName),
@@ -254,7 +254,7 @@ func testAccWorkteam_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkteamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkteamOIDCConfig(rName),
+				Config: testAccWorkteamConfig_oidc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkteamExists(resourceName, &workteam),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceWorkteam(), resourceName),
@@ -347,7 +347,7 @@ resource "aws_sagemaker_workforce" "test" {
 `, rName)
 }
 
-func testAccWorkteamCognitoConfig(rName string) string {
+func testAccWorkteamConfig_cognito(rName string) string {
 	return acctest.ConfigCompose(testAccWorkteamCognitoBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_workteam" "test" {
   workteam_name  = %[1]q
@@ -365,7 +365,7 @@ resource "aws_sagemaker_workteam" "test" {
 `, rName))
 }
 
-func testAccWorkteamCognitoUpdatedConfig(rName string) string {
+func testAccWorkteamConfig_cognitoUpdated(rName string) string {
 	return acctest.ConfigCompose(testAccWorkteamCognitoBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cognito_user_group" "test2" {
   name         = "%[1]s-2"
@@ -415,7 +415,7 @@ resource "aws_sagemaker_workforce" "test" {
 `, rName)
 }
 
-func testAccWorkteamOIDCConfig(rName string) string {
+func testAccWorkteamConfig_oidc(rName string) string {
 	return acctest.ConfigCompose(testAccWorkteamOIDCBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_workteam" "test" {
   workteam_name  = %[1]q
@@ -431,7 +431,7 @@ resource "aws_sagemaker_workteam" "test" {
 `, rName))
 }
 
-func testAccWorkteamOIDC2Config(rName, group string) string {
+func testAccWorkteamConfig_oidc2(rName, group string) string {
 	return acctest.ConfigCompose(testAccWorkteamOIDCBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_workteam" "test" {
   workteam_name  = %[1]q
@@ -447,7 +447,7 @@ resource "aws_sagemaker_workteam" "test" {
 `, rName, group))
 }
 
-func testAccWorkteamNotificationConfig(rName string) string {
+func testAccWorkteamConfig_notification(rName string) string {
 	return acctest.ConfigCompose(testAccWorkteamOIDCBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -493,7 +493,7 @@ resource "aws_sagemaker_workteam" "test" {
 `, rName))
 }
 
-func testAccWorkteamTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccWorkteamConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccWorkteamOIDCBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_workteam" "test" {
   workteam_name  = %[1]q
@@ -513,7 +513,7 @@ resource "aws_sagemaker_workteam" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccWorkteamTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccWorkteamConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccWorkteamOIDCBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_workteam" "test" {
   workteam_name  = %[1]q

--- a/internal/service/swf/domain_test.go
+++ b/internal/service/swf/domain_test.go
@@ -69,7 +69,7 @@ func TestAccSWFDomain_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainTags1Config(rName, "key1", "value1"),
+				Config: testAccDomainConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -82,7 +82,7 @@ func TestAccSWFDomain_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDomainTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccDomainConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -91,7 +91,7 @@ func TestAccSWFDomain_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainTags1Config(rName, "key2", "value2"),
+				Config: testAccDomainConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -268,7 +268,7 @@ resource "aws_swf_domain" "test" {
 `, rName)
 }
 
-func testAccDomainTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccDomainConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_swf_domain" "test" {
   name                                        = %[1]q
@@ -281,7 +281,7 @@ resource "aws_swf_domain" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDomainTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_swf_domain" "test" {
   name                                        = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
