### PR TITLE
route53resolver: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -355,7 +355,6 @@ rules:
         - internal/service/route53domains
         - internal/service/route53recoverycontrolconfig
         - internal/service/route53recoveryreadiness
-        - internal/service/route53resolver
         - internal/service/s3
         - internal/service/s3control
         - internal/service/s3outposts

--- a/internal/service/route53resolver/endpoint_data_source_test.go
+++ b/internal/service/route53resolver/endpoint_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccRoute53ResolverEndpointDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEndpointDataSourceConfig_NonExistent,
+				Config:      testAccEndpointDataSourceConfig_nonExistent,
 				ExpectError: regexp.MustCompile("The ID provided could not be found"),
 			},
 			{
@@ -53,7 +53,7 @@ func TestAccRoute53ResolverEndpointDataSource_filter(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEndpointDataSourceConfig_NonExistentFilter,
+				Config:      testAccEndpointDataSourceConfig_nonExistentFilter,
 				ExpectError: regexp.MustCompile("Your query returned no results. Please change your search criteria and try again"),
 			},
 			{
@@ -203,13 +203,13 @@ data "aws_route53_resolver_endpoint" "foo" {
 `, direction, name))
 }
 
-const testAccEndpointDataSourceConfig_NonExistent = `
+const testAccEndpointDataSourceConfig_nonExistent = `
 data "aws_route53_resolver_endpoint" "foo" {
   resolver_endpoint_id = "rslvr-in-8g85830108dd4c82b"
 }
 `
 
-const testAccEndpointDataSourceConfig_NonExistentFilter = `
+const testAccEndpointDataSourceConfig_nonExistentFilter = `
 data "aws_route53_resolver_endpoint" "foo" {
   filter {
     name   = "Name"

--- a/internal/service/route53resolver/rule_data_source_test.go
+++ b/internal/service/route53resolver/rule_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccRoute53ResolverRuleDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleDataSource_basic(rName),
+				Config: testAccRuleDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
@@ -79,7 +79,7 @@ func TestAccRoute53ResolverRuleDataSource_resolverEndpointIdWithTags(t *testing.
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleDataSource_resolverEndpointIdWithTags(rName),
+				Config: testAccRuleDataSourceConfig_resolverEndpointIDTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
@@ -116,7 +116,7 @@ func TestAccRoute53ResolverRuleDataSource_sharedByMe(t *testing.T) {
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleDataSource_sharedByMe(rName),
+				Config: testAccRuleDataSourceConfig_sharedByMe(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
@@ -154,7 +154,7 @@ func TestAccRoute53ResolverRuleDataSource_sharedWithMe(t *testing.T) {
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleDataSource_sharedWithMe(rName),
+				Config: testAccRuleDataSourceConfig_sharedWithMe(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
@@ -174,7 +174,7 @@ func TestAccRoute53ResolverRuleDataSource_sharedWithMe(t *testing.T) {
 	})
 }
 
-func testAccRuleDataSource_basic(rName string) string {
+func testAccRuleDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
@@ -197,7 +197,7 @@ data "aws_route53_resolver_rule" "by_name_and_rule_type" {
 `, rName)
 }
 
-func testAccRuleDataSource_resolverEndpointIdWithTags(rName string) string {
+func testAccRuleDataSourceConfig_resolverEndpointIDTags(rName string) string {
 	return testAccRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
@@ -222,7 +222,7 @@ data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
 `, rName)
 }
 
-func testAccRuleDataSource_sharedByMe(rName string) string {
+func testAccRuleDataSourceConfig_sharedByMe(rName string) string {
 	return acctest.ConfigAlternateAccountProvider() + testAccRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
@@ -266,7 +266,7 @@ data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
 `, rName)
 }
 
-func testAccRuleDataSource_sharedWithMe(rName string) string {
+func testAccRuleDataSourceConfig_sharedWithMe(rName string) string {
 	return acctest.ConfigAlternateAccountProvider() + testAccRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "%[1]s.example.com"

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccRoute53ResolverRulesDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRulesDataSource_basic,
+				Config: testAccRulesDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(dsResourceName, "resolver_rule_ids.*", "rslvr-autodefined-rr-internet-resolver"),
@@ -43,7 +43,7 @@ func TestAccRoute53ResolverRulesDataSource_resolverEndpointID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRulesDataSource_resolverEndpointID(rName1, rName2),
+				Config: testAccRulesDataSourceConfig_resolverEndpointID(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(ds1ResourceName, "resolver_rule_ids.#", "1"),
 					resource.TestCheckResourceAttr(ds2ResourceName, "resolver_rule_ids.#", "1"),
@@ -65,7 +65,7 @@ func TestAccRoute53ResolverRulesDataSource_nameRegex(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRulesDataSource_nameRegex(rCount, rName),
+				Config: testAccRulesDataSourceConfig_nameRegex(rCount, rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", strconv.Itoa(rCount)),
 				),
@@ -83,7 +83,7 @@ func TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRulesDataSource_nonExistentNameRegex,
+				Config: testAccRulesDataSourceConfig_nonExistentNameRegex,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", "0"),
 				),
@@ -92,7 +92,7 @@ func TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex(t *testing.T) {
 	})
 }
 
-const testAccRulesDataSource_basic = `
+const testAccRulesDataSourceConfig_basic = `
 # The default Internet Resolver rule.
 data "aws_route53_resolver_rules" "test" {
   owner_id     = "Route 53 Resolver"
@@ -101,7 +101,7 @@ data "aws_route53_resolver_rules" "test" {
 }
 `
 
-func testAccRulesDataSource_resolverEndpointID(rName1, rName2 string) string {
+func testAccRulesDataSourceConfig_resolverEndpointID(rName1, rName2 string) string {
 	return testAccRuleConfig_resolverEndpoint(rName1) + fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "forward" {
   domain_name = "%[1]s.example.com"
@@ -140,7 +140,7 @@ data "aws_route53_resolver_rules" "by_invalid_owner_id" {
 `, rName1, rName2)
 }
 
-func testAccRulesDataSource_nameRegex(rCount int, rName string) string {
+func testAccRulesDataSourceConfig_nameRegex(rCount int, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "test" {
   count       = %[1]d
@@ -157,7 +157,7 @@ data "aws_route53_resolver_rules" "test" {
 `, rCount, rName)
 }
 
-const testAccRulesDataSource_nonExistentNameRegex = `
+const testAccRulesDataSourceConfig_nonExistentNameRegex = `
 data "aws_route53_resolver_rules" "test" {
   name_regex = "dne-regex"
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
