### PR TITLE
location: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -329,7 +329,6 @@ rules:
         - internal/service/kinesisanalyticsv2
         - internal/service/kms
         - internal/service/lambda
-        - internal/service/location
         - internal/service/logs
         - internal/service/memorydb
         - internal/service/meta

--- a/internal/service/location/map_data_source_test.go
+++ b/internal/service/location/map_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccLocationMapDataSource_mapName(t *testing.T) {
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigMapDataSource_mapName(rName),
+				Config: testAccMapDataSourceConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "configuration.#", resourceName, "configuration.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "configuration.0.style", resourceName, "configuration.0.style"),
@@ -38,7 +38,7 @@ func TestAccLocationMapDataSource_mapName(t *testing.T) {
 	})
 }
 
-func testAccConfigMapDataSource_mapName(rName string) string {
+func testAccMapDataSourceConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_location_map" "test" {
   configuration {

--- a/internal/service/location/map_test.go
+++ b/internal/service/location/map_test.go
@@ -26,7 +26,7 @@ func TestAccLocationMap_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigMap_basic(rName),
+				Config: testAccMapConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -59,7 +59,7 @@ func TestAccLocationMap_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigMap_basic(rName),
+				Config: testAccMapConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourceMap(), resourceName),
@@ -81,7 +81,7 @@ func TestAccLocationMap_description(t *testing.T) {
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigMap_description(rName, "description1"),
+				Config: testAccMapConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
@@ -93,7 +93,7 @@ func TestAccLocationMap_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigMap_description(rName, "description2"),
+				Config: testAccMapConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -114,7 +114,7 @@ func TestAccLocationMap_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigMap_tags1(rName, "key1", "value1"),
+				Config: testAccMapConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -127,7 +127,7 @@ func TestAccLocationMap_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigMap_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccMapConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -136,7 +136,7 @@ func TestAccLocationMap_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConfigMap_tags1(rName, "key2", "value2"),
+				Config: testAccMapConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMapExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -201,7 +201,7 @@ func testAccCheckMapExists(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccConfigMap_basic(rName string) string {
+func testAccMapConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_location_map" "test" {
   configuration {
@@ -213,7 +213,7 @@ resource "aws_location_map" "test" {
 `, rName)
 }
 
-func testAccConfigMap_description(rName, description string) string {
+func testAccMapConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_location_map" "test" {
   configuration {
@@ -226,7 +226,7 @@ resource "aws_location_map" "test" {
 `, rName, description)
 }
 
-func testAccConfigMap_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccMapConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_location_map" "test" {
   configuration {
@@ -242,7 +242,7 @@ resource "aws_location_map" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccConfigMap_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccMapConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_location_map" "test" {
   configuration {

--- a/internal/service/location/place_index_test.go
+++ b/internal/service/location/place_index_test.go
@@ -26,7 +26,7 @@ func TestAccLocationPlaceIndex_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckPlaceIndexDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigPlaceIndex_basic(rName),
+				Config: testAccPlaceIndexConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "create_time"),
@@ -60,7 +60,7 @@ func TestAccLocationPlaceIndex_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigPlaceIndex_basic(rName),
+				Config: testAccPlaceIndexConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourcePlaceIndex(), resourceName),
@@ -82,7 +82,7 @@ func TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse(t *testing.T) 
 		CheckDestroy:      testAccCheckMapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigPlaceIndex_dataSourceConfigurationIntendedUse(rName, locationservice.IntendedUseSingleUse),
+				Config: testAccPlaceIndexConfig_configurationIntendedUse(rName, locationservice.IntendedUseSingleUse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.#", "1"),
@@ -95,7 +95,7 @@ func TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigPlaceIndex_dataSourceConfigurationIntendedUse(rName, locationservice.IntendedUseStorage),
+				Config: testAccPlaceIndexConfig_configurationIntendedUse(rName, locationservice.IntendedUseStorage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.#", "1"),
@@ -117,7 +117,7 @@ func TestAccLocationPlaceIndex_description(t *testing.T) {
 		CheckDestroy:      testAccCheckPlaceIndexDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigPlaceIndex_description(rName, "description1"),
+				Config: testAccPlaceIndexConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
@@ -129,7 +129,7 @@ func TestAccLocationPlaceIndex_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigPlaceIndex_description(rName, "description2"),
+				Config: testAccPlaceIndexConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -150,7 +150,7 @@ func TestAccLocationPlaceIndex_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckPlaceIndexDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigPlaceIndex_tags1(rName, "key1", "value1"),
+				Config: testAccPlaceIndexConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -163,7 +163,7 @@ func TestAccLocationPlaceIndex_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigPlaceIndex_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccPlaceIndexConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -172,7 +172,7 @@ func TestAccLocationPlaceIndex_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConfigPlaceIndex_tags1(rName, "key2", "value2"),
+				Config: testAccPlaceIndexConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlaceIndexExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -237,7 +237,7 @@ func testAccCheckPlaceIndexExists(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccConfigPlaceIndex_basic(rName string) string {
+func testAccPlaceIndexConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"
@@ -246,7 +246,7 @@ resource "aws_location_place_index" "test" {
 `, rName)
 }
 
-func testAccConfigPlaceIndex_dataSourceConfigurationIntendedUse(rName, intendedUse string) string {
+func testAccPlaceIndexConfig_configurationIntendedUse(rName, intendedUse string) string {
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"
@@ -260,7 +260,7 @@ resource "aws_location_place_index" "test" {
 `, rName, intendedUse)
 }
 
-func testAccConfigPlaceIndex_description(rName, description string) string {
+func testAccPlaceIndexConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"
@@ -270,7 +270,7 @@ resource "aws_location_place_index" "test" {
 `, rName, description)
 }
 
-func testAccConfigPlaceIndex_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccPlaceIndexConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"
@@ -283,7 +283,7 @@ resource "aws_location_place_index" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccConfigPlaceIndex_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccPlaceIndexConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
