### PR TITLE
neptune: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -335,7 +335,6 @@ rules:
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
-        - internal/service/neptune
         - internal/service/networkfirewall
         - internal/service/networkmanager
         - internal/service/opensearch

--- a/internal/service/neptune/cluster_endpoint_test.go
+++ b/internal/service/neptune/cluster_endpoint_test.go
@@ -29,7 +29,7 @@ func TestAccNeptuneClusterEndpoint_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterEndpointConfig(rName),
+				Config: testAccClusterEndpointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterEndpointExists(resourceName, &dbCluster),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(`cluster-endpoint:.+`)),
@@ -66,7 +66,7 @@ func TestAccNeptuneClusterEndpoint_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterEndpointTags1Config(rName, "key1", "value1"),
+				Config: testAccClusterEndpointConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -79,7 +79,7 @@ func TestAccNeptuneClusterEndpoint_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterEndpointTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccClusterEndpointConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -88,7 +88,7 @@ func TestAccNeptuneClusterEndpoint_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterEndpointTags1Config(rName, "key2", "value2"),
+				Config: testAccClusterEndpointConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -111,7 +111,7 @@ func TestAccNeptuneClusterEndpoint_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterEndpointConfig(rName),
+				Config: testAccClusterEndpointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterEndpointExists(resourceName, &dbCluster),
 					acctest.CheckResourceDisappears(acctest.Provider, tfneptune.ResourceClusterEndpoint(), resourceName),
@@ -134,7 +134,7 @@ func TestAccNeptuneClusterEndpoint_Disappears_cluster(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterEndpointConfig(rName),
+				Config: testAccClusterEndpointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterEndpointExists(resourceName, &dbCluster),
 					acctest.CheckResourceDisappears(acctest.Provider, tfneptune.ResourceCluster(), "aws_neptune_cluster.test"),
@@ -215,7 +215,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterEndpointConfig(rName string) string {
+func testAccClusterEndpointConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccClusterEndpointBaseConfig(rName), fmt.Sprintf(`
 resource "aws_neptune_cluster_endpoint" "test" {
   cluster_identifier          = aws_neptune_cluster.test.cluster_identifier
@@ -225,7 +225,7 @@ resource "aws_neptune_cluster_endpoint" "test" {
 `, rName))
 }
 
