### PR TITLE
secretsmanager: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -339,7 +339,6 @@ rules:
         - internal/service/s3control
         - internal/service/s3outposts
         - internal/service/schemas
-        - internal/service/secretsmanager
         - internal/service/servicecatalog
         - internal/service/servicediscovery
         - internal/service/servicequotas

--- a/internal/service/location/place_index_data_source_test.go
+++ b/internal/service/location/place_index_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccLocationPlaceIndexDataSource_indexName(t *testing.T) {
 		CheckDestroy:      testAccCheckPlaceIndexDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigPlaceIndexDataSource_indexName(rName),
+				Config: testAccPlaceIndexDataSourceConfig_indexName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "create_time", resourceName, "create_time"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "data_source", resourceName, "data_source"),
@@ -39,7 +39,7 @@ func TestAccLocationPlaceIndexDataSource_indexName(t *testing.T) {
 	})
 }
 
-func testAccConfigPlaceIndexDataSource_indexName(rName string) string {
+func testAccPlaceIndexDataSourceConfig_indexName(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_location_place_index" "test" {
   data_source = "Here"

--- a/internal/service/secretsmanager/secret_data_source_test.go
+++ b/internal/service/secretsmanager/secret_data_source_test.go
@@ -19,15 +19,15 @@ func TestAccSecretsManagerSecretDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecretDataSourceConfig_MissingRequired,
+				Config:      testAccSecretDataSourceConfig_missingRequired,
 				ExpectError: regexp.MustCompile(`must specify either arn or name`),
 			},
 			{
-				Config:      testAccSecretDataSourceConfig_MultipleSpecified,
+				Config:      testAccSecretDataSourceConfig_multipleSpecified,
 				ExpectError: regexp.MustCompile(`specify only arn or name`),
 			},
 			{
-				Config:      testAccSecretDataSourceConfig_NonExistent,
+				Config:      testAccSecretDataSourceConfig_nonExistent,
 				ExpectError: regexp.MustCompile(`not found`),
 			},
 		},
@@ -45,7 +45,7 @@ func TestAccSecretsManagerSecretDataSource_arn(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretDataSourceConfig_ARN(rName),
+				Config: testAccSecretDataSourceConfig_arn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretCheckDataSource(datasourceName, resourceName),
 				),
@@ -65,7 +65,7 @@ func TestAccSecretsManagerSecretDataSource_name(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretDataSourceConfig_Name(rName),
+				Config: testAccSecretDataSourceConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretCheckDataSource(datasourceName, resourceName),
 				),
@@ -85,7 +85,7 @@ func TestAccSecretsManagerSecretDataSource_policy(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretDataSourceConfig_Policy(rName),
+				Config: testAccSecretDataSourceConfig_policy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretCheckDataSource(datasourceName, resourceName),
 				),
@@ -133,7 +133,7 @@ func testAccSecretCheckDataSource(datasourceName, resourceName string) resource.
 	}
 }
 
