### PR TITLE
route53: Fix test configs names

### DIFF
--- a/internal/service/route53/health_check_test.go
+++ b/internal/service/route53/health_check_test.go
@@ -143,7 +143,7 @@ func TestAccRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 		CheckDestroy:      testAccCheckHealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHealthCheckConfig_childHealthChecks,
+				Config: testAccHealthCheckConfig_childs,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHealthCheckExists(resourceName, &check),
 				),
@@ -514,7 +514,7 @@ resource "aws_route53_health_check" "test" {
 `, ip)
 }
 
-const testAccHealthCheckConfig_childHealthChecks = `
+const testAccHealthCheckConfig_childs = `
 resource "aws_route53_health_check" "child1" {
   fqdn              = "child1.example.com"
   port              = 80

--- a/internal/service/route53/hosted_zone_dnssec_test.go
+++ b/internal/service/route53/hosted_zone_dnssec_test.go
@@ -29,7 +29,7 @@ func TestAccRoute53HostedZoneDNSSEC_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckHostedZoneDNSSECDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostedZoneDNSSECConfig(rName, domainName),
+				Config: testAccHostedZoneDNSSECConfig_basic(rName, domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccHostedZoneDNSSECExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "hosted_zone_id", route53ZoneResourceName, "id"),
@@ -58,7 +58,7 @@ func TestAccRoute53HostedZoneDNSSEC_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckHostedZoneDNSSECDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostedZoneDNSSECConfig(rName, domainName),
+				Config: testAccHostedZoneDNSSECConfig_basic(rName, domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccHostedZoneDNSSECExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfroute53.ResourceHostedZoneDNSSEC(), resourceName),
@@ -82,7 +82,7 @@ func TestAccRoute53HostedZoneDNSSEC_signingStatus(t *testing.T) {
 		CheckDestroy:      testAccCheckHostedZoneDNSSECDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostedZoneDNSSECConfig_SigningStatus(rName, domainName, tfroute53.ServeSignatureNotSigning),
+				Config: testAccHostedZoneDNSSECConfig_signingStatus(rName, domainName, tfroute53.ServeSignatureNotSigning),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccHostedZoneDNSSECExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "signing_status", tfroute53.ServeSignatureNotSigning),
@@ -94,14 +94,14 @@ func TestAccRoute53HostedZoneDNSSEC_signingStatus(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccHostedZoneDNSSECConfig_SigningStatus(rName, domainName, tfroute53.ServeSignatureSigning),
+				Config: testAccHostedZoneDNSSECConfig_signingStatus(rName, domainName, tfroute53.ServeSignatureSigning),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccHostedZoneDNSSECExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "signing_status", tfroute53.ServeSignatureSigning),
 				),
 			},
 			{
-				Config: testAccHostedZoneDNSSECConfig_SigningStatus(rName, domainName, tfroute53.ServeSignatureNotSigning),
+				Config: testAccHostedZoneDNSSECConfig_signingStatus(rName, domainName, tfroute53.ServeSignatureNotSigning),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccHostedZoneDNSSECExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "signing_status", tfroute53.ServeSignatureNotSigning),
@@ -217,7 +217,7 @@ resource "aws_route53_key_signing_key" "test" {
 `, rName, domainName))
 }
 
