### PR TITLE
servicediscovery: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -341,7 +341,6 @@ rules:
         - internal/service/schemas
         - internal/service/secretsmanager
         - internal/service/servicecatalog
-        - internal/service/servicediscovery
         - internal/service/servicequotas
         - internal/service/simpledb
         - internal/service/ssm

--- a/internal/service/servicediscovery/dns_namespace_data_source_test.go
+++ b/internal/service/servicediscovery/dns_namespace_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccServiceDiscoveryDNSNamespaceDataSource_private(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPrivateDNSNamespaceConfig(rName),
+				Config: testAccDNSNamespaceDataSourceConfig_private(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
@@ -52,7 +52,7 @@ func TestAccServiceDiscoveryDNSNamespaceDataSource_public(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPublicDNSNamespaceConfig(rName),
+				Config: testAccDNSNamespaceDataSourceConfig_public(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
@@ -64,7 +64,7 @@ func TestAccServiceDiscoveryDNSNamespaceDataSource_public(t *testing.T) {
 	})
 }
 
-func testAccCheckPrivateDNSNamespaceConfig(rName string) string {
+func testAccDNSNamespaceDataSourceConfig_private(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -82,7 +82,7 @@ data "aws_service_discovery_dns_namespace" "test" {
 `, rName)
 }
 
-func testAccCheckPublicDNSNamespaceConfig(rName string) string {
+func testAccDNSNamespaceDataSourceConfig_public(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_public_dns_namespace" "test" {
   name = "%[1]s.tf"

--- a/internal/service/servicediscovery/instance_test.go
+++ b/internal/service/servicediscovery/instance_test.go
@@ -30,11 +30,7 @@ func TestAccServiceDiscoveryInstance_private(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ConfigCompose(
-					testAccInstanceBaseConfig(rName),
-					testAccInstancePrivateNamespaceConfig(rName, domainName),
-					testAccInstanceConfig(rName, "AWS_INSTANCE_IPV4 = \"10.0.0.1\" \n    AWS_INSTANCE_IPV6 = \"2001:0db8:85a3:0000:0000:abcd:0001:2345\""),
-				),
+				Config: testAccInstanceConfig_private(rName, domainName, "AWS_INSTANCE_IPV4 = \"10.0.0.1\" \n    AWS_INSTANCE_IPV6 = \"2001:0db8:85a3:0000:0000:abcd:0001:2345\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
@@ -44,11 +40,7 @@ func TestAccServiceDiscoveryInstance_private(t *testing.T) {
 				),
 			},
 			{
-				Config: acctest.ConfigCompose(
-					testAccInstanceBaseConfig(rName),
-					testAccInstancePrivateNamespaceConfig(rName, domainName),
-					testAccInstanceConfig(rName, "AWS_INSTANCE_IPV4 = \"10.0.0.2\" \n    AWS_INSTANCE_IPV6 = \"2001:0db8:85a3:0000:0000:abcd:0001:2345\""),
-				),
+				Config: testAccInstanceConfig_private(rName, domainName, "AWS_INSTANCE_IPV4 = \"10.0.0.2\" \n    AWS_INSTANCE_IPV6 = \"2001:0db8:85a3:0000:0000:abcd:0001:2345\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
@@ -83,11 +75,7 @@ func TestAccServiceDiscoveryInstance_public(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ConfigCompose(
-					testAccInstanceBaseConfig(rName),
-					testAccInstancePublicNamespaceConfig(rName, domainName),
-					testAccInstanceConfig(rName, "AWS_INSTANCE_IPV4 = \"52.18.0.2\" \n    CUSTOM_KEY = \"this is a custom value\""),
-				),
+				Config: testAccInstanceConfig_public(rName, domainName, "AWS_INSTANCE_IPV4 = \"52.18.0.2\" \n    CUSTOM_KEY = \"this is a custom value\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
@@ -97,11 +85,7 @@ func TestAccServiceDiscoveryInstance_public(t *testing.T) {
 				),
 			},
 			{
-				Config: acctest.ConfigCompose(
-					testAccInstanceBaseConfig(rName),
-					testAccInstancePublicNamespaceConfig(rName, domainName),
-					testAccInstanceConfig(rName, "AWS_INSTANCE_IPV4 = \"52.18.0.2\" \n    CUSTOM_KEY = \"this is a custom value updated\""),
-				),
+				Config: testAccInstanceConfig_public(rName, domainName, "AWS_INSTANCE_IPV4 = \"52.18.0.2\" \n    CUSTOM_KEY = \"this is a custom value updated\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
@@ -136,11 +120,7 @@ func TestAccServiceDiscoveryInstance_http(t *testing.T) {
 		CheckDestroy:      testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ConfigCompose(
-					testAccInstanceBaseConfig(rName),
-					testAccInstanceHTTPNamespaceConfig(rName, domainName),
-					testAccInstanceConfig(rName, "AWS_EC2_INSTANCE_ID = aws_instance.test_instance.id"),
-				),
+				Config: testAccInstanceConfig_http(rName, domainName, "AWS_EC2_INSTANCE_ID = aws_instance.test_instance.id"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
@@ -149,11 +129,7 @@ func TestAccServiceDiscoveryInstance_http(t *testing.T) {
 				),
 			},
 			{
-				Config: acctest.ConfigCompose(
-					testAccInstanceBaseConfig(rName),
-					testAccInstanceHTTPNamespaceConfig(rName, domainName),
-					testAccInstanceConfig(rName, "AWS_INSTANCE_IPV4 = \"172.18.0.12\""),
-				),
+				Config: testAccInstanceConfig_http(rName, domainName, "AWS_INSTANCE_IPV4 = \"172.18.0.12\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
@@ -169,106 +145,6 @@ func TestAccServiceDiscoveryInstance_http(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccInstanceBaseConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "sd_register_instance" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-
-  tags = {
-    Name = %q
-  }
-}`, rName)
-}
-
-func testAccInstancePrivateNamespaceConfig(rName, domainName string) string {
-	return fmt.Sprintf(`
-resource "aws_service_discovery_private_dns_namespace" "sd_register_instance" {
-  name        = %[2]q
-  description = %[1]q
-  vpc         = aws_vpc.sd_register_instance.id
-}
-
-resource "aws_service_discovery_service" "sd_register_instance" {
-  name = %[1]q
-
-  dns_config {
-    namespace_id = aws_service_discovery_private_dns_namespace.sd_register_instance.id
-
-    dns_records {
-      ttl  = 10
-      type = "A"
-    }
-
-    routing_policy = "MULTIVALUE"
-  }
-
-  health_check_custom_config {
-    failure_threshold = 1
-  }
-}`, rName, domainName)
-}
-
-func testAccInstancePublicNamespaceConfig(rName, domainName string) string {
-	return fmt.Sprintf(`
-resource "aws_service_discovery_public_dns_namespace" "sd_register_instance" {
-  name = %[2]q
-}
-
-resource "aws_service_discovery_service" "sd_register_instance" {
-  name = %[1]q
-
-  dns_config {
-    namespace_id = aws_service_discovery_public_dns_namespace.sd_register_instance.id
-
-    dns_records {
-      ttl  = 10
-      type = "A"
-    }
-
-    routing_policy = "MULTIVALUE"
-  }
-
-  health_check_custom_config {
-    failure_threshold = 1
-  }
-}`, rName, domainName)
-}
-
-func testAccInstanceHTTPNamespaceConfig(rName, domainName string) string {
-	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
-resource "aws_instance" "test_instance" {
-  instance_type = "t2.micro"
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_service_discovery_http_namespace" "sd_register_instance" {
-  name = %[2]q
-}
-
-resource "aws_service_discovery_service" "sd_register_instance" {
-  name         = %[1]q
-  namespace_id = aws_service_discovery_http_namespace.sd_register_instance.id
-}`, rName, domainName))
-}
-
-func testAccInstanceConfig(instanceID string, attributes string) string {
-	return fmt.Sprintf(`
-resource "aws_service_discovery_instance" "instance" {
-  service_id  = aws_service_discovery_service.sd_register_instance.id
-  instance_id = %[1]q
-
-  attributes = {
-    %[2]s
-  }
-}`, instanceID, attributes)
 }
 
 func testAccCheckInstanceExists(name string) resource.TestCheckFunc {
@@ -327,4 +203,128 @@ func testAccCheckInstanceDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccInstanceConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "sd_register_instance" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %q
+  }
+}`, rName)
+}
+
+func testAccInstanceConfig_private(rName, domainName, attributes string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_base(rName),
+		testAccInstanceConfig_privateNamespace(rName, domainName),
+		testAccInstanceConfig_basic(rName, attributes),
+	)
+}
+
+func testAccInstanceConfig_public(rName, domainName, attributes string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_base(rName),
+		testAccInstanceConfig_publicNamespace(rName, domainName),
+		testAccInstanceConfig_basic(rName, attributes),
+	)
+}
+
+func testAccInstanceConfig_http(rName, domainName, attributes string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_base(rName),
+		testAccInstanceConfig_httpNamespace(rName, domainName),
+		testAccInstanceConfig_basic(rName, attributes),
+	)
+}
+
+func testAccInstanceConfig_privateNamespace(rName, domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_private_dns_namespace" "sd_register_instance" {
+  name        = %[2]q
+  description = %[1]q
+  vpc         = aws_vpc.sd_register_instance.id
+}
+
+resource "aws_service_discovery_service" "sd_register_instance" {
+  name = %[1]q
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.sd_register_instance.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}`, rName, domainName)
+}
+
+func testAccInstanceConfig_publicNamespace(rName, domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_public_dns_namespace" "sd_register_instance" {
+  name = %[2]q
+}
+
+resource "aws_service_discovery_service" "sd_register_instance" {
+  name = %[1]q
+
+  dns_config {
+    namespace_id = aws_service_discovery_public_dns_namespace.sd_register_instance.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}`, rName, domainName)
+}
+
+func testAccInstanceConfig_httpNamespace(rName, domainName string) string {
+	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
+resource "aws_instance" "test_instance" {
+  instance_type = "t2.micro"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_service_discovery_http_namespace" "sd_register_instance" {
+  name = %[2]q
+}
+
+resource "aws_service_discovery_service" "sd_register_instance" {
+  name         = %[1]q
+  namespace_id = aws_service_discovery_http_namespace.sd_register_instance.id
+}`, rName, domainName))
+}
+
+func testAccInstanceConfig_basic(instanceID string, attributes string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_instance" "instance" {
+  service_id  = aws_service_discovery_service.sd_register_instance.id
+  instance_id = %[1]q
+
+  attributes = {
+    %[2]s
+  }
+}`, instanceID, attributes)
 }


### PR DESCRIPTION
- servicediscovery: Fix test configs names
- servicediscovery: Fix test configs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
