### PR TITLE
ses: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -344,7 +344,6 @@ rules:
         - internal/service/servicecatalog
         - internal/service/servicediscovery
         - internal/service/servicequotas
-        - internal/service/ses
         - internal/service/simpledb
         - internal/service/ssm
         - internal/service/ssoadmin

--- a/internal/service/kms/grant_test.go
+++ b/internal/service/kms/grant_test.go
@@ -57,7 +57,7 @@ func TestAccKMSGrant_withConstraints(t *testing.T) {
 		CheckDestroy:      testAccCheckGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGrant_withConstraints(rName, "encryption_context_equals", `foo = "bar"
+				Config: testAccGrantConfig_constraints(rName, "encryption_context_equals", `foo = "bar"
                         baz = "kaz"`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
@@ -77,7 +77,7 @@ func TestAccKMSGrant_withConstraints(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
 			},
 			{
-				Config: testAccGrant_withConstraints(rName, "encryption_context_subset", `foo = "bar"
+				Config: testAccGrantConfig_constraints(rName, "encryption_context_subset", `foo = "bar"
 			            baz = "kaz"`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
@@ -313,7 +313,7 @@ resource "aws_kms_grant" "test" {
 `, rName, operations))
 }
 
-func testAccGrant_withConstraints(rName string, constraintName string, encryptionContext string) string {
+func testAccGrantConfig_constraints(rName string, constraintName string, encryptionContext string) string {
 	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name              = %[1]q

--- a/internal/service/ses/active_receipt_rule_set_data_source_test.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source_test.go
@@ -25,7 +25,7 @@ func testAccActiveReceiptRuleSetDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckActiveReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActiveReceiptRuleSetDataSourceConfig(rName),
+				Config: testAccActiveReceiptRuleSetDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActiveReceiptRuleSetExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-rule-set/%s", rName)),
@@ -35,7 +35,7 @@ func testAccActiveReceiptRuleSetDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccActiveReceiptRuleSetDataSourceConfig(name string) string {
+func testAccActiveReceiptRuleSetDataSourceConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q

--- a/internal/service/ses/active_receipt_rule_set_test.go
+++ b/internal/service/ses/active_receipt_rule_set_test.go
@@ -55,7 +55,7 @@ func testAccActiveReceiptRuleSet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckActiveReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActiveReceiptRuleSetConfig(rName),
+				Config: testAccActiveReceiptRuleSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActiveReceiptRuleSetExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-rule-set/%s", rName)),
@@ -80,7 +80,7 @@ func testAccActiveReceiptRuleSet_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckActiveReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActiveReceiptRuleSetConfig(rName),
+				Config: testAccActiveReceiptRuleSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActiveReceiptRuleSetExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceActiveReceiptRuleSet(), resourceName),
@@ -140,7 +140,7 @@ func testAccCheckActiveReceiptRuleSetExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccActiveReceiptRuleSetConfig(name string) string {
+func testAccActiveReceiptRuleSetConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q

--- a/internal/service/ses/configuration_set_test.go
+++ b/internal/service/ses/configuration_set_test.go
@@ -29,7 +29,7 @@ func TestAccSESConfigurationSet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetBasicConfig(rName),
+				Config: testAccConfigurationSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("configuration-set/%s", rName)),
@@ -63,7 +63,7 @@ func TestAccSESConfigurationSet_sendingEnabled(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetSendingConfig(rName, false),
+				Config: testAccConfigurationSetConfig_sending(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "false"),
@@ -76,7 +76,7 @@ func TestAccSESConfigurationSet_sendingEnabled(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigurationSetSendingConfig(rName, true),
+				Config: testAccConfigurationSetConfig_sending(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "true"),
@@ -84,7 +84,7 @@ func TestAccSESConfigurationSet_sendingEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConfigurationSetSendingConfig(rName, false),
+				Config: testAccConfigurationSetConfig_sending(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "false"),
@@ -109,7 +109,7 @@ func TestAccSESConfigurationSet_reputationMetricsEnabled(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetReputationMetricsConfig(rName, false),
+				Config: testAccConfigurationSetConfig_reputationMetrics(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
@@ -121,14 +121,14 @@ func TestAccSESConfigurationSet_reputationMetricsEnabled(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigurationSetReputationMetricsConfig(rName, true),
+				Config: testAccConfigurationSetConfig_reputationMetrics(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "true"),
 				),
 			},
 			{
-				Config: testAccConfigurationSetReputationMetricsConfig(rName, false),
+				Config: testAccConfigurationSetConfig_reputationMetrics(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
@@ -152,7 +152,7 @@ func TestAccSESConfigurationSet_deliveryOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetDeliveryOptionsConfig(rName, ses.TlsPolicyRequire),
+				Config: testAccConfigurationSetConfig_deliveryOptions(rName, ses.TlsPolicyRequire),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
@@ -182,13 +182,13 @@ func TestAccSESConfigurationSet_Update_deliveryOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetBasicConfig(rName),
+				Config: testAccConfigurationSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 				),
 			},
 			{
-				Config: testAccConfigurationSetDeliveryOptionsConfig(rName, ses.TlsPolicyRequire),
+				Config: testAccConfigurationSetConfig_deliveryOptions(rName, ses.TlsPolicyRequire),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
@@ -201,7 +201,7 @@ func TestAccSESConfigurationSet_Update_deliveryOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigurationSetDeliveryOptionsConfig(rName, ses.TlsPolicyOptional),
+				Config: testAccConfigurationSetConfig_deliveryOptions(rName, ses.TlsPolicyOptional),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
@@ -209,7 +209,7 @@ func TestAccSESConfigurationSet_Update_deliveryOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConfigurationSetBasicConfig(rName),
+				Config: testAccConfigurationSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "0"),
@@ -238,7 +238,7 @@ func TestAccSESConfigurationSet_emptyDeliveryOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetEmptyDeliveryOptionsConfig(rName),
+				Config: testAccConfigurationSetConfig_emptyDeliveryOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
@@ -268,14 +268,14 @@ func TestAccSESConfigurationSet_Update_emptyDeliveryOptions(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetBasicConfig(rName),
+				Config: testAccConfigurationSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "0"),
 				),
 			},
 			{
-				Config: testAccConfigurationSetEmptyDeliveryOptionsConfig(rName),
+				Config: testAccConfigurationSetConfig_emptyDeliveryOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
@@ -288,7 +288,7 @@ func TestAccSESConfigurationSet_Update_emptyDeliveryOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigurationSetBasicConfig(rName),
+				Config: testAccConfigurationSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "0"),
@@ -317,7 +317,7 @@ func TestAccSESConfigurationSet_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetBasicConfig(rName),
+				Config: testAccConfigurationSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceConfigurationSet(), resourceName),
@@ -379,7 +379,7 @@ func testAccCheckConfigurationSetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccConfigurationSetBasicConfig(rName string) string {
+func testAccConfigurationSetConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
   name = %[1]q
@@ -387,7 +387,7 @@ resource "aws_ses_configuration_set" "test" {
 `, rName)
 }
 
-func testAccConfigurationSetSendingConfig(rName string, enabled bool) string {
+func testAccConfigurationSetConfig_sending(rName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
   name            = %[1]q
@@ -396,7 +396,7 @@ resource "aws_ses_configuration_set" "test" {
 `, rName, enabled)
 }
 
-func testAccConfigurationSetReputationMetricsConfig(rName string, enabled bool) string {
+func testAccConfigurationSetConfig_reputationMetrics(rName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
   name                       = %[1]q
@@ -405,7 +405,7 @@ resource "aws_ses_configuration_set" "test" {
 `, rName, enabled)
 }
 
-func testAccConfigurationSetDeliveryOptionsConfig(rName, tlsPolicy string) string {
+func testAccConfigurationSetConfig_deliveryOptions(rName, tlsPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
   name = %[1]q
@@ -417,7 +417,7 @@ resource "aws_ses_configuration_set" "test" {
 `, rName, tlsPolicy)
 }
 
-func testAccConfigurationSetEmptyDeliveryOptionsConfig(rName string) string {
+func testAccConfigurationSetConfig_emptyDeliveryOptions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
   name = %[1]q

--- a/internal/service/ses/domain_dkim_test.go
+++ b/internal/service/ses/domain_dkim_test.go
@@ -28,7 +28,7 @@ func TestAccSESDomainDKIM_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainDKIMDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccDomainDKIMConfig, domain),
+				Config: fmt.Sprintf(testAccDomainDKIMConfig, domain), // nosemgrep:test-config-funcs-correct-form
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainDKIMExists(resourceName),
 					testAccCheckDomainDKIMTokens(resourceName),

--- a/internal/service/ses/domain_dkim_test.go
+++ b/internal/service/ses/domain_dkim_test.go
@@ -27,8 +27,8 @@ func TestAccSESDomainDKIM_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDomainDKIMDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(testAccDomainDKIMConfig, domain), // nosemgrep:test-config-funcs-correct-form
+			{ // nosemgrep:test-config-funcs-correct-form
+				Config: fmt.Sprintf(testAccDomainDKIMConfig, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainDKIMExists(resourceName),
 					testAccCheckDomainDKIMTokens(resourceName),

--- a/internal/service/ses/domain_identity_data_source_test.go
+++ b/internal/service/ses/domain_identity_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccSESDomainIdentityDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainIdentityDataSourceConfig(domain),
+				Config: testAccDomainIdentityDataSourceConfig_basic(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainIdentityExists("aws_ses_domain_identity.test"),
 					testAccCheckDomainIdentityARN("data.aws_ses_domain_identity.test", domain),
@@ -29,7 +29,7 @@ func TestAccSESDomainIdentityDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDomainIdentityDataSourceConfig(domain string) string {
+func testAccDomainIdentityDataSourceConfig_basic(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_domain_identity" "test" {
   domain = "%s"

--- a/internal/service/ses/domain_identity_test.go
+++ b/internal/service/ses/domain_identity_test.go
@@ -25,7 +25,7 @@ func TestAccSESDomainIdentity_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainIdentityConfig(domain),
+				Config: testAccDomainIdentityConfig_basic(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainIdentityExists("aws_ses_domain_identity.test"),
 					testAccCheckDomainIdentityARN("aws_ses_domain_identity.test", domain),
@@ -45,7 +45,7 @@ func TestAccSESDomainIdentity_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainIdentityConfig(domain),
+				Config: testAccDomainIdentityConfig_basic(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainIdentityExists("aws_ses_domain_identity.test"),
 					testAccCheckDomainIdentityDisappears(domain),
@@ -68,7 +68,7 @@ func TestAccSESDomainIdentity_trailingPeriod(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDomainIdentityConfig(domain),
+				Config:      testAccDomainIdentityConfig_basic(domain),
 				ExpectError: regexp.MustCompile(`invalid value for domain \(cannot end with a period\)`),
 			},
 		},
@@ -187,7 +187,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccDomainIdentityConfig(domain string) string {
+func testAccDomainIdentityConfig_basic(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_domain_identity" "test" {
   domain = "%s"

--- a/internal/service/ses/domain_identity_verification_test.go
+++ b/internal/service/ses/domain_identity_verification_test.go
@@ -38,7 +38,7 @@ func TestAccSESDomainIdentityVerification_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainIdentityVerification_basic(rootDomain, domain),
+				Config: testAccDomainIdentityVerificationConfig_basic(rootDomain, domain),
 				Check:  testAccCheckDomainIdentityVerificationPassed("aws_ses_domain_identity_verification.test"),
 			},
 		},
@@ -55,7 +55,7 @@ func TestAccSESDomainIdentityVerification_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDomainIdentityVerification_timeout(domain),
+				Config:      testAccDomainIdentityVerificationConfig_timeout(domain),
 				ExpectError: regexp.MustCompile("Expected domain verification Success, but was in state Pending"),
 			},
 		},
@@ -72,7 +72,7 @@ func TestAccSESDomainIdentityVerification_nonexistent(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDomainIdentityVerification_nonexistent(domain),
+				Config:      testAccDomainIdentityVerificationConfig_nonexistent(domain),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("SES Domain Identity %s not found in AWS", domain)),
 			},
 		},
@@ -128,7 +128,7 @@ func testAccCheckDomainIdentityVerificationPassed(n string) resource.TestCheckFu
 	}
 }
 
-func testAccDomainIdentityVerification_basic(rootDomain string, domain string) string {
+func testAccDomainIdentityVerificationConfig_basic(rootDomain string, domain string) string {
 	return fmt.Sprintf(`
 data "aws_route53_zone" "test" {
   name         = "%s."
@@ -155,7 +155,7 @@ resource "aws_ses_domain_identity_verification" "test" {
 `, rootDomain, domain)
 }
 
-func testAccDomainIdentityVerification_timeout(domain string) string {
+func testAccDomainIdentityVerificationConfig_timeout(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_domain_identity" "test" {
   domain = "%s"
@@ -171,7 +171,7 @@ resource "aws_ses_domain_identity_verification" "test" {
 `, domain)
 }
 
-func testAccDomainIdentityVerification_nonexistent(domain string) string {
+func testAccDomainIdentityVerificationConfig_nonexistent(domain string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_domain_identity_verification" "test" {
   domain = "%s"

--- a/internal/service/ses/domain_mail_from_test.go
+++ b/internal/service/ses/domain_mail_from_test.go
@@ -26,7 +26,7 @@ func TestAccSESDomainMailFrom_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainMailFromDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainMailFromConfig(domain, mailFromDomain1),
+				Config: testAccDomainMailFromConfig_basic(domain, mailFromDomain1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainMailFromExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", ses.BehaviorOnMXFailureUseDefaultValue),
@@ -35,7 +35,7 @@ func TestAccSESDomainMailFrom_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainMailFromConfig(domain, mailFromDomain2),
+				Config: testAccDomainMailFromConfig_basic(domain, mailFromDomain2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainMailFromExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", ses.BehaviorOnMXFailureUseDefaultValue),
@@ -65,7 +65,7 @@ func TestAccSESDomainMailFrom_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainMailFromDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainMailFromConfig(domain, mailFromDomain),
+				Config: testAccDomainMailFromConfig_basic(domain, mailFromDomain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainMailFromExists(resourceName),
 					testAccCheckDomainMailFromDisappears(domain),
@@ -89,7 +89,7 @@ func TestAccSESDomainMailFrom_Disappears_identity(t *testing.T) {
 		CheckDestroy:      testAccCheckDomainMailFromDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainMailFromConfig(domain, mailFromDomain),
+				Config: testAccDomainMailFromConfig_basic(domain, mailFromDomain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainMailFromExists(resourceName),
 					testAccCheckDomainIdentityDisappears(domain),
@@ -205,7 +205,7 @@ func testAccCheckDomainMailFromDisappears(identity string) resource.TestCheckFun
 	}
 }
 
-func testAccDomainMailFromConfig(domain, mailFromDomain string) string {
+func testAccDomainMailFromConfig_basic(domain, mailFromDomain string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_domain_identity" "test" {
   domain = "%s"

--- a/internal/service/ses/email_identity_data_dource_test.go
+++ b/internal/service/ses/email_identity_data_dource_test.go
@@ -21,7 +21,7 @@ func TestAccSESEmailIdentityDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailIdentityDataSourceConfig(email),
+				Config: testAccEmailIdentityDataDourceConfig_source(email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailIdentityExists("aws_ses_email_identity.test"),
 					acctest.MatchResourceAttrRegionalARN("data.aws_ses_email_identity.test", "arn", "ses", regexp.MustCompile(fmt.Sprintf("identity/%s$", regexp.QuoteMeta(email)))),
@@ -41,7 +41,7 @@ func TestAccSESEmailIdentityDataSource_trailingPeriod(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailIdentityDataSourceConfig(email),
+				Config: testAccEmailIdentityDataDourceConfig_source(email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailIdentityExists("aws_ses_email_identity.test"),
 					acctest.MatchResourceAttrRegionalARN("data.aws_ses_email_identity.test", "arn", "ses", regexp.MustCompile(fmt.Sprintf("identity/%s$", regexp.QuoteMeta(strings.TrimSuffix(email, "."))))),
@@ -51,7 +51,7 @@ func TestAccSESEmailIdentityDataSource_trailingPeriod(t *testing.T) {
 	})
 }
 
-func testAccEmailIdentityDataSourceConfig(email string) string {
+func testAccEmailIdentityDataDourceConfig_source(email string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_email_identity" "test" {
   email = %q

--- a/internal/service/ses/email_identity_test.go
+++ b/internal/service/ses/email_identity_test.go
@@ -25,7 +25,7 @@ func TestAccSESEmailIdentity_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailIdentityConfig(email),
+				Config: testAccEmailIdentityConfig_basic(email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailIdentityExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ses", regexp.MustCompile(fmt.Sprintf("identity/%s$", regexp.QuoteMeta(email)))),
@@ -51,7 +51,7 @@ func TestAccSESEmailIdentity_trailingPeriod(t *testing.T) {
 		CheckDestroy:      testAccCheckEmailIdentityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEmailIdentityConfig(email),
+				Config: testAccEmailIdentityConfig_basic(email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailIdentityExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ses", regexp.MustCompile(fmt.Sprintf("identity/%s$", regexp.QuoteMeta(strings.TrimSuffix(email, "."))))),
@@ -127,7 +127,7 @@ func testAccCheckEmailIdentityExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccEmailIdentityConfig(email string) string {
+func testAccEmailIdentityConfig_basic(email string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_email_identity" "test" {
   email = %q

--- a/internal/service/ses/event_destination_test.go
+++ b/internal/service/ses/event_destination_test.go
@@ -33,7 +33,7 @@ func TestAccSESEventDestination_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventDestinationConfig(rName1, rName2, rName3),
+				Config: testAccEventDestinationConfig_basic(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDestinationExists(cloudwatchDestinationResourceName, &v1),
 					testAccCheckEventDestinationExists(kinesisDestinationResourceName, &v2),
@@ -87,7 +87,7 @@ func TestAccSESEventDestination_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventDestinationConfig(rName1, rName2, rName3),
+				Config: testAccEventDestinationConfig_basic(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDestinationExists(cloudwatchDestinationResourceName, &v1),
 					testAccCheckEventDestinationExists(kinesisDestinationResourceName, &v2),
@@ -164,7 +164,7 @@ func testAccCheckEventDestinationExists(n string, v *ses.EventDestination) resou
 	}
 }
 
-func testAccEventDestinationConfig(rName1, rName2, rName3 string) string {
+func testAccEventDestinationConfig_basic(rName1, rName2, rName3 string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[2]q

--- a/internal/service/ses/identity_policy_test.go
+++ b/internal/service/ses/identity_policy_test.go
@@ -25,7 +25,7 @@ func TestAccSESIdentityPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckIdentityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityPolicyIdentityDomainConfig(domain),
+				Config: testAccIdentityPolicyConfig_domain(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityPolicyExists(resourceName),
 				),
@@ -51,7 +51,7 @@ func TestAccSESIdentityPolicy_Identity_email(t *testing.T) {
 		CheckDestroy:      testAccCheckIdentityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityPolicyIdentityEmailConfig(email),
+				Config: testAccIdentityPolicyConfig_email(email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityPolicyExists(resourceName),
 				),
@@ -76,13 +76,13 @@ func TestAccSESIdentityPolicy_policy(t *testing.T) {
 		CheckDestroy:      testAccCheckIdentityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityPolicyPolicy1Config(domain),
+				Config: testAccIdentityPolicyConfig_1(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityPolicyExists(resourceName),
 				),
 			},
 			{
-				Config: testAccIdentityPolicyPolicy2Config(domain),
+				Config: testAccIdentityPolicyConfig_2(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityPolicyExists(resourceName),
 				),
@@ -108,13 +108,13 @@ func TestAccSESIdentityPolicy_ignoreEquivalent(t *testing.T) {
 		CheckDestroy:      testAccCheckIdentityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityPolicyEquivalentConfig(rName, domain),
+				Config: testAccIdentityPolicyConfig_equivalent(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityPolicyExists(resourceName),
 				),
 			},
 			{
-				Config:   testAccIdentityPolicyEquivalent2Config(rName, domain),
+				Config:   testAccIdentityPolicyConfig_equivalent2(rName, domain),
 				PlanOnly: true,
 			},
 		},
@@ -190,7 +190,7 @@ func testAccCheckIdentityPolicyExists(resourceName string) resource.TestCheckFun
 	}
 }
 
-func testAccIdentityPolicyIdentityDomainConfig(domain string) string {
+func testAccIdentityPolicyConfig_domain(domain string) string {
 	return fmt.Sprintf(`
 data "aws_iam_policy_document" "test" {
   statement {
@@ -216,7 +216,7 @@ resource "aws_ses_identity_policy" "test" {
 `, domain)
 }
 
-func testAccIdentityPolicyIdentityEmailConfig(email string) string {
+func testAccIdentityPolicyConfig_email(email string) string {
 	return fmt.Sprintf(`
 data "aws_iam_policy_document" "test" {
   statement {
@@ -242,7 +242,7 @@ resource "aws_ses_identity_policy" "test" {
 `, email)
 }
 
-func testAccIdentityPolicyPolicy1Config(domain string) string {
+func testAccIdentityPolicyConfig_1(domain string) string {
 	return fmt.Sprintf(`
 data "aws_iam_policy_document" "test" {
   statement {
@@ -268,7 +268,7 @@ resource "aws_ses_identity_policy" "test" {
 `, domain)
 }
 
-func testAccIdentityPolicyPolicy2Config(domain string) string {
+func testAccIdentityPolicyConfig_2(domain string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -298,7 +298,7 @@ resource "aws_ses_identity_policy" "test" {
 `, domain)
 }
 
-func testAccIdentityPolicyEquivalentConfig(rName, domain string) string {
+func testAccIdentityPolicyConfig_equivalent(rName, domain string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -330,7 +330,7 @@ resource "aws_ses_identity_policy" "test" {
 `, domain, rName)
 }
 
-func testAccIdentityPolicyEquivalent2Config(rName, domain string) string {
+func testAccIdentityPolicyConfig_equivalent2(rName, domain string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 

--- a/internal/service/ses/receipt_filter_test.go
+++ b/internal/service/ses/receipt_filter_test.go
@@ -25,7 +25,7 @@ func TestAccSESReceiptFilter_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptFilterConfig(rName),
+				Config: testAccReceiptFilterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptFilterExists(resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-filter/%s", rName)),
@@ -54,7 +54,7 @@ func TestAccSESReceiptFilter_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptFilterConfig(rName),
+				Config: testAccReceiptFilterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptFilterExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceReceiptFilter(), resourceName),
@@ -117,7 +117,7 @@ func testAccCheckReceiptFilterExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccReceiptFilterConfig(rName string) string {
+func testAccReceiptFilterConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_filter" "test" {
   cidr   = "10.10.10.10"

--- a/internal/service/ses/receipt_rule_set_test.go
+++ b/internal/service/ses/receipt_rule_set_test.go
@@ -26,7 +26,7 @@ func TestAccSESReceiptRuleSet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleSetConfig(rName),
+				Config: testAccReceiptRuleSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "rule_set_name", rName),
@@ -53,7 +53,7 @@ func TestAccSESReceiptRuleSet_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleSetConfig(rName),
+				Config: testAccReceiptRuleSetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleSetExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceReceiptRuleSet(), resourceName),
@@ -115,7 +115,7 @@ func testAccCheckReceiptRuleSetExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccReceiptRuleSetConfig(rName string) string {
+func testAccReceiptRuleSetConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %q

--- a/internal/service/ses/receipt_rule_test.go
+++ b/internal/service/ses/receipt_rule_test.go
@@ -33,7 +33,7 @@ func TestAccSESReceiptRule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleBasicConfig(rName, acctest.DefaultEmailAddress),
+				Config: testAccReceiptRuleConfig_basic(rName, acctest.DefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -79,7 +79,7 @@ func TestAccSESReceiptRule_s3Action(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleS3ActionConfig(rName),
+				Config: testAccReceiptRuleConfig_s3Action(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -116,7 +116,7 @@ func TestAccSESReceiptRule_snsAction(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleSNSActionConfig(rName),
+				Config: testAccReceiptRuleConfig_snsAction(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "sns_action.#", "1"),
@@ -153,7 +153,7 @@ func TestAccSESReceiptRule_snsActionEncoding(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleSNSActionEncodingConfig(rName),
+				Config: testAccReceiptRuleConfig_snsActionEncoding(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "sns_action.#", "1"),
@@ -190,7 +190,7 @@ func TestAccSESReceiptRule_lambdaAction(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleLambdaActionConfig(rName),
+				Config: testAccReceiptRuleConfig_lambdaAction(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "lambda_action.#", "1"),
@@ -227,7 +227,7 @@ func TestAccSESReceiptRule_stopAction(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleStopActionConfig(rName),
+				Config: testAccReceiptRuleConfig_stopAction(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "stop_action.#", "1"),
@@ -263,7 +263,7 @@ func TestAccSESReceiptRule_order(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleOrderConfig(rName),
+				Config: testAccReceiptRuleConfig_order(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "name", "second"),
@@ -296,7 +296,7 @@ func TestAccSESReceiptRule_actions(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleActionsConfig(rName),
+				Config: testAccReceiptRuleConfig_actions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "add_header_action.*", map[string]string{
@@ -339,7 +339,7 @@ func TestAccSESReceiptRule_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReceiptRuleBasicConfig(rName, acctest.DefaultEmailAddress),
+				Config: testAccReceiptRuleConfig_basic(rName, acctest.DefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceReceiptRuleSet(), ruleSetResourceName),
@@ -347,7 +347,7 @@ func TestAccSESReceiptRule_disappears(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccReceiptRuleBasicConfig(rName, acctest.DefaultEmailAddress),
+				Config: testAccReceiptRuleConfig_basic(rName, acctest.DefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReceiptRuleExists(resourceName, &rule),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceReceiptRule(), resourceName),
@@ -451,7 +451,7 @@ func testAccPreCheckReceiptRule(t *testing.T) {
 	}
 }
 
-func testAccReceiptRuleBasicConfig(rName, email string) string {
+func testAccReceiptRuleConfig_basic(rName, email string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -468,7 +468,7 @@ resource "aws_ses_receipt_rule" "test" {
 `, rName, email)
 }
 
-func testAccReceiptRuleS3ActionConfig(rName string) string {
+func testAccReceiptRuleConfig_s3Action(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -500,7 +500,7 @@ resource "aws_ses_receipt_rule" "test" {
 `, rName, acctest.DefaultEmailAddress)
 }
 
-func testAccReceiptRuleSNSActionConfig(rName string) string {
+func testAccReceiptRuleConfig_snsAction(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -526,7 +526,7 @@ resource "aws_ses_receipt_rule" "test" {
 `, rName, acctest.DefaultEmailAddress)
 }
 
-func testAccReceiptRuleSNSActionEncodingConfig(rName string) string {
+func testAccReceiptRuleConfig_snsActionEncoding(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -553,7 +553,7 @@ resource "aws_ses_receipt_rule" "test" {
 `, rName, acctest.DefaultEmailAddress)
 }
 
-func testAccReceiptRuleLambdaActionConfig(rName string) string {
+func testAccReceiptRuleConfig_lambdaAction(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -610,7 +610,7 @@ resource "aws_ses_receipt_rule" "test" {
 `, rName, acctest.DefaultEmailAddress)
 }
 
-func testAccReceiptRuleStopActionConfig(rName string) string {
+func testAccReceiptRuleConfig_stopAction(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -637,7 +637,7 @@ resource "aws_ses_receipt_rule" "test" {
 `, rName, acctest.DefaultEmailAddress)
 }
 
-func testAccReceiptRuleOrderConfig(rName string) string {
+func testAccReceiptRuleConfig_order(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -656,7 +656,7 @@ resource "aws_ses_receipt_rule" "test1" {
 `, rName)
 }
 
-func testAccReceiptRuleActionsConfig(rName string) string {
+func testAccReceiptRuleConfig_actions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q

--- a/internal/service/ses/template_test.go
+++ b/internal/service/ses/template_test.go
@@ -28,7 +28,7 @@ func TestAccSESTemplate_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTemplateResourceBasic1Config(rName),
+				Config: testAccTemplateConfig_resourceBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -59,7 +59,7 @@ func TestAccSESTemplate_update(t *testing.T) {
 		CheckDestroy:      testAccCheckTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTemplateResourceBasic1Config(rName),
+				Config: testAccTemplateConfig_resourceBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(resourceName, &template),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("template/%s", rName)),
@@ -75,7 +75,7 @@ func TestAccSESTemplate_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckTemplateResourceBasic2Config(rName),
+				Config: testAccTemplateConfig_resourceBasic2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -85,7 +85,7 @@ func TestAccSESTemplate_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckTemplateResourceBasic3Config(rName),
+				Config: testAccTemplateConfig_resourceBasic3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -110,7 +110,7 @@ func TestAccSESTemplate_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTemplateResourceBasic1Config(rName),
+				Config: testAccTemplateConfig_resourceBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(resourceName, &template),
 					acctest.CheckResourceDisappears(acctest.Provider, tfses.ResourceTemplate(), resourceName),
@@ -186,7 +186,7 @@ func testAccCheckTemplateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTemplateResourceBasic1Config(name string) string {
+func testAccTemplateConfig_resourceBasic1(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_template" "test" {
   name    = "%s"
@@ -196,7 +196,7 @@ resource "aws_ses_template" "test" {
 `, name)
 }
 
-func testAccCheckTemplateResourceBasic2Config(name string) string {
+func testAccTemplateConfig_resourceBasic2(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_template" "test" {
   name    = "%s"
@@ -207,7 +207,7 @@ resource "aws_ses_template" "test" {
 `, name)
 }
 
-func testAccCheckTemplateResourceBasic3Config(name string) string {
+func testAccTemplateConfig_resourceBasic3(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_template" "test" {
   name    = "%s"


### PR DESCRIPTION
- ses: Fix test configs names
- ses: Fix

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
