### PR TITLE
kms: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -323,7 +323,6 @@ rules:
         - internal/service/kafkaconnect
         - internal/service/kinesis
         - internal/service/kinesisanalyticsv2
-        - internal/service/kms
         - internal/service/lambda
         - internal/service/logs
         - internal/service/meta

--- a/internal/service/kms/alias_data_source_test.go
+++ b/internal/service/kms/alias_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccKMSAliasDataSource_service(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasDataSourceConfig(rName),
+				Config: testAccAliasDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "kms", rName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -44,7 +44,7 @@ func TestAccKMSAliasDataSource_cmk(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasCMKDataSourceConfig(rName),
+				Config: testAccAliasDataSourceConfig_cmk(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceAliasResourceName, "arn", aliasResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceAliasResourceName, "target_key_arn", aliasResourceName, "target_key_arn"),
@@ -55,7 +55,7 @@ func TestAccKMSAliasDataSource_cmk(t *testing.T) {
 	})
 }
 
-func testAccAliasDataSourceConfig(rName string) string {
+func testAccAliasDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_kms_alias" "test" {
   name = %[1]q
@@ -63,7 +63,7 @@ data "aws_kms_alias" "test" {
 `, rName)
 }
 
-func testAccAliasCMKDataSourceConfig(rName string) string {
+func testAccAliasDataSourceConfig_cmk(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q

--- a/internal/service/kms/alias_test.go
+++ b/internal/service/kms/alias_test.go
@@ -29,7 +29,7 @@ func TestAccKMSAlias_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasNameConfig(rName),
+				Config: testAccAliasConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`alias/.+`)),
@@ -59,7 +59,7 @@ func TestAccKMSAlias_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasNameConfig(rName),
+				Config: testAccAliasConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkms.ResourceAlias(), resourceName),
@@ -82,7 +82,7 @@ func TestAccKMSAlias_Name_generated(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasNameGeneratedConfig(rName),
+				Config: testAccAliasConfig_nameGenerated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(fmt.Sprintf("%s[[:xdigit:]]{%d}", tfkms.AliasNamePrefix, resource.UniqueIDSuffixLength))),
@@ -110,7 +110,7 @@ func TestAccKMSAlias_namePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasNamePrefixConfig(rName, tfkms.AliasNamePrefix+"tf-acc-test-prefix-"),
+				Config: testAccAliasConfig_namePrefix(rName, tfkms.AliasNamePrefix+"tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", tfkms.AliasNamePrefix+"tf-acc-test-prefix-"),
@@ -140,7 +140,7 @@ func TestAccKMSAlias_updateKeyID(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasNameConfig(rName),
+				Config: testAccAliasConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					resource.TestCheckResourceAttrPair(resourceName, "target_key_arn", key1ResourceName, "arn"),
@@ -148,7 +148,7 @@ func TestAccKMSAlias_updateKeyID(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAliasUpdatedKeyIDConfig(rName),
+				Config: testAccAliasConfig_updatedKeyID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					resource.TestCheckResourceAttrPair(resourceName, "target_key_arn", key2ResourceName, "arn"),
@@ -178,7 +178,7 @@ func TestAccKMSAlias_multipleAliasesForSameKey(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasMultipleConfig(rName),
+				Config: testAccAliasConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					resource.TestCheckResourceAttrPair(resourceName, "target_key_arn", keyResourceName, "arn"),
@@ -209,7 +209,7 @@ func TestAccKMSAlias_arnDiffSuppress(t *testing.T) {
 		CheckDestroy:      testAccCheckAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasDiffSuppressConfig(rName),
+				Config: testAccAliasConfig_diffSuppress(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAliasExists(resourceName, &alias),
 					resource.TestCheckResourceAttrSet(resourceName, "target_key_arn"),
@@ -223,7 +223,7 @@ func TestAccKMSAlias_arnDiffSuppress(t *testing.T) {
 			{
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
-				Config:             testAccAliasDiffSuppressConfig(rName),
+				Config:             testAccAliasConfig_diffSuppress(rName),
 			},
 		},
 	})
@@ -278,7 +278,7 @@ func testAccCheckAliasExists(name string, v *kms.AliasListEntry) resource.TestCh
 	}
 }
 
-func testAccAliasNameConfig(rName string) string {
+func testAccAliasConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -292,7 +292,7 @@ resource "aws_kms_alias" "test" {
 `, rName)
 }
 
-func testAccAliasNameGeneratedConfig(rName string) string {
+func testAccAliasConfig_nameGenerated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -305,7 +305,7 @@ resource "aws_kms_alias" "test" {
 `, rName)
 }
 
-func testAccAliasNamePrefixConfig(rName, namePrefix string) string {
+func testAccAliasConfig_namePrefix(rName, namePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -319,7 +319,7 @@ resource "aws_kms_alias" "test" {
 `, rName, namePrefix)
 }
 