-func testAccClusterEndpointTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccClusterEndpointConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccClusterEndpointBaseConfig(rName), fmt.Sprintf(`
 resource "aws_neptune_cluster_endpoint" "test" {
   cluster_identifier          = aws_neptune_cluster.test.cluster_identifier
@@ -239,7 +239,7 @@ resource "aws_neptune_cluster_endpoint" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccClusterEndpointTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccClusterEndpointConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccClusterEndpointBaseConfig(rName), fmt.Sprintf(`
 resource "aws_neptune_cluster_endpoint" "test" {
   cluster_identifier          = aws_neptune_cluster.test.cluster_identifier

--- a/internal/service/neptune/cluster_instance_test.go
+++ b/internal/service/neptune/cluster_instance_test.go
@@ -34,7 +34,7 @@ func TestAccNeptuneClusterInstance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterInstanceConfig(clusterInstanceName, rInt),
+				Config: testAccClusterInstanceConfig_basic(clusterInstanceName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterInstanceExists(resourceName, &v),
 					testAccCheckClusterInstanceAttributes(&v),
@@ -61,7 +61,7 @@ func TestAccNeptuneClusterInstance_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterInstanceModifiedConfig(clusterInstanceName, rInt),
+				Config: testAccClusterInstanceConfig_modified(clusterInstanceName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterInstanceExists(resourceName, &v),
 					testAccCheckClusterInstanceAttributes(&v),
@@ -138,7 +138,7 @@ func TestAccNeptuneClusterInstance_withSubnetGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterInstanceConfig_withSubnetGroup(rInt),
+				Config: testAccClusterInstanceConfig_subnetGroup(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterInstanceExists(resourceName, &v),
 					testAccCheckClusterInstanceAttributes(&v),
@@ -187,7 +187,7 @@ func TestAccNeptuneClusterInstance_kmsKey(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterInstanceKMSKeyConfig(rInt),
+				Config: testAccClusterInstanceConfig_kmsKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", kmsKeyResourceName, "arn"),
@@ -262,7 +262,7 @@ func testAccCheckClusterAddress(v *neptune.DBInstance, resourceName string, port
 	}
 }
 
-func testAccClusterInstanceConfig(instanceName string, n int) string {
+func testAccClusterInstanceConfig_basic(instanceName string, n int) string {
 	return acctest.ConfigCompose(
 		testAccClusterBaseConfig(),
 		fmt.Sprintf(`
@@ -305,7 +305,7 @@ resource "aws_neptune_parameter_group" "test" {
 `, instanceName, n))
 }
 
-func testAccClusterInstanceModifiedConfig(instanceName string, n int) string {
+func testAccClusterInstanceConfig_modified(instanceName string, n int) string {
 	return acctest.ConfigCompose(
 		testAccClusterBaseConfig(),
 		fmt.Sprintf(`
@@ -393,7 +393,7 @@ resource "aws_neptune_parameter_group" "test" {
 `, n))
 }
 
-func testAccClusterInstanceConfig_withSubnetGroup(n int) string {
+func testAccClusterInstanceConfig_subnetGroup(n int) string {
 	return acctest.ConfigCompose(
 		testAccClusterBaseConfig(),
 		fmt.Sprintf(`
@@ -572,7 +572,7 @@ resource "aws_neptune_subnet_group" "test" {
 `, n))
 }
 
-func testAccClusterInstanceKMSKeyConfig(n int) string {
+func testAccClusterInstanceConfig_kmsKey(n int) string {
 	return acctest.ConfigCompose(
 		testAccClusterBaseConfig(),
 		fmt.Sprintf(`

--- a/internal/service/neptune/cluster_parameter_group_test.go
+++ b/internal/service/neptune/cluster_parameter_group_test.go
@@ -30,7 +30,7 @@ func TestAccNeptuneClusterParameterGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterParameterGroupConfig(parameterGroupName),
+				Config: testAccClusterParameterGroupConfig_basic(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -63,7 +63,7 @@ func TestAccNeptuneClusterParameterGroup_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterParameterGroupConfig_namePrefix,
+				Config: testAccClusterParameterGroupConfig_namePrefixEmpty,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-test-")),
@@ -119,7 +119,7 @@ func TestAccNeptuneClusterParameterGroup_description(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterParameterGroupConfig_Description(parameterGroupName, "custom description"),
+				Config: testAccClusterParameterGroupConfig_description(parameterGroupName, "custom description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -149,7 +149,7 @@ func TestAccNeptuneClusterParameterGroup_NamePrefix_parameter(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterParameterGroupConfig_NamePrefix_Parameter(prefix, "neptune_enable_audit_log", "1"),
+				Config: testAccClusterParameterGroupConfig_namePrefix(prefix, "neptune_enable_audit_log", "1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -167,7 +167,7 @@ func TestAccNeptuneClusterParameterGroup_NamePrefix_parameter(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 			{
-				Config: testAccClusterParameterGroupConfig_NamePrefix_Parameter(prefix, "neptune_enable_audit_log", "0"),
+				Config: testAccClusterParameterGroupConfig_namePrefix(prefix, "neptune_enable_audit_log", "0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -196,7 +196,7 @@ func TestAccNeptuneClusterParameterGroup_parameter(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterParameterGroupConfig_Parameter(parameterGroupName, "neptune_enable_audit_log", "1"),
+				Config: testAccClusterParameterGroupConfig_one(parameterGroupName, "neptune_enable_audit_log", "1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -214,7 +214,7 @@ func TestAccNeptuneClusterParameterGroup_parameter(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterParameterGroupConfig_Parameter(parameterGroupName, "neptune_enable_audit_log", "0"),
+				Config: testAccClusterParameterGroupConfig_one(parameterGroupName, "neptune_enable_audit_log", "0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -244,7 +244,7 @@ func TestAccNeptuneClusterParameterGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value1"),
+				Config: testAccClusterParameterGroupConfig_tags(parameterGroupName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -258,7 +258,7 @@ func TestAccNeptuneClusterParameterGroup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value2"),
+				Config: testAccClusterParameterGroupConfig_tags(parameterGroupName, "key1", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -267,7 +267,7 @@ func TestAccNeptuneClusterParameterGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterParameterGroupConfig_Tags(parameterGroupName, "key2", "value2"),
+				Config: testAccClusterParameterGroupConfig_tags(parameterGroupName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterParameterGroupExists(resourceName, &v),
 					testAccCheckClusterParameterGroupAttributes(&v, parameterGroupName),
@@ -358,7 +358,7 @@ func testAccCheckClusterParameterGroupExists(n string, v *neptune.DBClusterParam
 	}
 }
 
-func testAccClusterParameterGroupConfig_Description(name, description string) string {
+func testAccClusterParameterGroupConfig_description(name, description string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster_parameter_group" "test" {
   description = "%s"
@@ -368,7 +368,7 @@ resource "aws_neptune_cluster_parameter_group" "test" {
 `, description, name)
 }
 
-func testAccClusterParameterGroupConfig_Parameter(name, pName, pValue string) string {
+func testAccClusterParameterGroupConfig_one(name, pName, pValue string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster_parameter_group" "test" {
   family = "neptune1"
@@ -382,7 +382,7 @@ resource "aws_neptune_cluster_parameter_group" "test" {
 `, name, pName, pValue)
 }
 
-func testAccClusterParameterGroupConfig_NamePrefix_Parameter(namePrefix, pName, pValue string) string {
+func testAccClusterParameterGroupConfig_namePrefix(namePrefix, pName, pValue string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster_parameter_group" "test" {
   family      = "neptune1"
@@ -396,7 +396,7 @@ resource "aws_neptune_cluster_parameter_group" "test" {
 `, namePrefix, pName, pValue)
 }
 
-func testAccClusterParameterGroupConfig_Tags(name, tKey, tValue string) string {
+func testAccClusterParameterGroupConfig_tags(name, tKey, tValue string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster_parameter_group" "test" {
   family = "neptune1"
@@ -409,7 +409,7 @@ resource "aws_neptune_cluster_parameter_group" "test" {
 `, name, tKey, tValue)
 }
 
-func testAccClusterParameterGroupConfig(name string) string {
+func testAccClusterParameterGroupConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster_parameter_group" "test" {
   family = "neptune1"
@@ -418,7 +418,7 @@ resource "aws_neptune_cluster_parameter_group" "test" {
 `, name)
 }
 
-const testAccClusterParameterGroupConfig_namePrefix = `
+const testAccClusterParameterGroupConfig_namePrefixEmpty = `
 resource "aws_neptune_cluster_parameter_group" "test" {
   family      = "neptune1"
   name_prefix = "tf-test-"

--- a/internal/service/neptune/cluster_snapshot_test.go
+++ b/internal/service/neptune/cluster_snapshot_test.go
@@ -27,7 +27,7 @@ func TestAccNeptuneClusterSnapshot_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterSnapshotConfig(rName),
+				Config: testAccClusterSnapshotConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterSnapshotExists(resourceName, &dbClusterSnapshot),
 					resource.TestCheckResourceAttrSet(resourceName, "allocated_storage"),
@@ -114,7 +114,7 @@ func testAccCheckClusterSnapshotExists(resourceName string, dbClusterSnapshot *n
 	}
 }
 
-func testAccClusterSnapshotConfig(rName string) string {
+func testAccClusterSnapshotConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier  = %[1]q

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -31,7 +31,7 @@ func TestAccNeptuneCluster_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig(rName),
+				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(`cluster:.+`)),
@@ -73,7 +73,7 @@ func TestAccNeptuneCluster_copyTagsToSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterCopyTagsConfig(rName, true),
+				Config: testAccClusterConfig_copyTags(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "true"),
@@ -91,14 +91,14 @@ func TestAccNeptuneCluster_copyTagsToSnapshot(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccClusterCopyTagsConfig(rName, false),
+				Config: testAccClusterConfig_copyTags(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "false"),
 				),
 			},
 			{
-				Config: testAccClusterCopyTagsConfig(rName, true),
+				Config: testAccClusterConfig_copyTags(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "true"),
@@ -153,7 +153,7 @@ func TestAccNeptuneCluster_takeFinalSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterSnapshot(rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterWithFinalSnapshotConfig(rName),
+				Config: testAccClusterConfig_finalSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 				),
@@ -185,7 +185,7 @@ func TestAccNeptuneCluster_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterTags1Config(rName, "key1", "value1"),
+				Config: testAccClusterConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -204,7 +204,7 @@ func TestAccNeptuneCluster_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccClusterTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccClusterConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -213,7 +213,7 @@ func TestAccNeptuneCluster_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterTags1Config(rName, "key2", "value2"),
+				Config: testAccClusterConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -236,20 +236,20 @@ func TestAccNeptuneCluster_updateIAMRoles(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterIncludingIAMRolesConfig(rName),
+				Config: testAccClusterConfig_includingIAMRoles(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 				),
 			},
 			{
-				Config: testAccClusterAddIAMRolesConfig(rName),
+				Config: testAccClusterConfig_addIAMRoles(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iam_roles.#", "2"),
 				),
 			},
 			{
-				Config: testAccClusterRemoveIAMRolesConfig(rName),
+				Config: testAccClusterConfig_removeIAMRoles(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iam_roles.#", "1"),
@@ -426,7 +426,7 @@ func TestAccNeptuneCluster_updateCloudWatchLogsExports(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig(rName),
+				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckNoResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#"),
@@ -441,7 +441,7 @@ func TestAccNeptuneCluster_updateCloudWatchLogsExports(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterConfig(rName),
+				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#", "0"),
@@ -525,7 +525,7 @@ func TestAccNeptuneCluster_deleteProtection(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig(rName),
+				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
@@ -543,14 +543,14 @@ func TestAccNeptuneCluster_deleteProtection(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccClusterDeleteProtectionConfig(rName, true),
+				Config: testAccClusterConfig_deleteProtection(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "true"),
 				),
 			},
 			{
-				Config: testAccClusterDeleteProtectionConfig(rName, false),
+				Config: testAccClusterConfig_deleteProtection(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
@@ -572,7 +572,7 @@ func TestAccNeptuneCluster_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig(rName),
+				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dbCluster),
 					acctest.CheckResourceDisappears(acctest.Provider, tfneptune.ResourceCluster(), resourceName),
@@ -713,7 +713,7 @@ locals {
 `)
 }
 
-func testAccClusterConfig(rName string) string {
+func testAccClusterConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
@@ -725,7 +725,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterCopyTagsConfig(rName string, copy bool) string {
+func testAccClusterConfig_copyTags(rName string, copy bool) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
@@ -738,7 +738,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName, copy))
 }
 
-func testAccClusterDeleteProtectionConfig(rName string, isProtected bool) string {
+func testAccClusterConfig_deleteProtection(rName string, isProtected bool) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
@@ -762,7 +762,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName)
 }
 
-func testAccClusterWithFinalSnapshotConfig(rName string) string {
+func testAccClusterConfig_finalSnapshot(rName string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
@@ -773,7 +773,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
@@ -789,7 +789,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccClusterTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccClusterConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
@@ -806,7 +806,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccClusterIncludingIAMRolesConfig(rName string) string {
+func testAccClusterConfig_includingIAMRoles(rName string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -893,7 +893,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterAddIAMRolesConfig(rName string) string {
+func testAccClusterConfig_addIAMRoles(rName string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -980,7 +980,7 @@ resource "aws_neptune_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterRemoveIAMRolesConfig(rName string) string {
+func testAccClusterConfig_removeIAMRoles(rName string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q

--- a/internal/service/neptune/engine_version_data_source_test.go
+++ b/internal/service/neptune/engine_version_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccNeptuneEngineVersionDataSource_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEngineVersionBasicDataSourceConfig(version),
+				Config: testAccEngineVersionDataSourceConfig_basic(version),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "engine", "neptune"),
 					resource.TestCheckResourceAttr(dataSourceName, "version", version),
@@ -51,7 +51,7 @@ func TestAccNeptuneEngineVersionDataSource_preferred(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEngineVersionPreferredDataSourceConfig(),
+				Config: testAccEngineVersionDataSourceConfig_preferred(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "engine", "neptune"),
 					resource.TestCheckResourceAttr(dataSourceName, "version", "1.0.3.0"),
@@ -71,7 +71,7 @@ func TestAccNeptuneEngineVersionDataSource_defaultOnly(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEngineVersionDefaultOnlyDataSourceConfig(),
+				Config: testAccEngineVersionDataSourceConfig_defaultOnly(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "engine", "neptune"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
@@ -100,7 +100,7 @@ func testAccEngineVersionPreCheck(t *testing.T) {
 	}
 }
 
-func testAccEngineVersionBasicDataSourceConfig(version string) string {
+func testAccEngineVersionDataSourceConfig_basic(version string) string {
 	return fmt.Sprintf(`
 data "aws_neptune_engine_version" "test" {
   engine  = "neptune"
@@ -109,7 +109,7 @@ data "aws_neptune_engine_version" "test" {
 `, version)
 }
 
-func testAccEngineVersionPreferredDataSourceConfig() string {
+func testAccEngineVersionDataSourceConfig_preferred() string {
 	return `
 data "aws_neptune_engine_version" "test" {
   preferred_versions = ["85.9.12", "1.0.3.0", "1.0.2.2"]
@@ -117,7 +117,7 @@ data "aws_neptune_engine_version" "test" {
 `
 }
 
-func testAccEngineVersionDefaultOnlyDataSourceConfig() string {
+func testAccEngineVersionDataSourceConfig_defaultOnly() string {
 	return `
 data "aws_neptune_engine_version" "test" {}
 `

--- a/internal/service/neptune/event_subscription_test.go
+++ b/internal/service/neptune/event_subscription_test.go
@@ -29,7 +29,7 @@ func TestAccNeptuneEventSubscription_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionConfig(rName, rInt),
+				Config: testAccEventSubscriptionConfig_basic(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("es:%s", rName)),
@@ -41,7 +41,7 @@ func TestAccNeptuneEventSubscription_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEventSubscriptionUpdateConfig(rName, rInt),
+				Config: testAccEventSubscriptionConfig_update(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -73,7 +73,7 @@ func TestAccNeptuneEventSubscription_withPrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionWithPrefixConfig(rInt),
+				Config: testAccEventSubscriptionConfig_prefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestMatchResourceAttr(resourceName, "name", startsWithPrefix),
@@ -102,7 +102,7 @@ func TestAccNeptuneEventSubscription_withSourceIDs(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionWithSourceIDsConfig(rInt),
+				Config: testAccEventSubscriptionConfig_sourceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
@@ -110,7 +110,7 @@ func TestAccNeptuneEventSubscription_withSourceIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEventSubscriptionUpdateSourceIDsConfig(rInt),
+				Config: testAccEventSubscriptionConfig_updateSourceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
@@ -140,7 +140,7 @@ func TestAccNeptuneEventSubscription_withCategories(t *testing.T) {
 		CheckDestroy:      testAccCheckEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSubscriptionConfig(rName, rInt),
+				Config: testAccEventSubscriptionConfig_basic(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
@@ -148,7 +148,7 @@ func TestAccNeptuneEventSubscription_withCategories(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEventSubscriptionUpdateCategoriesConfig(rName, rInt),
+				Config: testAccEventSubscriptionConfig_updateCategories(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
@@ -228,7 +228,7 @@ func testAccCheckEventSubscriptionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccEventSubscriptionConfig(subscriptionName string, rInt int) string {
+func testAccEventSubscriptionConfig_basic(subscriptionName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
@@ -254,7 +254,7 @@ resource "aws_neptune_event_subscription" "test" {
 `, rInt, subscriptionName)
 }
 
-func testAccEventSubscriptionUpdateConfig(subscriptionName string, rInt int) string {
+func testAccEventSubscriptionConfig_update(subscriptionName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
@@ -277,7 +277,7 @@ resource "aws_neptune_event_subscription" "test" {
 `, rInt, subscriptionName)
 }
 
-func testAccEventSubscriptionWithPrefixConfig(rInt int) string {
+func testAccEventSubscriptionConfig_prefix(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
@@ -303,7 +303,7 @@ resource "aws_neptune_event_subscription" "test" {
 `, rInt)
 }
 
-func testAccEventSubscriptionWithSourceIDsConfig(rInt int) string {
+func testAccEventSubscriptionConfig_sourceIDs(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
@@ -332,7 +332,7 @@ resource "aws_neptune_event_subscription" "test" {
 `, rInt)
 }
 
-func testAccEventSubscriptionUpdateSourceIDsConfig(rInt int) string {
+func testAccEventSubscriptionConfig_updateSourceIDs(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
@@ -367,7 +367,7 @@ resource "aws_neptune_event_subscription" "test" {
 `, rInt)
 }
 
-func testAccEventSubscriptionUpdateCategoriesConfig(subscriptionName string, rInt int) string {
+func testAccEventSubscriptionConfig_updateCategories(subscriptionName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"

--- a/internal/service/neptune/orderable_db_instance_data_source_test.go
+++ b/internal/service/neptune/orderable_db_instance_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccNeptuneOrderableDBInstanceDataSource_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrderableDBInstanceBasicDataSourceConfig(class, engine, engineVersion, licenseModel),
+				Config: testAccOrderableDBInstanceDataSourceConfig_basic(class, engine, engineVersion, licenseModel),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
 					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
@@ -51,7 +51,7 @@ func TestAccNeptuneOrderableDBInstanceDataSource_preferred(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrderableDBInstancePreferredDataSourceConfig(engine, engineVersion, licenseModel, preferredOption),
+				Config: testAccOrderableDBInstanceDataSourceConfig_preferred(engine, engineVersion, licenseModel, preferredOption),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
 					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
@@ -81,7 +81,7 @@ func testAccPreCheckOrderableDBInstance(t *testing.T) {
 	}
 }
 
-func testAccOrderableDBInstanceBasicDataSourceConfig(class, engine, version, license string) string {
+func testAccOrderableDBInstanceDataSourceConfig_basic(class, engine, version, license string) string {
 	return fmt.Sprintf(`
 data "aws_neptune_orderable_db_instance" "test" {
   instance_class = %q
@@ -92,7 +92,7 @@ data "aws_neptune_orderable_db_instance" "test" {
 `, class, engine, version, license)
 }
 
-func testAccOrderableDBInstancePreferredDataSourceConfig(engine, version, license, preferredOption string) string {
+func testAccOrderableDBInstanceDataSourceConfig_preferred(engine, version, license, preferredOption string) string {
 	return fmt.Sprintf(`
 data "aws_neptune_orderable_db_instance" "test" {
   engine         = %q

--- a/internal/service/neptune/parameter_group_test.go
+++ b/internal/service/neptune/parameter_group_test.go
@@ -27,7 +27,7 @@ func TestAccNeptuneParameterGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig_Required(rName),
+				Config: testAccParameterGroupConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					testAccCheckParameterGroupAttributes(&v, rName),
@@ -60,7 +60,7 @@ func TestAccNeptuneParameterGroup_description(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig_Description(rName, "description1"),
+				Config: testAccParameterGroupConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					testAccCheckParameterGroupAttributes(&v, rName),
@@ -88,7 +88,7 @@ func TestAccNeptuneParameterGroup_parameter(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig_Parameter(rName, "neptune_query_timeout", "25", "pending-reboot"),
+				Config: testAccParameterGroupConfig_basic(rName, "neptune_query_timeout", "25", "pending-reboot"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					testAccCheckParameterGroupAttributes(&v, rName),
@@ -107,12 +107,12 @@ func TestAccNeptuneParameterGroup_parameter(t *testing.T) {
 			},
 			// This test should be updated with a dynamic parameter when available
 			{
-				Config:      testAccParameterGroupConfig_Parameter(rName, "neptune_query_timeout", "25", "immediate"),
+				Config:      testAccParameterGroupConfig_basic(rName, "neptune_query_timeout", "25", "immediate"),
 				ExpectError: regexp.MustCompile(`cannot use immediate apply method for static parameter`),
 			},
 			// Test removing the configuration
 			{
-				Config: testAccParameterGroupConfig_Required(rName),
+				Config: testAccParameterGroupConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					testAccCheckParameterGroupAttributes(&v, rName),
@@ -136,7 +136,7 @@ func TestAccNeptuneParameterGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig_Tags_SingleTag(rName, "key1", "value1"),
+				Config: testAccParameterGroupConfig_tagsSingle(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -149,7 +149,7 @@ func TestAccNeptuneParameterGroup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_Tags_SingleTag(rName, "key1", "value2"),
+				Config: testAccParameterGroupConfig_tagsSingle(rName, "key1", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -157,7 +157,7 @@ func TestAccNeptuneParameterGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccParameterGroupConfig_Tags_MultipleTags(rName, "key2", "value2", "key3", "value3"),
+				Config: testAccParameterGroupConfig_tagsMultiple(rName, "key2", "value2", "key3", "value3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -246,7 +246,7 @@ func testAccCheckParameterGroupExists(n string, v *neptune.DBParameterGroup) res
 	}
 }
 
-func testAccParameterGroupConfig_Parameter(rName, pName, pValue, pApplyMethod string) string {
+func testAccParameterGroupConfig_basic(rName, pName, pValue, pApplyMethod string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
@@ -261,7 +261,7 @@ resource "aws_neptune_parameter_group" "test" {
 `, rName, pApplyMethod, pName, pValue)
 }
 
-func testAccParameterGroupConfig_Description(rName, description string) string {
+func testAccParameterGroupConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   description = %q
@@ -271,7 +271,7 @@ resource "aws_neptune_parameter_group" "test" {
 `, description, rName)
 }
 
-func testAccParameterGroupConfig_Required(rName string) string {
+func testAccParameterGroupConfig_required(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
@@ -280,7 +280,7 @@ resource "aws_neptune_parameter_group" "test" {
 `, rName)
 }
 
-func testAccParameterGroupConfig_Tags_SingleTag(name, tKey, tValue string) string {
+func testAccParameterGroupConfig_tagsSingle(name, tKey, tValue string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
@@ -293,7 +293,7 @@ resource "aws_neptune_parameter_group" "test" {
 `, name, tKey, tValue)
 }
 
-func testAccParameterGroupConfig_Tags_MultipleTags(name, tKey1, tValue1, tKey2, tValue2 string) string {
+func testAccParameterGroupConfig_tagsMultiple(name, tKey1, tValue1, tKey2, tValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
