### PR TITLE
keyspaces: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -324,7 +324,6 @@ rules:
         - internal/service/iot
         - internal/service/kafka
         - internal/service/kafkaconnect
-        - internal/service/keyspaces
         - internal/service/kinesis
         - internal/service/kinesisanalyticsv2
         - internal/service/kms

--- a/internal/service/keyspaces/keyspace_test.go
+++ b/internal/service/keyspaces/keyspace_test.go
@@ -31,7 +31,7 @@ func TestAccKeyspacesKeyspace_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyspaceConfig(rName),
+				Config: testAccKeyspaceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyspaceExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "cassandra", "/keyspace/"+rName+"/"),
@@ -59,7 +59,7 @@ func TestAccKeyspacesKeyspace_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyspaceConfig(rName),
+				Config: testAccKeyspaceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyspaceExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkeyspaces.ResourceKeyspace(), resourceName),
@@ -81,7 +81,7 @@ func TestAccKeyspacesKeyspace_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyspaceConfigTags1(rName, "key1", "value1"),
+				Config: testAccKeyspaceConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyspaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -94,7 +94,7 @@ func TestAccKeyspacesKeyspace_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccKeyspaceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccKeyspaceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyspaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -103,7 +103,7 @@ func TestAccKeyspacesKeyspace_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKeyspaceConfigTags1(rName, "key2", "value2"),
+				Config: testAccKeyspaceConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyspaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -161,7 +161,7 @@ func testAccCheckKeyspaceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccKeyspaceConfig(rName string) string {
+func testAccKeyspaceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q
@@ -169,7 +169,7 @@ resource "aws_keyspaces_keyspace" "test" {
 `, rName)
 }
 
-func testAccKeyspaceConfigTags1(rName, tag1Key, tag1Value string) string {
+func testAccKeyspaceConfig_tags1(rName, tag1Key, tag1Value string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q
@@ -181,7 +181,7 @@ resource "aws_keyspaces_keyspace" "test" {
 `, rName, tag1Key, tag1Value)
 }
 
-func testAccKeyspaceConfigTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccKeyspaceConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q

--- a/internal/service/keyspaces/table_test.go
+++ b/internal/service/keyspaces/table_test.go
@@ -30,7 +30,7 @@ func TestAccKeyspacesTable_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfig(rName1, rName2),
+				Config: testAccTableConfig_basic(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "cassandra", fmt.Sprintf("/keyspace/%s/table/%s", rName1, rName2)),
@@ -83,7 +83,7 @@ func TestAccKeyspacesTable_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfig(rName1, rName2),
+				Config: testAccTableConfig_basic(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkeyspaces.ResourceTable(), resourceName),
@@ -107,7 +107,7 @@ func TestAccKeyspacesTable_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfigTags1(rName1, rName2, "key1", "value1"),
+				Config: testAccTableConfig_tags1(rName1, rName2, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -120,7 +120,7 @@ func TestAccKeyspacesTable_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTableConfigTags2(rName1, rName2, "key1", "value1updated", "key2", "value2"),
+				Config: testAccTableConfig_tags2(rName1, rName2, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -129,7 +129,7 @@ func TestAccKeyspacesTable_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTableConfigTags1(rName1, rName2, "key2", "value2"),
+				Config: testAccTableConfig_tags1(rName1, rName2, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -153,7 +153,7 @@ func TestAccKeyspacesTable_multipleColumns(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableMultipleColumnsConfig(rName1, rName2),
+				Config: testAccTableConfig_multipleColumns(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "schema_definition.#", "1"),
@@ -239,7 +239,7 @@ func TestAccKeyspacesTable_update(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableAllAttributesConfig(rName1, rName2),
+				Config: testAccTableConfig_allAttributes(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v1),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "cassandra", fmt.Sprintf("/keyspace/%s/table/%s", rName1, rName2)),
@@ -269,7 +269,7 @@ func TestAccKeyspacesTable_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTableAllAttributesUpdatedConfig(rName1, rName2),
+				Config: testAccTableConfig_allAttributesUpdated(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v2),
 					testAccCheckTableNotRecreated(&v1, &v2),
@@ -311,7 +311,7 @@ func TestAccKeyspacesTable_addColumns(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfig(rName1, rName2),
+				Config: testAccTableConfig_basic(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "schema_definition.#", "1"),
@@ -334,7 +334,7 @@ func TestAccKeyspacesTable_addColumns(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTableNewColumnsConfig(rName1, rName2),
+				Config: testAccTableConfig_newColumns(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v2),
 					testAccCheckTableNotRecreated(&v1, &v2),
@@ -377,7 +377,7 @@ func TestAccKeyspacesTable_delColumns(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableNewColumnsConfig(rName1, rName2),
+				Config: testAccTableConfig_newColumns(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "schema_definition.#", "1"),
@@ -408,7 +408,7 @@ func TestAccKeyspacesTable_delColumns(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTableConfig(rName1, rName2),
+				Config: testAccTableConfig_basic(rName1, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableExists(resourceName, &v2),
 					testAccCheckTableRecreated(&v1, &v2),
@@ -511,7 +511,7 @@ func testAccCheckTableRecreated(i, j *keyspaces.GetTableOutput) resource.TestChe
 	}
 }
 
-func testAccTableConfig(rName1, rName2 string) string {
+func testAccTableConfig_basic(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q
@@ -535,7 +535,7 @@ resource "aws_keyspaces_table" "test" {
 `, rName1, rName2)
 }
 
-func testAccTableConfigTags1(rName1, rName2, tagKey1, tagValue1 string) string {
+func testAccTableConfig_tags1(rName1, rName2, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q
@@ -563,7 +563,7 @@ resource "aws_keyspaces_table" "test" {
 `, rName1, rName2, tagKey1, tagValue1)
 }
 
-func testAccTableConfigTags2(rName1, rName2, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccTableConfig_tags2(rName1, rName2, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q
@@ -592,7 +592,7 @@ resource "aws_keyspaces_table" "test" {
 `, rName1, rName2, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccTableMultipleColumnsConfig(rName1, rName2 string) string {
+func testAccTableConfig_multipleColumns(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q
@@ -674,7 +674,7 @@ resource "aws_keyspaces_table" "test" {
 `, rName1, rName2)
 }
 
-func testAccTableAllAttributesConfig(rName1, rName2 string) string {
+func testAccTableConfig_allAttributes(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q
@@ -727,7 +727,7 @@ resource "aws_keyspaces_table" "test" {
 `, rName1, rName2)
 }
 
-func testAccTableAllAttributesUpdatedConfig(rName1, rName2 string) string {
+func testAccTableConfig_allAttributesUpdated(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q
@@ -777,7 +777,7 @@ resource "aws_keyspaces_table" "test" {
 `, rName1, rName2)
 }
 
-func testAccTableNewColumnsConfig(rName1, rName2 string) string {
+func testAccTableConfig_newColumns(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_keyspaces_keyspace" "test" {
   name = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
