### PR TITLE
redshift: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -348,7 +348,6 @@ rules:
         - internal/service/quicksight
         - internal/service/ram
         - internal/service/rds
-        - internal/service/redshift
         - internal/service/resourcegroups
         - internal/service/resourcegroupstaggingapi
         - internal/service/route53

--- a/internal/service/redshift/authentication_profile_test.go
+++ b/internal/service/redshift/authentication_profile_test.go
@@ -26,7 +26,7 @@ func TestAccRedshiftAuthenticationProfile_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAuthenticationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAuthenticationProfileBasic(rName, rName),
+				Config: testAccAuthenticationProfileConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthenticationProfileExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_profile_name", rName),
@@ -38,7 +38,7 @@ func TestAccRedshiftAuthenticationProfile_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAuthenticationProfileBasic(rName, rNameUpdated),
+				Config: testAccAuthenticationProfileConfig_basic(rName, rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthenticationProfileExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_profile_name", rName),
@@ -59,7 +59,7 @@ func TestAccRedshiftAuthenticationProfile_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAuthenticationProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAuthenticationProfileBasic(rName, rName),
+				Config: testAccAuthenticationProfileConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthenticationProfileExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceAuthenticationProfile(), resourceName),
@@ -117,7 +117,7 @@ func testAccCheckAuthenticationProfileExists(name string) resource.TestCheckFunc
 	}
 }
 
