### PR TITLE
mwaa: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -327,7 +327,6 @@ rules:
         - internal/service/lambda
         - internal/service/logs
         - internal/service/meta
-        - internal/service/mwaa
         - internal/service/networkfirewall
         - internal/service/networkmanager
         - internal/service/opsworks

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -28,7 +28,7 @@ func TestAccMWAAEnvironment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentBasicConfig(rName),
+				Config: testAccEnvironmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttrSet(resourceName, "airflow_version"),
@@ -91,7 +91,7 @@ func TestAccMWAAEnvironment_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentBasicConfig(rName),
+				Config: testAccEnvironmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					acctest.CheckResourceDisappears(acctest.Provider, tfmwaa.ResourceEnvironment(), resourceName),
@@ -115,7 +115,7 @@ func TestAccMWAAEnvironment_airflowOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentAirflowConfigurationOptionsConfig(rName, "1", "16"),
+				Config: testAccEnvironmentConfig_airflowConfigurationOptions(rName, "1", "16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "airflow_configuration_options.%", "2"),
@@ -129,7 +129,7 @@ func TestAccMWAAEnvironment_airflowOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEnvironmentAirflowConfigurationOptionsConfig(rName, "2", "32"),
+				Config: testAccEnvironmentConfig_airflowConfigurationOptions(rName, "2", "32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "airflow_configuration_options.%", "2"),
@@ -138,7 +138,7 @@ func TestAccMWAAEnvironment_airflowOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEnvironmentBasicConfig(rName),
+				Config: testAccEnvironmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "airflow_configuration_options.%", "0"),
@@ -161,7 +161,7 @@ func TestAccMWAAEnvironment_log(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentLoggingConfigurationConfig(rName, "true", mwaa.LoggingLevelCritical),
+				Config: testAccEnvironmentConfig_loggingConfiguration(rName, "true", mwaa.LoggingLevelCritical),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
@@ -198,7 +198,7 @@ func TestAccMWAAEnvironment_log(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEnvironmentLoggingConfigurationConfig(rName, "false", mwaa.LoggingLevelInfo),
+				Config: testAccEnvironmentConfig_loggingConfiguration(rName, "false", mwaa.LoggingLevelInfo),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
@@ -246,7 +246,7 @@ func TestAccMWAAEnvironment_full(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentFullConfig(rName),
+				Config: testAccEnvironmentConfig_full(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "airflow_configuration_options.%", "2"),
@@ -322,7 +322,7 @@ func TestAccMWAAEnvironment_pluginsS3ObjectVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentPluginsS3ObjectVersionConfig(rName, "test"),
+				Config: testAccEnvironmentConfig_pluginsS3ObjectVersion(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttrPair(resourceName, "plugins_s3_object_version", s3ObjectResourceName, "version_id"),
@@ -334,7 +334,7 @@ func TestAccMWAAEnvironment_pluginsS3ObjectVersion(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEnvironmentPluginsS3ObjectVersionConfig(rName, "test-updated"),
+				Config: testAccEnvironmentConfig_pluginsS3ObjectVersion(rName, "test-updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttrPair(resourceName, "plugins_s3_object_version", s3ObjectResourceName, "version_id"),
@@ -595,7 +595,7 @@ POLICY
 `, rName)
 }
 
-func testAccEnvironmentBasicConfig(rName string) string {
+func testAccEnvironmentConfig_basic(rName string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   dag_s3_path        = aws_s3_object.dags.key
@@ -612,7 +612,7 @@ resource "aws_mwaa_environment" "test" {
 `, rName)
 }
 
-func testAccEnvironmentAirflowConfigurationOptionsConfig(rName, retries, parallelism string) string {
+func testAccEnvironmentConfig_airflowConfigurationOptions(rName, retries, parallelism string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   airflow_configuration_options = {
@@ -634,7 +634,7 @@ resource "aws_mwaa_environment" "test" {
 `, rName, retries, parallelism)
 }
 
-func testAccEnvironmentLoggingConfigurationConfig(rName, logEnabled, logLevel string) string {
+func testAccEnvironmentConfig_loggingConfiguration(rName, logEnabled, logLevel string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   dag_s3_path        = aws_s3_object.dags.key
@@ -679,7 +679,7 @@ resource "aws_mwaa_environment" "test" {
 `, rName, logEnabled, logLevel)
 }
 
-func testAccEnvironmentFullConfig(rName string) string {
+func testAccEnvironmentConfig_full(rName string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   airflow_configuration_options = {
@@ -790,7 +790,7 @@ resource "aws_s3_object" "requirements" {
 `, rName)
 }
 
-func testAccEnvironmentPluginsS3ObjectVersionConfig(rName, content string) string {
+func testAccEnvironmentConfig_pluginsS3ObjectVersion(rName, content string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   dag_s3_path        = aws_s3_object.dags.key

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -115,7 +115,7 @@ func TestAccMWAAEnvironment_airflowOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentConfig_airflowConfigurationOptions(rName, "1", "16"),
+				Config: testAccEnvironmentConfig_airflowOptions(rName, "1", "16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "airflow_configuration_options.%", "2"),
@@ -129,7 +129,7 @@ func TestAccMWAAEnvironment_airflowOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEnvironmentConfig_airflowConfigurationOptions(rName, "2", "32"),
+				Config: testAccEnvironmentConfig_airflowOptions(rName, "2", "32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "airflow_configuration_options.%", "2"),
@@ -161,7 +161,7 @@ func TestAccMWAAEnvironment_log(t *testing.T) {
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironmentConfig_loggingConfiguration(rName, "true", mwaa.LoggingLevelCritical),
+				Config: testAccEnvironmentConfig_logging(rName, "true", mwaa.LoggingLevelCritical),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
@@ -198,7 +198,7 @@ func TestAccMWAAEnvironment_log(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEnvironmentConfig_loggingConfiguration(rName, "false", mwaa.LoggingLevelInfo),
+				Config: testAccEnvironmentConfig_logging(rName, "false", mwaa.LoggingLevelInfo),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(resourceName, &environment),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
@@ -612,7 +612,7 @@ resource "aws_mwaa_environment" "test" {
 `, rName)
 }
 
-func testAccEnvironmentConfig_airflowConfigurationOptions(rName, retries, parallelism string) string {
+func testAccEnvironmentConfig_airflowOptions(rName, retries, parallelism string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   airflow_configuration_options = {
@@ -634,7 +634,7 @@ resource "aws_mwaa_environment" "test" {
 `, rName, retries, parallelism)
 }
 
-func testAccEnvironmentConfig_loggingConfiguration(rName, logEnabled, logLevel string) string {
+func testAccEnvironmentConfig_logging(rName, logEnabled, logLevel string) string {
 	return testAccEnvironmentBase(rName) + fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
   dag_s3_path        = aws_s3_object.dags.key


### PR DESCRIPTION
- mwaa: Fix test configs names
- mwaa: Clean up test configs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
