### PR TITLE
glue: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -313,7 +313,6 @@ rules:
         - internal/service/gamelift
         - internal/service/glacier
         - internal/service/globalaccelerator
-        - internal/service/glue
         - internal/service/grafana
         - internal/service/guardduty
         - internal/service/iam

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -124,7 +124,7 @@ func TestAccGlueCatalogDatabase_targetDatabase(t *testing.T) {
 		CheckDestroy:      testAccCheckDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccCatalogDatabaseConfig_targetDatabase(rName),
+				Config:  testAccCatalogDatabaseConfig_target(rName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCatalogDatabaseExists(resourceName),
@@ -139,7 +139,7 @@ func TestAccGlueCatalogDatabase_targetDatabase(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:  testAccCatalogDatabaseConfig_targetDatabaseLocation(rName),
+				Config:  testAccCatalogDatabaseConfig_targetLocation(rName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCatalogDatabaseExists(resourceName),
@@ -228,7 +228,7 @@ resource "aws_glue_catalog_database" "test" {
 `, rName, desc)
 }
 
-func testAccCatalogDatabaseConfig_targetDatabase(rName string) string {
+func testAccCatalogDatabaseConfig_target(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -245,7 +245,7 @@ resource "aws_glue_catalog_database" "test2" {
 `, rName)
 }
 
-func testAccCatalogDatabaseConfig_targetDatabaseLocation(rName string) string {
+func testAccCatalogDatabaseConfig_targetLocation(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -287,7 +287,7 @@ func TestAccGlueCatalogTable_Update_replaceValues(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:  testAccCatalogTableConfig_Full_replacedValues(rName),
+				Config:  testAccCatalogTableConfig_fullReplacedValues(rName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCatalogTableExists(resourceName),
@@ -619,7 +619,7 @@ func TestAccGlueCatalogTable_targetTable(t *testing.T) {
 		CheckDestroy:      testAccCheckTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccCatalogTableConfig_targetTable(rName),
+				Config:  testAccCatalogTableConfig_target(rName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCatalogTableExists(resourceName),
@@ -765,7 +765,7 @@ resource "aws_glue_catalog_table" "test" {
 `, rName, desc)
 }
 
-func testAccCatalogTableConfig_Full_replacedValues(rName string) string {
+func testAccCatalogTableConfig_fullReplacedValues(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1361,7 +1361,7 @@ resource "aws_glue_catalog_table" "test" {
 `, rName)
 }
 
-func testAccCatalogTableConfig_targetTable(rName string) string {
+func testAccCatalogTableConfig_target(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q

--- a/internal/service/glue/classifier_test.go
+++ b/internal/service/glue/classifier_test.go
@@ -28,7 +28,7 @@ func TestAccGlueClassifier_csvClassifier(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_CSVClassifier(rName, false, "PRESENT", "|", false),
+				Config: testAccClassifierConfig_csv(rName, false, "PRESENT", "|", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
@@ -45,7 +45,7 @@ func TestAccGlueClassifier_csvClassifier(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_CSVClassifier(rName, false, "PRESENT", ",", false),
+				Config: testAccClassifierConfig_csv(rName, false, "PRESENT", ",", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
@@ -83,7 +83,7 @@ func TestAccGlueClassifier_CSVClassifier_quoteSymbol(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierCSVClassifierQuoteSymbolConfig(rName, "\""),
+				Config: testAccClassifierConfig_csvQuoteSymbol(rName, "\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
@@ -91,7 +91,7 @@ func TestAccGlueClassifier_CSVClassifier_quoteSymbol(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierCSVClassifierQuoteSymbolConfig(rName, "'"),
+				Config: testAccClassifierConfig_csvQuoteSymbol(rName, "'"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
@@ -120,7 +120,7 @@ func TestAccGlueClassifier_grokClassifier(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_GrokClassifier(rName, "classification1", "pattern1"),
+				Config: testAccClassifierConfig_grok(rName, "classification1", "pattern1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -134,7 +134,7 @@ func TestAccGlueClassifier_grokClassifier(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_GrokClassifier(rName, "classification2", "pattern2"),
+				Config: testAccClassifierConfig_grok(rName, "classification2", "pattern2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -169,7 +169,7 @@ func TestAccGlueClassifier_GrokClassifier_customPatterns(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_GrokClassifier_CustomPatterns(rName, "custompattern1"),
+				Config: testAccClassifierConfig_grokCustomPatterns(rName, "custompattern1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -183,7 +183,7 @@ func TestAccGlueClassifier_GrokClassifier_customPatterns(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_GrokClassifier_CustomPatterns(rName, "custompattern2"),
+				Config: testAccClassifierConfig_grokCustomPatterns(rName, "custompattern2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -218,7 +218,7 @@ func TestAccGlueClassifier_jsonClassifier(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_JSONClassifier(rName, "jsonpath1"),
+				Config: testAccClassifierConfig_json(rName, "jsonpath1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -230,7 +230,7 @@ func TestAccGlueClassifier_jsonClassifier(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_JSONClassifier(rName, "jsonpath2"),
+				Config: testAccClassifierConfig_json(rName, "jsonpath2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -263,7 +263,7 @@ func TestAccGlueClassifier_typeChange(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_GrokClassifier(rName, "classification1", "pattern1"),
+				Config: testAccClassifierConfig_grok(rName, "classification1", "pattern1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -277,7 +277,7 @@ func TestAccGlueClassifier_typeChange(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_JSONClassifier(rName, "jsonpath1"),
+				Config: testAccClassifierConfig_json(rName, "jsonpath1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -289,7 +289,7 @@ func TestAccGlueClassifier_typeChange(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_XmlClassifier(rName, "classification1", "rowtag1"),
+				Config: testAccClassifierConfig_xml(rName, "classification1", "rowtag1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -302,7 +302,7 @@ func TestAccGlueClassifier_typeChange(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_GrokClassifier(rName, "classification1", "pattern1"),
+				Config: testAccClassifierConfig_grok(rName, "classification1", "pattern1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -332,7 +332,7 @@ func TestAccGlueClassifier_xmlClassifier(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_XmlClassifier(rName, "classification1", "rowtag1"),
+				Config: testAccClassifierConfig_xml(rName, "classification1", "rowtag1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -345,7 +345,7 @@ func TestAccGlueClassifier_xmlClassifier(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClassifierConfig_XmlClassifier(rName, "classification2", "rowtag2"),
+				Config: testAccClassifierConfig_xml(rName, "classification2", "rowtag2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "0"),
@@ -379,7 +379,7 @@ func TestAccGlueClassifier_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckClassifierDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClassifierConfig_CSVClassifier(rName, false, "PRESENT", "|", false),
+				Config: testAccClassifierConfig_csv(rName, false, "PRESENT", "|", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClassifierExists(resourceName, &classifier),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceClassifier(), resourceName),
@@ -449,7 +449,7 @@ func testAccCheckClassifierDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccClassifierConfig_CSVClassifier(rName string, allowSingleColumn bool, containsHeader string, delimiter string, disableValueTrimming bool) string {
+func testAccClassifierConfig_csv(rName string, allowSingleColumn bool, containsHeader string, delimiter string, disableValueTrimming bool) string {
 	return fmt.Sprintf(`
 resource "aws_glue_classifier" "test" {
   name = "%s"
@@ -465,7 +465,7 @@ resource "aws_glue_classifier" "test" {
 `, rName, allowSingleColumn, containsHeader, delimiter, disableValueTrimming)
 }
 
-func testAccClassifierCSVClassifierQuoteSymbolConfig(rName, symbol string) string {
+func testAccClassifierConfig_csvQuoteSymbol(rName, symbol string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_classifier" "test" {
   name = %[1]q
@@ -481,7 +481,7 @@ resource "aws_glue_classifier" "test" {
 `, rName, symbol)
 }
 
-func testAccClassifierConfig_GrokClassifier(rName, classification, grokPattern string) string {
+func testAccClassifierConfig_grok(rName, classification, grokPattern string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_classifier" "test" {
   name = "%s"
@@ -494,7 +494,7 @@ resource "aws_glue_classifier" "test" {
 `, rName, classification, grokPattern)
 }
 
-func testAccClassifierConfig_GrokClassifier_CustomPatterns(rName, customPatterns string) string {
+func testAccClassifierConfig_grokCustomPatterns(rName, customPatterns string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_classifier" "test" {
   name = "%s"
@@ -508,7 +508,7 @@ resource "aws_glue_classifier" "test" {
 `, rName, customPatterns)
 }
 
-func testAccClassifierConfig_JSONClassifier(rName, jsonPath string) string {
+func testAccClassifierConfig_json(rName, jsonPath string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_classifier" "test" {
   name = "%s"
@@ -520,7 +520,7 @@ resource "aws_glue_classifier" "test" {
 `, rName, jsonPath)
 }
 
-func testAccClassifierConfig_XmlClassifier(rName, classification, rowTag string) string {
+func testAccClassifierConfig_xml(rName, classification, rowTag string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_classifier" "test" {
   name = "%s"

--- a/internal/service/glue/connection_data_source_test.go
+++ b/internal/service/glue/connection_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccGlueConnectionDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionDataSourceConfig(rName, jdbcConnectionUrl),
+				Config: testAccConnectionDataSourceConfig_basic(rName, jdbcConnectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccConnectionCheckDataSource(datasourceName),
 					resource.TestCheckResourceAttrPair(datasourceName, "catalog_id", resourceName, "catalog_id"),
@@ -53,7 +53,7 @@ func testAccConnectionCheckDataSource(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccConnectionDataSourceConfig(rName, jdbcConnectionUrl string) string {
+func testAccConnectionDataSourceConfig_basic(rName, jdbcConnectionUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q

--- a/internal/service/glue/connection_test.go
+++ b/internal/service/glue/connection_test.go
@@ -29,7 +29,7 @@ func TestAccGlueConnection_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_Required(rName, jdbcConnectionUrl),
+				Config: testAccConnectionConfig_required(rName, jdbcConnectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("connection/%s", rName)),
@@ -66,7 +66,7 @@ func TestAccGlueConnection_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionTags1Config(rName, jdbcConnectionUrl, "key1", "value1"),
+				Config: testAccConnectionConfig_tags1(rName, jdbcConnectionUrl, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -79,7 +79,7 @@ func TestAccGlueConnection_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConnectionTags2Config(rName, jdbcConnectionUrl, "key1", "value1updated", "key2", "value2"),
+				Config: testAccConnectionConfig_tags2(rName, jdbcConnectionUrl, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -88,7 +88,7 @@ func TestAccGlueConnection_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConnectionTags1Config(rName, jdbcConnectionUrl, "key2", "value2"),
+				Config: testAccConnectionConfig_tags1(rName, jdbcConnectionUrl, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -114,7 +114,7 @@ func TestAccGlueConnection_mongoDB(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_MongoDB(rName, connectionUrl),
+				Config: testAccConnectionConfig_mongoDB(rName, connectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "3"),
@@ -150,7 +150,7 @@ func TestAccGlueConnection_kafka(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_Kafka(rName, bootstrapServers),
+				Config: testAccConnectionConfig_kafka(rName, bootstrapServers),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "1"),
@@ -182,7 +182,7 @@ func TestAccGlueConnection_network(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_Network(rName),
+				Config: testAccConnectionConfig_network(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "0"),
@@ -218,14 +218,14 @@ func TestAccGlueConnection_description(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_Description(rName, jdbcConnectionUrl, "First Description"),
+				Config: testAccConnectionConfig_description(rName, jdbcConnectionUrl, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccConnectionConfig_Description(rName, jdbcConnectionUrl, "Second Description"),
+				Config: testAccConnectionConfig_description(rName, jdbcConnectionUrl, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -255,7 +255,7 @@ func TestAccGlueConnection_matchCriteria(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_MatchCriteria_First(rName, jdbcConnectionUrl),
+				Config: testAccConnectionConfig_matchCriteriaFirst(rName, jdbcConnectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "4"),
@@ -266,7 +266,7 @@ func TestAccGlueConnection_matchCriteria(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConnectionConfig_MatchCriteria_Second(rName, jdbcConnectionUrl),
+				Config: testAccConnectionConfig_matchCriteriaSecond(rName, jdbcConnectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "1"),
@@ -274,7 +274,7 @@ func TestAccGlueConnection_matchCriteria(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConnectionConfig_MatchCriteria_Third(rName, jdbcConnectionUrl),
+				Config: testAccConnectionConfig_matchCriteriaThird(rName, jdbcConnectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "3"),
@@ -305,7 +305,7 @@ func TestAccGlueConnection_physicalConnectionRequirements(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_PhysicalConnectionRequirements(rName),
+				Config: testAccConnectionConfig_physicalRequirements(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "3"),
@@ -344,7 +344,7 @@ func TestAccGlueConnection_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectionConfig_Required(rName, jdbcConnectionUrl),
+				Config: testAccConnectionConfig_required(rName, jdbcConnectionUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceConnection(), resourceName),
@@ -413,7 +413,7 @@ func testAccCheckConnectionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccConnectionConfig_Description(rName, jdbcConnectionUrl, description string) string {
+func testAccConnectionConfig_description(rName, jdbcConnectionUrl, description string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name        = %[1]q
@@ -429,7 +429,7 @@ resource "aws_glue_connection" "test" {
 `, rName, description, jdbcConnectionUrl)
 }
 
-func testAccConnectionConfig_MatchCriteria_First(rName, jdbcConnectionUrl string) string {
+func testAccConnectionConfig_matchCriteriaFirst(rName, jdbcConnectionUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -445,7 +445,7 @@ resource "aws_glue_connection" "test" {
 `, rName, jdbcConnectionUrl)
 }
 
-func testAccConnectionConfig_MatchCriteria_Second(rName, jdbcConnectionUrl string) string {
+func testAccConnectionConfig_matchCriteriaSecond(rName, jdbcConnectionUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -461,7 +461,7 @@ resource "aws_glue_connection" "test" {
 `, rName, jdbcConnectionUrl)
 }
 
-func testAccConnectionConfig_MatchCriteria_Third(rName, jdbcConnectionUrl string) string {
+func testAccConnectionConfig_matchCriteriaThird(rName, jdbcConnectionUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = "%s"
@@ -477,7 +477,7 @@ resource "aws_glue_connection" "test" {
 `, rName, jdbcConnectionUrl)
 }
 
-func testAccConnectionConfig_PhysicalConnectionRequirements(rName string) string {
+func testAccConnectionConfig_physicalRequirements(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -562,7 +562,7 @@ resource "aws_glue_connection" "test" {
 `, rName)
 }
 
-func testAccConnectionConfig_Required(rName, jdbcConnectionUrl string) string {
+func testAccConnectionConfig_required(rName, jdbcConnectionUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -576,7 +576,7 @@ resource "aws_glue_connection" "test" {
 `, rName, jdbcConnectionUrl)
 }
 
-func testAccConnectionTags1Config(rName, jdbcConnectionUrl, tagKey1, tagValue1 string) string {
+func testAccConnectionConfig_tags1(rName, jdbcConnectionUrl, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -594,7 +594,7 @@ resource "aws_glue_connection" "test" {
 `, rName, jdbcConnectionUrl, tagKey1, tagValue1)
 }
 
-func testAccConnectionTags2Config(rName, jdbcConnectionUrl, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccConnectionConfig_tags2(rName, jdbcConnectionUrl, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -613,7 +613,7 @@ resource "aws_glue_connection" "test" {
 `, rName, jdbcConnectionUrl, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccConnectionConfig_MongoDB(rName, connectionUrl string) string {
+func testAccConnectionConfig_mongoDB(rName, connectionUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -628,7 +628,7 @@ resource "aws_glue_connection" "test" {
 `, rName, connectionUrl)
 }
 
-func testAccConnectionConfig_Kafka(rName, bootstrapServers string) string {
+func testAccConnectionConfig_kafka(rName, bootstrapServers string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
   name = %[1]q
@@ -641,7 +641,7 @@ resource "aws_glue_connection" "test" {
 `, rName, bootstrapServers)
 }
 
-func testAccConnectionConfig_Network(rName string) string {
+func testAccConnectionConfig_network(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -261,7 +261,7 @@ func TestAccGlueCrawler_JDBCTarget_exclusions(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_jDBCTargetExclusions2(rName, jdbcConnectionUrl, "exclusion1", "exclusion2"),
+				Config: testAccCrawlerConfig_jdbcTargetExclusions2(rName, jdbcConnectionUrl, "exclusion1", "exclusion2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -272,7 +272,7 @@ func TestAccGlueCrawler_JDBCTarget_exclusions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_jDBCTargetExclusions1(rName, jdbcConnectionUrl, "exclusion1"),
+				Config: testAccCrawlerConfig_jdbcTargetExclusions1(rName, jdbcConnectionUrl, "exclusion1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -304,7 +304,7 @@ func TestAccGlueCrawler_JDBCTarget_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_jDBCTargetMultiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
+				Config: testAccCrawlerConfig_jdbcTargetMultiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -329,7 +329,7 @@ func TestAccGlueCrawler_JDBCTarget_multiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_jDBCTargetMultiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
+				Config: testAccCrawlerConfig_jdbcTargetMultiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "2"),
@@ -1848,7 +1848,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, path)
 }
 
-func testAccCrawlerConfig_jDBCTargetExclusions1(rName, jdbcConnectionUrl, exclusion1 string) string {
+func testAccCrawlerConfig_jdbcTargetExclusions1(rName, jdbcConnectionUrl, exclusion1 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1880,7 +1880,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, exclusion1)
 }
 
-func testAccCrawlerConfig_jDBCTargetExclusions2(rName, jdbcConnectionUrl, exclusion1, exclusion2 string) string {
+func testAccCrawlerConfig_jdbcTargetExclusions2(rName, jdbcConnectionUrl, exclusion1, exclusion2 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1912,7 +1912,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, exclusion1, exclusion2)
 }
 
-func testAccCrawlerConfig_jDBCTargetMultiple(rName, jdbcConnectionUrl, path1, path2 string) string {
+func testAccCrawlerConfig_jdbcTargetMultiple(rName, jdbcConnectionUrl, path1, path2 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -261,7 +261,7 @@ func TestAccGlueCrawler_JDBCTarget_exclusions(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_JDBCTarget_exclusions2(rName, jdbcConnectionUrl, "exclusion1", "exclusion2"),
+				Config: testAccCrawlerConfig_jDBCTargetExclusions2(rName, jdbcConnectionUrl, "exclusion1", "exclusion2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -272,7 +272,7 @@ func TestAccGlueCrawler_JDBCTarget_exclusions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_JDBCTarget_exclusions1(rName, jdbcConnectionUrl, "exclusion1"),
+				Config: testAccCrawlerConfig_jDBCTargetExclusions1(rName, jdbcConnectionUrl, "exclusion1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -304,7 +304,7 @@ func TestAccGlueCrawler_JDBCTarget_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_JDBCTarget_multiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
+				Config: testAccCrawlerConfig_jDBCTargetMultiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -329,7 +329,7 @@ func TestAccGlueCrawler_JDBCTarget_multiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_JDBCTarget_multiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
+				Config: testAccCrawlerConfig_jDBCTargetMultiple(rName, jdbcConnectionUrl, "database-name/table1", "database-name/table2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "2"),
@@ -628,7 +628,7 @@ func TestAccGlueCrawler_S3Target_connectionName(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_S3Target_connectionName(rName),
+				Config: testAccCrawlerConfig_s3TargetConnectionName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -693,7 +693,7 @@ func TestAccGlueCrawler_S3Target_exclusions(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_S3Target_exclusions2(rName, "exclusion1", "exclusion2"),
+				Config: testAccCrawlerConfig_s3TargetExclusions2(rName, "exclusion1", "exclusion2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -704,7 +704,7 @@ func TestAccGlueCrawler_S3Target_exclusions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_S3Target_exclusions1(rName, "exclusion1"),
+				Config: testAccCrawlerConfig_s3TargetExclusions1(rName, "exclusion1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -734,7 +734,7 @@ func TestAccGlueCrawler_S3Target_eventqueue(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_S3Target_eventQueue(rName),
+				Config: testAccCrawlerConfig_s3TargetEventQueue(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -764,7 +764,7 @@ func TestAccGlueCrawler_S3Target_dlqeventqueue(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_S3Target_dlqEventQueue(rName),
+				Config: testAccCrawlerConfig_s3TargetDlqEventQueue(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -795,7 +795,7 @@ func TestAccGlueCrawler_S3Target_multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_S3Target_multiple(rName, "s3://bucket1", "s3://bucket2"),
+				Config: testAccCrawlerConfig_s3TargetMultiple(rName, "s3://bucket1", "s3://bucket2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -817,7 +817,7 @@ func TestAccGlueCrawler_S3Target_multiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_S3Target_multiple(rName, "s3://bucket1", "s3://bucket2"),
+				Config: testAccCrawlerConfig_s3TargetMultiple(rName, "s3://bucket1", "s3://bucket2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -933,7 +933,7 @@ func TestAccGlueCrawler_CatalogTarget_multiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_CatalogTarget_multiple(rName),
+				Config: testAccCrawlerConfig_catalogTargetMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -1001,7 +1001,7 @@ func TestAccGlueCrawler_classifiers(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_Classifiers_single(rName),
+				Config: testAccCrawlerConfig_classifiersSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "1"),
@@ -1009,7 +1009,7 @@ func TestAccGlueCrawler_classifiers(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_Classifiers_multiple(rName),
+				Config: testAccCrawlerConfig_classifiersMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "2"),
@@ -1018,7 +1018,7 @@ func TestAccGlueCrawler_classifiers(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCrawlerConfig_Classifiers_single(rName),
+				Config: testAccCrawlerConfig_classifiersSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "1"),
@@ -1124,7 +1124,7 @@ func TestAccGlueCrawler_RoleARN_noPath(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_Role_ARN_noPath(rName),
+				Config: testAccCrawlerConfig_roleARNNoPath(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttrPair(resourceName, "role", iamRoleResourceName, "name"),
@@ -1151,7 +1151,7 @@ func TestAccGlueCrawler_RoleARN_path(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_Role_ARN_path(rName),
+				Config: testAccCrawlerConfig_roleARNPath(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "role", fmt.Sprintf("path/%s", rName)),
@@ -1178,7 +1178,7 @@ func TestAccGlueCrawler_RoleName_path(t *testing.T) {
 		CheckDestroy:      testAccCheckCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCrawlerConfig_Role_Name_path(rName),
+				Config: testAccCrawlerConfig_roleNamePath(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "role", fmt.Sprintf("path/%s", rName)),
@@ -1635,7 +1635,7 @@ EOF
 `, rName)
 }
 
-func testAccCrawlerConfig_Classifiers_single(rName string) string {
+func testAccCrawlerConfig_classifiersSingle(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %q
@@ -1674,7 +1674,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, rName+"1", rName+"2", rName)
 }
 
-func testAccCrawlerConfig_Classifiers_multiple(rName string) string {
+func testAccCrawlerConfig_classifiersMultiple(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %q
@@ -1848,7 +1848,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, path)
 }
 
-func testAccCrawlerConfig_JDBCTarget_exclusions1(rName, jdbcConnectionUrl, exclusion1 string) string {
+func testAccCrawlerConfig_jDBCTargetExclusions1(rName, jdbcConnectionUrl, exclusion1 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1880,7 +1880,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, exclusion1)
 }
 
-func testAccCrawlerConfig_JDBCTarget_exclusions2(rName, jdbcConnectionUrl, exclusion1, exclusion2 string) string {
+func testAccCrawlerConfig_jDBCTargetExclusions2(rName, jdbcConnectionUrl, exclusion1, exclusion2 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1912,7 +1912,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, exclusion1, exclusion2)
 }
 
-func testAccCrawlerConfig_JDBCTarget_multiple(rName, jdbcConnectionUrl, path1, path2 string) string {
+func testAccCrawlerConfig_jDBCTargetMultiple(rName, jdbcConnectionUrl, path1, path2 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1948,7 +1948,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, jdbcConnectionUrl, path1, path2)
 }
 
-func testAccCrawlerConfig_Role_ARN_noPath(rName string) string {
+func testAccCrawlerConfig_roleARNNoPath(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -1968,7 +1968,7 @@ resource "aws_glue_crawler" "test" {
 `, rName)
 }
 
-func testAccCrawlerConfig_Role_ARN_path(rName string) string {
+func testAccCrawlerConfig_roleARNPath(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -2016,7 +2016,7 @@ resource "aws_glue_crawler" "test" {
 `, rName)
 }
 
-func testAccCrawlerConfig_Role_Name_path(rName string) string {
+func testAccCrawlerConfig_roleNamePath(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -2084,7 +2084,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, path)
 }
 
-func testAccCrawlerConfig_S3Target_exclusions1(rName, exclusion1 string) string {
+func testAccCrawlerConfig_s3TargetExclusions1(rName, exclusion1 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2105,7 +2105,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, exclusion1)
 }
 
-func testAccCrawlerConfig_S3Target_connectionName(rName string) string {
+func testAccCrawlerConfig_s3TargetConnectionName(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -2183,7 +2183,7 @@ resource "aws_glue_crawler" "test" {
 `, rName)
 }
 
-func testAccCrawlerConfig_S3Target_exclusions2(rName, exclusion1, exclusion2 string) string {
+func testAccCrawlerConfig_s3TargetExclusions2(rName, exclusion1, exclusion2 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2204,7 +2204,7 @@ resource "aws_glue_crawler" "test" {
 `, rName, exclusion1, exclusion2)
 }
 
-func testAccCrawlerConfig_S3Target_eventQueue(rName string) string {
+func testAccCrawlerConfig_s3TargetEventQueue(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2272,7 +2272,7 @@ resource "aws_glue_crawler" "test" {
 `, rName)
 }
 
-func testAccCrawlerConfig_S3Target_dlqEventQueue(rName string) string {
+func testAccCrawlerConfig_s3TargetDlqEventQueue(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2348,7 +2348,7 @@ resource "aws_glue_crawler" "test" {
 `, rName)
 }
 
-func testAccCrawlerConfig_S3Target_multiple(rName, path1, path2 string) string {
+func testAccCrawlerConfig_s3TargetMultiple(rName, path1, path2 string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2435,7 +2435,7 @@ EOF
 `, rName, tableCount)
 }
 
-func testAccCrawlerConfig_CatalogTarget_multiple(rName string) string {
+func testAccCrawlerConfig_catalogTargetMultiple(rName string) string {
 	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   count = 2

--- a/internal/service/glue/data_catalog_encryption_settings_data_source_test.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source_test.go
@@ -20,7 +20,7 @@ func testAccDataCatalogEncryptionSettingsDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCatalogEncryptionSettingsDataSourceConfig(),
+				Config: testAccDataCatalogEncryptionSettingsDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "catalog_id", resourceName, "catalog_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "data_catalog_encryption_settings", resourceName, "data_catalog_encryption_settings"),
@@ -30,7 +30,7 @@ func testAccDataCatalogEncryptionSettingsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDataCatalogEncryptionSettingsDataSourceConfig() string {
+func testAccDataCatalogEncryptionSettingsDataSourceConfig_basic() string {
 	return `
 resource "aws_glue_data_catalog_encryption_settings" "test" {
   data_catalog_encryption_settings {

--- a/internal/service/glue/data_catalog_encryption_settings_test.go
+++ b/internal/service/glue/data_catalog_encryption_settings_test.go
@@ -29,7 +29,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCatalogEncryptionSettingsNonEncryptedConfig(),
+				Config: testAccDataCatalogEncryptionSettingsConfig_nonEncrypted(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogEncryptionSettingsExists(resourceName, &settings),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.#", "1"),
@@ -47,7 +47,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDataCatalogEncryptionSettingsEncryptedConfig(rName),
+				Config: testAccDataCatalogEncryptionSettingsConfig_encrypted(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogEncryptionSettingsExists(resourceName, &settings),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.#", "1"),
@@ -60,7 +60,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataCatalogEncryptionSettingsNonEncryptedConfig(),
+				Config: testAccDataCatalogEncryptionSettingsConfig_nonEncrypted(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogEncryptionSettingsExists(resourceName, &settings),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.#", "1"),
@@ -103,7 +103,7 @@ func testAccCheckDataCatalogEncryptionSettingsExists(resourceName string, v *glu
 	}
 }
 
-func testAccDataCatalogEncryptionSettingsEncryptedConfig(rName string) string {
+func testAccDataCatalogEncryptionSettingsConfig_encrypted(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q
@@ -142,7 +142,7 @@ resource "aws_glue_data_catalog_encryption_settings" "test" {
 `, rName)
 }
 
-func testAccDataCatalogEncryptionSettingsNonEncryptedConfig() string {
+func testAccDataCatalogEncryptionSettingsConfig_nonEncrypted() string {
 	return `
 resource "aws_glue_data_catalog_encryption_settings" "test" {
   data_catalog_encryption_settings {

--- a/internal/service/glue/dev_endpoint_test.go
+++ b/internal/service/glue/dev_endpoint_test.go
@@ -431,7 +431,7 @@ func TestAccGlueDevEndpoint_SubnetID_securityGroupIDs(t *testing.T) {
 		CheckDestroy:      testAccCheckDevEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDevEndpointConfig_SubnetID_securityGroupIDs(rName),
+				Config: testAccDevEndpointConfig_subnetIDSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDevEndpointExists(resourceName, &endpoint),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
@@ -462,7 +462,7 @@ func TestAccGlueDevEndpoint_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckDevEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDevEndpointConfig_Tags1(rName, "key1", "value1"),
+				Config: testAccDevEndpointConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDevEndpointExists(resourceName, &endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -475,7 +475,7 @@ func TestAccGlueDevEndpoint_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDevEndpointConfig_Tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccDevEndpointConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDevEndpointExists(resourceName, &endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -484,7 +484,7 @@ func TestAccGlueDevEndpoint_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDevEndpointConfig_Tags1(rName, "key2", "value2"),
+				Config: testAccDevEndpointConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDevEndpointExists(resourceName, &endpoint3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -508,7 +508,7 @@ func TestAccGlueDevEndpoint_workerType(t *testing.T) {
 		CheckDestroy:      testAccCheckDevEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDevEndpointConfig_WorkerType_standard(rName),
+				Config: testAccDevEndpointConfig_workerTypeStandard(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDevEndpointExists(resourceName, &endpoint),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", glue.WorkerTypeStandard),
@@ -790,7 +790,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccDevEndpointConfig_SubnetID_securityGroupIDs(rName string) string {
+func testAccDevEndpointConfig_subnetIDSecurityGroupIDs(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), testAccDevEndpointConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_dev_endpoint" "test" {
   name               = %[1]q
@@ -865,7 +865,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccDevEndpointConfig_Tags1(rName, tagKey1, tagValue1 string) string {
+func testAccDevEndpointConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccJobConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_glue_dev_endpoint" "test" {
   name     = %[1]q
@@ -878,7 +878,7 @@ resource "aws_glue_dev_endpoint" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccDevEndpointConfig_Tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccDevEndpointConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccJobConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_glue_dev_endpoint" "test" {
   name     = %[1]q
@@ -903,7 +903,7 @@ resource "aws_glue_dev_endpoint" "test" {
 `, rName, workerType)
 }
 
-func testAccDevEndpointConfig_WorkerType_standard(rName string) string {
+func testAccDevEndpointConfig_workerTypeStandard(rName string) string {
 	return testAccDevEndpointConfig_base(rName) + fmt.Sprintf(`
 resource "aws_glue_dev_endpoint" "test" {
   name              = %[1]q

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -30,7 +30,7 @@ func TestAccGlueJob_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Required(rName),
+				Config: testAccJobConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("job/%s", rName)),
@@ -67,7 +67,7 @@ func TestAccGlueJob_basicStreaming(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_RequiredStreaming(rName),
+				Config: testAccJobConfig_requiredStreaming(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("job/%s", rName)),
@@ -103,7 +103,7 @@ func TestAccGlueJob_command(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Command(rName, "testscriptlocation1"),
+				Config: testAccJobConfig_command(rName, "testscriptlocation1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
@@ -111,7 +111,7 @@ func TestAccGlueJob_command(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobConfig_Command(rName, "testscriptlocation2"),
+				Config: testAccJobConfig_command(rName, "testscriptlocation2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
@@ -140,7 +140,7 @@ func TestAccGlueJob_defaultArguments(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_DefaultArguments(rName, "job-bookmark-disable", "python"),
+				Config: testAccJobConfig_defaultArguments(rName, "job-bookmark-disable", "python"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "default_arguments.%", "2"),
@@ -149,7 +149,7 @@ func TestAccGlueJob_defaultArguments(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobConfig_DefaultArguments(rName, "job-bookmark-enable", "scala"),
+				Config: testAccJobConfig_defaultArguments(rName, "job-bookmark-enable", "scala"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "default_arguments.%", "2"),
@@ -179,7 +179,7 @@ func TestAccGlueJob_nonOverridableArguments(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobnonOverridableArgumentsConfig(rName, "job-bookmark-disable", "python"),
+				Config: testAccJobConfig_nonOverridableArguments(rName, "job-bookmark-disable", "python"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.%", "2"),
@@ -188,7 +188,7 @@ func TestAccGlueJob_nonOverridableArguments(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobnonOverridableArgumentsConfig(rName, "job-bookmark-enable", "scala"),
+				Config: testAccJobConfig_nonOverridableArguments(rName, "job-bookmark-enable", "scala"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.%", "2"),
@@ -218,14 +218,14 @@ func TestAccGlueJob_description(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Description(rName, "First Description"),
+				Config: testAccJobConfig_description(rName, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccJobConfig_Description(rName, "Second Description"),
+				Config: testAccJobConfig_description(rName, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -253,14 +253,14 @@ func TestAccGlueJob_glueVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Version_maxCapacity(rName, "0.9"),
+				Config: testAccJobConfig_versionMaxCapacity(rName, "0.9"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "0.9"),
 				),
 			},
 			{
-				Config: testAccJobConfig_Version_maxCapacity(rName, "1.0"),
+				Config: testAccJobConfig_versionMaxCapacity(rName, "1.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "1.0"),
@@ -272,7 +272,7 @@ func TestAccGlueJob_glueVersion(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccJobConfig_Version_numberOfWorkers(rName, "2.0"),
+				Config: testAccJobConfig_versionNumberOfWorkers(rName, "2.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "2.0"),
@@ -295,11 +295,11 @@ func TestAccGlueJob_executionProperty(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccJobConfig_ExecutionProperty(rName, 0),
+				Config:      testAccJobConfig_executionProperty(rName, 0),
 				ExpectError: regexp.MustCompile(`expected execution_property.0.max_concurrent_runs to be at least`),
 			},
 			{
-				Config: testAccJobConfig_ExecutionProperty(rName, 1),
+				Config: testAccJobConfig_executionProperty(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "execution_property.#", "1"),
@@ -307,7 +307,7 @@ func TestAccGlueJob_executionProperty(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobConfig_ExecutionProperty(rName, 2),
+				Config: testAccJobConfig_executionProperty(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "execution_property.#", "1"),
@@ -336,18 +336,18 @@ func TestAccGlueJob_maxRetries(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccJobConfig_MaxRetries(rName, 11),
+				Config:      testAccJobConfig_maxRetries(rName, 11),
 				ExpectError: regexp.MustCompile(`expected max_retries to be in the range`),
 			},
 			{
-				Config: testAccJobConfig_MaxRetries(rName, 0),
+				Config: testAccJobConfig_maxRetries(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "0"),
 				),
 			},
 			{
-				Config: testAccJobConfig_MaxRetries(rName, 10),
+				Config: testAccJobConfig_maxRetries(rName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "10"),
@@ -375,11 +375,11 @@ func TestAccGlueJob_notificationProperty(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccJobConfig_NotificationProperty(rName, 0),
+				Config:      testAccJobConfig_notificationProperty(rName, 0),
 				ExpectError: regexp.MustCompile(`expected notification_property.0.notify_delay_after to be at least`),
 			},
 			{
-				Config: testAccJobConfig_NotificationProperty(rName, 1),
+				Config: testAccJobConfig_notificationProperty(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "notification_property.#", "1"),
@@ -387,7 +387,7 @@ func TestAccGlueJob_notificationProperty(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobConfig_NotificationProperty(rName, 2),
+				Config: testAccJobConfig_notificationProperty(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "notification_property.#", "1"),
@@ -416,7 +416,7 @@ func TestAccGlueJob_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTags1Config(rName, "key1", "value1"),
+				Config: testAccJobConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -429,7 +429,7 @@ func TestAccGlueJob_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccJobTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccJobConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -438,7 +438,7 @@ func TestAccGlueJob_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobTags1Config(rName, "key2", "value2"),
+				Config: testAccJobConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -462,14 +462,14 @@ func TestAccGlueJob_streamingTimeout(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Timeout(rName, 1),
+				Config: testAccJobConfig_timeout(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
 				),
 			},
 			{
-				Config: testAccJobConfig_Timeout(rName, 2),
+				Config: testAccJobConfig_timeout(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "2"),
@@ -496,14 +496,14 @@ func TestAccGlueJob_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Timeout(rName, 1),
+				Config: testAccJobConfig_timeout(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
 				),
 			},
 			{
-				Config: testAccJobConfig_Timeout(rName, 2),
+				Config: testAccJobConfig_timeout(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "2"),
@@ -531,14 +531,14 @@ func TestAccGlueJob_security(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_SecurityConfiguration(rName, "default_encryption"),
+				Config: testAccJobConfig_securityConfiguration(rName, "default_encryption"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "security_configuration", "default_encryption"),
 				),
 			},
 			{
-				Config: testAccJobConfig_SecurityConfiguration(rName, "custom_encryption2"),
+				Config: testAccJobConfig_securityConfiguration(rName, "custom_encryption2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "security_configuration", "custom_encryption2"),
@@ -566,21 +566,21 @@ func TestAccGlueJob_workerType(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_WorkerType(rName, "Standard"),
+				Config: testAccJobConfig_workerType(rName, "Standard"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "Standard"),
 				),
 			},
 			{
-				Config: testAccJobConfig_WorkerType(rName, "G.1X"),
+				Config: testAccJobConfig_workerType(rName, "G.1X"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "G.1X"),
 				),
 			},
 			{
-				Config: testAccJobConfig_WorkerType(rName, "G.2X"),
+				Config: testAccJobConfig_workerType(rName, "G.2X"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "G.2X"),
@@ -608,7 +608,7 @@ func TestAccGlueJob_pythonShell(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_PythonShell(rName),
+				Config: testAccJobConfig_pythonShell(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "0.0625"),
@@ -623,7 +623,7 @@ func TestAccGlueJob_pythonShell(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccJobConfig_PythonShellWithVersion(rName, "2"),
+				Config: testAccJobConfig_pythonShellVersion(rName, "2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
@@ -638,7 +638,7 @@ func TestAccGlueJob_pythonShell(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccJobConfig_PythonShellWithVersion(rName, "3"),
+				Config: testAccJobConfig_pythonShellVersion(rName, "3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
@@ -664,7 +664,7 @@ func TestAccGlueJob_maxCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_MaxCapacity(rName, 10),
+				Config: testAccJobConfig_maxCapacity(rName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "10"),
@@ -674,7 +674,7 @@ func TestAccGlueJob_maxCapacity(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccJobConfig_MaxCapacity(rName, 15),
+				Config: testAccJobConfig_maxCapacity(rName, 15),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "15"),
@@ -702,7 +702,7 @@ func TestAccGlueJob_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_Required(rName),
+				Config: testAccJobConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobExists(resourceName, &job),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceJob(), resourceName),
@@ -811,7 +811,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, rName)
 }
 
-func testAccJobConfig_Command(rName, scriptLocation string) string {
+func testAccJobConfig_command(rName, scriptLocation string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -829,7 +829,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, scriptLocation)
 }
 
-func testAccJobConfig_DefaultArguments(rName, jobBookmarkOption, jobLanguage string) string {
+func testAccJobConfig_defaultArguments(rName, jobBookmarkOption, jobLanguage string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -852,7 +852,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, jobBookmarkOption, jobLanguage)
 }
 
-func testAccJobnonOverridableArgumentsConfig(rName, jobBookmarkOption, jobLanguage string) string {
+func testAccJobConfig_nonOverridableArguments(rName, jobBookmarkOption, jobLanguage string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -875,7 +875,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, jobBookmarkOption, jobLanguage)
 }
 
-func testAccJobConfig_Description(rName, description string) string {
+func testAccJobConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -894,7 +894,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), description, rName)
 }
 
-func testAccJobConfig_Version_maxCapacity(rName, glueVersion string) string {
+func testAccJobConfig_versionMaxCapacity(rName, glueVersion string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -913,7 +913,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), glueVersion, rName)
 }
 
-func testAccJobConfig_Version_numberOfWorkers(rName, glueVersion string) string {
+func testAccJobConfig_versionNumberOfWorkers(rName, glueVersion string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -933,7 +933,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), glueVersion, rName)
 }
 
-func testAccJobConfig_ExecutionProperty(rName string, maxConcurrentRuns int) string {
+func testAccJobConfig_executionProperty(rName string, maxConcurrentRuns int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -955,7 +955,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, maxConcurrentRuns)
 }
 
-func testAccJobConfig_MaxRetries(rName string, maxRetries int) string {
+func testAccJobConfig_maxRetries(rName string, maxRetries int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -974,7 +974,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), maxRetries, rName)
 }
 
-func testAccJobConfig_NotificationProperty(rName string, notifyDelayAfter int) string {
+func testAccJobConfig_notificationProperty(rName string, notifyDelayAfter int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -996,7 +996,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, notifyDelayAfter)
 }
 
-func testAccJobConfig_Required(rName string) string {
+func testAccJobConfig_required(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1014,7 +1014,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName)
 }
 
-func testAccJobConfig_RequiredStreaming(rName string) string {
+func testAccJobConfig_requiredStreaming(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1033,7 +1033,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName)
 }
 
-func testAccJobTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccJobConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccJobConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_glue_job" "test" {
   name              = %[1]q
@@ -1054,7 +1054,7 @@ resource "aws_glue_job" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccJobTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccJobConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccJobConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_glue_job" "test" {
   name              = %[1]q
@@ -1076,7 +1076,7 @@ resource "aws_glue_job" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccJobConfig_Timeout(rName string, timeout int) string {
+func testAccJobConfig_timeout(rName string, timeout int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1095,7 +1095,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, timeout)
 }
 
-func testAccJobConfig_SecurityConfiguration(rName string, securityConfiguration string) string {
+func testAccJobConfig_securityConfiguration(rName string, securityConfiguration string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1114,7 +1114,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, securityConfiguration)
 }
 
-func testAccJobConfig_WorkerType(rName string, workerType string) string {
+func testAccJobConfig_workerType(rName string, workerType string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1133,7 +1133,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, workerType)
 }
 
-func testAccJobConfig_PythonShell(rName string) string {
+func testAccJobConfig_pythonShell(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1152,7 +1152,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName)
 }
 
-func testAccJobConfig_PythonShellWithVersion(rName string, pythonVersion string) string {
+func testAccJobConfig_pythonShellVersion(rName string, pythonVersion string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1172,7 +1172,7 @@ resource "aws_glue_job" "test" {
 `, testAccJobConfig_Base(rName), rName, pythonVersion)
 }
 
-func testAccJobConfig_MaxCapacity(rName string, maxCapacity float64) string {
+func testAccJobConfig_maxCapacity(rName string, maxCapacity float64) string {
 	return fmt.Sprintf(`
 %s
 

--- a/internal/service/glue/ml_transform_test.go
+++ b/internal/service/glue/ml_transform_test.go
@@ -31,7 +31,7 @@ func TestAccGlueMlTransform_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformBasicConfig(rName),
+				Config: testAccMlTransformConfig_mLBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "glue", regexp.MustCompile(`mlTransform/tfm-.+`)),
@@ -79,7 +79,7 @@ func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformTypeFindMatchesFullConfig(rName, true, 0.5),
+				Config: testAccMlTransformConfig_mLTypeFindMatchesFull(rName, true, 0.5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
@@ -97,7 +97,7 @@ func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMLTransformTypeFindMatchesFullConfig(rName, false, 1),
+				Config: testAccMlTransformConfig_mLTypeFindMatchesFull(rName, false, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
@@ -110,7 +110,7 @@ func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMLTransformTypeFindMatchesFullConfig(rName, true, 0.5),
+				Config: testAccMlTransformConfig_mLTypeFindMatchesFull(rName, true, 0.5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
@@ -139,14 +139,14 @@ func TestAccGlueMlTransform_description(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformDescriptionConfig(rName, "First Description"),
+				Config: testAccMlTransformConfig_mLDescription(rName, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccMLTransformDescriptionConfig(rName, "Second Description"),
+				Config: testAccMlTransformConfig_mLDescription(rName, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -174,14 +174,14 @@ func TestAccGlueMlTransform_glueVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLTransformVersion(rName, "0.9"),
+				Config: testAccMlTransformConfig_mLVersion(rName, "0.9"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "0.9"),
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLTransformVersion(rName, "1.0"),
+				Config: testAccMlTransformConfig_mLVersion(rName, "1.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "1.0"),
@@ -209,18 +209,18 @@ func TestAccGlueMlTransform_maxRetries(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMLTransformMaxRetriesConfig(rName, 11),
+				Config:      testAccMlTransformConfig_mLMaxRetries(rName, 11),
 				ExpectError: regexp.MustCompile(`expected max_retries to be in the range`),
 			},
 			{
-				Config: testAccMLTransformMaxRetriesConfig(rName, 0),
+				Config: testAccMlTransformConfig_mLMaxRetries(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "0"),
 				),
 			},
 			{
-				Config: testAccMLTransformMaxRetriesConfig(rName, 10),
+				Config: testAccMlTransformConfig_mLMaxRetries(rName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "10"),
@@ -248,7 +248,7 @@ func TestAccGlueMlTransform_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformTags1Config(rName, "key1", "value1"),
+				Config: testAccMlTransformConfig_mLTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -261,7 +261,7 @@ func TestAccGlueMlTransform_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMLTransformTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccMlTransformConfig_mLTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -270,7 +270,7 @@ func TestAccGlueMlTransform_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMLTransformTags1Config(rName, "key2", "value2"),
+				Config: testAccMlTransformConfig_mLTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -294,14 +294,14 @@ func TestAccGlueMlTransform_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformTimeoutConfig(rName, 1),
+				Config: testAccMlTransformConfig_mLTimeout(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
 				),
 			},
 			{
-				Config: testAccMLTransformTimeoutConfig(rName, 2),
+				Config: testAccMlTransformConfig_mLTimeout(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "2"),
@@ -329,7 +329,7 @@ func TestAccGlueMlTransform_workerType(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformWorkerTypeConfig(rName, "Standard", 1),
+				Config: testAccMlTransformConfig_mLWorkerType(rName, "Standard", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "Standard"),
@@ -337,7 +337,7 @@ func TestAccGlueMlTransform_workerType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMLTransformWorkerTypeConfig(rName, "G.1X", 2),
+				Config: testAccMlTransformConfig_mLWorkerType(rName, "G.1X", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "G.1X"),
@@ -366,14 +366,14 @@ func TestAccGlueMlTransform_maxCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformMaxCapacityConfig(rName, 10),
+				Config: testAccMlTransformConfig_mLMaxCapacity(rName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "10"),
 				),
 			},
 			{
-				Config: testAccMLTransformMaxCapacityConfig(rName, 15),
+				Config: testAccMlTransformConfig_mLMaxCapacity(rName, 15),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "15"),
@@ -401,7 +401,7 @@ func TestAccGlueMlTransform_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMLTransformBasicConfig(rName),
+				Config: testAccMlTransformConfig_mLBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceMLTransform(), resourceName),
@@ -594,7 +594,7 @@ resource "aws_glue_catalog_table" "test" {
 `, rName)
 }
 
-func testAccMLTransformBasicConfig(rName string) string {
+func testAccMlTransformConfig_mLBasic(rName string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -618,7 +618,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName)
 }
 
-func testAccMLTransformTypeFindMatchesFullConfig(rName string, enforce bool, tradeOff float64) string {
+func testAccMlTransformConfig_mLTypeFindMatchesFull(rName string, enforce bool, tradeOff float64) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -645,7 +645,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, enforce, tradeOff)
 }
 
-func testAccMLTransformDescriptionConfig(rName, description string) string {
+func testAccMlTransformConfig_mLDescription(rName, description string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name        = %[1]q
@@ -670,7 +670,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, description)
 }
 
-func testAccMlTransformConfig_mLTransformVersion(rName, glueVersion string) string {
+func testAccMlTransformConfig_mLVersion(rName, glueVersion string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name         = %[1]q
@@ -695,7 +695,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, glueVersion)
 }
 
-func testAccMLTransformMaxRetriesConfig(rName string, maxRetries int) string {
+func testAccMlTransformConfig_mLMaxRetries(rName string, maxRetries int) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name        = %[1]q
@@ -720,7 +720,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, maxRetries)
 }
 
-func testAccMLTransformTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccMlTransformConfig_mLTags1(rName, tagKey1, tagValue1 string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -748,7 +748,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccMLTransformTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccMlTransformConfig_mLTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -777,7 +777,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccMLTransformTimeoutConfig(rName string, timeout int) string {
+func testAccMlTransformConfig_mLTimeout(rName string, timeout int) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -802,7 +802,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, timeout)
 }
 
-func testAccMLTransformWorkerTypeConfig(rName, workerType string, numOfWorkers int) string {
+func testAccMlTransformConfig_mLWorkerType(rName, workerType string, numOfWorkers int) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name              = %[1]q
@@ -828,7 +828,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, workerType, numOfWorkers)
 }
 
-func testAccMLTransformMaxCapacityConfig(rName string, maxCapacity float64) string {
+func testAccMlTransformConfig_mLMaxCapacity(rName string, maxCapacity float64) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name         = %[1]q

--- a/internal/service/glue/ml_transform_test.go
+++ b/internal/service/glue/ml_transform_test.go
@@ -31,7 +31,7 @@ func TestAccGlueMlTransform_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLBasic(rName),
+				Config: testAccMLTransformConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "glue", regexp.MustCompile(`mlTransform/tfm-.+`)),
@@ -79,7 +79,7 @@ func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLTypeFindMatchesFull(rName, true, 0.5),
+				Config: testAccMLTransformConfig_typeFindMatchesFull(rName, true, 0.5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
@@ -97,7 +97,7 @@ func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMlTransformConfig_mLTypeFindMatchesFull(rName, false, 1),
+				Config: testAccMLTransformConfig_typeFindMatchesFull(rName, false, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
@@ -110,7 +110,7 @@ func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLTypeFindMatchesFull(rName, true, 0.5),
+				Config: testAccMLTransformConfig_typeFindMatchesFull(rName, true, 0.5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
@@ -139,14 +139,14 @@ func TestAccGlueMlTransform_description(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLDescription(rName, "First Description"),
+				Config: testAccMLTransformConfig_description(rName, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLDescription(rName, "Second Description"),
+				Config: testAccMLTransformConfig_description(rName, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -174,14 +174,14 @@ func TestAccGlueMlTransform_glueVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLVersion(rName, "0.9"),
+				Config: testAccMLTransformConfig_version(rName, "0.9"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "0.9"),
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLVersion(rName, "1.0"),
+				Config: testAccMLTransformConfig_version(rName, "1.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "glue_version", "1.0"),
@@ -209,18 +209,18 @@ func TestAccGlueMlTransform_maxRetries(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMlTransformConfig_mLMaxRetries(rName, 11),
+				Config:      testAccMLTransformConfig_maxRetries(rName, 11),
 				ExpectError: regexp.MustCompile(`expected max_retries to be in the range`),
 			},
 			{
-				Config: testAccMlTransformConfig_mLMaxRetries(rName, 0),
+				Config: testAccMLTransformConfig_maxRetries(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "0"),
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLMaxRetries(rName, 10),
+				Config: testAccMLTransformConfig_maxRetries(rName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "10"),
@@ -248,7 +248,7 @@ func TestAccGlueMlTransform_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLTags1(rName, "key1", "value1"),
+				Config: testAccMLTransformConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -261,7 +261,7 @@ func TestAccGlueMlTransform_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMlTransformConfig_mLTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccMLTransformConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -270,7 +270,7 @@ func TestAccGlueMlTransform_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLTags1(rName, "key2", "value2"),
+				Config: testAccMLTransformConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -294,14 +294,14 @@ func TestAccGlueMlTransform_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLTimeout(rName, 1),
+				Config: testAccMLTransformConfig_timeout(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLTimeout(rName, 2),
+				Config: testAccMLTransformConfig_timeout(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "2"),
@@ -329,7 +329,7 @@ func TestAccGlueMlTransform_workerType(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLWorkerType(rName, "Standard", 1),
+				Config: testAccMLTransformConfig_workerType(rName, "Standard", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "Standard"),
@@ -337,7 +337,7 @@ func TestAccGlueMlTransform_workerType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLWorkerType(rName, "G.1X", 2),
+				Config: testAccMLTransformConfig_workerType(rName, "G.1X", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "worker_type", "G.1X"),
@@ -366,14 +366,14 @@ func TestAccGlueMlTransform_maxCapacity(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLMaxCapacity(rName, 10),
+				Config: testAccMLTransformConfig_maxCapacity(rName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "10"),
 				),
 			},
 			{
-				Config: testAccMlTransformConfig_mLMaxCapacity(rName, 15),
+				Config: testAccMLTransformConfig_maxCapacity(rName, 15),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "15"),
@@ -401,7 +401,7 @@ func TestAccGlueMlTransform_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckMLTransformDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMlTransformConfig_mLBasic(rName),
+				Config: testAccMLTransformConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMLTransformExists(resourceName, &transform),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceMLTransform(), resourceName),
@@ -594,7 +594,7 @@ resource "aws_glue_catalog_table" "test" {
 `, rName)
 }
 
-func testAccMlTransformConfig_mLBasic(rName string) string {
+func testAccMLTransformConfig_basic(rName string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -618,7 +618,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName)
 }
 
-func testAccMlTransformConfig_mLTypeFindMatchesFull(rName string, enforce bool, tradeOff float64) string {
+func testAccMLTransformConfig_typeFindMatchesFull(rName string, enforce bool, tradeOff float64) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -645,7 +645,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, enforce, tradeOff)
 }
 
-func testAccMlTransformConfig_mLDescription(rName, description string) string {
+func testAccMLTransformConfig_description(rName, description string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name        = %[1]q
@@ -670,7 +670,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, description)
 }
 
-func testAccMlTransformConfig_mLVersion(rName, glueVersion string) string {
+func testAccMLTransformConfig_version(rName, glueVersion string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name         = %[1]q
@@ -695,7 +695,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, glueVersion)
 }
 
-func testAccMlTransformConfig_mLMaxRetries(rName string, maxRetries int) string {
+func testAccMLTransformConfig_maxRetries(rName string, maxRetries int) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name        = %[1]q
@@ -720,7 +720,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, maxRetries)
 }
 
-func testAccMlTransformConfig_mLTags1(rName, tagKey1, tagValue1 string) string {
+func testAccMLTransformConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -748,7 +748,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccMlTransformConfig_mLTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccMLTransformConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -777,7 +777,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccMlTransformConfig_mLTimeout(rName string, timeout int) string {
+func testAccMLTransformConfig_timeout(rName string, timeout int) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name     = %[1]q
@@ -802,7 +802,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, timeout)
 }
 
-func testAccMlTransformConfig_mLWorkerType(rName, workerType string, numOfWorkers int) string {
+func testAccMLTransformConfig_workerType(rName, workerType string, numOfWorkers int) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name              = %[1]q
@@ -828,7 +828,7 @@ resource "aws_glue_ml_transform" "test" {
 `, rName, workerType, numOfWorkers)
 }
 
-func testAccMlTransformConfig_mLMaxCapacity(rName string, maxCapacity float64) string {
+func testAccMLTransformConfig_maxCapacity(rName string, maxCapacity float64) string {
 	return testAccMLTransformBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_glue_ml_transform" "test" {
   name         = %[1]q

--- a/internal/service/glue/registry_test.go
+++ b/internal/service/glue/registry_test.go
@@ -28,7 +28,7 @@ func TestAccGlueRegistry_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegistryBasicConfig(rName),
+				Config: testAccRegistryConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("registry/%s", rName)),
@@ -59,14 +59,14 @@ func TestAccGlueRegistry_description(t *testing.T) {
 		CheckDestroy:      testAccCheckRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegistryDescriptionConfig(rName, "First Description"),
+				Config: testAccRegistryConfig_description(rName, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccRegistryDescriptionConfig(rName, "Second Description"),
+				Config: testAccRegistryConfig_description(rName, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -93,7 +93,7 @@ func TestAccGlueRegistry_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegistryTags1Config(rName, "key1", "value1"),
+				Config: testAccRegistryConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -106,7 +106,7 @@ func TestAccGlueRegistry_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRegistryTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccRegistryConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -115,7 +115,7 @@ func TestAccGlueRegistry_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRegistryTags1Config(rName, "key2", "value2"),
+				Config: testAccRegistryConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -139,7 +139,7 @@ func TestAccGlueRegistry_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegistryBasicConfig(rName),
+				Config: testAccRegistryConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegistryExists(resourceName, &registry),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceRegistry(), resourceName),
@@ -220,7 +220,7 @@ func testAccCheckRegistryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccRegistryDescriptionConfig(rName, description string) string {
+func testAccRegistryConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_registry" "test" {
   registry_name = %[1]q
@@ -229,7 +229,7 @@ resource "aws_glue_registry" "test" {
 `, rName, description)
 }
 
-func testAccRegistryBasicConfig(rName string) string {
+func testAccRegistryConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_registry" "test" {
   registry_name = %[1]q
@@ -237,7 +237,7 @@ resource "aws_glue_registry" "test" {
 `, rName)
 }
 
-func testAccRegistryTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccRegistryConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_registry" "test" {
   registry_name = %[1]q
@@ -249,7 +249,7 @@ resource "aws_glue_registry" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccRegistryTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccRegistryConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_registry" "test" {
   registry_name = %[1]q

--- a/internal/service/glue/resource_policy_test.go
+++ b/internal/service/glue/resource_policy_test.go
@@ -24,7 +24,7 @@ func testAccResourcePolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyRequiredConfig("glue:CreateTable"),
+				Config: testAccResourcePolicyConfig_required("glue:CreateTable"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourcePolicy(resourceName, "glue:CreateTable"),
 				),
@@ -47,7 +47,7 @@ func testAccResourcePolicy_hybrid(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyHybridConfig("glue:CreateTable", "TRUE"),
+				Config: testAccResourcePolicyConfig_hybrid("glue:CreateTable", "TRUE"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enable_hybrid", "TRUE"),
 				),
@@ -59,13 +59,13 @@ func testAccResourcePolicy_hybrid(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"enable_hybrid"},
 			},
 			{
-				Config: testAccResourcePolicyHybridConfig("glue:CreateTable", "FALSE"),
+				Config: testAccResourcePolicyConfig_hybrid("glue:CreateTable", "FALSE"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enable_hybrid", "FALSE"),
 				),
 			},
 			{
-				Config: testAccResourcePolicyHybridConfig("glue:CreateTable", "TRUE"),
+				Config: testAccResourcePolicyConfig_hybrid("glue:CreateTable", "TRUE"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enable_hybrid", "TRUE"),
 				),
@@ -82,7 +82,7 @@ func testAccResourcePolicy_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyRequiredConfig("glue:CreateTable"),
+				Config: testAccResourcePolicyConfig_required("glue:CreateTable"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourcePolicy(resourceName, "glue:CreateTable"),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceResourcePolicy(), resourceName),
@@ -103,13 +103,13 @@ func testAccResourcePolicy_update(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyRequiredConfig("glue:CreateTable"),
+				Config: testAccResourcePolicyConfig_required("glue:CreateTable"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourcePolicy(resourceName, "glue:CreateTable"),
 				),
 			},
 			{
-				Config: testAccResourcePolicyRequiredConfig("glue:DeleteTable"),
+				Config: testAccResourcePolicyConfig_required("glue:DeleteTable"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourcePolicy(resourceName, "glue:DeleteTable"),
 				),
@@ -133,13 +133,13 @@ func testAccResourcePolicy_ignoreEquivalent(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyEquivalentConfig(),
+				Config: testAccResourcePolicyConfig_equivalent(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourcePolicy(resourceName, "glue:CreateTable"),
 				),
 			},
 			{
-				Config:   testAccResourcePolicyEquivalent2Config(),
+				Config:   testAccResourcePolicyConfig_equivalent2(),
 				PlanOnly: true,
 			},
 		},
@@ -216,7 +216,7 @@ func CreateTablePolicy(action string) string {
 }`, action, acctest.Partition(), acctest.Region(), acctest.AccountID())
 }
 
-func testAccResourcePolicyRequiredConfig(action string) string {
+func testAccResourcePolicyConfig_required(action string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -241,7 +241,7 @@ resource "aws_glue_resource_policy" "test" {
 `, action)
 }
 
-func testAccResourcePolicyHybridConfig(action, hybrid string) string {
+func testAccResourcePolicyConfig_hybrid(action, hybrid string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -267,7 +267,7 @@ resource "aws_glue_resource_policy" "test" {
 `, action, hybrid)
 }
 
-func testAccResourcePolicyEquivalentConfig() string {
+func testAccResourcePolicyConfig_equivalent() string {
 	return `
 data "aws_caller_identity" "current" {}
 
@@ -293,7 +293,7 @@ resource "aws_glue_resource_policy" "test" {
 `
 }
 
-func testAccResourcePolicyEquivalent2Config() string {
+func testAccResourcePolicyConfig_equivalent2() string {
 	return `
 data "aws_caller_identity" "current" {}
 

--- a/internal/service/glue/schema_test.go
+++ b/internal/service/glue/schema_test.go
@@ -161,14 +161,14 @@ func TestAccGlueSchema_compatibility(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaConfig_compatibillity(rName, "DISABLED"),
+				Config: testAccSchemaConfig_compatibility(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "compatibility", "DISABLED"),
 				),
 			},
 			{
-				Config: testAccSchemaConfig_compatibillity(rName, "FULL"),
+				Config: testAccSchemaConfig_compatibility(rName, "FULL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "compatibility", "FULL"),
@@ -406,7 +406,7 @@ resource "aws_glue_schema" "test" {
 `, rName, description)
 }
 
-func testAccSchemaConfig_compatibillity(rName, compat string) string {
+func testAccSchemaConfig_compatibility(rName, compat string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q

--- a/internal/service/glue/schema_test.go
+++ b/internal/service/glue/schema_test.go
@@ -29,7 +29,7 @@ func TestAccGlueSchema_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaBasicConfig(rName),
+				Config: testAccSchemaConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("schema/%s/%s", rName, rName)),
@@ -97,7 +97,7 @@ func TestAccGlueSchema_protobuf(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaProtobufConfig(rName),
+				Config: testAccSchemaConfig_protobuf(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "data_format", "PROTOBUF"),
@@ -126,14 +126,14 @@ func TestAccGlueSchema_description(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaDescriptionConfig(rName, "First Description"),
+				Config: testAccSchemaConfig_description(rName, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccSchemaDescriptionConfig(rName, "Second Description"),
+				Config: testAccSchemaConfig_description(rName, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -161,14 +161,14 @@ func TestAccGlueSchema_compatibility(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaCompatibillityConfig(rName, "DISABLED"),
+				Config: testAccSchemaConfig_compatibillity(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "compatibility", "DISABLED"),
 				),
 			},
 			{
-				Config: testAccSchemaCompatibillityConfig(rName, "FULL"),
+				Config: testAccSchemaConfig_compatibillity(rName, "FULL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "compatibility", "FULL"),
@@ -195,7 +195,7 @@ func TestAccGlueSchema_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaTags1Config(rName, "key1", "value1"),
+				Config: testAccSchemaConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -208,7 +208,7 @@ func TestAccGlueSchema_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccSchemaTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccSchemaConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -217,7 +217,7 @@ func TestAccGlueSchema_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSchemaTags1Config(rName, "key2", "value2"),
+				Config: testAccSchemaConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -241,7 +241,7 @@ func TestAccGlueSchema_schemaDefUpdated(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaBasicConfig(rName),
+				Config: testAccSchemaConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "schema_definition", "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [ {\"name\": \"f1\", \"type\": \"int\"}, {\"name\": \"f2\", \"type\": \"string\"} ]}"),
@@ -250,7 +250,7 @@ func TestAccGlueSchema_schemaDefUpdated(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSchemaSchemaDefinitionUpdatedConfig(rName),
+				Config: testAccSchemaConfig_definitionUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					resource.TestCheckResourceAttr(resourceName, "schema_definition", "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [ {\"name\": \"f1\", \"type\": \"string\"}, {\"name\": \"f2\", \"type\": \"int\"} ]}"),
@@ -280,7 +280,7 @@ func TestAccGlueSchema_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaBasicConfig(rName),
+				Config: testAccSchemaConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceSchema(), resourceName),
@@ -304,7 +304,7 @@ func TestAccGlueSchema_Disappears_registry(t *testing.T) {
 		CheckDestroy:      testAccCheckSchemaDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchemaBasicConfig(rName),
+				Config: testAccSchemaConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists(resourceName, &schema),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceRegistry(), "aws_glue_registry.test"),
@@ -393,7 +393,7 @@ resource "aws_glue_registry" "test" {
 `, rName)
 }
 
-func testAccSchemaDescriptionConfig(rName, description string) string {
+func testAccSchemaConfig_description(rName, description string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q
@@ -406,7 +406,7 @@ resource "aws_glue_schema" "test" {
 `, rName, description)
 }
 
-func testAccSchemaCompatibillityConfig(rName, compat string) string {
+func testAccSchemaConfig_compatibillity(rName, compat string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q
@@ -418,7 +418,7 @@ resource "aws_glue_schema" "test" {
 `, rName, compat)
 }
 
-func testAccSchemaBasicConfig(rName string) string {
+func testAccSchemaConfig_basic(rName string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q
@@ -442,7 +442,7 @@ resource "aws_glue_schema" "test" {
 `, rName)
 }
 
-func testAccSchemaProtobufConfig(rName string) string {
+func testAccSchemaConfig_protobuf(rName string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q
@@ -454,7 +454,7 @@ resource "aws_glue_schema" "test" {
 `, rName)
 }
 
-func testAccSchemaTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccSchemaConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q
@@ -470,7 +470,7 @@ resource "aws_glue_schema" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccSchemaTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccSchemaConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q
@@ -487,7 +487,7 @@ resource "aws_glue_schema" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccSchemaSchemaDefinitionUpdatedConfig(rName string) string {
+func testAccSchemaConfig_definitionUpdated(rName string) string {
 	return testAccSchemaBase(rName) + fmt.Sprintf(`
 resource "aws_glue_schema" "test" {
   schema_name       = %[1]q

--- a/internal/service/glue/script_data_source_test.go
+++ b/internal/service/glue/script_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccGlueScriptDataSource_Language_python(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptPythonDataSourceConfig(),
+				Config: testAccScriptDataSourceConfig_python(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "python_script", regexp.MustCompile(`from awsglue\.job import Job`)),
 				),
@@ -36,7 +36,7 @@ func TestAccGlueScriptDataSource_Language_scala(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptScalaDataSourceConfig(),
+				Config: testAccScriptDataSourceConfig_scala(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "scala_code", regexp.MustCompile(`import com\.amazonaws\.services\.glue\.util\.Job`)),
 				),
@@ -45,7 +45,7 @@ func TestAccGlueScriptDataSource_Language_scala(t *testing.T) {
 	})
 }
 
-func testAccScriptPythonDataSourceConfig() string {
+func testAccScriptDataSourceConfig_python() string {
 	return `
 data "aws_glue_script" "test" {
   language = "PYTHON"
@@ -143,7 +143,7 @@ data "aws_glue_script" "test" {
 `
 }
 
-func testAccScriptScalaDataSourceConfig() string {
+func testAccScriptDataSourceConfig_scala() string {
 	return `
 data "aws_glue_script" "test" {
   language = "SCALA"

--- a/internal/service/glue/security_configuration_test.go
+++ b/internal/service/glue/security_configuration_test.go
@@ -27,7 +27,7 @@ func TestAccGlueSecurityConfiguration_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_Basic(rName),
+				Config: testAccSecurityConfigurationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -66,7 +66,7 @@ func TestAccGlueSecurityConfiguration_CloudWatchEncryptionCloudWatchEncryptionMo
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_CloudWatchEncryption_CloudWatchEncryptionMode_SSEKMS(rName),
+				Config: testAccSecurityConfigurationConfig_cloudWatchEncryptionCloudWatchEncryptionModeSSEKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -98,7 +98,7 @@ func TestAccGlueSecurityConfiguration_JobBookmarksEncryptionJobBookmarksEncrypti
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_JobBookmarksEncryption_JobBookmarksEncryptionMode_CSEKMS(rName),
+				Config: testAccSecurityConfigurationConfig_jobBookmarksEncryptionJobBookmarksEncryptionModecsEKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -130,7 +130,7 @@ func TestAccGlueSecurityConfiguration_S3EncryptionS3EncryptionMode_sseKMS(t *tes
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSEKMS(rName),
+				Config: testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSEKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -161,7 +161,7 @@ func TestAccGlueSecurityConfiguration_S3EncryptionS3EncryptionMode_sseS3(t *test
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSES3(rName),
+				Config: testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSES3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -241,7 +241,7 @@ func testAccCheckSecurityConfigurationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccSecurityConfigurationConfig_Basic(rName string) string {
+func testAccSecurityConfigurationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_security_configuration" "test" {
   name = %q
@@ -263,7 +263,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_CloudWatchEncryption_CloudWatchEncryptionMode_SSEKMS(rName string) string {
+func testAccSecurityConfigurationConfig_cloudWatchEncryptionCloudWatchEncryptionModeSSEKMS(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -290,7 +290,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_JobBookmarksEncryption_JobBookmarksEncryptionMode_CSEKMS(rName string) string {
+func testAccSecurityConfigurationConfig_jobBookmarksEncryptionJobBookmarksEncryptionModecsEKMS(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -317,7 +317,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSEKMS(rName string) string {
+func testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSEKMS(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -344,7 +344,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSES3(rName string) string {
+func testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSES3(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_security_configuration" "test" {
   name = %q

--- a/internal/service/glue/security_configuration_test.go
+++ b/internal/service/glue/security_configuration_test.go
@@ -66,7 +66,7 @@ func TestAccGlueSecurityConfiguration_CloudWatchEncryptionCloudWatchEncryptionMo
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_cloudWatchEncryptionCloudWatchEncryptionModeSSEKMS(rName),
+				Config: testAccSecurityConfigurationConfig_cloudWatchEncryptionModeSSEKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -98,7 +98,7 @@ func TestAccGlueSecurityConfiguration_JobBookmarksEncryptionJobBookmarksEncrypti
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_jobBookmarksEncryptionJobBookmarksEncryptionModecsEKMS(rName),
+				Config: testAccSecurityConfigurationConfig_jobBookmarksEncryptionModeCSEKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -130,7 +130,7 @@ func TestAccGlueSecurityConfiguration_S3EncryptionS3EncryptionMode_sseKMS(t *tes
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSEKMS(rName),
+				Config: testAccSecurityConfigurationConfig_s3EncryptionModeSSEKMS(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -161,7 +161,7 @@ func TestAccGlueSecurityConfiguration_S3EncryptionS3EncryptionMode_sseS3(t *test
 		CheckDestroy:      testAccCheckSecurityConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSES3(rName),
+				Config: testAccSecurityConfigurationConfig_s3EncryptionModeSSES3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityConfigurationExists(resourceName, &securityConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -263,7 +263,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_cloudWatchEncryptionCloudWatchEncryptionModeSSEKMS(rName string) string {
+func testAccSecurityConfigurationConfig_cloudWatchEncryptionModeSSEKMS(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -290,7 +290,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_jobBookmarksEncryptionJobBookmarksEncryptionModecsEKMS(rName string) string {
+func testAccSecurityConfigurationConfig_jobBookmarksEncryptionModeCSEKMS(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -317,7 +317,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSEKMS(rName string) string {
+func testAccSecurityConfigurationConfig_s3EncryptionModeSSEKMS(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -344,7 +344,7 @@ resource "aws_glue_security_configuration" "test" {
 `, rName)
 }
 
-func testAccSecurityConfigurationConfig_s3EncryptionS3EncryptionModeSSES3(rName string) string {
+func testAccSecurityConfigurationConfig_s3EncryptionModeSSES3(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_security_configuration" "test" {
   name = %q

--- a/internal/service/glue/trigger_test.go
+++ b/internal/service/glue/trigger_test.go
@@ -28,7 +28,7 @@ func TestAccGlueTrigger_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_OnDemand(rName),
+				Config: testAccTriggerConfig_onDemand(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -69,7 +69,7 @@ func TestAccGlueTrigger_crawler(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_Crawler(rName, "SUCCEEDED"),
+				Config: testAccTriggerConfig_crawler(rName, "SUCCEEDED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -82,7 +82,7 @@ func TestAccGlueTrigger_crawler(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTriggerConfig_Crawler(rName, "FAILED"),
+				Config: testAccTriggerConfig_crawler(rName, "FAILED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -117,14 +117,14 @@ func TestAccGlueTrigger_description(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_Description(rName, "description1"),
+				Config: testAccTriggerConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
 				),
 			},
 			{
-				Config: testAccTriggerConfig_Description(rName, "description2"),
+				Config: testAccTriggerConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -153,21 +153,21 @@ func TestAccGlueTrigger_enabled(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_Enabled(rName, true),
+				Config: testAccTriggerConfig_enabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
 			},
 			{
-				Config: testAccTriggerConfig_Enabled(rName, false),
+				Config: testAccTriggerConfig_enabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
-				Config: testAccTriggerConfig_Enabled(rName, true),
+				Config: testAccTriggerConfig_enabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -196,7 +196,7 @@ func TestAccGlueTrigger_predicate(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_Predicate(rName, "SUCCEEDED"),
+				Config: testAccTriggerConfig_predicate(rName, "SUCCEEDED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
@@ -207,7 +207,7 @@ func TestAccGlueTrigger_predicate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTriggerConfig_Predicate(rName, "FAILED"),
+				Config: testAccTriggerConfig_predicate(rName, "FAILED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
@@ -240,14 +240,14 @@ func TestAccGlueTrigger_schedule(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_Schedule(rName, "cron(1 2 * * ? *)"),
+				Config: testAccTriggerConfig_schedule(rName, "cron(1 2 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(1 2 * * ? *)"),
 				),
 			},
 			{
-				Config: testAccTriggerConfig_Schedule(rName, "cron(2 3 * * ? *)"),
+				Config: testAccTriggerConfig_schedule(rName, "cron(2 3 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(2 3 * * ? *)"),
@@ -276,7 +276,7 @@ func TestAccGlueTrigger_startOnCreate(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_ScheduleStart(rName, "cron(1 2 * * ? *)"),
+				Config: testAccTriggerConfig_scheduleStart(rName, "cron(1 2 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(1 2 * * ? *)"),
@@ -305,7 +305,7 @@ func TestAccGlueTrigger_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerTags1Config(rName, "key1", "value1"),
+				Config: testAccTriggerConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -319,7 +319,7 @@ func TestAccGlueTrigger_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"enabled"},
 			},
 			{
-				Config: testAccTriggerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccTriggerConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -328,7 +328,7 @@ func TestAccGlueTrigger_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTriggerTags1Config(rName, "key2", "value2"),
+				Config: testAccTriggerConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -352,7 +352,7 @@ func TestAccGlueTrigger_workflowName(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_WorkflowName(rName),
+				Config: testAccTriggerConfig_workflowName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "workflow_name", rName),
@@ -381,7 +381,7 @@ func TestAccGlueTrigger_Actions_notify(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerActionsNotificationConfig(rName, 1),
+				Config: testAccTriggerConfig_actionsNotification(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -397,7 +397,7 @@ func TestAccGlueTrigger_Actions_notify(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"enabled"},
 			},
 			{
-				Config: testAccTriggerActionsNotificationConfig(rName, 2),
+				Config: testAccTriggerConfig_actionsNotification(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -407,7 +407,7 @@ func TestAccGlueTrigger_Actions_notify(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTriggerActionsNotificationConfig(rName, 1),
+				Config: testAccTriggerConfig_actionsNotification(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -433,7 +433,7 @@ func TestAccGlueTrigger_Actions_security(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerActionsSecurityConfigurationConfig(rName),
+				Config: testAccTriggerConfig_actionsSecurityConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
@@ -464,7 +464,7 @@ func TestAccGlueTrigger_onDemandDisable(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_OnDemand(rName),
+				Config: testAccTriggerConfig_onDemand(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -472,7 +472,7 @@ func TestAccGlueTrigger_onDemandDisable(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTriggerConfig_OnDemandEnabled(rName, false),
+				Config: testAccTriggerConfig_onDemandEnabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -486,7 +486,7 @@ func TestAccGlueTrigger_onDemandDisable(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"enabled"},
 			},
 			{
-				Config: testAccTriggerConfig_OnDemandEnabled(rName, true),
+				Config: testAccTriggerConfig_onDemandEnabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -510,7 +510,7 @@ func TestAccGlueTrigger_eventBatchingCondition(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfigEvent(rName),
+				Config: testAccTriggerConfig_event(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "event_batching_condition.#", "1"),
@@ -526,7 +526,7 @@ func TestAccGlueTrigger_eventBatchingCondition(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"enabled", "start_on_creation"},
 			},
 			{
-				Config: testAccTriggerConfigEventUpdated(rName),
+				Config: testAccTriggerConfig_eventUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "event_batching_condition.#", "1"),
@@ -552,7 +552,7 @@ func TestAccGlueTrigger_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTriggerConfig_OnDemand(rName),
+				Config: testAccTriggerConfig_onDemand(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTriggerExists(resourceName, &trigger),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceTrigger(), resourceName),
@@ -622,8 +622,8 @@ func testAccCheckTriggerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTriggerConfig_Description(rName, description string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_description(rName, description string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   description = %[1]q
   name        = %[2]q
@@ -636,8 +636,8 @@ resource "aws_glue_trigger" "test" {
 `, description, rName))
 }
 
-func testAccTriggerConfig_Enabled(rName string, enabled bool) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_enabled(rName string, enabled bool) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   enabled  = %[1]t
   name     = %[2]q
@@ -651,8 +651,8 @@ resource "aws_glue_trigger" "test" {
 `, enabled, rName))
 }
 
-func testAccTriggerConfig_OnDemand(rName string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_onDemand(rName string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name = %[1]q
   type = "ON_DEMAND"
@@ -664,8 +664,8 @@ resource "aws_glue_trigger" "test" {
 `, rName))
 }
 
-func testAccTriggerConfig_OnDemandEnabled(rName string, enabled bool) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_onDemandEnabled(rName string, enabled bool) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name    = %[1]q
   type    = "ON_DEMAND"
@@ -678,8 +678,8 @@ resource "aws_glue_trigger" "test" {
 `, rName, enabled))
 }
 
-func testAccTriggerConfig_Predicate(rName, state string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_predicate(rName, state string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_job" "test2" {
   name     = "%[1]s2"
   role_arn = aws_iam_role.test.arn
@@ -709,7 +709,7 @@ resource "aws_glue_trigger" "test" {
 `, rName, state))
 }
 
-func testAccTriggerConfig_Crawler(rName, state string) string {
+func testAccTriggerConfig_crawler(rName, state string) string {
 	return acctest.ConfigCompose(testAccCrawlerConfig_s3Target(rName, "s3://test_bucket"), fmt.Sprintf(`
 resource "aws_glue_crawler" "test2" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
@@ -741,8 +741,8 @@ resource "aws_glue_trigger" "test_trigger" {
 `, rName, state))
 }
 
-func testAccTriggerConfig_Schedule(rName, schedule string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_schedule(rName, schedule string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name     = %[1]q
   schedule = %[2]q
@@ -755,8 +755,8 @@ resource "aws_glue_trigger" "test" {
 `, rName, schedule))
 }
 
-func testAccTriggerConfig_ScheduleStart(rName, schedule string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_scheduleStart(rName, schedule string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name              = %[1]q
   schedule          = %[2]q
@@ -770,8 +770,8 @@ resource "aws_glue_trigger" "test" {
 `, rName, schedule))
 }
 
-func testAccTriggerTags1Config(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name = %[1]q
   type = "ON_DEMAND"
@@ -787,8 +787,8 @@ resource "aws_glue_trigger" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccTriggerTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name = %[1]q
   type = "ON_DEMAND"
@@ -805,8 +805,8 @@ resource "aws_glue_trigger" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccTriggerConfig_WorkflowName(rName string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_workflowName(rName string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_workflow" test {
   name = %[1]q
 }
@@ -823,8 +823,8 @@ resource "aws_glue_trigger" "test" {
 `, rName))
 }
 
-func testAccTriggerActionsNotificationConfig(rName string, delay int) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_actionsNotification(rName string, delay int) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {
   name = %[1]q
   type = "ON_DEMAND"
@@ -840,8 +840,8 @@ resource "aws_glue_trigger" "test" {
 `, rName, delay))
 }
 
-func testAccTriggerActionsSecurityConfigurationConfig(rName string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_actionsSecurityConfiguration(rName string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_security_configuration" "test" {
   name = %[1]q
 
@@ -872,8 +872,8 @@ resource "aws_glue_trigger" "test" {
 `, rName))
 }
 
-func testAccTriggerConfigEvent(rName string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_event(rName string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_workflow" test {
   name = %[1]q
 }
@@ -895,8 +895,8 @@ resource "aws_glue_trigger" "test" {
 `, rName))
 }
 
-func testAccTriggerConfigEventUpdated(rName string) string {
-	return acctest.ConfigCompose(testAccJobConfig_Required(rName), fmt.Sprintf(`
+func testAccTriggerConfig_eventUpdated(rName string) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_workflow" test {
   name = %[1]q
 }

--- a/internal/service/glue/workflow_test.go
+++ b/internal/service/glue/workflow_test.go
@@ -28,7 +28,7 @@ func TestAccGlueWorkflow_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkflowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowConfig_Required(rName),
+				Config: testAccWorkflowConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("workflow/%s", rName)),
@@ -58,7 +58,7 @@ func TestAccGlueWorkflow_maxConcurrentRuns(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkflowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowMaxConcurrentRunsConfig(rName, 1),
+				Config: testAccWorkflowConfig_maxConcurrentRuns(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "max_concurrent_runs", "1"),
@@ -70,14 +70,14 @@ func TestAccGlueWorkflow_maxConcurrentRuns(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkflowMaxConcurrentRunsConfig(rName, 2),
+				Config: testAccWorkflowConfig_maxConcurrentRuns(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "max_concurrent_runs", "2"),
 				),
 			},
 			{
-				Config: testAccWorkflowMaxConcurrentRunsConfig(rName, 1),
+				Config: testAccWorkflowConfig_maxConcurrentRuns(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "max_concurrent_runs", "1"),
@@ -100,7 +100,7 @@ func TestAccGlueWorkflow_defaultRunProperties(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkflowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowConfig_DefaultRunProperties(rName, "firstPropValue", "secondPropValue"),
+				Config: testAccWorkflowConfig_defaultRunProperties(rName, "firstPropValue", "secondPropValue"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "default_run_properties.%", "2"),
@@ -130,14 +130,14 @@ func TestAccGlueWorkflow_description(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkflowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowConfig_Description(rName, "First Description"),
+				Config: testAccWorkflowConfig_description(rName, "First Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
 				),
 			},
 			{
-				Config: testAccWorkflowConfig_Description(rName, "Second Description"),
+				Config: testAccWorkflowConfig_description(rName, "Second Description"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
@@ -164,7 +164,7 @@ func TestAccGlueWorkflow_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkflowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowTags1Config(rName, "key1", "value1"),
+				Config: testAccWorkflowConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -177,7 +177,7 @@ func TestAccGlueWorkflow_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkflowTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccWorkflowConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -186,7 +186,7 @@ func TestAccGlueWorkflow_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkflowTags1Config(rName, "key2", "value2"),
+				Config: testAccWorkflowConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -210,7 +210,7 @@ func TestAccGlueWorkflow_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckWorkflowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowConfig_Required(rName),
+				Config: testAccWorkflowConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkflowExists(resourceName, &workflow),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglue.ResourceWorkflow(), resourceName),
@@ -299,7 +299,7 @@ func testAccCheckWorkflowDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccWorkflowConfig_DefaultRunProperties(rName, firstPropValue, secondPropValue string) string {
+func testAccWorkflowConfig_defaultRunProperties(rName, firstPropValue, secondPropValue string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_workflow" "test" {
   name = "%s"
@@ -312,7 +312,7 @@ resource "aws_glue_workflow" "test" {
 `, rName, firstPropValue, secondPropValue)
 }
 
-func testAccWorkflowConfig_Description(rName, description string) string {
+func testAccWorkflowConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_workflow" "test" {
   description = "%s"
@@ -321,7 +321,7 @@ resource "aws_glue_workflow" "test" {
 `, description, rName)
 }
 
-func testAccWorkflowConfig_Required(rName string) string {
+func testAccWorkflowConfig_required(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_workflow" "test" {
   name = "%s"
@@ -329,7 +329,7 @@ resource "aws_glue_workflow" "test" {
 `, rName)
 }
 
-func testAccWorkflowMaxConcurrentRunsConfig(rName string, runs int) string {
+func testAccWorkflowConfig_maxConcurrentRuns(rName string, runs int) string {
 	return fmt.Sprintf(`
 resource "aws_glue_workflow" "test" {
   name                = %[1]q
@@ -338,7 +338,7 @@ resource "aws_glue_workflow" "test" {
 `, rName, runs)
 }
 
-func testAccWorkflowTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccWorkflowConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_workflow" "test" {
   name = %[1]q
@@ -350,7 +350,7 @@ resource "aws_glue_workflow" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccWorkflowTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccWorkflowConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_workflow" "test" {
   name = %[1]q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
