### PR TITLE
qldb: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -344,7 +344,6 @@ rules:
         - internal/service/outposts
         - internal/service/pinpoint
         - internal/service/pricing
-        - internal/service/qldb
         - internal/service/quicksight
         - internal/service/ram
         - internal/service/rds

--- a/internal/service/qldb/ledger_data_source_test.go
+++ b/internal/service/qldb/ledger_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccQLDBLedgerDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerDataSourceConfig(rName),
+				Config: testAccLedgerDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "deletion_protection", resourceName, "deletion_protection"),
@@ -35,7 +35,7 @@ func TestAccQLDBLedgerDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccLedgerDataSourceConfig(rName string) string {
+func testAccLedgerDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_qldb_ledger" "test" {
   name                = %[1]q

--- a/internal/service/qldb/ledger_test.go
+++ b/internal/service/qldb/ledger_test.go
@@ -28,7 +28,7 @@ func TestAccQLDBLedger_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckLedgerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerConfig(rName),
+				Config: testAccLedgerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "qldb", regexp.MustCompile(`ledger/.+`)),
@@ -60,7 +60,7 @@ func TestAccQLDBLedger_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckLedgerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerConfig(rName),
+				Config: testAccLedgerConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfqldb.ResourceLedger(), resourceName),
@@ -82,7 +82,7 @@ func TestAccQLDBLedger_nameGenerated(t *testing.T) {
 		CheckDestroy:      testAccCheckLedgerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerNameGeneratedConfig(),
+				Config: testAccLedgerConfig_nameGenerated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(`tf\d+`)),
@@ -109,7 +109,7 @@ func TestAccQLDBLedger_update(t *testing.T) {
 		CheckDestroy:      testAccCheckLedgerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerConfig(rName),
+				Config: testAccLedgerConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
@@ -122,7 +122,7 @@ func TestAccQLDBLedger_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLedgerUpdatedConfig(rName),
+				Config: testAccLedgerConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "true"),
@@ -130,7 +130,7 @@ func TestAccQLDBLedger_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLedgerConfig(rName),
+				Config: testAccLedgerConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
@@ -154,7 +154,7 @@ func TestAccQLDBLedger_kmsKey(t *testing.T) {
 		CheckDestroy:      testAccCheckLedgerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerKMSKeyConfig(rName),
+				Config: testAccLedgerConfig_kmsKey(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key", kmsKeyResourceName, "arn"),
@@ -166,7 +166,7 @@ func TestAccQLDBLedger_kmsKey(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLedgerKMSKeyUpdatedConfig(rName),
+				Config: testAccLedgerConfig_kmsKeyUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "kms_key", "AWS_OWNED_KMS_KEY"),
@@ -188,7 +188,7 @@ func TestAccQLDBLedger_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckLedgerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLedgerConfigTags1(rName, "key1", "value1"),
+				Config: testAccLedgerConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -201,7 +201,7 @@ func TestAccQLDBLedger_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLedgerConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccLedgerConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -210,7 +210,7 @@ func TestAccQLDBLedger_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLedgerConfigTags1(rName, "key2", "value2"),
+				Config: testAccLedgerConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLedgerExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -270,7 +270,7 @@ func testAccCheckLedgerExists(n string, v *qldb.DescribeLedgerOutput) resource.T
 	}
 }
 
-func testAccLedgerConfig(rName string) string {
+func testAccLedgerConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_qldb_ledger" "test" {
   name                = %[1]q
@@ -280,7 +280,7 @@ resource "aws_qldb_ledger" "test" {
 `, rName)
 }
 
-func testAccLedgerUpdatedConfig(rName string) string {
+func testAccLedgerConfig_updated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_qldb_ledger" "test" {
   name                = %[1]q
@@ -290,7 +290,7 @@ resource "aws_qldb_ledger" "test" {
 `, rName)
 }
 
-func testAccLedgerNameGeneratedConfig() string {
+func testAccLedgerConfig_nameGenerated() string {
 	return `
 resource "aws_qldb_ledger" "test" {
   permissions_mode    = "ALLOW_ALL"
@@ -299,7 +299,7 @@ resource "aws_qldb_ledger" "test" {
 `
 }
 
-func testAccLedgerKMSKeyConfig(rName string) string {
+func testAccLedgerConfig_kmsKey(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -315,7 +315,7 @@ resource "aws_qldb_ledger" "test" {
 `, rName)
 }
 
-func testAccLedgerKMSKeyUpdatedConfig(rName string) string {
+func testAccLedgerConfig_kmsKeyUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -331,7 +331,7 @@ resource "aws_qldb_ledger" "test" {
 `, rName)
 }
 
-func testAccLedgerConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccLedgerConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_qldb_ledger" "test" {
   name                = %[1]q
@@ -345,7 +345,7 @@ resource "aws_qldb_ledger" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccLedgerConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccLedgerConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_qldb_ledger" "test" {
   name                = %[1]q

--- a/internal/service/qldb/stream_test.go
+++ b/internal/service/qldb/stream_test.go
@@ -28,7 +28,7 @@ func TestAccQLDBStream_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStreamConfig(rName),
+				Config: testAccStreamConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "qldb", regexp.MustCompile(`stream/.+`)),
@@ -59,7 +59,7 @@ func TestAccQLDBStream_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStreamConfig(rName),
+				Config: testAccStreamConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStreamExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfqldb.ResourceStream(), resourceName),
@@ -82,7 +82,7 @@ func TestAccQLDBStream_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStreamConfigTags1(rName, "key1", "value1"),
+				Config: testAccStreamConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStreamExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -90,7 +90,7 @@ func TestAccQLDBStream_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStreamConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccStreamConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStreamExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -99,7 +99,7 @@ func TestAccQLDBStream_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStreamConfigTags1(rName, "key2", "value2"),
+				Config: testAccStreamConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStreamExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -122,7 +122,7 @@ func TestAccQLDBStream_withEndTime(t *testing.T) {
 		CheckDestroy:      testAccCheckStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStreamEndTimeConfig(rName),
+				Config: testAccStreamConfig_endTime(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStreamExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "exclusive_end_time"),
@@ -233,7 +233,7 @@ resource "aws_iam_role" "test" {
 `, rName)
 }
 
-func testAccStreamConfig(rName string) string {
+func testAccStreamConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccStreamBaseConfig(rName), fmt.Sprintf(`
 resource "aws_qldb_stream" "test" {
   stream_name          = %[1]q
@@ -248,7 +248,7 @@ resource "aws_qldb_stream" "test" {
 `, rName))
 }
 
-func testAccStreamEndTimeConfig(rName string) string {
+func testAccStreamConfig_endTime(rName string) string {
 	return acctest.ConfigCompose(testAccStreamBaseConfig(rName), fmt.Sprintf(`
 resource "aws_qldb_stream" "test" {
   stream_name          = %[1]q
@@ -265,7 +265,7 @@ resource "aws_qldb_stream" "test" {
 `, rName))
 }
 
-func testAccStreamConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccStreamConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccStreamBaseConfig(rName), fmt.Sprintf(`
 resource "aws_qldb_stream" "test" {
   stream_name          = %[1]q
@@ -284,7 +284,7 @@ resource "aws_qldb_stream" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccStreamConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccStreamConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccStreamBaseConfig(rName), fmt.Sprintf(`
 resource "aws_qldb_stream" "test" {
   stream_name          = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
