### PR TITLE
opensearch: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -338,7 +338,6 @@ rules:
         - internal/service/neptune
         - internal/service/networkfirewall
         - internal/service/networkmanager
-        - internal/service/opensearch
         - internal/service/opsworks
         - internal/service/organizations
         - internal/service/outposts

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccOpenSearchDomainDataSource_Data_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainWithDataSourceConfig(rName, autoTuneStartAtTime),
+				Config: testAccDomainDataSourceConfig_basic(rName, autoTuneStartAtTime),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "processing", "false"),
 					resource.TestCheckResourceAttrPair(datasourceName, "engine_version", resourceName, "engine_version"),
@@ -68,7 +68,7 @@ func TestAccOpenSearchDomainDataSource_Data_advanced(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAdvancedWithDataSourceConfig(rName, autoTuneStartAtTime),
+				Config: testAccDomainDataSourceConfig_advanced(rName, autoTuneStartAtTime),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "engine_version", resourceName, "engine_version"),
 					resource.TestCheckResourceAttrPair(datasourceName, "auto_tune_options.#", resourceName, "auto_tune_options.#"),
@@ -96,7 +96,7 @@ func TestAccOpenSearchDomainDataSource_Data_advanced(t *testing.T) {
 	})
 }
 
-func testAccDomainWithDataSourceConfig(rName, autoTuneStartAtTime string) string {
+func testAccDomainDataSourceConfig_basic(rName, autoTuneStartAtTime string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -178,7 +178,7 @@ data "aws_opensearch_domain" "test" {
 `, rName, autoTuneStartAtTime)
 }
 
-func testAccDomainAdvancedWithDataSourceConfig(rName, autoTuneStartAtTime string) string {
+func testAccDomainDataSourceConfig_advanced(rName, autoTuneStartAtTime string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`

--- a/internal/service/opensearch/domain_policy_test.go
+++ b/internal/service/opensearch/domain_policy_test.go
@@ -53,7 +53,7 @@ func TestAccOpenSearchDomainPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainPolicyConfig(ri, policy),
+				Config: testAccDomainPolicyConfig_basic(ri, policy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists("aws_opensearch_domain.test", &domain),
 					resource.TestCheckResourceAttr("aws_opensearch_domain.test", "engine_version", "OpenSearch_1.1"),
@@ -113,7 +113,7 @@ func buildDomainARN(name, partition, accId, region string) (string, error) {
 	return fmt.Sprintf("arn:%s:es:%s:%s:domain/%s", partition, region, accId, name), nil
 }
 
-func testAccDomainPolicyConfig(randInt int, policy string) string {
+func testAccDomainPolicyConfig_basic(randInt int, policy string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
   domain_name    = "tf-test-%d"

--- a/internal/service/opensearch/domain_saml_options_test.go
+++ b/internal/service/opensearch/domain_saml_options_test.go
@@ -31,7 +31,7 @@ func TestAccOpenSearchDomainSAMLOptions_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckESDomainSAMLOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSAMLOptionsConfig(rUserName, rName, idpEntityId),
+				Config: testAccDomainSAMLOptionsConfig_basic(rUserName, rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(esDomainResourceName, &domain),
 					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
@@ -65,7 +65,7 @@ func TestAccOpenSearchDomainSAMLOptions_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckESDomainSAMLOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSAMLOptionsConfig(rUserName, rName, idpEntityId),
+				Config: testAccDomainSAMLOptionsConfig_basic(rUserName, rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfopensearch.ResourceDomainSAMLOptions(), resourceName),
@@ -90,7 +90,7 @@ func TestAccOpenSearchDomainSAMLOptions_disappears_Domain(t *testing.T) {
 		CheckDestroy:      testAccCheckESDomainSAMLOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSAMLOptionsConfig(rUserName, rName, idpEntityId),
+				Config: testAccDomainSAMLOptionsConfig_basic(rUserName, rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfopensearch.ResourceDomain(), esDomainResourceName),
@@ -116,7 +116,7 @@ func TestAccOpenSearchDomainSAMLOptions_Update(t *testing.T) {
 		CheckDestroy:      testAccCheckESDomainSAMLOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSAMLOptionsConfig(rUserName, rName, idpEntityId),
+				Config: testAccDomainSAMLOptionsConfig_basic(rUserName, rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "60"),
@@ -124,7 +124,7 @@ func TestAccOpenSearchDomainSAMLOptions_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainSAMLOptionsConfigUpdate(rUserName, rName, idpEntityId),
+				Config: testAccDomainSAMLOptionsConfig_update(rUserName, rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "180"),
@@ -150,7 +150,7 @@ func TestAccOpenSearchDomainSAMLOptions_Disabled(t *testing.T) {
 		CheckDestroy:      testAccCheckESDomainSAMLOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainSAMLOptionsConfig(rUserName, rName, idpEntityId),
+				Config: testAccDomainSAMLOptionsConfig_basic(rUserName, rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "60"),
@@ -158,7 +158,7 @@ func TestAccOpenSearchDomainSAMLOptions_Disabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainSAMLOptionsConfigDisabled(rUserName, rName),
+				Config: testAccDomainSAMLOptionsConfig_disabled(rUserName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "0"),
@@ -215,7 +215,7 @@ func testAccCheckESDomainSAMLOptions(esResource string, samlOptionsResource stri
 	}
 }
 
-func testAccDomainSAMLOptionsConfig(userName, domainName, idpEntityId string) string {
+func testAccDomainSAMLOptionsConfig_basic(userName, domainName, idpEntityId string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
   name = %[1]q
@@ -272,7 +272,7 @@ resource "aws_opensearch_domain_saml_options" "test" {
 `, userName, domainName, idpEntityId)
 }
 
-func testAccDomainSAMLOptionsConfigUpdate(userName, domainName, idpEntityId string) string {
+func testAccDomainSAMLOptionsConfig_update(userName, domainName, idpEntityId string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
   name = %[1]q
@@ -330,7 +330,7 @@ resource "aws_opensearch_domain_saml_options" "test" {
 `, userName, domainName, idpEntityId)
 }
 
-func testAccDomainSAMLOptionsConfigDisabled(userName string, domainName string) string {
+func testAccDomainSAMLOptionsConfig_disabled(userName string, domainName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
   name = %[1]q

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -91,7 +91,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "OpenSearch_1.1"),
@@ -121,7 +121,7 @@ func TestAccOpenSearchDomain_requireHTTPS(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_domainEndpointOptions(rName, true, "Policy-Min-TLS-1-0-2019-07"),
+				Config: testAccDomainConfig_endpointOptions(rName, true, "Policy-Min-TLS-1-0-2019-07"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists("aws_opensearch_domain.test", &domain),
 					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-0-2019-07", &domain),
@@ -134,7 +134,7 @@ func TestAccOpenSearchDomain_requireHTTPS(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDomainConfig_domainEndpointOptions(rName, true, "Policy-Min-TLS-1-2-2019-07"),
+				Config: testAccDomainConfig_endpointOptions(rName, true, "Policy-Min-TLS-1-2-2019-07"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists("aws_opensearch_domain.test", &domain),
 					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-2-2019-07", &domain),
@@ -274,7 +274,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_clusterWithColdStorageOptions(rName, true, false),
+				Config: testAccDomainConfig_clusterColdStorageOptions(rName, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cluster_config.0.cold_storage_options.*", map[string]string{
@@ -288,7 +288,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDomainConfig_clusterWithColdStorageOptions(rName, true, true),
+				Config: testAccDomainConfig_clusterColdStorageOptions(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cluster_config.0.cold_storage_options.*", map[string]string{
@@ -476,7 +476,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 						t.Fatal(err)
 					}
 				},
-				Config: testAccDomainConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "OpenSearch_1.1")),
@@ -632,7 +632,7 @@ func TestAccOpenSearchDomain_VPC_internetToVPCEndpoint(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 				),
@@ -1143,7 +1143,7 @@ func TestAccOpenSearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_encryptAtRestWithKey(rName, "Elasticsearch_6.0", true),
+				Config: testAccDomainConfig_encryptAtRestKey(rName, "Elasticsearch_6.0", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					testAccCheckDomainEncrypted(true, &domain),
@@ -1540,7 +1540,7 @@ func TestAccOpenSearchDomain_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig(rName),
+				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceDisappears(acctest.Provider, tfopensearch.ResourceDomain(), resourceName),
 				),
@@ -1869,7 +1869,7 @@ func testAccCheckELBDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccDomainConfig(rName string) string {
+func testAccDomainConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
   domain_name = substr(%[1]q, 0, 28)
@@ -1932,7 +1932,7 @@ resource "aws_opensearch_domain" "test" {
 `, rName)
 }
 
-func testAccDomainConfig_domainEndpointOptions(rName string, enforceHttps bool, tlsSecurityPolicy string) string {
+func testAccDomainConfig_endpointOptions(rName string, enforceHttps bool, tlsSecurityPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
   domain_name = substr(%[1]q, 0, 28)
@@ -2000,7 +2000,7 @@ resource "aws_opensearch_domain" "test" {
 `, rName, availabilityZoneCount)
 }
 
-func testAccDomainConfig_clusterWithColdStorageOptions(rName string, warmEnabled bool, csEnabled bool) string {
+func testAccDomainConfig_clusterColdStorageOptions(rName string, warmEnabled bool, csEnabled bool) string {
 	warmConfig := ""
 	if warmEnabled {
 		warmConfig = `
@@ -2429,7 +2429,7 @@ resource "aws_opensearch_domain" "test" {
 `, rName, version, enabled)
 }
 
-func testAccDomainConfig_encryptAtRestWithKey(rName, version string, enabled bool) string {
+func testAccDomainConfig_encryptAtRestKey(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