-func testAccSecretDataSourceConfig_ARN(rName string) string {
+func testAccSecretDataSourceConfig_arn(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "wrong" {
   name = "%[1]s-wrong"
@@ -149,19 +149,19 @@ data "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-const testAccSecretDataSourceConfig_MissingRequired = `
+const testAccSecretDataSourceConfig_missingRequired = `
 data "aws_secretsmanager_secret" "test" {}
 `
 
 //lintignore:AWSAT003,AWSAT005
-const testAccSecretDataSourceConfig_MultipleSpecified = `
+const testAccSecretDataSourceConfig_multipleSpecified = `
 data "aws_secretsmanager_secret" "test" {
   arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:tf-acc-test-does-not-exist"
   name = "tf-acc-test-does-not-exist"
 }
 `
 
-func testAccSecretDataSourceConfig_Name(rName string) string {
+func testAccSecretDataSourceConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "wrong" {
   name = "%[1]s-wrong"
@@ -177,7 +177,7 @@ data "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretDataSourceConfig_Policy(rName string) string {
+func testAccSecretDataSourceConfig_policy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%[1]s"
@@ -206,7 +206,7 @@ data "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-const testAccSecretDataSourceConfig_NonExistent = `
+const testAccSecretDataSourceConfig_nonExistent = `
 data "aws_secretsmanager_secret" "test" {
   name = "tf-acc-test-does-not-exist"
 }

--- a/internal/service/secretsmanager/secret_policy_test.go
+++ b/internal/service/secretsmanager/secret_policy_test.go
@@ -29,7 +29,7 @@ func TestAccSecretsManagerSecretPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretPolicyBasicConfig(rName),
+				Config: testAccSecretPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(resourceName, &policy),
 					resource.TestMatchResourceAttr(resourceName, "policy",
@@ -43,7 +43,7 @@ func TestAccSecretsManagerSecretPolicy_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"block_public_policy"},
 			},
 			{
-				Config: testAccSecretPolicyUpdatedConfig(rName),
+				Config: testAccSecretPolicyConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(resourceName, &policy),
 					resource.TestMatchResourceAttr(resourceName, "policy",
@@ -66,7 +66,7 @@ func TestAccSecretsManagerSecretPolicy_blockPublicPolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretPolicyBlockConfig(rName, true),
+				Config: testAccSecretPolicyConfig_block(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(resourceName, &policy),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "true"),
@@ -79,14 +79,14 @@ func TestAccSecretsManagerSecretPolicy_blockPublicPolicy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"block_public_policy"},
 			},
 			{
-				Config: testAccSecretPolicyBlockConfig(rName, false),
+				Config: testAccSecretPolicyConfig_block(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(resourceName, &policy),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "false"),
 				),
 			},
 			{
-				Config: testAccSecretPolicyBlockConfig(rName, true),
+				Config: testAccSecretPolicyConfig_block(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(resourceName, &policy),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "true"),
@@ -108,7 +108,7 @@ func TestAccSecretsManagerSecretPolicy_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretPolicyBasicConfig(rName),
+				Config: testAccSecretPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(resourceName, &policy),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsecretsmanager.ResourceSecretPolicy(), resourceName),
@@ -213,7 +213,7 @@ func testAccCheckSecretPolicyExists(resourceName string, policy *secretsmanager.
 	}
 }
 
-func testAccSecretPolicyBasicConfig(rName string) string {
+func testAccSecretPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name               = %[1]q
@@ -261,7 +261,7 @@ POLICY
 `, rName)
 }
 
-func testAccSecretPolicyUpdatedConfig(rName string) string {
+func testAccSecretPolicyConfig_updated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = %[1]q
@@ -290,7 +290,7 @@ POLICY
 `, rName)
 }
 
-func testAccSecretPolicyBlockConfig(rName string, block bool) string {
+func testAccSecretPolicyConfig_block(rName string, block bool) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name               = %[1]q

--- a/internal/service/secretsmanager/secret_rotation_data_source_test.go
+++ b/internal/service/secretsmanager/secret_rotation_data_source_test.go
@@ -22,11 +22,11 @@ func TestAccSecretsManagerSecretRotationDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecretRotationDataSourceConfig_NonExistent,
+				Config:      testAccSecretRotationDataSourceConfig_nonExistent,
 				ExpectError: regexp.MustCompile(`ResourceNotFoundException`),
 			},
 			{
-				Config: testAccSecretRotationDataSourceConfig_Default(rName, 7),
+				Config: testAccSecretRotationDataSourceConfig_default(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "rotation_enabled", resourceName, "rotation_enabled"),
 					resource.TestCheckResourceAttrPair(datasourceName, "rotation_lambda_arn", resourceName, "rotation_lambda_arn"),
@@ -37,13 +37,13 @@ func TestAccSecretsManagerSecretRotationDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccSecretRotationDataSourceConfig_NonExistent = `
+const testAccSecretRotationDataSourceConfig_nonExistent = `
 data "aws_secretsmanager_secret_rotation" "test" {
   secret_id = "tf-acc-test-does-not-exist"
 }
 `
 
-func testAccSecretRotationDataSourceConfig_Default(rName string, automaticallyAfterDays int) string {
+func testAccSecretRotationDataSourceConfig_default(rName string, automaticallyAfterDays int) string {
 	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
 # Not a real rotation function
 resource "aws_lambda_function" "test" {

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -42,7 +42,7 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 			// InvalidRequestException: A previous rotation isn’t complete. That rotation will be reattempted.
 			/*
 				{
-					Config: testAccSecretRotationConfig_sManagerUpdated(rName),
+					Config: testAccSecretRotationConfig_managerUpdated(rName),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckSecretRotationExists(resourceName, &secret),
 						resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -28,7 +28,7 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creating secret rotation resource
 			{
-				Config: testAccSecretRotationConfig(rName, 7),
+				Config: testAccSecretRotationConfig_basic(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretRotationExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -42,7 +42,7 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 			// InvalidRequestException: A previous rotation isn’t complete. That rotation will be reattempted.
 			/*
 				{
-					Config: testAccSecretsManagerSecretConfig_Updated(rName),
+					Config: testAccSecretRotationConfig_sManagerUpdated(rName),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckSecretRotationExists(resourceName, &secret),
 						resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -121,7 +121,7 @@ func testAccCheckSecretRotationExists(resourceName string, secret *secretsmanage
 	}
 }
 
-func testAccSecretRotationConfig(rName string, automaticallyAfterDays int) string {
+func testAccSecretRotationConfig_basic(rName string, automaticallyAfterDays int) string {
 	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
 # Not a real rotation function
 resource "aws_lambda_function" "test1" {

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -29,7 +29,7 @@ func TestAccSecretsManagerSecret_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretConfig_Name(rName),
+				Config: testAccSecretConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "secretsmanager", regexp.MustCompile(fmt.Sprintf("secret:%s-[[:alnum:]]+$", rName))),
@@ -66,7 +66,7 @@ func TestAccSecretsManagerSecret_withNamePrefix(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretConfig_withNamePrefix("tf-acc-test-prefix-"),
+				Config: testAccSecretConfig_namePrefix("tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
@@ -95,14 +95,14 @@ func TestAccSecretsManagerSecret_description(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretConfig_Description(rName, "description1"),
+				Config: testAccSecretConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
 				),
 			},
 			{
-				Config: testAccSecretConfig_Description(rName, "description2"),
+				Config: testAccSecretConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -191,14 +191,14 @@ func TestAccSecretsManagerSecret_kmsKeyID(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretConfig_KMSKeyID(rName),
+				Config: testAccSecretConfig_kmsKeyID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 				),
 			},
 			{
-				Config: testAccSecretConfig_KMSKeyID_Updated(rName),
+				Config: testAccSecretConfig_kmsKeyIDUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
@@ -226,14 +226,14 @@ func TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretConfig_RecoveryWindowInDays(rName, 0),
+				Config: testAccSecretConfig_recoveryWindowInDays(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "recovery_window_in_days", "0"),
 				),
 			},
 			{
-				Config: testAccSecretConfig_RecoveryWindowInDays(rName, 0),
+				Config: testAccSecretConfig_recoveryWindowInDays(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "recovery_window_in_days", "0"),
@@ -264,7 +264,7 @@ func TestAccSecretsManagerSecret_rotationLambdaARN(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test enabling rotation on resource creation
 			{
-				Config: testAccSecretConfig_RotationLambdaARN(rName),
+				Config: testAccSecretConfig_rotationLambdaARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -276,7 +276,7 @@ func TestAccSecretsManagerSecret_rotationLambdaARN(t *testing.T) {
 			// InvalidRequestException: A previous rotation isn’t complete. That rotation will be reattempted.
 			/*
 				{
-					Config: testAccSecretsManagerSecretConfig_RotationLambdaARN_Updated(rName),
+					Config: testAccSecretConfig_managerRotationLambdaARNUpdated(rName),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckSecretExists(resourceName, &secret),
 						resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -293,7 +293,7 @@ func TestAccSecretsManagerSecret_rotationLambdaARN(t *testing.T) {
 			},
 			// Test removing rotation on resource update
 			{
-				Config: testAccSecretConfig_Name(rName),
+				Config: testAccSecretConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"), // Must be removed with aws_secretsmanager_secret_rotation after version 2.67.0
@@ -316,7 +316,7 @@ func TestAccSecretsManagerSecret_rotationRules(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creating rotation rules on resource creation
 			{
-				Config: testAccSecretConfig_RotationRules(rName, 7),
+				Config: testAccSecretConfig_rotationRules(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -329,7 +329,7 @@ func TestAccSecretsManagerSecret_rotationRules(t *testing.T) {
 			// InvalidRequestException: A previous rotation isn’t complete. That rotation will be reattempted.
 			/*
 				{
-					Config: testAccSecretConfig_RotationRules(rName, 1),
+					Config: testAccSecretConfig_rotationRules(rName, 1),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckSecretExists(resourceName, &secret),
 						resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
@@ -347,7 +347,7 @@ func TestAccSecretsManagerSecret_rotationRules(t *testing.T) {
 			},
 			// Test removing rotation rules on resource update
 			{
-				Config: testAccSecretConfig_Name(rName),
+				Config: testAccSecretConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"), // Must be removed with aws_secretsmanager_secret_rotation after version 2.67.0
@@ -369,7 +369,7 @@ func TestAccSecretsManagerSecret_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretConfig_Tags_Single(rName),
+				Config: testAccSecretConfig_tagsSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -377,7 +377,7 @@ func TestAccSecretsManagerSecret_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretConfig_Tags_SingleUpdated(rName),
+				Config: testAccSecretConfig_tagsSingleUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -385,7 +385,7 @@ func TestAccSecretsManagerSecret_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretConfig_Tags_Multiple(rName),
+				Config: testAccSecretConfig_tagsMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -394,7 +394,7 @@ func TestAccSecretsManagerSecret_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretConfig_Tags_Single(rName),
+				Config: testAccSecretConfig_tagsSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -423,7 +423,7 @@ func TestAccSecretsManagerSecret_policy(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretPolicyConfig(rName),
+				Config: testAccSecretConfig_policy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "description", "San Holo feat. Duskus"),
@@ -432,7 +432,7 @@ func TestAccSecretsManagerSecret_policy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretPolicyEmptyConfig(rName),
+				Config: testAccSecretConfig_policyEmpty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "description", "Poliça"),
@@ -440,7 +440,7 @@ func TestAccSecretsManagerSecret_policy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretPolicyConfig(rName),
+				Config: testAccSecretConfig_policy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists(resourceName, &secret),
 					resource.TestMatchResourceAttr(resourceName, "policy",
@@ -517,7 +517,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccSecretConfig_Description(rName, description string) string {
+func testAccSecretConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   description = "%s"
@@ -604,7 +604,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName, force_overwrite_replica_secret))
 }
 
-func testAccSecretConfig_Name(rName string) string {
+func testAccSecretConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -612,7 +612,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretConfig_withNamePrefix(rName string) string {
+func testAccSecretConfig_namePrefix(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name_prefix = %[1]q
@@ -620,7 +620,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretConfig_KMSKeyID(rName string) string {
+func testAccSecretConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test1" {
   deletion_window_in_days = 7
@@ -637,7 +637,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretConfig_KMSKeyID_Updated(rName string) string {
+func testAccSecretConfig_kmsKeyIDUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test1" {
   deletion_window_in_days = 7
@@ -654,7 +654,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretConfig_RecoveryWindowInDays(rName string, recoveryWindowInDays int) string {
+func testAccSecretConfig_recoveryWindowInDays(rName string, recoveryWindowInDays int) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name                    = %q
@@ -663,7 +663,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName, recoveryWindowInDays)
 }
 
-func testAccSecretConfig_RotationLambdaARN(rName string) string {
+func testAccSecretConfig_rotationLambdaARN(rName string) string {
 	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name                = "%[1]s"
@@ -706,7 +706,7 @@ resource "aws_lambda_permission" "test2" {
 `, rName)
 }
 
-func testAccSecretConfig_RotationRules(rName string, automaticallyAfterDays int) string {
+func testAccSecretConfig_rotationRules(rName string, automaticallyAfterDays int) string {
 	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
 # Not a real rotation function
 resource "aws_lambda_function" "test" {
@@ -737,7 +737,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName, automaticallyAfterDays)
 }
 
-func testAccSecretConfig_Tags_Single(rName string) string {
+func testAccSecretConfig_tagsSingle(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -749,7 +749,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretConfig_Tags_SingleUpdated(rName string) string {
+func testAccSecretConfig_tagsSingleUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -761,7 +761,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretConfig_Tags_Multiple(rName string) string {
+func testAccSecretConfig_tagsMultiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -774,7 +774,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretPolicyConfig(rName string) string {
+func testAccSecretConfig_policy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -812,7 +812,7 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccSecretPolicyEmptyConfig(rName string) string {
+func testAccSecretConfig_policyEmpty(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q

--- a/internal/service/secretsmanager/secret_version_data_source_test.go
+++ b/internal/service/secretsmanager/secret_version_data_source_test.go
@@ -23,11 +23,11 @@ func TestAccSecretsManagerSecretVersionDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecretVersionDataSourceConfig_NonExistent,
+				Config:      testAccSecretVersionDataSourceConfig_nonExistent,
 				ExpectError: regexp.MustCompile(`not found`),
 			},
 			{
-				Config: testAccSecretVersionDataSourceConfig_VersionStage_Default(rName),
+				Config: testAccSecretVersionDataSourceConfig_stageDefault(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
 				),
@@ -47,7 +47,7 @@ func TestAccSecretsManagerSecretVersionDataSource_versionID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionDataSourceConfig_VersionID(rName),
+				Config: testAccSecretVersionDataSourceConfig_id(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
 				),
@@ -67,7 +67,7 @@ func TestAccSecretsManagerSecretVersionDataSource_versionStage(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionDataSourceConfig_VersionStage_Custom(rName),
+				Config: testAccSecretVersionDataSourceConfig_stageCustom(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
 				),
@@ -108,13 +108,13 @@ func testAccSecretVersionCheckDataSource(datasourceName, resourceName string) re
 	}
 }
 
-const testAccSecretVersionDataSourceConfig_NonExistent = `
+const testAccSecretVersionDataSourceConfig_nonExistent = `
 data "aws_secretsmanager_secret_version" "test" {
   secret_id = "tf-acc-test-does-not-exist"
 }
 `
 
-func testAccSecretVersionDataSourceConfig_VersionID(rName string) string {
+func testAccSecretVersionDataSourceConfig_id(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%[1]s"
@@ -132,7 +132,7 @@ data "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccSecretVersionDataSourceConfig_VersionStage_Custom(rName string) string {
+func testAccSecretVersionDataSourceConfig_stageCustom(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%[1]s"
@@ -151,7 +151,7 @@ data "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccSecretVersionDataSourceConfig_VersionStage_Default(rName string) string {
+func testAccSecretVersionDataSourceConfig_stageDefault(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%[1]s"

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -29,7 +29,7 @@ func TestAccSecretsManagerSecretVersion_basicString(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionConfig_SecretString(rName),
+				Config: testAccSecretVersionConfig_string(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -61,7 +61,7 @@ func TestAccSecretsManagerSecretVersion_base64Binary(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionConfig_SecretBinary(rName),
+				Config: testAccSecretVersionConfig_binary(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_binary", verify.Base64Encode([]byte("test-binary"))),
@@ -92,7 +92,7 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionConfig_VersionStages_Single(rName),
+				Config: testAccSecretVersionConfig_stagesSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -102,7 +102,7 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretVersionConfig_VersionStages_SingleUpdated(rName),
+				Config: testAccSecretVersionConfig_stagesSingleUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -112,7 +112,7 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecretVersionConfig_VersionStages_Multiple(rName),
+				Config: testAccSecretVersionConfig_stagesMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -215,7 +215,7 @@ func testAccCheckSecretVersionExists(resourceName string, version *secretsmanage
 	}
 }
 
-func testAccSecretVersionConfig_SecretString(rName string) string {
+func testAccSecretVersionConfig_string(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -228,7 +228,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccSecretVersionConfig_SecretBinary(rName string) string {
+func testAccSecretVersionConfig_binary(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -241,7 +241,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccSecretVersionConfig_VersionStages_Single(rName string) string {
+func testAccSecretVersionConfig_stagesSingle(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -256,7 +256,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccSecretVersionConfig_VersionStages_SingleUpdated(rName string) string {
+func testAccSecretVersionConfig_stagesSingleUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"
@@ -271,7 +271,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccSecretVersionConfig_VersionStages_Multiple(rName string) string {
+func testAccSecretVersionConfig_stagesMultiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = "%s"

--- a/internal/service/secretsmanager/secrets_data_source_test.go
+++ b/internal/service/secretsmanager/secrets_data_source_test.go
@@ -33,11 +33,11 @@ func TestAccSecretsManagerSecretsDataSource_filter(t *testing.T) {
 		CheckDestroy:      testAccCheckSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigSecrets_filter(rName),
+				Config: testAccSecretsDataSourceConfig_filter2(rName),
 				Check:  propagationSleep(),
 			},
 			{
-				Config: testAccConfigSecretsWithDataSource_filter(rName),
+				Config: testAccSecretsDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
@@ -49,7 +49,7 @@ func TestAccSecretsManagerSecretsDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccConfigSecrets_filter(rName string) string {
+func testAccSecretsDataSourceConfig_filter2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = %[1]q
@@ -57,9 +57,9 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccConfigSecretsWithDataSource_filter(rName string) string {
+func testAccSecretsDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(
-		testAccConfigSecrets_filter(rName),
+		testAccSecretsDataSourceConfig_filter2(rName),
 		`
 data "aws_secretsmanager_secrets" "test" {
   filter {


### PR DESCRIPTION
- secretsmanager: Fix test configs names
- location: Fix configs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
