### PR TITLE
memorydb: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -331,7 +331,6 @@ rules:
         - internal/service/lambda
         - internal/service/location
         - internal/service/logs
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa

--- a/internal/service/memorydb/acl_data_source_test.go
+++ b/internal/service/memorydb/acl_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccMemoryDBACLDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACLDataSourceConfig(rName, userName1, userName2),
+				Config: testAccACLDataSourceConfig_basic(rName, userName1, userName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "minimum_engine_version", resourceName, "minimum_engine_version"),
@@ -39,7 +39,7 @@ func TestAccMemoryDBACLDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccACLDataSourceConfig(rName, userName1, userName2 string) string {
+func testAccACLDataSourceConfig_basic(rName, userName1, userName2 string) string {
 	return acctest.ConfigCompose(
 		testAccACLConfigUsers(userName1, userName2),
 		fmt.Sprintf(`

--- a/internal/service/memorydb/acl_test.go
+++ b/internal/service/memorydb/acl_test.go
@@ -28,7 +28,7 @@ func TestAccMemoryDBACL_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACLConfig(rName, []string{user1}, []string{user1}),
+				Config: testAccACLConfig_basic(rName, []string{user1}, []string{user1}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "memorydb", "acl/"+rName),
@@ -60,7 +60,7 @@ func TestAccMemoryDBACL_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACLConfig(rName, nil, nil),
+				Config: testAccACLConfig_basic(rName, nil, nil),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfmemorydb.ResourceACL(), resourceName),
@@ -81,7 +81,7 @@ func TestAccMemoryDBACL_nameGenerated(t *testing.T) {
 		CheckDestroy:      testAccCheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACLConfig_withNoName(),
+				Config: testAccACLConfig_noName(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -102,7 +102,7 @@ func TestAccMemoryDBACL_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACLConfig_withNamePrefix("tftest-"),
+				Config: testAccACLConfig_namePrefix("tftest-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tftest-"),
@@ -124,7 +124,7 @@ func TestAccMemoryDBACL_update_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACLConfig_withTags0(rName),
+				Config: testAccACLConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -137,7 +137,7 @@ func TestAccMemoryDBACL_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccACLConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Config: testAccACLConfig_tags2(rName, "Key1", "value1", "Key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -154,7 +154,7 @@ func TestAccMemoryDBACL_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccACLConfig_withTags1(rName, "Key1", "value1"),
+				Config: testAccACLConfig_tags1(rName, "Key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -169,7 +169,7 @@ func TestAccMemoryDBACL_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccACLConfig_withTags0(rName),
+				Config: testAccACLConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -200,7 +200,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Empty ACL.
-				Config: testAccACLConfig(rName, []string{}, []string{}),
+				Config: testAccACLConfig_basic(rName, []string{}, []string{}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_names.#", "0"),
@@ -213,7 +213,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 			},
 			{
 				// Adding users.
-				Config: testAccACLConfig(rName, []string{user1, user2}, []string{user1, user2}),
+				Config: testAccACLConfig_basic(rName, []string{user1, user2}, []string{user1, user2}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_names.#", "2"),
@@ -228,7 +228,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 			},
 			{
 				// Removing and adding a user.
-				Config: testAccACLConfig(rName, []string{user1, user2, user3}, []string{user1, user3}),
+				Config: testAccACLConfig_basic(rName, []string{user1, user2, user3}, []string{user1, user3}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_names.#", "2"),
@@ -243,7 +243,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 			},
 			{
 				// Removing a user.
-				Config: testAccACLConfig(rName, []string{user1, user2, user3}, []string{user1}),
+				Config: testAccACLConfig_basic(rName, []string{user1, user2, user3}, []string{user1}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_names.#", "1"),
@@ -256,7 +256,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccACLConfig(rName, []string{user1, user2}, []string{user1, user2}),
+				Config: testAccACLConfig_basic(rName, []string{user1, user2}, []string{user1, user2}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_names.#", "2"),
@@ -271,7 +271,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 			},
 			{
 				// Deleting a user before disassociating it.
-				Config: testAccACLConfig(rName, []string{user1}, []string{user1}),
+				Config: testAccACLConfig_basic(rName, []string{user1}, []string{user1}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckACLExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_names.#", "1"),
@@ -361,7 +361,7 @@ resource "aws_memorydb_user" "test" {
 `, userNames)
 }
 
-func testAccACLConfig(rName string, userNames []string, usersInACL []string) string {
+func testAccACLConfig_basic(rName string, userNames []string, usersInACL []string) string {
 	var userNamesInACL string
 	for i, userName := range usersInACL {
 		if i > 0 {
@@ -387,13 +387,13 @@ resource "aws_memorydb_acl" "test" {
 	)
 }
 
-func testAccACLConfig_withNoName() string {
+func testAccACLConfig_noName() string {
 	return `
 resource "aws_memorydb_acl" "test" {}
 `
 }
 
-func testAccACLConfig_withNamePrefix(namePrefix string) string {
+func testAccACLConfig_namePrefix(namePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_acl" "test" {
   name_prefix = %[1]q
@@ -401,7 +401,7 @@ resource "aws_memorydb_acl" "test" {
 `, namePrefix)
 }
 
-func testAccACLConfig_withTags0(rName string) string {
+func testAccACLConfig_tags0(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_acl" "test" {
   name = %[1]q
@@ -409,7 +409,7 @@ resource "aws_memorydb_acl" "test" {
 `, rName)
 }
 
-func testAccACLConfig_withTags1(rName, tagKey1, tagValue1 string) string {
+func testAccACLConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_acl" "test" {
   name = %[1]q
@@ -421,7 +421,7 @@ resource "aws_memorydb_acl" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccACLConfig_withTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccACLConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_acl" "test" {
   name = %[1]q

--- a/internal/service/memorydb/cluster_data_source_test.go
+++ b/internal/service/memorydb/cluster_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccMemoryDBClusterDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterDataSourceConfig(rName),
+				Config: testAccClusterDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "acl_name", resourceName, "acl_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -64,7 +64,7 @@ func TestAccMemoryDBClusterDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccClusterDataSourceConfig(rName string) string {
+func testAccClusterDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		testAccClusterConfigBaseUserAndACL(rName),

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -158,7 +158,7 @@ func TestAccMemoryDBCluster_nameGenerated(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNoName(rName),
+				Config: testAccClusterConfig_noName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -180,7 +180,7 @@ func TestAccMemoryDBCluster_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNamePrefix(rName, "tftest-"),
+				Config: testAccClusterConfig_namePrefix(rName, "tftest-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tftest-"),
@@ -204,7 +204,7 @@ func TestAccMemoryDBCluster_create_noTLS(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNoTLS(rName),
+				Config: testAccClusterConfig_noTLS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tls_enabled", "false"),
@@ -230,7 +230,7 @@ func TestAccMemoryDBCluster_create_withKMS(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withKMS(rName),
+				Config: testAccClusterConfig_kms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", "aws_kms_key.test", "arn"),
@@ -256,7 +256,7 @@ func TestAccMemoryDBCluster_create_withPort(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withPort(rName, 9999),
+				Config: testAccClusterConfig_port(rName, 9999),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "9999"),
@@ -283,7 +283,7 @@ func TestAccMemoryDBCluster_create_fromSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withSnapshotFromCluster(rName1, rName2),
+				Config: testAccClusterConfig_snapshotFrom(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("aws_memorydb_cluster.test1"),
 					testAccCheckClusterExists("aws_memorydb_cluster.test2"),
@@ -304,7 +304,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withFinalSnapshotName(rName, rName+"-1"),
+				Config: testAccClusterConfig_finalSnapshotName(rName, rName+"-1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "final_snapshot_name", rName+"-1"),
@@ -317,7 +317,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"final_snapshot_name"},
 			},
 			{
-				Config: testAccClusterConfig_withFinalSnapshotName(rName, rName),
+				Config: testAccClusterConfig_finalSnapshotName(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "final_snapshot_name", rName),
@@ -350,7 +350,7 @@ func TestAccMemoryDBCluster_Update_aclName(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withACLName(rName, rName),
+				Config: testAccClusterConfig_aclName(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl_name", rName),
@@ -362,7 +362,7 @@ func TestAccMemoryDBCluster_Update_aclName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withACLName(rName, "open-access"),
+				Config: testAccClusterConfig_aclName(rName, "open-access"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl_name", "open-access"),
@@ -388,7 +388,7 @@ func TestAccMemoryDBCluster_Update_description(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withDescription(rName, "Test 1"),
+				Config: testAccClusterConfig_description(rName, "Test 1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test 1"),
@@ -400,7 +400,7 @@ func TestAccMemoryDBCluster_Update_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withDescription(rName, "Test 2"),
+				Config: testAccClusterConfig_description(rName, "Test 2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test 2"),
@@ -412,7 +412,7 @@ func TestAccMemoryDBCluster_Update_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withDescription(rName, ""),
+				Config: testAccClusterConfig_description(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -444,7 +444,7 @@ func TestAccMemoryDBCluster_Update_engineVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withEngineVersionNull(rName),
+				Config: testAccClusterConfig_engineVersionNull(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.2"),
@@ -456,7 +456,7 @@ func TestAccMemoryDBCluster_Update_engineVersion(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withEngineVersion(rName, "6.2"),
+				Config: testAccClusterConfig_engineVersion(rName, "6.2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.2"),
@@ -482,7 +482,7 @@ func TestAccMemoryDBCluster_Update_maintenanceWindow(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withMaintenanceWindow(rName, "thu:09:00-thu:10:00"),
+				Config: testAccClusterConfig_maintenanceWindow(rName, "thu:09:00-thu:10:00"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "thu:09:00-thu:10:00"),
@@ -494,7 +494,7 @@ func TestAccMemoryDBCluster_Update_maintenanceWindow(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withMaintenanceWindow(rName, "fri:09:00-fri:10:00"),
+				Config: testAccClusterConfig_maintenanceWindow(rName, "fri:09:00-fri:10:00"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "fri:09:00-fri:10:00"),
@@ -520,7 +520,7 @@ func TestAccMemoryDBCluster_Update_nodeType(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNodeType(rName, "db.t4g.small"),
+				Config: testAccClusterConfig_nodeType(rName, "db.t4g.small"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.t4g.small"),
@@ -532,7 +532,7 @@ func TestAccMemoryDBCluster_Update_nodeType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withNodeType(rName, "db.t4g.medium"),
+				Config: testAccClusterConfig_nodeType(rName, "db.t4g.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.t4g.medium"),
@@ -561,7 +561,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleUp(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNumShards(rName, 1),
+				Config: testAccClusterConfig_numShards(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "1"),
@@ -573,7 +573,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleUp(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withNumShards(rName, 2),
+				Config: testAccClusterConfig_numShards(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "2"),
@@ -597,7 +597,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleDown(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNumShards(rName, 2),
+				Config: testAccClusterConfig_numShards(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "2"),
@@ -609,7 +609,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleDown(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withNumShards(rName, 1),
+				Config: testAccClusterConfig_numShards(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "1"),
@@ -633,7 +633,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNumReplicasPerShard(rName, 1),
+				Config: testAccClusterConfig_numReplicasPerShard(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "1"),
@@ -645,7 +645,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withNumReplicasPerShard(rName, 2),
+				Config: testAccClusterConfig_numReplicasPerShard(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "2"),
@@ -669,7 +669,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withNumReplicasPerShard(rName, 1),
+				Config: testAccClusterConfig_numReplicasPerShard(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "1"),
@@ -681,7 +681,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withNumReplicasPerShard(rName, 0),
+				Config: testAccClusterConfig_numReplicasPerShard(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "0"),
@@ -702,7 +702,7 @@ func TestAccMemoryDBCluster_Update_parameterGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withParameterGroup(rName, "default.memorydb-redis6"),
+				Config: testAccClusterConfig_parameterGroup(rName, "default.memorydb-redis6"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.memorydb-redis6"),
@@ -714,14 +714,14 @@ func TestAccMemoryDBCluster_Update_parameterGroup(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withParameterGroup(rName, rName),
+				Config: testAccClusterConfig_parameterGroup(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", rName),
 				),
 			},
 			{
-				Config: testAccClusterConfig_withParameterGroup(rName, "default.memorydb-redis6"),
+				Config: testAccClusterConfig_parameterGroup(rName, "default.memorydb-redis6"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.memorydb-redis6"),
@@ -747,7 +747,7 @@ func TestAccMemoryDBCluster_Update_securityGroupIds(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withSecurityGroups(rName, 2, 1),
+				Config: testAccClusterConfig_securityGroups(rName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
@@ -760,7 +760,7 @@ func TestAccMemoryDBCluster_Update_securityGroupIds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withSecurityGroups(rName, 2, 2),
+				Config: testAccClusterConfig_securityGroups(rName, 2, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"), // add one
@@ -774,11 +774,11 @@ func TestAccMemoryDBCluster_Update_securityGroupIds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      testAccClusterConfig_withSecurityGroups(rName, 2, 0), // attempt to remove all
+				Config:      testAccClusterConfig_securityGroups(rName, 2, 0), // attempt to remove all
 				ExpectError: regexp.MustCompile(`removing all security groups is not possible`),
 			},
 			{
-				Config: testAccClusterConfig_withSecurityGroups(rName, 2, 1),
+				Config: testAccClusterConfig_securityGroups(rName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"), // remove one
@@ -805,7 +805,7 @@ func TestAccMemoryDBCluster_Update_snapshotRetentionLimit(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withSnapshotRetentionLimit(rName, 2),
+				Config: testAccClusterConfig_snapshotRetentionLimit(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "2"),
@@ -817,7 +817,7 @@ func TestAccMemoryDBCluster_Update_snapshotRetentionLimit(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withSnapshotRetentionLimit(rName, 35),
+				Config: testAccClusterConfig_snapshotRetentionLimit(rName, 35),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "35"),
@@ -829,7 +829,7 @@ func TestAccMemoryDBCluster_Update_snapshotRetentionLimit(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withSnapshotRetentionLimit(rName, 0),
+				Config: testAccClusterConfig_snapshotRetentionLimit(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "0"),
@@ -855,7 +855,7 @@ func TestAccMemoryDBCluster_Update_snapshotWindow(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withSnapshotWindow(rName, "00:30-01:30"),
+				Config: testAccClusterConfig_snapshotWindow(rName, "00:30-01:30"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "00:30-01:30"),
@@ -867,7 +867,7 @@ func TestAccMemoryDBCluster_Update_snapshotWindow(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withSnapshotWindow(rName, "02:30-03:30"),
+				Config: testAccClusterConfig_snapshotWindow(rName, "02:30-03:30"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "02:30-03:30"),
@@ -943,7 +943,7 @@ func TestAccMemoryDBCluster_Update_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_withTags0(rName),
+				Config: testAccClusterConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -956,7 +956,7 @@ func TestAccMemoryDBCluster_Update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Config: testAccClusterConfig_tags2(rName, "Key1", "value1", "Key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -973,7 +973,7 @@ func TestAccMemoryDBCluster_Update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withTags1(rName, "Key1", "value1"),
+				Config: testAccClusterConfig_tags1(rName, "Key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -988,7 +988,7 @@ func TestAccMemoryDBCluster_Update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_withTags0(rName),
+				Config: testAccClusterConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -1140,7 +1140,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withNoName(rName string) string {
+func testAccClusterConfig_noName(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		`
@@ -1155,7 +1155,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withNamePrefix(rName, prefix string) string {
+func testAccClusterConfig_namePrefix(rName, prefix string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1171,7 +1171,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withNoTLS(rName string) string {
+func testAccClusterConfig_noTLS(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1188,7 +1188,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withACLName(rName, aclName string) string {
+func testAccClusterConfig_aclName(rName, aclName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		testAccClusterConfigBaseUserAndACL(rName),
@@ -1206,7 +1206,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withDescription(rName, description string) string {
+func testAccClusterConfig_description(rName, description string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1221,7 +1221,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withEngineVersionNull(rName string) string {
+func testAccClusterConfig_engineVersionNull(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1237,7 +1237,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withEngineVersion(rName, engineVersion string) string {
+func testAccClusterConfig_engineVersion(rName, engineVersion string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1254,7 +1254,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withFinalSnapshotName(rName, finalSnapshotName string) string {
+func testAccClusterConfig_finalSnapshotName(rName, finalSnapshotName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1271,7 +1271,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withKMS(rName string) string {
+func testAccClusterConfig_kms(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1290,7 +1290,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withMaintenanceWindow(rName, maintenanceWindow string) string {
+func testAccClusterConfig_maintenanceWindow(rName, maintenanceWindow string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1307,7 +1307,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withNodeType(rName, nodeType string) string {
+func testAccClusterConfig_nodeType(rName, nodeType string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1323,7 +1323,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withNumReplicasPerShard(rName string, numReplicasPerShard int) string {
+func testAccClusterConfig_numReplicasPerShard(rName string, numReplicasPerShard int) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1338,7 +1338,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withNumShards(rName string, numShards int) string {
+func testAccClusterConfig_numShards(rName string, numShards int) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1353,7 +1353,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withParameterGroup(rName, parameterGroup string) string {
+func testAccClusterConfig_parameterGroup(rName, parameterGroup string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1386,7 +1386,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withPort(rName string, port int) string {
+func testAccClusterConfig_port(rName string, port int) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1403,7 +1403,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withSecurityGroups(rName string, sgCount, sgCountInCluster int) string {
+func testAccClusterConfig_securityGroups(rName string, sgCount, sgCountInCluster int) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1425,7 +1425,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withSnapshotRetentionLimit(rName string, retentionLimit int) string {
+func testAccClusterConfig_snapshotRetentionLimit(rName string, retentionLimit int) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1442,7 +1442,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withSnapshotFromCluster(rName1, rName2 string) string {
+func testAccClusterConfig_snapshotFrom(rName1, rName2 string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName1),
 		fmt.Sprintf(`
@@ -1472,7 +1472,7 @@ resource "aws_memorydb_cluster" "test2" {
 	)
 }
 
-func testAccClusterConfig_withSnapshotWindow(rName, snapshotWindow string) string {
+func testAccClusterConfig_snapshotWindow(rName, snapshotWindow string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1535,7 +1535,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withTags0(rName string) string {
+func testAccClusterConfig_tags0(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1551,7 +1551,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withTags1(rName, tag1Key, tag1Value string) string {
+func testAccClusterConfig_tags1(rName, tag1Key, tag1Value string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`
@@ -1571,7 +1571,7 @@ resource "aws_memorydb_cluster" "test" {
 	)
 }
 
-func testAccClusterConfig_withTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccClusterConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfigBaseNetwork(rName),
 		fmt.Sprintf(`

--- a/internal/service/memorydb/parameter_group_data_source_test.go
+++ b/internal/service/memorydb/parameter_group_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccMemoryDBParameterGroupDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupDataSourceConfig(rName),
+				Config: testAccParameterGroupDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
@@ -46,7 +46,7 @@ func TestAccMemoryDBParameterGroupDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccParameterGroupDataSourceConfig(rName string) string {
+func testAccParameterGroupDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q

--- a/internal/service/memorydb/parameter_group_test.go
+++ b/internal/service/memorydb/parameter_group_test.go
@@ -29,7 +29,7 @@ func TestAccMemoryDBParameterGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig(rName),
+				Config: testAccParameterGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "memorydb", "parametergroup/"+rName),
@@ -70,7 +70,7 @@ func TestAccMemoryDBParameterGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig(rName),
+				Config: testAccParameterGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfmemorydb.ResourceParameterGroup(), resourceName),
@@ -92,7 +92,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig_withParameter0(rName),
+				Config: testAccParameterGroupConfig_none(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
@@ -104,7 +104,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withParameter1(rName, "timeout", "0"), // 0 is the default value
+				Config: testAccParameterGroupConfig_one(rName, "timeout", "0"), // 0 is the default value
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -123,7 +123,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"parameter"},
 			},
 			{
-				Config: testAccParameterGroupConfig_withParameter1(rName, "timeout", "20"),
+				Config: testAccParameterGroupConfig_one(rName, "timeout", "20"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -139,7 +139,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withParameter2(rName, "timeout", "20", "activerehashing", "no"),
+				Config: testAccParameterGroupConfig_multiple(rName, "timeout", "20", "activerehashing", "no"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
@@ -159,7 +159,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withParameter1(rName, "timeout", "20"),
+				Config: testAccParameterGroupConfig_one(rName, "timeout", "20"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -175,7 +175,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withParameter0(rName),
+				Config: testAccParameterGroupConfig_none(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
@@ -201,7 +201,7 @@ func TestAccMemoryDBParameterGroup_update_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterGroupConfig_withTags0(rName),
+				Config: testAccParameterGroupConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -214,7 +214,7 @@ func TestAccMemoryDBParameterGroup_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Config: testAccParameterGroupConfig_tags2(rName, "Key1", "value1", "Key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -231,7 +231,7 @@ func TestAccMemoryDBParameterGroup_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withTags1(rName, "Key1", "value1"),
+				Config: testAccParameterGroupConfig_tags1(rName, "Key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -246,7 +246,7 @@ func TestAccMemoryDBParameterGroup_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccParameterGroupConfig_withTags0(rName),
+				Config: testAccParameterGroupConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckParameterGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -309,7 +309,7 @@ func testAccCheckParameterGroupExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccParameterGroupConfig(rName string) string {
+func testAccParameterGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q
@@ -332,7 +332,7 @@ resource "aws_memorydb_parameter_group" "test" {
 `, rName)
 }
 
-func testAccParameterGroupConfig_withParameter0(rName string) string {
+func testAccParameterGroupConfig_none(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q
@@ -341,7 +341,7 @@ resource "aws_memorydb_parameter_group" "test" {
 `, rName)
 }
 
-func testAccParameterGroupConfig_withParameter1(rName, paramName1, paramValue1 string) string {
+func testAccParameterGroupConfig_one(rName, paramName1, paramValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q
@@ -355,7 +355,7 @@ resource "aws_memorydb_parameter_group" "test" {
 `, rName, paramName1, paramValue1)
 }
 
-func testAccParameterGroupConfig_withParameter2(rName, paramName1, paramValue1, paramName2, paramValue2 string) string {
+func testAccParameterGroupConfig_multiple(rName, paramName1, paramValue1, paramName2, paramValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q
@@ -374,7 +374,7 @@ resource "aws_memorydb_parameter_group" "test" {
 `, rName, paramName1, paramValue1, paramName2, paramValue2)
 }
 
-func testAccParameterGroupConfig_withTags0(rName string) string {
+func testAccParameterGroupConfig_tags0(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q
@@ -383,7 +383,7 @@ resource "aws_memorydb_parameter_group" "test" {
 `, rName)
 }
 
-func testAccParameterGroupConfig_withTags1(rName, tagKey1, tagValue1 string) string {
+func testAccParameterGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q
@@ -396,7 +396,7 @@ resource "aws_memorydb_parameter_group" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccParameterGroupConfig_withTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccParameterGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_parameter_group" "test" {
   name   = %[1]q

--- a/internal/service/memorydb/snapshot_data_source_test.go
+++ b/internal/service/memorydb/snapshot_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccMemoryDBSnapshotDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotDataSourceConfig(rName),
+				Config: testAccSnapshotDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_configuration.0.description", resourceName, "cluster_configuration.0.description"),
@@ -49,7 +49,7 @@ func TestAccMemoryDBSnapshotDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccSnapshotDataSourceConfig(rName string) string {
+func testAccSnapshotDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`

--- a/internal/service/memorydb/snapshot_test.go
+++ b/internal/service/memorydb/snapshot_test.go
@@ -93,7 +93,7 @@ func TestAccMemoryDBSnapshot_nameGenerated(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotConfig_withNoName(rName),
+				Config: testAccSnapshotConfig_noName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -115,7 +115,7 @@ func TestAccMemoryDBSnapshot_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotConfig_withNamePrefix(rName, "tftest-"),
+				Config: testAccSnapshotConfig_namePrefix(rName, "tftest-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tftest-"),
@@ -137,7 +137,7 @@ func TestAccMemoryDBSnapshot_create_withKMS(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotConfig_withKMS(rName),
+				Config: testAccSnapshotConfig_kms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "kms_key_arn", "aws_kms_key.test", "arn"),
@@ -163,7 +163,7 @@ func TestAccMemoryDBSnapshot_update_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotConfig_withTags0(rName),
+				Config: testAccSnapshotConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -176,7 +176,7 @@ func TestAccMemoryDBSnapshot_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSnapshotConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Config: testAccSnapshotConfig_tags2(rName, "Key1", "value1", "Key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -193,7 +193,7 @@ func TestAccMemoryDBSnapshot_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSnapshotConfig_withTags1(rName, "Key1", "value1"),
+				Config: testAccSnapshotConfig_tags1(rName, "Key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -208,7 +208,7 @@ func TestAccMemoryDBSnapshot_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSnapshotConfig_withTags0(rName),
+				Config: testAccSnapshotConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -315,7 +315,7 @@ resource "aws_memorydb_snapshot" "test" {
 	)
 }
 
-func testAccSnapshotConfig_withKMS(rName string) string {
+func testAccSnapshotConfig_kms(rName string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`
@@ -330,7 +330,7 @@ resource "aws_memorydb_snapshot" "test" {
 	)
 }
 
-func testAccSnapshotConfig_withNoName(rName string) string {
+func testAccSnapshotConfig_noName(rName string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		`
@@ -341,7 +341,7 @@ resource "aws_memorydb_snapshot" "test" {
 	)
 }
 
-func testAccSnapshotConfig_withNamePrefix(rName, prefix string) string {
+func testAccSnapshotConfig_namePrefix(rName, prefix string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`
@@ -357,7 +357,7 @@ resource "aws_memorydb_snapshot" "test" {
 	)
 }
 
-func testAccSnapshotConfig_withTags0(rName string) string {
+func testAccSnapshotConfig_tags0(rName string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`
@@ -369,7 +369,7 @@ resource "aws_memorydb_snapshot" "test" {
 	)
 }
 
-func testAccSnapshotConfig_withTags1(rName, tag1Key, tag1Value string) string {
+func testAccSnapshotConfig_tags1(rName, tag1Key, tag1Value string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`
@@ -385,7 +385,7 @@ resource "aws_memorydb_snapshot" "test" {
 	)
 }
 
-func testAccSnapshotConfig_withTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccSnapshotConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`

--- a/internal/service/memorydb/subnet_group_data_source_test.go
+++ b/internal/service/memorydb/subnet_group_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccMemoryDBSubnetGroupDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupDataSourceConfig(rName),
+				Config: testAccSubnetGroupDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
@@ -38,7 +38,7 @@ func TestAccMemoryDBSubnetGroupDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccSubnetGroupDataSourceConfig(rName string) string {
+func testAccSubnetGroupDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`

--- a/internal/service/memorydb/subnet_group_test.go
+++ b/internal/service/memorydb/subnet_group_test.go
@@ -37,7 +37,7 @@ func TestAccMemoryDBSubnetGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig(rName),
+				Config: testAccSubnetGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "memorydb", "subnetgroup/"+rName),
@@ -71,7 +71,7 @@ func TestAccMemoryDBSubnetGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig(rName),
+				Config: testAccSubnetGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfmemorydb.ResourceSubnetGroup(), resourceName),
@@ -93,7 +93,7 @@ func TestAccMemoryDBSubnetGroup_nameGenerated(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig_withNoName(rName),
+				Config: testAccSubnetGroupConfig_noName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -115,7 +115,7 @@ func TestAccMemoryDBSubnetGroup_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig_withNamePrefix(rName, "tftest-"),
+				Config: testAccSubnetGroupConfig_namePrefix(rName, "tftest-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tftest-"),
@@ -137,7 +137,7 @@ func TestAccMemoryDBSubnetGroup_update_description(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig(rName),
+				Config: testAccSubnetGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
@@ -149,7 +149,7 @@ func TestAccMemoryDBSubnetGroup_update_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetGroupConfig_withDescription(rName, "Updated Description"),
+				Config: testAccSubnetGroupConfig_description(rName, "Updated Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated Description"),
@@ -175,7 +175,7 @@ func TestAccMemoryDBSubnetGroup_update_subnetIds(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig_withSubnetCount(rName, 1),
+				Config: testAccSubnetGroupConfig_count(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -188,7 +188,7 @@ func TestAccMemoryDBSubnetGroup_update_subnetIds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetGroupConfig_withSubnetCount(rName, 3),
+				Config: testAccSubnetGroupConfig_count(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "3"),
@@ -203,7 +203,7 @@ func TestAccMemoryDBSubnetGroup_update_subnetIds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetGroupConfig_withSubnetCount(rName, 2),
+				Config: testAccSubnetGroupConfig_count(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -231,7 +231,7 @@ func TestAccMemoryDBSubnetGroup_update_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetGroupConfig_withTags0(rName),
+				Config: testAccSubnetGroupConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -244,7 +244,7 @@ func TestAccMemoryDBSubnetGroup_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetGroupConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Config: testAccSubnetGroupConfig_tags2(rName, "Key1", "value1", "Key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -261,7 +261,7 @@ func TestAccMemoryDBSubnetGroup_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetGroupConfig_withTags1(rName, "Key1", "value1"),
+				Config: testAccSubnetGroupConfig_tags1(rName, "Key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -276,7 +276,7 @@ func TestAccMemoryDBSubnetGroup_update_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSubnetGroupConfig_withTags0(rName),
+				Config: testAccSubnetGroupConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -339,7 +339,7 @@ func testAccCheckSubnetGroupExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccSubnetGroupConfig(rName string) string {
+func testAccSubnetGroupConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
@@ -355,7 +355,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withNoName(rName string) string {
+func testAccSubnetGroupConfig_noName(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		`
@@ -366,7 +366,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withNamePrefix(rName, rNamePrefix string) string {
+func testAccSubnetGroupConfig_namePrefix(rName, rNamePrefix string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
@@ -378,7 +378,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withDescription(rName, description string) string {
+func testAccSubnetGroupConfig_description(rName, description string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
@@ -391,7 +391,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withSubnetCount(rName string, subnetCount int) string {
+func testAccSubnetGroupConfig_count(rName string, subnetCount int) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, subnetCount),
 		fmt.Sprintf(`
@@ -403,7 +403,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withTags0(rName string) string {
+func testAccSubnetGroupConfig_tags0(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
@@ -415,7 +415,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withTags1(rName, tag1Key, tag1Value string) string {
+func testAccSubnetGroupConfig_tags1(rName, tag1Key, tag1Value string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
@@ -431,7 +431,7 @@ resource "aws_memorydb_subnet_group" "test" {
 	)
 }
 
-func testAccSubnetGroupConfig_withTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccSubnetGroupConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`

--- a/internal/service/memorydb/user_data_source_test.go
+++ b/internal/service/memorydb/user_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccMemoryDBUserDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserDataSourceConfig(rName),
+				Config: testAccUserDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "access_string", resourceName, "access_string"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -37,7 +37,7 @@ func TestAccMemoryDBUserDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccUserDataSourceConfig(rName string) string {
+func testAccUserDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"

--- a/internal/service/memorydb/user_test.go
+++ b/internal/service/memorydb/user_test.go
@@ -26,7 +26,7 @@ func TestAccMemoryDBUser_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig(rName),
+				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "access_string", "on ~* &* +@all"),
@@ -62,7 +62,7 @@ func TestAccMemoryDBUser_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig(rName),
+				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfmemorydb.ResourceUser(), resourceName),
@@ -84,7 +84,7 @@ func TestAccMemoryDBUser_update_accessString(t *testing.T) {
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_withAccessString(rName, "on ~* &* +@all"),
+				Config: testAccUserConfig_accessString(rName, "on ~* &* +@all"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "access_string", "on ~* &* +@all"),
@@ -97,7 +97,7 @@ func TestAccMemoryDBUser_update_accessString(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
 			},
 			{
-				Config: testAccUserConfig_withAccessString(rName, "off ~* &* +@all"),
+				Config: testAccUserConfig_accessString(rName, "off ~* &* +@all"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "access_string", "off ~* &* +@all"),
@@ -118,7 +118,7 @@ func TestAccMemoryDBUser_update_passwords(t *testing.T) {
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_withPasswords2(rName, "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"),
+				Config: testAccUserConfig_passwords2(rName, "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
@@ -131,7 +131,7 @@ func TestAccMemoryDBUser_update_passwords(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
 			},
 			{
-				Config: testAccUserConfig_withPasswords1(rName, "aaaaaaaaaaaaaaaa"),
+				Config: testAccUserConfig_passwords1(rName, "aaaaaaaaaaaaaaaa"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
@@ -144,7 +144,7 @@ func TestAccMemoryDBUser_update_passwords(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
 			},
 			{
-				Config: testAccUserConfig_withPasswords2(rName, "cccccccccccccccc", "dddddddddddddddd"),
+				Config: testAccUserConfig_passwords2(rName, "cccccccccccccccc", "dddddddddddddddd"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
@@ -171,7 +171,7 @@ func TestAccMemoryDBUser_update_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_withTags0(rName),
+				Config: testAccUserConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -185,7 +185,7 @@ func TestAccMemoryDBUser_update_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
 			},
 			{
-				Config: testAccUserConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Config: testAccUserConfig_tags2(rName, "Key1", "value1", "Key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -203,7 +203,7 @@ func TestAccMemoryDBUser_update_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
 			},
 			{
-				Config: testAccUserConfig_withTags1(rName, "Key1", "value1"),
+				Config: testAccUserConfig_tags1(rName, "Key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -219,7 +219,7 @@ func TestAccMemoryDBUser_update_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
 			},
 			{
-				Config: testAccUserConfig_withTags0(rName),
+				Config: testAccUserConfig_tags0(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -283,7 +283,7 @@ func testAccCheckUserExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccUserConfig(rName string) string {
+func testAccUserConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"
@@ -301,7 +301,7 @@ resource "aws_memorydb_user" "test" {
 `, rName)
 }
 
-func testAccUserConfig_withAccessString(rName, accessString string) string {
+func testAccUserConfig_accessString(rName, accessString string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = %[2]q
@@ -315,7 +315,7 @@ resource "aws_memorydb_user" "test" {
 `, rName, accessString)
 }
 
-func testAccUserConfig_withPasswords1(rName, password1 string) string {
+func testAccUserConfig_passwords1(rName, password1 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"
@@ -329,7 +329,7 @@ resource "aws_memorydb_user" "test" {
 `, rName, password1)
 }
 
-func testAccUserConfig_withPasswords2(rName, password1, password2 string) string {
+func testAccUserConfig_passwords2(rName, password1, password2 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"
@@ -343,7 +343,7 @@ resource "aws_memorydb_user" "test" {
 `, rName, password1, password2)
 }
 
-func testAccUserConfig_withTags0(rName string) string {
+func testAccUserConfig_tags0(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"
@@ -357,7 +357,7 @@ resource "aws_memorydb_user" "test" {
 `, rName)
 }
 
-func testAccUserConfig_withTags1(rName, tagKey1, tagValue1 string) string {
+func testAccUserConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"
@@ -375,7 +375,7 @@ resource "aws_memorydb_user" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccUserConfig_withTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccUserConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_memorydb_user" "test" {
   access_string = "on ~* &* +@all"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