-func testAccAliasUpdatedKeyIDConfig(rName string) string {
+func testAccAliasConfig_updatedKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -338,7 +338,7 @@ resource "aws_kms_alias" "test" {
 `, rName)
 }
 
-func testAccAliasMultipleConfig(rName string) string {
+func testAccAliasConfig_multiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -357,7 +357,7 @@ resource "aws_kms_alias" "test2" {
 `, rName)
 }
 
-func testAccAliasDiffSuppressConfig(rName string) string {
+func testAccAliasConfig_diffSuppress(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q

--- a/internal/service/kms/ciphertext_data_source_test.go
+++ b/internal/service/kms/ciphertext_data_source_test.go
@@ -49,7 +49,7 @@ func TestAccKMSCiphertextDataSource_Validate_withContext(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCiphertextDataSourceConfig_validate_withContext,
+				Config: testAccCiphertextDataSourceConfig_validateContext,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.aws_kms_ciphertext.foo", "ciphertext_blob"),
@@ -85,7 +85,7 @@ data "aws_kms_ciphertext" "foo" {
 }
 `
 
-const testAccCiphertextDataSourceConfig_validate_withContext = `
+const testAccCiphertextDataSourceConfig_validateContext = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
   is_enabled  = true

--- a/internal/service/kms/ciphertext_test.go
+++ b/internal/service/kms/ciphertext_test.go
@@ -16,7 +16,7 @@ func TestAccKMSCiphertext_Resource_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCiphertextConfig_resourceBasic,
+				Config: testAccCiphertextConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"aws_kms_ciphertext.foo", "ciphertext_blob"),
@@ -37,7 +37,7 @@ func TestAccKMSCiphertext_Resource_validate(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCiphertextConfig_resourceValidate,
+				Config: testAccCiphertextConfig_validate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
 					resource.TestCheckResourceAttrPair(resourceName, "plaintext", kmsSecretsDataSource, "plaintext.plaintext"),
@@ -58,7 +58,7 @@ func TestAccKMSCiphertext_ResourceValidate_withContext(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCiphertextConfig_resourceValidateContext,
+				Config: testAccCiphertextConfig_validateContext,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
 					resource.TestCheckResourceAttrPair(resourceName, "plaintext", kmsSecretsDataSource, "plaintext.plaintext"),
@@ -68,7 +68,7 @@ func TestAccKMSCiphertext_ResourceValidate_withContext(t *testing.T) {
 	})
 }
 
-const testAccCiphertextConfig_resourceBasic = `
+const testAccCiphertextConfig_basic = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
   is_enabled  = true
@@ -81,7 +81,7 @@ resource "aws_kms_ciphertext" "foo" {
 }
 `
 
-const testAccCiphertextConfig_resourceValidate = `
+const testAccCiphertextConfig_validate = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
   is_enabled  = true
@@ -101,7 +101,7 @@ data "aws_kms_secrets" "foo" {
 }
 `
 
-const testAccCiphertextConfig_resourceValidateContext = `
+const testAccCiphertextConfig_validateContext = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
   is_enabled  = true

--- a/internal/service/kms/ciphertext_test.go
+++ b/internal/service/kms/ciphertext_test.go
@@ -16,7 +16,7 @@ func TestAccKMSCiphertext_Resource_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceCiphertextConfig_basic,
+				Config: testAccCiphertextConfig_resourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"aws_kms_ciphertext.foo", "ciphertext_blob"),
@@ -37,7 +37,7 @@ func TestAccKMSCiphertext_Resource_validate(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceCiphertextConfig_validate,
+				Config: testAccCiphertextConfig_resourceValidate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
 					resource.TestCheckResourceAttrPair(resourceName, "plaintext", kmsSecretsDataSource, "plaintext.plaintext"),
@@ -58,7 +58,7 @@ func TestAccKMSCiphertext_ResourceValidate_withContext(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceCiphertextConfig_validate_withContext,
+				Config: testAccCiphertextConfig_resourceValidateContext,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
 					resource.TestCheckResourceAttrPair(resourceName, "plaintext", kmsSecretsDataSource, "plaintext.plaintext"),
@@ -68,7 +68,7 @@ func TestAccKMSCiphertext_ResourceValidate_withContext(t *testing.T) {
 	})
 }
 
-const testAccResourceCiphertextConfig_basic = `
+const testAccCiphertextConfig_resourceBasic = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
   is_enabled  = true
@@ -81,7 +81,7 @@ resource "aws_kms_ciphertext" "foo" {
 }
 `
 
-const testAccResourceCiphertextConfig_validate = `
+const testAccCiphertextConfig_resourceValidate = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
   is_enabled  = true
@@ -101,7 +101,7 @@ data "aws_kms_secrets" "foo" {
 }
 `
 
-const testAccResourceCiphertextConfig_validate_withContext = `
+const testAccCiphertextConfig_resourceValidateContext = `
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
   is_enabled  = true

--- a/internal/service/kms/external_key_test.go
+++ b/internal/service/kms/external_key_test.go
@@ -29,7 +29,7 @@ func TestAccKMSExternalKey_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyConfig(),
+				Config: testAccExternalKeyConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`key/.+`)),
@@ -71,7 +71,7 @@ func TestAccKMSExternalKey_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyConfig(),
+				Config: testAccExternalKeyConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkms.ResourceExternalKey(), resourceName),
@@ -94,7 +94,7 @@ func TestAccKMSExternalKey_multiRegion(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyMultiRegionConfig(rName),
+				Config: testAccExternalKeyConfig_multiRegion(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "multi_region", "true"),
@@ -126,7 +126,7 @@ func TestAccKMSExternalKey_deletionWindowInDays(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyDeletionWindowInDaysConfig(rName, 8),
+				Config: testAccExternalKeyConfig_deletionWindowInDays(rName, 8),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "deletion_window_in_days", "8"),
@@ -143,7 +143,7 @@ func TestAccKMSExternalKey_deletionWindowInDays(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccExternalKeyDeletionWindowInDaysConfig(rName, 7),
+				Config: testAccExternalKeyConfig_deletionWindowInDays(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyNotRecreated(&key1, &key2),
@@ -166,7 +166,7 @@ func TestAccKMSExternalKey_description(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyDescriptionConfig(rName + "-1"),
+				Config: testAccExternalKeyConfig_description(rName + "-1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "description", rName+"-1"),
@@ -183,7 +183,7 @@ func TestAccKMSExternalKey_description(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccExternalKeyDescriptionConfig(rName + "-2"),
+				Config: testAccExternalKeyConfig_description(rName + "-2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyNotRecreated(&key1, &key2),
@@ -206,7 +206,7 @@ func TestAccKMSExternalKey_enabled(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyEnabledConfig(rName, false),
+				Config: testAccExternalKeyConfig_enabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -223,7 +223,7 @@ func TestAccKMSExternalKey_enabled(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccExternalKeyEnabledConfig(rName, true),
+				Config: testAccExternalKeyConfig_enabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyNotRecreated(&key1, &key2),
@@ -231,7 +231,7 @@ func TestAccKMSExternalKey_enabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExternalKeyEnabledConfig(rName, false),
+				Config: testAccExternalKeyConfig_enabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key3),
 					testAccCheckExternalKeyNotRecreated(&key2, &key3),
@@ -255,7 +255,7 @@ func TestAccKMSExternalKey_keyMaterialBase64(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
-				Config: testAccExternalKeyKeyMaterialBase64Config(rName, "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="),
+				Config: testAccExternalKeyConfig_materialBase64(rName, "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "key_material_base64", "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="),
@@ -273,7 +273,7 @@ func TestAccKMSExternalKey_keyMaterialBase64(t *testing.T) {
 			},
 			{
 				// ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
-				Config: testAccExternalKeyKeyMaterialBase64Config(rName, "O1zsg06cKRCsZnoT5oizMlwHEtnk0HoOmBLkFtwh2Vw="),
+				Config: testAccExternalKeyConfig_materialBase64(rName, "O1zsg06cKRCsZnoT5oizMlwHEtnk0HoOmBLkFtwh2Vw="),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyRecreated(&key1, &key2),
@@ -298,7 +298,7 @@ func TestAccKMSExternalKey_policy(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyPolicyConfig(rName, policy1),
+				Config: testAccExternalKeyConfig_policy(rName, policy1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					testAccCheckExternalKeyHasPolicy(resourceName, policy1),
@@ -315,7 +315,7 @@ func TestAccKMSExternalKey_policy(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccExternalKeyPolicyConfig(rName, policy2),
+				Config: testAccExternalKeyConfig_policy(rName, policy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyNotRecreated(&key1, &key2),
@@ -339,7 +339,7 @@ func TestAccKMSExternalKey_policyBypass(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyPolicyBypassConfig(rName, policy),
+				Config: testAccExternalKeyConfig_policyBypass(rName, policy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key),
 					testAccCheckExternalKeyHasPolicy(resourceName, policy),
@@ -372,7 +372,7 @@ func TestAccKMSExternalKey_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyTags1Config(rName, "key1", "value1"),
+				Config: testAccExternalKeyConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -390,7 +390,7 @@ func TestAccKMSExternalKey_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccExternalKeyTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccExternalKeyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyNotRecreated(&key1, &key2),
@@ -400,7 +400,7 @@ func TestAccKMSExternalKey_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExternalKeyTags1Config(rName, "key2", "value2"),
+				Config: testAccExternalKeyConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key3),
 					testAccCheckExternalKeyNotRecreated(&key2, &key3),
@@ -426,7 +426,7 @@ func TestAccKMSExternalKey_validTo(t *testing.T) {
 		CheckDestroy:      testAccCheckExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExternalKeyValidToConfig(rName, validTo1),
+				Config: testAccExternalKeyConfig_validTo(rName, validTo1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "expiration_model", "KEY_MATERIAL_EXPIRES"),
@@ -444,7 +444,7 @@ func TestAccKMSExternalKey_validTo(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccExternalKeyEnabledConfig(rName, true),
+				Config: testAccExternalKeyConfig_enabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key2),
 					testAccCheckExternalKeyNotRecreated(&key1, &key2),
@@ -453,7 +453,7 @@ func TestAccKMSExternalKey_validTo(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExternalKeyValidToConfig(rName, validTo1),
+				Config: testAccExternalKeyConfig_validTo(rName, validTo1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key3),
 					testAccCheckExternalKeyNotRecreated(&key2, &key3),
@@ -462,7 +462,7 @@ func TestAccKMSExternalKey_validTo(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExternalKeyValidToConfig(rName, validTo2),
+				Config: testAccExternalKeyConfig_validTo(rName, validTo2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExternalKeyExists(resourceName, &key4),
 					testAccCheckExternalKeyNotRecreated(&key3, &key4),
@@ -579,13 +579,13 @@ func testAccCheckExternalKeyRecreated(i, j *kms.KeyMetadata) resource.TestCheckF
 	}
 }
 
-func testAccExternalKeyConfig() string {
+func testAccExternalKeyConfig_basic() string {
 	return `
 resource "aws_kms_external_key" "test" {}
 `
 }
 
-func testAccExternalKeyMultiRegionConfig(rName string) string {
+func testAccExternalKeyConfig_multiRegion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description  = %[1]q
@@ -596,7 +596,7 @@ resource "aws_kms_external_key" "test" {
 `, rName)
 }
 