-func testAccAuthenticationProfileBasic(rName, id string) string {
+func testAccAuthenticationProfileConfig_basic(rName, id string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_authentication_profile" "test" {
   authentication_profile_name = %[1]q

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccRedshiftClusterDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterDataSourceConfig(rName),
+				Config: testAccClusterDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "allow_version_upgrade"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "automated_snapshot_retention_period"),
@@ -59,7 +59,7 @@ func TestAccRedshiftClusterDataSource_vpc(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterWithVPCDataSourceConfig(rName),
+				Config: testAccClusterDataSourceConfig_vpc(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "vpc_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "vpc_security_group_ids.#", "1"),
@@ -82,7 +82,7 @@ func TestAccRedshiftClusterDataSource_logging(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterWithLoggingDataSourceConfig(rName),
+				Config: testAccClusterDataSourceConfig_logging(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "enable_logging", "true"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bucket_name", bucketResourceName, "bucket"),
@@ -113,7 +113,7 @@ func TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled(t *testi
 	})
 }
 
-func testAccClusterDataSourceConfig(rName string) string {
+func testAccClusterDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier = %[1]q
@@ -132,7 +132,7 @@ data "aws_redshift_cluster" "test" {
 `, rName)
 }
 
-func testAccClusterWithVPCDataSourceConfig(rName string) string {
+func testAccClusterDataSourceConfig_vpc(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -197,7 +197,7 @@ data "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterWithLoggingDataSourceConfig(rName string) string {
+func testAccClusterDataSourceConfig_logging(rName string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_service_account" "test" {}
 

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -141,7 +141,7 @@ func TestAccRedshiftCluster_withFinalSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckDestroyClusterSnapshot(rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterWithFinalSnapshotConfig(rName),
+				Config: testAccClusterConfig_finalSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 				),
@@ -452,7 +452,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfigTags1(rName, "key1", "value1"),
+				Config: testAccClusterConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -471,7 +471,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccClusterConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccClusterConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -480,7 +480,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterConfigTags1(rName, "key2", "value2"),
+				Config: testAccClusterConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -567,7 +567,7 @@ func TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocati
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_updateAvailabilityZone_availabilityZoneRelocationNotSet(rName, 0),
+				Config: testAccClusterConfig_updateAvailabilityZoneAvailabilityZoneRelocationNotSet(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
@@ -600,7 +600,7 @@ func TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNot
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_updateAvailabilityZone_availabilityZoneRelocationNotSet(rName, 0),
+				Config: testAccClusterConfig_updateAvailabilityZoneAvailabilityZoneRelocationNotSet(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
@@ -609,7 +609,7 @@ func TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNot
 				),
 			},
 			{
-				Config:      testAccClusterConfig_updateAvailabilityZone_availabilityZoneRelocationNotSet(rName, 1),
+				Config:      testAccClusterConfig_updateAvailabilityZoneAvailabilityZoneRelocationNotSet(rName, 1),
 				ExpectError: regexp.MustCompile("cannot change `availability_zone` if `availability_zone_relocation_enabled` is not true"),
 			},
 		},
@@ -726,7 +726,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *tes
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccClusterConfig_availabilityZoneRelocation_publiclyAccessible(rName),
+				Config:      testAccClusterConfig_availabilityZoneRelocationPubliclyAccessible(rName),
 				ExpectError: regexp.MustCompile("`availability_zone_relocation_enabled` cannot be true when `publicly_accessible` is true"),
 			},
 		},
@@ -745,7 +745,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckDestroyClusterSnapshot(rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterCreateSnapshotConfig(rName),
+				Config: testAccClusterConfig_createSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", "data.aws_availability_zones.available", "names.0"),
@@ -758,7 +758,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 				Config: acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
 			},
 			{
-				Config: testAccClusterRestoreFromSnapshotConfig(rName),
+				Config: testAccClusterConfig_restoreFromSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", "data.aws_availability_zones.available", "names.1"),
@@ -1057,7 +1057,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterWithFinalSnapshotConfig(rName string) string {
+func testAccClusterConfig_finalSnapshot(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
@@ -1303,7 +1303,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
@@ -1323,7 +1323,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccClusterConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
@@ -1582,7 +1582,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName, regionIndex))
 }
 
-func testAccClusterConfig_updateAvailabilityZone_availabilityZoneRelocationNotSet(rName string, regionIndex int) string {
+func testAccClusterConfig_updateAvailabilityZoneAvailabilityZoneRelocationNotSet(rName string, regionIndex int) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
 		fmt.Sprintf(`
@@ -1624,7 +1624,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName, enabled))
 }
 
-func testAccClusterConfig_availabilityZoneRelocation_publiclyAccessible(rName string) string {
+func testAccClusterConfig_availabilityZoneRelocationPubliclyAccessible(rName string) string {
 	return acctest.ConfigCompose(
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
@@ -1643,7 +1643,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterCreateSnapshotConfig(rName string) string {
+func testAccClusterConfig_createSnapshot(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier        = %[1]q
@@ -1658,7 +1658,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterRestoreFromSnapshotConfig(rName string) string {
+func testAccClusterConfig_restoreFromSnapshot(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier  = %[1]q

--- a/internal/service/redshift/event_subscription_test.go
+++ b/internal/service/redshift/event_subscription_test.go
@@ -27,7 +27,7 @@ func TestAccRedshiftEventSubscription_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionConfig(rName),
+				Config: testAccEventSubscriptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "redshift", regexp.MustCompile(`eventsubscription:.+`)),
@@ -48,7 +48,7 @@ func TestAccRedshiftEventSubscription_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEventSubscriptionUpdateConfig(rName),
+				Config: testAccEventSubscriptionConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -76,7 +76,7 @@ func TestAccRedshiftEventSubscription_withSourceIDs(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionWithSourceIDsConfig(rName),
+				Config: testAccEventSubscriptionConfig_sourceIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -86,7 +86,7 @@ func TestAccRedshiftEventSubscription_withSourceIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEventSubscriptionUpdateSourceIDsConfig(rName),
+				Config: testAccEventSubscriptionConfig_updateSourceIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -116,7 +116,7 @@ func TestAccRedshiftEventSubscription_categoryUpdate(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionConfig(rName),
+				Config: testAccEventSubscriptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -124,7 +124,7 @@ func TestAccRedshiftEventSubscription_categoryUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEventSubscriptionUpdateCategoriesConfig(rName),
+				Config: testAccEventSubscriptionConfig_updateCategories(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -152,7 +152,7 @@ func TestAccRedshiftEventSubscription_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionConfigTags1(rName, "key1", "value1"),
+				Config: testAccEventSubscriptionConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -165,7 +165,7 @@ func TestAccRedshiftEventSubscription_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEventSubscriptionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccEventSubscriptionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -174,7 +174,7 @@ func TestAccRedshiftEventSubscription_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEventSubscriptionConfigTags1(rName, "key2", "value2"),
+				Config: testAccEventSubscriptionConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -197,7 +197,7 @@ func TestAccRedshiftEventSubscription_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionConfig(rName),
+				Config: testAccEventSubscriptionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceEventSubscription(), resourceName),
@@ -257,7 +257,7 @@ func testAccCheckEventSubscriptionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccEventSubscriptionConfig(rName string) string {
+func testAccEventSubscriptionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -270,7 +270,7 @@ resource "aws_redshift_event_subscription" "test" {
 `, rName)
 }
 
-func testAccEventSubscriptionUpdateConfig(rName string) string {
+func testAccEventSubscriptionConfig_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -290,7 +290,7 @@ resource "aws_redshift_event_subscription" "test" {
 `, rName)
 }
 
-func testAccEventSubscriptionWithSourceIDsConfig(rName string) string {
+func testAccEventSubscriptionConfig_sourceIDs(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -316,7 +316,7 @@ resource "aws_redshift_event_subscription" "test" {
 `, rName)
 }
 
-func testAccEventSubscriptionUpdateSourceIDsConfig(rName string) string {
+func testAccEventSubscriptionConfig_updateSourceIDs(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -348,7 +348,7 @@ resource "aws_redshift_event_subscription" "test" {
 `, rName)
 }
 
-func testAccEventSubscriptionUpdateCategoriesConfig(rName string) string {
+func testAccEventSubscriptionConfig_updateCategories(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -367,7 +367,7 @@ resource "aws_redshift_event_subscription" "test" {
 `, rName)
 }
 
-func testAccEventSubscriptionConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccEventSubscriptionConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -393,7 +393,7 @@ resource "aws_redshift_event_subscription" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccEventSubscriptionConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccEventSubscriptionConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q

--- a/internal/service/redshift/orderable_cluster_data_source_test.go
+++ b/internal/service/redshift/orderable_cluster_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccRedshiftOrderableClusterDataSource_clusterType(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrderableClusterDataSourceConfig_ClusterType("multi-node"),
+				Config: testAccOrderableClusterDataSourceConfig_type("multi-node"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_type", "multi-node"),
 				),
@@ -40,7 +40,7 @@ func TestAccRedshiftOrderableClusterDataSource_clusterVersion(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrderableClusterDataSourceConfig_ClusterVersion("1.0"),
+				Config: testAccOrderableClusterDataSourceConfig_version("1.0"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_version", "1.0"),
 				),
@@ -60,7 +60,7 @@ func TestAccRedshiftOrderableClusterDataSource_nodeType(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrderableClusterDataSourceConfig_NodeType(nodeType),
+				Config: testAccOrderableClusterDataSourceConfig_nodeType(nodeType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "node_type", nodeType),
 				),
@@ -80,7 +80,7 @@ func TestAccRedshiftOrderableClusterDataSource_preferredNodeTypes(t *testing.T) 
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrderableClusterDataSourceConfig_PreferredNodeTypes(preferredNodeType),
+				Config: testAccOrderableClusterDataSourceConfig_preferredNodeTypes(preferredNodeType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "node_type", preferredNodeType),
 				),
@@ -107,7 +107,7 @@ func testAccOrderableClusterPreCheck(t *testing.T) {
 	}
 }
 
-func testAccOrderableClusterDataSourceConfig_ClusterType(clusterType string) string {
+func testAccOrderableClusterDataSourceConfig_type(clusterType string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   cluster_type         = %[1]q
@@ -116,7 +116,7 @@ data "aws_redshift_orderable_cluster" "test" {
 `, clusterType)
 }
 
-func testAccOrderableClusterDataSourceConfig_ClusterVersion(clusterVersion string) string {
+func testAccOrderableClusterDataSourceConfig_version(clusterVersion string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   cluster_version      = %[1]q
@@ -125,7 +125,7 @@ data "aws_redshift_orderable_cluster" "test" {
 `, clusterVersion)
 }
 
-func testAccOrderableClusterDataSourceConfig_NodeType(nodeType string) string {
+func testAccOrderableClusterDataSourceConfig_nodeType(nodeType string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   node_type            = %[1]q
@@ -134,7 +134,7 @@ data "aws_redshift_orderable_cluster" "test" {
 `, nodeType)
 }
 
-func testAccOrderableClusterDataSourceConfig_PreferredNodeTypes(preferredNodeType string) string {
+func testAccOrderableClusterDataSourceConfig_preferredNodeTypes(preferredNodeType string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   preferred_node_types = [

--- a/internal/service/redshift/parameter_group_test.go
+++ b/internal/service/redshift/parameter_group_test.go
@@ -26,7 +26,7 @@ func TestAccRedshiftParameterGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig(rInt),
+				Config: testAccParameterGroupConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 				),
@@ -52,7 +52,7 @@ func TestAccRedshiftParameterGroup_withParameters(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig(rInt),
+				Config: testAccParameterGroupConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -96,7 +96,7 @@ func TestAccRedshiftParameterGroup_withoutParameters(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupOnlyConfig(rInt),
+				Config: testAccParameterGroupConfig_only(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -128,7 +128,7 @@ func TestAccRedshiftParameterGroup_withTags(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupWithTagsConfig(rInt, "aaa"),
+				Config: testAccParameterGroupConfig_tags(rInt, "aaa"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -144,7 +144,7 @@ func TestAccRedshiftParameterGroup_withTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupWithTagsConfig(rInt, "bbb"),
+				Config: testAccParameterGroupConfig_tags(rInt, "bbb"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -153,7 +153,7 @@ func TestAccRedshiftParameterGroup_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccParameterGroupWithTagsUpdateConfig(rInt),
+				Config: testAccParameterGroupConfig_tagsUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -233,7 +233,7 @@ func testAccCheckParameterGroupExists(n string, v *redshift.ClusterParameterGrou
 	}
 }
 
-func testAccParameterGroupOnlyConfig(rInt int) string {
+func testAccParameterGroupConfig_only(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_parameter_group" "test" {
   name        = "test-terraform-%d"
@@ -243,7 +243,7 @@ resource "aws_redshift_parameter_group" "test" {
 `, rInt)
 }
 
-func testAccParameterGroupConfig(rInt int) string {
+func testAccParameterGroupConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_parameter_group" "test" {
   name   = "test-terraform-%d"
@@ -267,7 +267,7 @@ resource "aws_redshift_parameter_group" "test" {
 `, rInt)
 }
 
-func testAccParameterGroupWithTagsConfig(rInt int, rString string) string {
+func testAccParameterGroupConfig_tags(rInt int, rString string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_parameter_group" "test" {
   name        = "test-terraform-%[1]d"
@@ -283,7 +283,7 @@ resource "aws_redshift_parameter_group" "test" {
 `, rInt, rString)
 }
 
-func testAccParameterGroupWithTagsUpdateConfig(rInt int) string {
+func testAccParameterGroupConfig_tagsUpdate(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_parameter_group" "test" {
   name        = "test-terraform-%[1]d"

--- a/internal/service/redshift/scheduled_action_test.go
+++ b/internal/service/redshift/scheduled_action_test.go
@@ -27,7 +27,7 @@ func TestAccRedshiftScheduledAction_basicPauseCluster(t *testing.T) {
 		CheckDestroy:      testAccCheckScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionPauseClusterConfig(rName, "cron(00 23 * * ? *)"),
+				Config: testAccScheduledActionConfig_pauseCluster(rName, "cron(00 23 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -49,7 +49,7 @@ func TestAccRedshiftScheduledAction_basicPauseCluster(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccScheduledActionPauseClusterConfig(rName, "at(2060-03-04T17:27:00)"),
+				Config: testAccScheduledActionConfig_pauseCluster(rName, "at(2060-03-04T17:27:00)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -83,7 +83,7 @@ func TestAccRedshiftScheduledAction_pauseClusterWithOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionPauseClusterWithFullOptionsConfig(rName, "cron(00 * * * ? *)", "This is test action", true, startTime, endTime),
+				Config: testAccScheduledActionConfig_pauseClusterFullOptions(rName, "cron(00 * * * ? *)", "This is test action", true, startTime, endTime),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", "This is test action"),
@@ -120,7 +120,7 @@ func TestAccRedshiftScheduledAction_basicResumeCluster(t *testing.T) {
 		CheckDestroy:      testAccCheckScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionResumeClusterConfig(rName, "cron(00 23 * * ? *)"),
+				Config: testAccScheduledActionConfig_resumeCluster(rName, "cron(00 23 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -142,7 +142,7 @@ func TestAccRedshiftScheduledAction_basicResumeCluster(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccScheduledActionResumeClusterConfig(rName, "at(2060-03-04T17:27:00)"),
+				Config: testAccScheduledActionConfig_resumeCluster(rName, "at(2060-03-04T17:27:00)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -174,7 +174,7 @@ func TestAccRedshiftScheduledAction_basicResizeCluster(t *testing.T) {
 		CheckDestroy:      testAccCheckScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionResizeClusterBasicConfig(rName, "cron(00 23 * * ? *)"),
+				Config: testAccScheduledActionConfig_resizeClusterBasic(rName, "cron(00 23 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -196,7 +196,7 @@ func TestAccRedshiftScheduledAction_basicResizeCluster(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccScheduledActionResizeClusterBasicConfig(rName, "at(2060-03-04T17:27:00)"),
+				Config: testAccScheduledActionConfig_resizeClusterBasic(rName, "at(2060-03-04T17:27:00)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -228,7 +228,7 @@ func TestAccRedshiftScheduledAction_resizeClusterWithOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionResizeClusterWithFullOptionsConfig(rName, "cron(00 23 * * ? *)", true, "multi-node", "dc2.large", 2),
+				Config: testAccScheduledActionConfig_resizeClusterFullOptions(rName, "cron(00 23 * * ? *)", true, "multi-node", "dc2.large", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -269,7 +269,7 @@ func TestAccRedshiftScheduledAction_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionPauseClusterConfig(rName, "cron(00 23 * * ? *)"),
+				Config: testAccScheduledActionConfig_pauseCluster(rName, "cron(00 23 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceScheduledAction(), resourceName),
@@ -383,7 +383,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, rName, rName)
 }
 
-func testAccScheduledActionPauseClusterConfig(rName, schedule string) string {
+func testAccScheduledActionConfig_pauseCluster(rName, schedule string) string {
 	return acctest.ConfigCompose(testAccScheduledActionBaseConfig(rName), fmt.Sprintf(`
 resource "aws_redshift_scheduled_action" "test" {
   name     = %[1]q
@@ -399,7 +399,7 @@ resource "aws_redshift_scheduled_action" "test" {
 `, rName, schedule))
 }
 
-func testAccScheduledActionPauseClusterWithFullOptionsConfig(rName, schedule, description string, enable bool, startTime, endTime string) string {
+func testAccScheduledActionConfig_pauseClusterFullOptions(rName, schedule, description string, enable bool, startTime, endTime string) string {
 	return acctest.ConfigCompose(testAccScheduledActionBaseConfig(rName), fmt.Sprintf(`
 resource "aws_redshift_scheduled_action" "test" {
   name        = %[1]q
@@ -419,7 +419,7 @@ resource "aws_redshift_scheduled_action" "test" {
 `, rName, description, enable, startTime, endTime, schedule))
 }
 
-func testAccScheduledActionResumeClusterConfig(rName, schedule string) string {
+func testAccScheduledActionConfig_resumeCluster(rName, schedule string) string {
 	return acctest.ConfigCompose(testAccScheduledActionBaseConfig(rName), fmt.Sprintf(`
 resource "aws_redshift_scheduled_action" "test" {
   name     = %[1]q
@@ -435,7 +435,7 @@ resource "aws_redshift_scheduled_action" "test" {
 `, rName, schedule))
 }
 
-func testAccScheduledActionResizeClusterBasicConfig(rName, schedule string) string {
+func testAccScheduledActionConfig_resizeClusterBasic(rName, schedule string) string {
 	return acctest.ConfigCompose(testAccScheduledActionBaseConfig(rName), fmt.Sprintf(`
 resource "aws_redshift_scheduled_action" "test" {
   name     = %[1]q
@@ -451,7 +451,7 @@ resource "aws_redshift_scheduled_action" "test" {
 `, rName, schedule))
 }
 
-func testAccScheduledActionResizeClusterWithFullOptionsConfig(rName, schedule string, classic bool, clusterType, nodeType string, numberOfNodes int) string {
+func testAccScheduledActionConfig_resizeClusterFullOptions(rName, schedule string, classic bool, clusterType, nodeType string, numberOfNodes int) string {
 	return acctest.ConfigCompose(testAccScheduledActionBaseConfig(rName), fmt.Sprintf(`
 resource "aws_redshift_scheduled_action" "test" {
   name     = %[1]q

--- a/internal/service/redshift/service_account_data_source_test.go
+++ b/internal/service/redshift/service_account_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccRedshiftServiceAccountDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAccountConfig_basic,
+				Config: testAccServiceAccountDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
 					acctest.CheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "user/logs"),
@@ -41,7 +41,7 @@ func TestAccRedshiftServiceAccountDataSource_region(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAccountConfig_explicitRegion,
+				Config: testAccServiceAccountDataSourceConfig_explicitRegion,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
 					acctest.CheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "user/logs"),
@@ -51,11 +51,11 @@ func TestAccRedshiftServiceAccountDataSource_region(t *testing.T) {
 	})
 }
 
-const testAccServiceAccountConfig_basic = `
+const testAccServiceAccountDataSourceConfig_basic = `
 data "aws_redshift_service_account" "main" {}
 `
 
-const testAccServiceAccountConfig_explicitRegion = `
+const testAccServiceAccountDataSourceConfig_explicitRegion = `
 data "aws_region" "current" {}
 
 data "aws_redshift_service_account" "regional" {

--- a/internal/service/redshift/snapshot_copy_grant_test.go
+++ b/internal/service/redshift/snapshot_copy_grant_test.go
@@ -25,7 +25,7 @@ func TestAccRedshiftSnapshotCopyGrant_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotCopyGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotCopyGrant_Basic(rName),
+				Config: testAccSnapshotCopyGrantConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotCopyGrantExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_copy_grant_name", rName),
@@ -53,7 +53,7 @@ func TestAccRedshiftSnapshotCopyGrant_update(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotCopyGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotCopyGrantWithTags(rName),
+				Config: testAccSnapshotCopyGrantConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotCopyGrantExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -62,14 +62,14 @@ func TestAccRedshiftSnapshotCopyGrant_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSnapshotCopyGrant_Basic(rName),
+				Config: testAccSnapshotCopyGrantConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotCopyGrantExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				Config: testAccSnapshotCopyGrantWithTags(rName),
+				Config: testAccSnapshotCopyGrantConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotCopyGrantExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -97,7 +97,7 @@ func TestAccRedshiftSnapshotCopyGrant_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotCopyGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotCopyGrant_Basic(rName),
+				Config: testAccSnapshotCopyGrantConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotCopyGrantExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceSnapshotCopyGrant(), resourceName),
@@ -159,7 +159,7 @@ func testAccCheckSnapshotCopyGrantExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccSnapshotCopyGrant_Basic(rName string) string {
+func testAccSnapshotCopyGrantConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_copy_grant" "test" {
   snapshot_copy_grant_name = %[1]q
@@ -167,7 +167,7 @@ resource "aws_redshift_snapshot_copy_grant" "test" {
 `, rName)
 }
 
-func testAccSnapshotCopyGrantWithTags(rName string) string {
+func testAccSnapshotCopyGrantConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_copy_grant" "test" {
   snapshot_copy_grant_name = %[1]q

--- a/internal/service/redshift/snapshot_schedule_association_test.go
+++ b/internal/service/redshift/snapshot_schedule_association_test.go
@@ -27,7 +27,7 @@ func TestAccRedshiftSnapshotScheduleAssociation_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleAssociationConfig(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleAssociationConfig_basic(rName, "rate(12 hours)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "schedule_identifier", snapshotScheduleResourceName, "id"),
@@ -54,7 +54,7 @@ func TestAccRedshiftSnapshotScheduleAssociation_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleAssociationConfig(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleAssociationConfig_basic(rName, "rate(12 hours)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceSnapshotScheduleAssociation(), resourceName),
@@ -77,7 +77,7 @@ func TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster(t *testing.T)
 		CheckDestroy:      testAccCheckSnapshotScheduleAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleAssociationConfig(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleAssociationConfig_basic(rName, "rate(12 hours)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceCluster(), clusterResourceName),
@@ -135,8 +135,8 @@ func testAccCheckSnapshotScheduleAssociationExists(n string) resource.TestCheckF
 	}
 }
 
-func testAccSnapshotScheduleAssociationConfig(rName, definition string) string {
-	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), testAccSnapshotScheduleConfig(rName, definition), `
+func testAccSnapshotScheduleAssociationConfig_basic(rName, definition string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), testAccSnapshotScheduleConfig_basic(rName, definition), `
 resource "aws_redshift_snapshot_schedule_association" "test" {
   schedule_identifier = aws_redshift_snapshot_schedule.default.id
   cluster_identifier  = aws_redshift_cluster.test.id

--- a/internal/service/redshift/snapshot_schedule_test.go
+++ b/internal/service/redshift/snapshot_schedule_test.go
@@ -26,14 +26,14 @@ func TestAccRedshiftSnapshotSchedule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleConfig(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleConfig_basic(rName, "rate(12 hours)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "definitions.#", "1"),
 				),
 			},
 			{
-				Config: testAccSnapshotScheduleConfig(rName, "cron(30 12 *)"),
+				Config: testAccSnapshotScheduleConfig_basic(rName, "cron(30 12 *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "definitions.#", "1"),
@@ -63,14 +63,14 @@ func TestAccRedshiftSnapshotSchedule_withMultipleDefinition(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleWithMultipleDefinitionConfig(rName, "cron(30 12 *)", "cron(15 6 *)"),
+				Config: testAccSnapshotScheduleConfig_multipleDefinition(rName, "cron(30 12 *)", "cron(15 6 *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "definitions.#", "2"),
 				),
 			},
 			{
-				Config: testAccSnapshotScheduleWithMultipleDefinitionConfig(rName, "cron(30 8 *)", "cron(15 10 *)"),
+				Config: testAccSnapshotScheduleConfig_multipleDefinition(rName, "cron(30 8 *)", "cron(15 10 *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "definitions.#", "2"),
@@ -100,7 +100,7 @@ func TestAccRedshiftSnapshotSchedule_withIdentifierPrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleWithIdentifierPrefixConfig,
+				Config: testAccSnapshotScheduleConfig_identifierPrefix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 				),
@@ -130,7 +130,7 @@ func TestAccRedshiftSnapshotSchedule_withDescription(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleWithDescriptionConfig(rName),
+				Config: testAccSnapshotScheduleConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -161,7 +161,7 @@ func TestAccRedshiftSnapshotSchedule_withTags(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleWithTagsConfig(rName),
+				Config: testAccSnapshotScheduleConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -170,7 +170,7 @@ func TestAccRedshiftSnapshotSchedule_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSnapshotScheduleWithTagsUpdateConfig(rName),
+				Config: testAccSnapshotScheduleConfig_tagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -204,7 +204,7 @@ func TestAccRedshiftSnapshotSchedule_withForceDestroy(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleWithForceDestroyConfig(rName),
+				Config: testAccSnapshotScheduleConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(resourceName, &snapshotSchedule),
 					testAccCheckClusterExists(clusterResourceName, &cluster),
@@ -302,7 +302,7 @@ func testAccCheckSnapshotScheduleCreateSnapshotScheduleAssociation(cluster *reds
 	}
 }
 
-const testAccSnapshotScheduleWithIdentifierPrefixConfig = `
+const testAccSnapshotScheduleConfig_identifierPrefix = `
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier_prefix = "tf-acc-test"
   definitions = [
@@ -311,7 +311,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 }
 `
 
-func testAccSnapshotScheduleConfig(rName, definition string) string {
+func testAccSnapshotScheduleConfig_basic(rName, definition string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier = %[1]q
@@ -322,7 +322,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 `, rName, definition)
 }
 
-func testAccSnapshotScheduleWithMultipleDefinitionConfig(rName, definition1, definition2 string) string {
+func testAccSnapshotScheduleConfig_multipleDefinition(rName, definition1, definition2 string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier = %[1]q
@@ -334,7 +334,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 `, rName, definition1, definition2)
 }
 
-func testAccSnapshotScheduleWithDescriptionConfig(rName string) string {
+func testAccSnapshotScheduleConfig_description(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier  = %[1]q
@@ -346,7 +346,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 `, rName)
 }
 
-func testAccSnapshotScheduleWithTagsConfig(rName string) string {
+func testAccSnapshotScheduleConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier = %[1]q
@@ -362,7 +362,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 `, rName)
 }
 
-func testAccSnapshotScheduleWithTagsUpdateConfig(rName string) string {
+func testAccSnapshotScheduleConfig_tagsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier = %[1]q
@@ -378,7 +378,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 `, rName)
 }
 
-func testAccSnapshotScheduleWithForceDestroyConfig(rName string) string {
+func testAccSnapshotScheduleConfig_forceDestroy(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
   identifier  = %[1]q

--- a/internal/service/redshift/subnet_group_test.go
+++ b/internal/service/redshift/subnet_group_test.go
@@ -135,7 +135,7 @@ func TestAccRedshiftSubnetGroup_updateSubnetIDs(t *testing.T) {
 					"description"},
 			},
 			{
-				Config: testAccSubnetGroupConfig_updateSubnetIDs(rInt),
+				Config: testAccSubnetGroupConfig_updateIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -406,7 +406,7 @@ resource "aws_redshift_subnet_group" "test" {
 `, rInt))
 }
 
-func testAccSubnetGroupConfig_updateSubnetIDs(rInt int) string {
+func testAccSubnetGroupConfig_updateIDs(rInt int) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/internal/service/redshift/usage_limit_test.go
+++ b/internal/service/redshift/usage_limit_test.go
@@ -25,7 +25,7 @@ func TestAccRedshiftUsageLimit_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckUsageLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUsageLimitBasicConfig(rName, 60),
+				Config: testAccUsageLimitConfig_basic(rName, 60),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUsageLimitExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "feature_type", "concurrency-scaling"),
@@ -43,7 +43,7 @@ func TestAccRedshiftUsageLimit_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccUsageLimitBasicConfig(rName, 120),
+				Config: testAccUsageLimitConfig_basic(rName, 120),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUsageLimitExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "feature_type", "concurrency-scaling"),
@@ -70,7 +70,7 @@ func TestAccRedshiftUsageLimit_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckUsageLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUsageLimitConfigTags1(rName, "key1", "value1"),
+				Config: testAccUsageLimitConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUsageLimitExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -83,7 +83,7 @@ func TestAccRedshiftUsageLimit_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccUsageLimitConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccUsageLimitConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -91,7 +91,7 @@ func TestAccRedshiftUsageLimit_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccUsageLimitConfigTags1(rName, "key2", "value2"),
+				Config: testAccUsageLimitConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUsageLimitExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -113,7 +113,7 @@ func TestAccRedshiftUsageLimit_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckUsageLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUsageLimitBasicConfig(rName, 60),
+				Config: testAccUsageLimitConfig_basic(rName, 60),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUsageLimitExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceUsageLimit(), resourceName),
@@ -170,7 +170,7 @@ func testAccCheckUsageLimitExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccUsageLimitBasicConfig(rName string, amount int) string {
+func testAccUsageLimitConfig_basic(rName string, amount int) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_usage_limit" "test" {
   cluster_identifier = aws_redshift_cluster.test.id
@@ -181,7 +181,7 @@ resource "aws_redshift_usage_limit" "test" {
 `, amount))
 }
 
-func testAccUsageLimitConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccUsageLimitConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_usage_limit" "test" {
   cluster_identifier = aws_redshift_cluster.test.id
@@ -196,7 +196,7 @@ resource "aws_redshift_usage_limit" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccUsageLimitConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccUsageLimitConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_usage_limit" "test" {
   cluster_identifier = aws_redshift_cluster.test.id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
