### PR TITLE
pinpoint: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -342,7 +342,6 @@ rules:
         - internal/service/opsworks
         - internal/service/organizations
         - internal/service/outposts
-        - internal/service/pinpoint
         - internal/service/pricing
         - internal/service/qldb
         - internal/service/quicksight

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -26,7 +26,7 @@ func TestAccPinpointApp_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppConfig_withGeneratedName,
+				Config: testAccAppConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 				),
@@ -52,7 +52,7 @@ func TestAccPinpointApp_campaignHookLambda(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppConfig_CampaignHookLambda(rName),
+				Config: testAccAppConfig_campaignHookLambda(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "campaign_hook.#", "1"),
@@ -80,7 +80,7 @@ func TestAccPinpointApp_limits(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppConfig_Limits(rName),
+				Config: testAccAppConfig_limits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "limits.#", "1"),
@@ -108,7 +108,7 @@ func TestAccPinpointApp_quietTime(t *testing.T) {
 		CheckDestroy:      testAccCheckAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppConfig_QuietTime(rName),
+				Config: testAccAppConfig_quietTime(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "quiet_time.#", "1"),
@@ -136,7 +136,7 @@ func TestAccPinpointApp_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckRAMResourceShareDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppConfig_Tag1(rName, "key1", "value1"),
+				Config: testAccAppConfig_tag1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -149,7 +149,7 @@ func TestAccPinpointApp_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAppConfig_Tag2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAppConfig_tag2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -158,7 +158,7 @@ func TestAccPinpointApp_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAppConfig_Tag1(rName, "key2", "value2"),
+				Config: testAccAppConfig_tag1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -214,11 +214,11 @@ func testAccCheckAppExists(n string, application *pinpoint.ApplicationResponse) 
 	}
 }
 
-const testAccAppConfig_withGeneratedName = `
+const testAccAppConfig_generatedName = `
 resource "aws_pinpoint_app" "test" {}
 `
 
-func testAccAppConfig_CampaignHookLambda(rName string) string {
+func testAccAppConfig_campaignHookLambda(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
   name = %[1]q
@@ -276,7 +276,7 @@ resource "aws_lambda_permission" "test" {
 `, rName)
 }
 
-func testAccAppConfig_Limits(rName string) string {
+func testAccAppConfig_limits(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
   name = %[1]q
@@ -291,7 +291,7 @@ resource "aws_pinpoint_app" "test" {
 `, rName)
 }
 
-func testAccAppConfig_QuietTime(rName string) string {
+func testAccAppConfig_quietTime(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
   name = %[1]q
@@ -304,7 +304,7 @@ resource "aws_pinpoint_app" "test" {
 `, rName)
 }
 
-func testAccAppConfig_Tag1(rName, tagKey1, tagValue1 string) string {
+func testAccAppConfig_tag1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
   name = %[1]q
@@ -316,7 +316,7 @@ resource "aws_pinpoint_app" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAppConfig_Tag2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAppConfig_tag2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
   name = %[1]q

--- a/internal/service/pinpoint/email_channel_test.go
+++ b/internal/service/pinpoint/email_channel_test.go
@@ -30,7 +30,7 @@ func TestAccPinpointEmailChannel_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailChannelConfig_FromAddress(domain, address1),
+				Config: testAccEmailChannelConfig_fromAddress(domain, address1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -46,7 +46,7 @@ func TestAccPinpointEmailChannel_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEmailChannelConfig_FromAddress(domain, address2),
+				Config: testAccEmailChannelConfig_fromAddress(domain, address2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -73,7 +73,7 @@ func TestAccPinpointEmailChannel_set(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailChannelConfigurationSetConfig(domain, address, rName),
+				Config: testAccEmailChannelConfig_configurationSet(domain, address, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_set", "aws_ses_configuration_set.test", "name"),
@@ -103,7 +103,7 @@ func TestAccPinpointEmailChannel_noRole(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailChannelNoRoleConfig(domain, address, rName),
+				Config: testAccEmailChannelConfig_noRole(domain, address, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_set", "aws_ses_configuration_set.test", "arn"),
@@ -132,7 +132,7 @@ func TestAccPinpointEmailChannel_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailChannelConfig_FromAddress(domain, address),
+				Config: testAccEmailChannelConfig_fromAddress(domain, address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailChannelExists(resourceName, &channel),
 					acctest.CheckResourceDisappears(acctest.Provider, tfpinpoint.ResourceEmailChannel(), resourceName),
@@ -172,7 +172,7 @@ func testAccCheckEmailChannelExists(n string, channel *pinpoint.EmailChannelResp
 	}
 }
 
-func testAccEmailChannelConfig_FromAddress(domain, fromAddress string) string {
+func testAccEmailChannelConfig_fromAddress(domain, fromAddress string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {}
 
@@ -229,7 +229,7 @@ EOF
 `, domain, fromAddress)
 }
 
-func testAccEmailChannelConfigurationSetConfig(domain, fromAddress, rName string) string {
+func testAccEmailChannelConfig_configurationSet(domain, fromAddress, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {}
 
@@ -291,7 +291,7 @@ EOF
 `, domain, fromAddress, rName)
 }
 
-func testAccEmailChannelNoRoleConfig(domain, fromAddress, rName string) string {
+func testAccEmailChannelConfig_noRole(domain, fromAddress, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