-func testAccExternalKeyDeletionWindowInDaysConfig(rName string, deletionWindowInDays int) string {
+func testAccExternalKeyConfig_deletionWindowInDays(rName string, deletionWindowInDays int) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -605,7 +605,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, deletionWindowInDays)
 }
 
-func testAccExternalKeyDescriptionConfig(rName string) string {
+func testAccExternalKeyConfig_description(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -614,7 +614,7 @@ resource "aws_kms_external_key" "test" {
 `, rName)
 }
 
-func testAccExternalKeyEnabledConfig(rName string, enabled bool) string {
+func testAccExternalKeyConfig_enabled(rName string, enabled bool) string {
 	return fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {
@@ -626,7 +626,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, enabled)
 }
 
-func testAccExternalKeyKeyMaterialBase64Config(rName, keyMaterialBase64 string) string {
+func testAccExternalKeyConfig_materialBase64(rName, keyMaterialBase64 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -636,7 +636,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, keyMaterialBase64)
 }
 
-func testAccExternalKeyPolicyConfig(rName, policy string) string {
+func testAccExternalKeyConfig_policy(rName, policy string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -647,7 +647,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, policy)
 }
 
-func testAccExternalKeyPolicyBypassConfig(rName, policy string) string {
+func testAccExternalKeyConfig_policyBypass(rName, policy string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -660,7 +660,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, policy)
 }
 
-func testAccExternalKeyTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccExternalKeyConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -673,7 +673,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccExternalKeyTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccExternalKeyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_external_key" "test" {
   description             = %[1]q
@@ -687,7 +687,7 @@ resource "aws_kms_external_key" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccExternalKeyValidToConfig(rName, validTo string) string {
+func testAccExternalKeyConfig_validTo(rName, validTo string) string {
 	return fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {

--- a/internal/service/kms/grant_test.go
+++ b/internal/service/kms/grant_test.go
@@ -25,7 +25,7 @@ func TestAccKMSGrant_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_Basic(rName, "\"Encrypt\", \"Decrypt\""),
+				Config: testAccGrantConfig_basic(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -105,7 +105,7 @@ func TestAccKMSGrant_withRetiringPrincipal(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_withRetiringPrincipal(rName),
+				Config: testAccGrantConfig_retiringPrincipal(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "retiring_principal"),
@@ -132,7 +132,7 @@ func TestAccKMSGrant_bare(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_bare(rName),
+				Config: testAccGrantConfig_bare(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
 					resource.TestCheckNoResourceAttr(resourceName, "name"),
@@ -161,7 +161,7 @@ func TestAccKMSGrant_arn(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_ARN(rName, "\"Encrypt\", \"Decrypt\""),
+				Config: testAccGrantConfig_arn(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -193,7 +193,7 @@ func TestAccKMSGrant_asymmetricKey(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_AsymmetricKey(rName),
+				Config: testAccGrantConfig_asymmetricKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
 				),
@@ -219,7 +219,7 @@ func TestAccKMSGrant_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_Basic(rName, "\"Encrypt\", \"Decrypt\""),
+				Config: testAccGrantConfig_basic(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
 					testAccCheckGrantDisappears(resourceName),
@@ -302,7 +302,7 @@ resource "aws_iam_role" "test" {
 `, rName)
 }
 
-func testAccGrant_Basic(rName string, operations string) string {
+func testAccGrantConfig_basic(rName string, operations string) string {
 	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name              = %[1]q
@@ -330,7 +330,7 @@ resource "aws_kms_grant" "test" {
 `, rName, constraintName, encryptionContext))
 }
 
-func testAccGrant_withRetiringPrincipal(rName string) string {
+func testAccGrantConfig_retiringPrincipal(rName string) string {
 	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name               = %[1]q
@@ -342,7 +342,7 @@ resource "aws_kms_grant" "test" {
 `, rName))
 }
 
-func testAccGrant_bare(rName string) string {
+func testAccGrantConfig_bare(rName string) string {
 	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), `
 resource "aws_kms_grant" "test" {
   key_id            = aws_kms_key.test.key_id
@@ -352,7 +352,7 @@ resource "aws_kms_grant" "test" {
 `)
 }
 