-func testAccHostedZoneDNSSECConfig(rName, domainName string) string {
+func testAccHostedZoneDNSSECConfig_basic(rName, domainName string) string {
 	return acctest.ConfigCompose(
 		testAccHostedZoneDNSSECConfig_Base(rName, domainName), `
 resource "aws_route53_hosted_zone_dnssec" "test" {
@@ -226,7 +226,7 @@ resource "aws_route53_hosted_zone_dnssec" "test" {
 `)
 }
 
-func testAccHostedZoneDNSSECConfig_SigningStatus(rName, domainName, signingStatus string) string {
+func testAccHostedZoneDNSSECConfig_signingStatus(rName, domainName, signingStatus string) string {
 	return acctest.ConfigCompose(
 		testAccHostedZoneDNSSECConfig_Base(rName, domainName),
 		fmt.Sprintf(`

--- a/internal/service/route53/key_signing_key_test.go
+++ b/internal/service/route53/key_signing_key_test.go
@@ -38,7 +38,7 @@ func TestAccRoute53KeySigningKey_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeySigningKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeySigningKeyConfig_Name(rName, domainName),
+				Config: testAccKeySigningKeyConfig_name(rName, domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccKeySigningKeyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "digest_algorithm_mnemonic", "SHA-256"),
@@ -79,7 +79,7 @@ func TestAccRoute53KeySigningKey_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckKeySigningKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeySigningKeyConfig_Name(rName, domainName),
+				Config: testAccKeySigningKeyConfig_name(rName, domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccKeySigningKeyExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfroute53.ResourceKeySigningKey(), resourceName),
@@ -103,7 +103,7 @@ func TestAccRoute53KeySigningKey_status(t *testing.T) {
 		CheckDestroy:      testAccCheckKeySigningKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeySigningKeyConfig_Status(rName, domainName, tfroute53.KeySigningKeyStatusInactive),
+				Config: testAccKeySigningKeyConfig_status(rName, domainName, tfroute53.KeySigningKeyStatusInactive),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccKeySigningKeyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "status", tfroute53.KeySigningKeyStatusInactive),
@@ -115,14 +115,14 @@ func TestAccRoute53KeySigningKey_status(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccKeySigningKeyConfig_Status(rName, domainName, tfroute53.KeySigningKeyStatusActive),
+				Config: testAccKeySigningKeyConfig_status(rName, domainName, tfroute53.KeySigningKeyStatusActive),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccKeySigningKeyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "status", tfroute53.KeySigningKeyStatusActive),
 				),
 			},
 			{
-				Config: testAccKeySigningKeyConfig_Status(rName, domainName, tfroute53.KeySigningKeyStatusInactive),
+				Config: testAccKeySigningKeyConfig_status(rName, domainName, tfroute53.KeySigningKeyStatusInactive),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccKeySigningKeyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "status", tfroute53.KeySigningKeyStatusInactive),
@@ -232,7 +232,7 @@ resource "aws_route53_zone" "test" {
 `, rName, domainName))
 }
 
-func testAccKeySigningKeyConfig_Name(rName, domainName string) string {
+func testAccKeySigningKeyConfig_name(rName, domainName string) string {
 	return acctest.ConfigCompose(
 		testAccKeySigningKeyConfig_Base(rName, domainName),
 		fmt.Sprintf(`
@@ -244,7 +244,7 @@ resource "aws_route53_key_signing_key" "test" {
 `, rName))
 }
 
-func testAccKeySigningKeyConfig_Status(rName, domainName, status string) string {
+func testAccKeySigningKeyConfig_status(rName, domainName, status string) string {
 	return acctest.ConfigCompose(
 		testAccKeySigningKeyConfig_Base(rName, domainName),
 		fmt.Sprintf(`
@@ -290,11 +290,11 @@ func testAccPreCheckKeySigningKey(t *testing.T) {
 	testAccProviderRoute53KeySigningKeyConfigure.Do(func() {
 		testAccProviderRoute53KeySigningKey = provider.Provider()
 
-		config := map[string]interface{}{
+		testAccRecordConfig_config := map[string]interface{}{
 			"region": region,
 		}
 
-		diags := testAccProviderRoute53KeySigningKey.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+		diags := testAccProviderRoute53KeySigningKey.Configure(context.Background(), terraform.NewResourceConfigRaw(testAccRecordConfig_config))
 
 		if diags != nil && diags.HasError() {
 			for _, d := range diags {

--- a/internal/service/route53/query_log_test.go
+++ b/internal/service/route53/query_log_test.go
@@ -38,7 +38,7 @@ func TestAccRoute53QueryLog_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckQueryLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckQueryLogResourceBasic1Config(rName, domainName),
+				Config: testAccQueryLogConfig_resourceBasic1(rName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueryLogExists(resourceName, &queryLoggingConfig),
 					acctest.MatchResourceAttrGlobalARNNoAccount(resourceName, "arn", "route53", regexp.MustCompile("queryloggingconfig/.+")),
@@ -69,7 +69,7 @@ func TestAccRoute53QueryLog_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckQueryLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckQueryLogResourceBasic1Config(rName, domainName),
+				Config: testAccQueryLogConfig_resourceBasic1(rName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueryLogExists(resourceName, &queryLoggingConfig),
 					acctest.CheckResourceDisappears(acctest.Provider, tfroute53.ResourceQueryLog(), resourceName),
@@ -95,7 +95,7 @@ func TestAccRoute53QueryLog_Disappears_hostedZone(t *testing.T) {
 		CheckDestroy:      testAccCheckQueryLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckQueryLogResourceBasic1Config(rName, domainName),
+				Config: testAccQueryLogConfig_resourceBasic1(rName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueryLogExists(resourceName, &queryLoggingConfig),
 					acctest.CheckResourceDisappears(acctest.Provider, tfroute53.ResourceZone(), route53ZoneResourceName),
@@ -162,7 +162,7 @@ func testAccCheckQueryLogDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckQueryLogResourceBasic1Config(rName, domainName string) string {
+func testAccQueryLogConfig_resourceBasic1(rName, domainName string) string {
 	return acctest.ConfigCompose(
 		testAccQueryLogRegionProviderConfig(),
 		fmt.Sprintf(`
@@ -240,11 +240,11 @@ func testAccPreCheckQueryLog(t *testing.T) {
 	testAccProviderRoute53QueryLogConfigure.Do(func() {
 		testAccProviderRoute53QueryLog = provider.Provider()
 
-		config := map[string]interface{}{
+		testAccRecordConfig_config := map[string]interface{}{
 			"region": region,
 		}
 
-		diags := testAccProviderRoute53QueryLog.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+		diags := testAccProviderRoute53QueryLog.Configure(context.Background(), terraform.NewResourceConfigRaw(testAccRecordConfig_config))
 
 		if diags != nil && diags.HasError() {
 			for _, d := range diags {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -466,7 +466,7 @@ func TestAccRoute53Record_failover(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_failoverCNAMERecord,
+				Config: testAccRecordConfig_failoverCNAME,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					testAccCheckRecordExists("aws_route53_record.www-secondary", &record2),
@@ -493,7 +493,7 @@ func TestAccRoute53Record_Weighted_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_weightedCNAMERecord,
+				Config: testAccRecordConfig_weightedCNAME,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.www-dev", &record1),
 					testAccCheckRecordExists(resourceName, &record2),
@@ -521,7 +521,7 @@ func TestAccRoute53Record_WeightedToSimple_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testaccRecordConfig_weightedRoutingPolicy,
+				Config: testAccRecordConfig_weightedRoutingPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -533,7 +533,7 @@ func TestAccRoute53Record_WeightedToSimple_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 			{
-				Config: testaccRecordConfig_simpleRoutingPolicy,
+				Config: testAccRecordConfig_simpleRoutingPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -547,7 +547,7 @@ func TestAccRoute53Record_Alias_elb(t *testing.T) {
 	resourceName := "aws_route53_record.alias"
 
 	rs := sdkacctest.RandString(10)
-	config := fmt.Sprintf(testAccRecordConfig_aliasELB, rs)
+	testAccRecordConfig_config := fmt.Sprintf(testAccRecordConfig_aliasELB, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
@@ -555,7 +555,7 @@ func TestAccRoute53Record_Alias_elb(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccRecordConfig_config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -633,7 +633,7 @@ func TestAccRoute53Record_Alias_uppercase(t *testing.T) {
 	resourceName := "aws_route53_record.alias"
 
 	rs := sdkacctest.RandString(10)
-	config := fmt.Sprintf(testAccRecordConfig_aliasELBUppercase, rs)
+	testAccRecordConfig_config := fmt.Sprintf(testAccRecordConfig_aliasELBUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
@@ -641,7 +641,7 @@ func TestAccRoute53Record_Alias_uppercase(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccRecordConfig_config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -667,7 +667,7 @@ func TestAccRoute53Record_Weighted_alias(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_weightedELBAliasRecord,
+				Config: testAccRecordConfig_weightedELBAlias,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					testAccCheckRecordExists("aws_route53_record.elb_weighted_alias_dev", &record2),
@@ -681,7 +681,7 @@ func TestAccRoute53Record_Weighted_alias(t *testing.T) {
 			},
 
 			{
-				Config: testAccRecordConfig_weightedAliasRecord,
+				Config: testAccRecordConfig_weightedAlias,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.green_origin", &record3),
 					testAccCheckRecordExists("aws_route53_record.r53_weighted_alias_live", &record4),
@@ -704,7 +704,7 @@ func TestAccRoute53Record_Geolocation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_geolocationCNAMERecord,
+				Config: testAccRecordConfig_geolocationCNAME,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.default", &record1),
 					testAccCheckRecordExists("aws_route53_record.california", &record2),
@@ -983,7 +983,7 @@ func TestAccRoute53Record_longTXTrecord(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_longTxtRecord,
+				Config: testAccRecordConfig_longTxt,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 				),
@@ -1009,7 +1009,7 @@ func TestAccRoute53Record_MultiValueAnswer_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_multiValueAnswerARecord,
+				Config: testAccRecordConfig_multiValueAnswerA,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("aws_route53_record.www-server1", &record1),
 					testAccCheckRecordExists("aws_route53_record.www-server2", &record2),
@@ -1472,7 +1472,7 @@ resource "aws_route53_record" "default" {
 }
 `
 
-const testAccRecordConfig_failoverCNAMERecord = `
+const testAccRecordConfig_failoverCNAME = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1520,7 +1520,7 @@ resource "aws_route53_record" "www-secondary" {
 }
 `
 
-const testAccRecordConfig_weightedCNAMERecord = `
+const testAccRecordConfig_weightedCNAME = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1568,7 +1568,7 @@ resource "aws_route53_record" "www-off" {
 }
 `
 
-const testAccRecordConfig_geolocationCNAMERecord = `
+const testAccRecordConfig_geolocationCNAME = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -1982,7 +1982,7 @@ resource "aws_route53_record" "test" {
 `
 }
 
-const testAccRecordConfig_weightedELBAliasRecord = `
+const testAccRecordConfig_weightedELBAlias = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -2057,7 +2057,7 @@ resource "aws_route53_record" "elb_weighted_alias_dev" {
 }
 `
 
-const testAccRecordConfig_weightedAliasRecord = `
+const testAccRecordConfig_weightedAlias = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2271,7 +2271,7 @@ resource "aws_route53_record" "empty" {
 }
 `
 
-const testAccRecordConfig_longTxtRecord = `
+const testAccRecordConfig_longTxt = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2301,7 +2301,7 @@ resource "aws_route53_record" "underscore" {
 }
 `
 
-const testAccRecordConfig_multiValueAnswerARecord = `
+const testAccRecordConfig_multiValueAnswerA = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2327,7 +2327,7 @@ resource "aws_route53_record" "www-server2" {
 }
 `
 
-const testaccRecordConfig_weightedRoutingPolicy = `
+const testAccRecordConfig_weightedRoutingPolicy = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2347,7 +2347,7 @@ resource "aws_route53_record" "www-server1" {
 }
 `
 
-const testaccRecordConfig_simpleRoutingPolicy = `
+const testAccRecordConfig_simpleRoutingPolicy = `
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }

--- a/internal/service/route53/traffic_policy_document_data_source_test.go
+++ b/internal/service/route53/traffic_policy_document_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccRoute53TrafficPolicyDocumentDataSource_basic(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyDocumentDataSourceConfig,
+				Config: testAccTrafficPolicyDocumentDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicySameJSON("data.aws_route53_traffic_policy_document.test",
 						testAccTrafficPolicyDocumentConfigExpectedJSON()),
@@ -37,7 +37,7 @@ func TestAccRoute53TrafficPolicyDocumentDataSource_complete(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyDocumentDataSourceConfigComplete,
+				Config: testAccTrafficPolicyDocumentDataSourceConfig_complete,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicySameJSON("data.aws_route53_traffic_policy_document.test",
 						testAccTrafficPolicyDocumentConfigCompleteExpectedJSON()),
@@ -162,7 +162,7 @@ func testAccTrafficPolicyDocumentConfigCompleteExpectedJSON() string {
 }`, acctest.Region(), acctest.AlternateRegion())
 }
 
-const testAccTrafficPolicyDocumentDataSourceConfig = `
+const testAccTrafficPolicyDocumentDataSourceConfig_basic = `
 data "aws_region" "current" {}
 
 data "aws_route53_traffic_policy_document" "test" {
@@ -195,7 +195,7 @@ data "aws_route53_traffic_policy_document" "test" {
 }
 `
 
-const testAccTrafficPolicyDocumentDataSourceConfigComplete = `
+const testAccTrafficPolicyDocumentDataSourceConfig_complete = `
 data "aws_availability_zones" "available" {
   state = "available"
 }

--- a/internal/service/route53/traffic_policy_instance_test.go
+++ b/internal/service/route53/traffic_policy_instance_test.go
@@ -37,7 +37,7 @@ func TestAccRoute53TrafficPolicyInstance_basic(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyInstanceConfig(rName, zoneName, 3600),
+				Config: testAccTrafficPolicyInstanceConfig_basic(rName, zoneName, 3600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s.%s", rName, zoneName)),
@@ -66,7 +66,7 @@ func TestAccRoute53TrafficPolicyInstance_disappears(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyInstanceConfig(rName, zoneName, 360),
+				Config: testAccTrafficPolicyInstanceConfig_basic(rName, zoneName, 360),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyInstanceExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfroute53.ResourceTrafficPolicyInstance(), resourceName),
@@ -90,14 +90,14 @@ func TestAccRoute53TrafficPolicyInstance_update(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyInstanceConfig(rName, zoneName, 3600),
+				Config: testAccTrafficPolicyInstanceConfig_basic(rName, zoneName, 3600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
 				),
 			},
 			{
-				Config: testAccTrafficPolicyInstanceConfig(rName, zoneName, 7200),
+				Config: testAccTrafficPolicyInstanceConfig_basic(rName, zoneName, 7200),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "7200"),
@@ -160,7 +160,7 @@ func testAccCheckTrafficPolicyInstanceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTrafficPolicyInstanceConfig(rName, zoneName string, ttl int) string {
+func testAccTrafficPolicyInstanceConfig_basic(rName, zoneName string, ttl int) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
   name = %[2]q

--- a/internal/service/route53/traffic_policy_test.go
+++ b/internal/service/route53/traffic_policy_test.go
@@ -27,7 +27,7 @@ func TestAccRoute53TrafficPolicy_basic(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyConfig(rName),
+				Config: testAccTrafficPolicyConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTrafficPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "comment", ""),
@@ -58,7 +58,7 @@ func TestAccRoute53TrafficPolicy_disappears(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyConfig(rName),
+				Config: testAccTrafficPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfroute53.ResourceTrafficPolicy(), resourceName),
@@ -83,14 +83,14 @@ func TestAccRoute53TrafficPolicy_update(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyConfigComplete(rName, comment),
+				Config: testAccTrafficPolicyConfig_complete(rName, comment),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "comment", comment),
 				),
 			},
 			{
-				Config: testAccTrafficPolicyConfigComplete(rName, commentUpdated),
+				Config: testAccTrafficPolicyConfig_complete(rName, commentUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrafficPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "comment", commentUpdated),
@@ -165,7 +165,7 @@ func testAccTrafficPolicyImportStateIdFunc(resourceName string) resource.ImportS
 	}
 }
 
-func testAccTrafficPolicyConfig(rName string) string {
+func testAccTrafficPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_traffic_policy" "test" {
   name     = %[1]q
@@ -186,7 +186,7 @@ EOT
 `, rName)
 }
 
-func testAccTrafficPolicyConfigComplete(rName, comment string) string {
+func testAccTrafficPolicyConfig_complete(rName, comment string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_traffic_policy" "test" {
   name     = %[1]q

--- a/internal/service/route53/zone_data_source_test.go
+++ b/internal/service/route53/zone_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccRoute53ZoneDataSource_id(t *testing.T) {
 		CheckDestroy:      testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneIDDataSourceConfig(fqdn),
+				Config: testAccZoneDataSourceConfig_id(fqdn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
@@ -49,7 +49,7 @@ func TestAccRoute53ZoneDataSource_name(t *testing.T) {
 		CheckDestroy:      testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneNameDataSourceConfig(fqdn),
+				Config: testAccZoneDataSourceConfig_name(fqdn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
@@ -75,7 +75,7 @@ func TestAccRoute53ZoneDataSource_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneTagsPrivateDataSourceConfig(fqdn, rInt),
+				Config: testAccZoneDataSourceConfig_tagsPrivate(fqdn, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
@@ -99,7 +99,7 @@ func TestAccRoute53ZoneDataSource_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneVPCDataSourceConfig(rInt),
+				Config: testAccZoneDataSourceConfig_vpc(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
@@ -123,7 +123,7 @@ func TestAccRoute53ZoneDataSource_serviceDiscovery(t *testing.T) {
 		CheckDestroy:      testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneServiceDiscoveryDataSourceConfig(rInt),
+				Config: testAccZoneDataSourceConfig_serviceDiscovery(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttr(dataSourceName, "linked_service_principal", "servicediscovery.amazonaws.com"),
@@ -134,7 +134,7 @@ func TestAccRoute53ZoneDataSource_serviceDiscovery(t *testing.T) {
 	})
 }
 
-func testAccZoneIDDataSourceConfig(fqdn string) string {
+func testAccZoneDataSourceConfig_id(fqdn string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
   name = %[1]q
@@ -146,7 +146,7 @@ data "aws_route53_zone" "test" {
 `, fqdn)
 }
 
-func testAccZoneNameDataSourceConfig(fqdn string) string {
+func testAccZoneDataSourceConfig_name(fqdn string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
   name = %[1]q
@@ -158,7 +158,7 @@ data "aws_route53_zone" "test" {
 `, fqdn)
 }
 
-func testAccZoneTagsPrivateDataSourceConfig(fqdn string, rInt int) string {
+func testAccZoneDataSourceConfig_tagsPrivate(fqdn string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -189,7 +189,7 @@ data "aws_route53_zone" "test" {
 `, fqdn, rInt)
 }
 
-func testAccZoneVPCDataSourceConfig(rInt int) string {
+func testAccZoneDataSourceConfig_vpc(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -219,7 +219,7 @@ data "aws_route53_zone" "test" {
 `, rInt)
 }
 
-func testAccZoneServiceDiscoveryDataSourceConfig(rInt int) string {
+func testAccZoneDataSourceConfig_serviceDiscovery(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