-func testAccGrant_ARN(rName string, operations string) string {
+func testAccGrantConfig_arn(rName string, operations string) string {
 	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name              = %[1]q
@@ -363,7 +363,7 @@ resource "aws_kms_grant" "test" {
 `, rName, operations))
 }
 
-func testAccGrant_AsymmetricKey(rName string) string {
+func testAccGrantConfig_asymmetricKey(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name              = %[1]q

--- a/internal/service/kms/key_data_source_test.go
+++ b/internal/service/kms/key_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccKMSKeyDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyDataSourceConfig(rName),
+				Config: testAccKeyDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
@@ -55,7 +55,7 @@ func TestAccKMSKeyDataSource_grantToken(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyDataSourceGrantTokenConfig(rName),
+				Config: testAccKeyDataSourceConfig_grantToken(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
@@ -89,7 +89,7 @@ func TestAccKMSKeyDataSource_multiRegionConfiguration(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyDataSourceMultiRegionConfig(rName),
+				Config: testAccKeyDataSourceConfig_multiRegion(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
@@ -117,7 +117,7 @@ func TestAccKMSKeyDataSource_multiRegionConfiguration(t *testing.T) {
 	})
 }
 
-func testAccKeyDataSourceConfig(rName string) string {
+func testAccKeyDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -130,7 +130,7 @@ data "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKeyDataSourceGrantTokenConfig(rName string) string {
+func testAccKeyDataSourceConfig_grantToken(rName string) string {
 	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name              = %[1]q
@@ -146,7 +146,7 @@ data "aws_kms_key" "test" {
 `, rName))
 }
 
-func testAccKeyDataSourceMultiRegionConfig(rName string) string {
+func testAccKeyDataSourceConfig_multiRegion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -28,7 +28,7 @@ func TestAccKMSKey_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyConfig(),
+				Config: testAccKeyConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "customer_master_key_spec", "SYMMETRIC_DEFAULT"),
@@ -59,7 +59,7 @@ func TestAccKMSKey_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyNameConfig(rName),
+				Config: testAccKeyConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkms.ResourceKey(), resourceName),
@@ -82,7 +82,7 @@ func TestAccKMSKey_multiRegion(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKey_multiRegion(rName),
+				Config: testAccKeyConfig_multiRegion(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "multi_region", "true"),
@@ -110,7 +110,7 @@ func TestAccKMSKey_asymmetricKey(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKey_asymmetric(rName),
+				Config: testAccKeyConfig_asymmetric(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "customer_master_key_spec", "ECC_NIST_P384"),
@@ -134,7 +134,7 @@ func TestAccKMSKey_Policy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKey_policy(rName),
+				Config: testAccKeyConfig_policy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					testAccCheckKeyHasPolicy(resourceName, expectedPolicyText),
@@ -147,7 +147,7 @@ func TestAccKMSKey_Policy_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccKey_removedPolicy(rName),
+				Config: testAccKeyConfig_removedPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -168,11 +168,11 @@ func TestAccKMSKey_Policy_bypass(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccKey_policyBypass(rName, false),
+				Config:      testAccKeyConfig_policyBypass(rName, false),
 				ExpectError: regexp.MustCompile(`The new key policy will not allow you to update the key policy in the future`),
 			},
 			{
-				Config: testAccKey_policyBypass(rName, true),
+				Config: testAccKeyConfig_policyBypass(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
@@ -200,14 +200,14 @@ func TestAccKMSKey_Policy_bypassUpdate(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyNameConfig(rName),
+				Config: testAccKeyConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
 				),
 			},
 			{
-				Config: testAccKey_policyBypass(rName, true),
+				Config: testAccKeyConfig_policyBypass(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
@@ -229,7 +229,7 @@ func TestAccKMSKey_Policy_iamRole(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPolicyIAMRoleConfig(rName),
+				Config: testAccKeyConfig_policyIAMRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -256,13 +256,13 @@ func TestAccKMSKey_Policy_iamRoleUpdate(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKey_policy(rName),
+				Config: testAccKeyConfig_policy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
 			},
 			{
-				Config: testAccKeyPolicyIAMRoleConfig(rName),
+				Config: testAccKeyConfig_policyIAMRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -284,27 +284,27 @@ func TestAccKMSKey_Policy_iamRoleOrder(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPolicyIAMMultiRoleConfig(rName),
+				Config: testAccKeyConfig_policyIAMMultiRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
 			},
 			{
-				Config: testAccKeyPolicyIAMMultiRoleConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKeyExists(resourceName, &key),
-				),
-				PlanOnly: true,
-			},
-			{
-				Config: testAccKeyPolicyIAMMultiRoleConfig(rName),
+				Config: testAccKeyConfig_policyIAMMultiRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
 				PlanOnly: true,
 			},
 			{
-				Config: testAccKeyPolicyIAMMultiRoleConfig(rName),
+				Config: testAccKeyConfig_policyIAMMultiRole(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(resourceName, &key),
+				),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccKeyConfig_policyIAMMultiRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -327,7 +327,7 @@ func TestAccKMSKey_Policy_iamServiceLinkedRole(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPolicyIAMServiceLinkedRoleConfig(rName),
+				Config: testAccKeyConfig_policyIAMServiceLinkedRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -354,7 +354,7 @@ func TestAccKMSKey_Policy_booleanCondition(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyPolicyBooleanConditionConfig(rName),
+				Config: testAccKeyConfig_policyBooleanCondition(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -375,7 +375,7 @@ func TestAccKMSKey_isEnabled(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKey_enabledRotation(rName),
+				Config: testAccKeyConfig_enabledRotation(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key1),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
@@ -389,7 +389,7 @@ func TestAccKMSKey_isEnabled(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccKey_disabled(rName),
+				Config: testAccKeyConfig_disabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key2),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
@@ -397,7 +397,7 @@ func TestAccKMSKey_isEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKey_enabled(rName),
+				Config: testAccKeyConfig_enabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key3),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
@@ -420,7 +420,7 @@ func TestAccKMSKey_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyTags1Config(rName, "key1", "value1"),
+				Config: testAccKeyConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -434,7 +434,7 @@ func TestAccKMSKey_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccKeyTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccKeyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -443,7 +443,7 @@ func TestAccKMSKey_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKeyTags1Config(rName, "key2", "value2"),
+				Config: testAccKeyConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -541,13 +541,13 @@ func testAccCheckKeyExists(name string, key *kms.KeyMetadata) resource.TestCheck
 	}
 }
 
-func testAccKeyConfig() string {
+func testAccKeyConfig_basic() string {
 	return `
 resource "aws_kms_key" "test" {}
 `
 }
 
-func testAccKeyNameConfig(rName string) string {
+func testAccKeyConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -556,7 +556,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_multiRegion(rName string) string {
+func testAccKeyConfig_multiRegion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -568,7 +568,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_asymmetric(rName string) string {
+func testAccKeyConfig_asymmetric(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -580,7 +580,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_policy(rName string) string {
+func testAccKeyConfig_policy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -603,7 +603,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_policyBypass(rName string, bypassFlag bool) string {
+func testAccKeyConfig_policyBypass(rName string, bypassFlag bool) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -641,7 +641,7 @@ resource "aws_kms_key" "test" {
 `, rName, bypassFlag)
 }
 
-func testAccKeyPolicyIAMRoleConfig(rName string) string {
+func testAccKeyConfig_policyIAMRole(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -700,7 +700,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKeyPolicyIAMMultiRoleConfig(rName string) string {
+func testAccKeyConfig_policyIAMMultiRole(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -825,7 +825,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKeyPolicyIAMServiceLinkedRoleConfig(rName string) string {
+func testAccKeyConfig_policyIAMServiceLinkedRole(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -874,7 +874,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKeyPolicyBooleanConditionConfig(rName string) string {
+func testAccKeyConfig_policyBooleanCondition(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -926,7 +926,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_removedPolicy(rName string) string {
+func testAccKeyConfig_removedPolicy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -935,7 +935,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_enabledRotation(rName string) string {
+func testAccKeyConfig_enabledRotation(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -945,7 +945,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_disabled(rName string) string {
+func testAccKeyConfig_disabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -956,7 +956,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKey_enabled(rName string) string {
+func testAccKeyConfig_enabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -967,7 +967,7 @@ resource "aws_kms_key" "test" {
 `, rName)
 }
 
-func testAccKeyTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccKeyConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q
@@ -979,7 +979,7 @@ resource "aws_kms_key" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccKeyTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccKeyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q

--- a/internal/service/kms/public_key_data_source_test.go
+++ b/internal/service/kms/public_key_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccKMSPublicKeyDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicKeyDataSourceConfig(rName),
+				Config: testAccPublicKeyDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPublicKeyCheckDataSource(datasourceName),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
@@ -48,7 +48,7 @@ func TestAccKMSPublicKeyDataSource_encrypt(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicKeyEncryptDataSourceConfig(rName),
+				Config: testAccPublicKeyDataSourceConfig_encrypt(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPublicKeyCheckDataSource(datasourceName),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
@@ -74,7 +74,7 @@ func testAccPublicKeyCheckDataSource(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccPublicKeyDataSourceConfig(rName string) string {
+func testAccPublicKeyDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description              = %[1]q
@@ -89,7 +89,7 @@ data "aws_kms_public_key" "test" {
 `, rName)
 }
 
-func testAccPublicKeyEncryptDataSourceConfig(rName string) string {
+func testAccPublicKeyDataSourceConfig_encrypt(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description              = %[1]q

--- a/internal/service/kms/replica_external_key_test.go
+++ b/internal/service/kms/replica_external_key_test.go
@@ -29,7 +29,7 @@ func TestAccKMSReplicaExternalKey_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaExternalKeyConfig(rName),
+				Config: testAccReplicaExternalKeyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`key/.+`)),
@@ -80,7 +80,7 @@ func TestAccKMSReplicaExternalKey_descriptionAndEnabled(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaExternalKeyDescriptionAndEnabledConfig(rName1, rName2, false),
+				Config: testAccReplicaExternalKeyConfig_descriptionAndEnabled(rName1, rName2, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", rName2),
@@ -98,7 +98,7 @@ func TestAccKMSReplicaExternalKey_descriptionAndEnabled(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccReplicaExternalKeyDescriptionAndEnabledConfig(rName1, rName3, true),
+				Config: testAccReplicaExternalKeyConfig_descriptionAndEnabled(rName1, rName3, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", rName3),
@@ -106,7 +106,7 @@ func TestAccKMSReplicaExternalKey_descriptionAndEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccReplicaExternalKeyDescriptionAndEnabledConfig(rName1, rName4, false),
+				Config: testAccReplicaExternalKeyConfig_descriptionAndEnabled(rName1, rName4, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", rName4),
@@ -135,7 +135,7 @@ func TestAccKMSReplicaExternalKey_policy(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaExternalKeyPolicyConfig(rName, policy1, false),
+				Config: testAccReplicaExternalKeyConfig_policy(rName, policy1, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
@@ -153,7 +153,7 @@ func TestAccKMSReplicaExternalKey_policy(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccReplicaExternalKeyPolicyConfig(rName, policy2, true),
+				Config: testAccReplicaExternalKeyConfig_policy(rName, policy2, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
@@ -180,7 +180,7 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaExternalKeyTags1Config(rName, "key1", "value1"),
+				Config: testAccReplicaExternalKeyConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -198,7 +198,7 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccReplicaExternalKeyTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccReplicaExternalKeyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -207,7 +207,7 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccReplicaExternalKeyTags1Config(rName, "key2", "value2"),
+				Config: testAccReplicaExternalKeyConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -218,7 +218,7 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 	})
 }
 
-func testAccReplicaExternalKeyConfig(rName string) string {
+func testAccReplicaExternalKeyConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {
@@ -237,7 +237,7 @@ resource "aws_kms_replica_external_key" "test" {
 `, rName))
 }
 
-func testAccReplicaExternalKeyDescriptionAndEnabledConfig(rName, description string, enabled bool) string {
+func testAccReplicaExternalKeyConfig_descriptionAndEnabled(rName, description string, enabled bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {
@@ -264,7 +264,7 @@ resource "aws_kms_replica_external_key" "test" {
 `, rName, description, enabled))
 }
 
-func testAccReplicaExternalKeyPolicyConfig(rName, policy string, bypassLockoutCheck bool) string {
+func testAccReplicaExternalKeyConfig_policy(rName, policy string, bypassLockoutCheck bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {
@@ -295,7 +295,7 @@ resource "aws_kms_replica_external_key" "test" {
 `, rName, policy, bypassLockoutCheck))
 }
 
-func testAccReplicaExternalKeyTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccReplicaExternalKeyConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {
@@ -330,7 +330,7 @@ resource "aws_kms_replica_external_key" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccReplicaExternalKeyTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccReplicaExternalKeyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 # ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
 resource "aws_kms_external_key" "test" {

--- a/internal/service/kms/replica_key_test.go
+++ b/internal/service/kms/replica_key_test.go
@@ -30,7 +30,7 @@ func TestAccKMSReplicaKey_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyConfig(rName),
+				Config: testAccReplicaKeyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`key/.+`)),
@@ -71,7 +71,7 @@ func TestAccKMSReplicaKey_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyConfig(rName),
+				Config: testAccReplicaKeyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkms.ResourceReplicaKey(), resourceName),
@@ -101,7 +101,7 @@ func TestAccKMSReplicaKey_descriptionAndEnabled(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyDescriptionAndEnabledConfig(rName1, rName2, false),
+				Config: testAccReplicaKeyConfig_descriptionAndEnabled(rName1, rName2, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", rName2),
@@ -115,7 +115,7 @@ func TestAccKMSReplicaKey_descriptionAndEnabled(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccReplicaKeyDescriptionAndEnabledConfig(rName1, rName3, true),
+				Config: testAccReplicaKeyConfig_descriptionAndEnabled(rName1, rName3, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", rName3),
@@ -123,7 +123,7 @@ func TestAccKMSReplicaKey_descriptionAndEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccReplicaKeyDescriptionAndEnabledConfig(rName1, rName4, false),
+				Config: testAccReplicaKeyConfig_descriptionAndEnabled(rName1, rName4, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", rName4),
@@ -152,7 +152,7 @@ func TestAccKMSReplicaKey_policy(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyPolicyConfig(rName, policy1, false),
+				Config: testAccReplicaKeyConfig_policy(rName, policy1, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
@@ -166,7 +166,7 @@ func TestAccKMSReplicaKey_policy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccReplicaKeyPolicyConfig(rName, policy2, true),
+				Config: testAccReplicaKeyConfig_policy(rName, policy2, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
@@ -193,7 +193,7 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyTags1Config(rName, "key1", "value1"),
+				Config: testAccReplicaKeyConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -207,7 +207,7 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccReplicaKeyTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccReplicaKeyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -216,7 +216,7 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccReplicaKeyTags1Config(rName, "key2", "value2"),
+				Config: testAccReplicaKeyConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -243,7 +243,7 @@ func TestAccKMSReplicaKey_twoReplicas(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyTwoReplicasConfig(rName),
+				Config: testAccReplicaKeyConfig_twos(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -252,7 +252,7 @@ func TestAccKMSReplicaKey_twoReplicas(t *testing.T) {
 	})
 }
 
-func testAccReplicaKeyConfig(rName string) string {
+func testAccReplicaKeyConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate
@@ -267,7 +267,7 @@ resource "aws_kms_replica_key" "test" {
 `, rName))
 }
 
-func testAccReplicaKeyDescriptionAndEnabledConfig(rName, description string, enabled bool) string {
+func testAccReplicaKeyConfig_descriptionAndEnabled(rName, description string, enabled bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate
@@ -288,7 +288,7 @@ resource "aws_kms_replica_key" "test" {
 `, rName, description, enabled))
 }
 
-func testAccReplicaKeyPolicyConfig(rName, policy string, bypassLockoutCheck bool) string {
+func testAccReplicaKeyConfig_policy(rName, policy string, bypassLockoutCheck bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate
@@ -312,7 +312,7 @@ resource "aws_kms_replica_key" "test" {
 `, rName, policy, bypassLockoutCheck))
 }
 
-func testAccReplicaKeyTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccReplicaKeyConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate
@@ -340,7 +340,7 @@ resource "aws_kms_replica_key" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccReplicaKeyTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccReplicaKeyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate
@@ -369,7 +369,7 @@ resource "aws_kms_replica_key" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccReplicaKeyTwoReplicasConfig(rName string) string {
+func testAccReplicaKeyConfig_twos(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(3), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate

--- a/internal/service/kms/replica_key_test.go
+++ b/internal/service/kms/replica_key_test.go
@@ -243,7 +243,7 @@ func TestAccKMSReplicaKey_twoReplicas(t *testing.T) {
 		CheckDestroy:      testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaKeyConfig_twos(rName),
+				Config: testAccReplicaKeyConfig_two(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(resourceName, &key),
 				),
@@ -369,7 +369,7 @@ resource "aws_kms_replica_key" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccReplicaKeyConfig_twos(rName string) string {
+func testAccReplicaKeyConfig_two(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(3), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = awsalternate

--- a/internal/service/kms/secret_data_source_test.go
+++ b/internal/service/kms/secret_data_source_test.go
@@ -17,14 +17,14 @@ func TestAccKMSSecretDataSource_removed(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecretDataSourceConfig,
+				Config:      testAccSecretDataSourceConfig_basic,
 				ExpectError: regexp.MustCompile(tfkms.SecretRemovedMessage),
 			},
 		},
 	})
 }
 
-const testAccSecretDataSourceConfig = `
+const testAccSecretDataSourceConfig_basic = `
 data "aws_kms_secret" "testing" {
   secret {
     name    = "secret_name"

--- a/internal/service/kms/secrets_data_source_test.go
+++ b/internal/service/kms/secrets_data_source_test.go
@@ -72,7 +72,7 @@ func testAccSecretsDecryptDataSource(t *testing.T, plaintext string, encryptedPa
 			ProviderFactories: acctest.ProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccCheckSecretsSecretDataSource(*encryptedPayload),
+					Config: testAccSecretsDataSourceConfig_secret(*encryptedPayload),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(dataSourceName, "plaintext.%", "1"),
 						resource.TestCheckResourceAttr(dataSourceName, "plaintext.secret1", plaintext),
@@ -92,7 +92,7 @@ resource "aws_kms_key" "test" {
 }
 `
 
-func testAccCheckSecretsSecretDataSource(payload string) string {
+func testAccSecretsDataSourceConfig_secret(payload string) string {
 	return testAccSecretsDataSourceConfig_key + fmt.Sprintf(`
 data "aws_kms_secrets" "test" {
   secret {


### PR DESCRIPTION
- kms: Fix test configs names
- kms: Fix test configs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
