### PR TITLE
codebuild: Fix test configs names

### DIFF
--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -279,7 +279,6 @@ rules:
         - internal/service/cloudtrail
         - internal/service/cloudwatch
         - internal/service/codeartifact
-        - internal/service/codebuild
         - internal/service/codecommit
         - internal/service/codepipeline
         - internal/service/codestarconnections

--- a/.semgrep-service-name0.yml
+++ b/.semgrep-service-name0.yml
@@ -328,7 +328,6 @@ rules:
         - internal/service/rds
         - internal/service/resourcegroups
         - internal/service/resourcegroupstaggingapi
-        - internal/service/route53
         - internal/service/route53domains
         - internal/service/route53recoverycontrolconfig
         - internal/service/route53recoveryreadiness

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -126,7 +126,7 @@ func TestAccCodeBuildProject_publicVisibility(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_projectVisibility(rName, "PUBLIC_READ"),
+				Config: testAccProjectConfig_visibility(rName, "PUBLIC_READ"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "project_visibility", "PUBLIC_READ"),
@@ -139,14 +139,14 @@ func TestAccCodeBuildProject_publicVisibility(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_projectVisibility(rName, "PRIVATE"),
+				Config: testAccProjectConfig_visibility(rName, "PRIVATE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "project_visibility", "PRIVATE"),
 				),
 			},
 			{
-				Config: testAccProjectConfig_projectVisibility_resourceRole(rName, "PRIVATE"),
+				Config: testAccProjectConfig_visibilityResourceRole(rName, "PRIVATE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "project_visibility", "PRIVATE"),
@@ -169,7 +169,7 @@ func TestAccCodeBuildProject_badgeEnabled(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_BadgeEnabled(rName, true),
+				Config: testAccProjectConfig_badgeEnabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "badge_enabled", "true"),
@@ -197,7 +197,7 @@ func TestAccCodeBuildProject_buildTimeout(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_BuildTimeout(rName, 120),
+				Config: testAccProjectConfig_buildTimeout(rName, 120),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "build_timeout", "120"),
@@ -209,7 +209,7 @@ func TestAccCodeBuildProject_buildTimeout(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_BuildTimeout(rName, 240),
+				Config: testAccProjectConfig_buildTimeout(rName, 240),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "build_timeout", "240"),
@@ -231,7 +231,7 @@ func TestAccCodeBuildProject_queuedTimeout(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_QueuedTimeout(rName, 120),
+				Config: testAccProjectConfig_queuedTimeout(rName, 120),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "queued_timeout", "120"),
@@ -243,7 +243,7 @@ func TestAccCodeBuildProject_queuedTimeout(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_QueuedTimeout(rName, 240),
+				Config: testAccProjectConfig_queuedTimeout(rName, 240),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "queued_timeout", "240"),
@@ -267,11 +267,11 @@ func TestAccCodeBuildProject_cache(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccProjectConfig_Cache(rName, "", "S3"),
+				Config:      testAccProjectConfig_cache(rName, "", "S3"),
 				ExpectError: regexp.MustCompile(`cache location is required when cache type is "S3"`),
 			},
 			{
-				Config: testAccProjectConfig_Cache(rName, "", codebuild.CacheTypeNoCache),
+				Config: testAccProjectConfig_cache(rName, "", codebuild.CacheTypeNoCache),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
@@ -292,7 +292,7 @@ func TestAccCodeBuildProject_cache(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_Cache(rName, s3Location1, "S3"),
+				Config: testAccProjectConfig_cache(rName, s3Location1, "S3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
@@ -301,7 +301,7 @@ func TestAccCodeBuildProject_cache(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_Cache(rName, s3Location2, "S3"),
+				Config: testAccProjectConfig_cache(rName, s3Location2, "S3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
@@ -318,7 +318,7 @@ func TestAccCodeBuildProject_cache(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_LocalCache(rName, "LOCAL_DOCKER_LAYER_CACHE"),
+				Config: testAccProjectConfig_localCache(rName, "LOCAL_DOCKER_LAYER_CACHE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
@@ -327,7 +327,7 @@ func TestAccCodeBuildProject_cache(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_S3_ComputedLocation(rName),
+				Config: testAccProjectConfig_s3ComputedLocation(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
@@ -350,7 +350,7 @@ func TestAccCodeBuildProject_description(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Description(rName, "description1"),
+				Config: testAccProjectConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
@@ -362,7 +362,7 @@ func TestAccCodeBuildProject_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Description(rName, "description2"),
+				Config: testAccProjectConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -384,7 +384,7 @@ func TestAccCodeBuildProject_fileSystemLocations(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_FileSystemLocations(rName, "/mount1"),
+				Config: testAccProjectConfig_fileSystemLocations(rName, "/mount1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "environment.#", "1"),
@@ -407,7 +407,7 @@ func TestAccCodeBuildProject_fileSystemLocations(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_FileSystemLocations(rName, "/mount2"),
+				Config: testAccProjectConfig_fileSystemLocations(rName, "/mount2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "file_system_locations.#", "1"),
@@ -434,7 +434,7 @@ func TestAccCodeBuildProject_sourceVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SourceVersion(rName, "master"),
+				Config: testAccProjectConfig_sourceVersion(rName, "master"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source_version", "master"),
@@ -456,7 +456,7 @@ func TestAccCodeBuildProject_encryptionKey(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_EncryptionKey(rName),
+				Config: testAccProjectConfig_encryptionKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_key", "aws_kms_key.test", "arn"),
@@ -483,7 +483,7 @@ func TestAccCodeBuildProject_Environment_environmentVariable(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_One(rName, "KEY1", "VALUE1"),
+				Config: testAccProjectConfig_environmentVariableOne(rName, "KEY1", "VALUE1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project1),
 				),
@@ -494,7 +494,7 @@ func TestAccCodeBuildProject_Environment_environmentVariable(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_Two(rName, "KEY1", "VALUE1UPDATED", "KEY2", "VALUE2"),
+				Config: testAccProjectConfig_environmentVariableTwo(rName, "KEY1", "VALUE1UPDATED", "KEY2", "VALUE2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project2),
 				),
@@ -505,7 +505,7 @@ func TestAccCodeBuildProject_Environment_environmentVariable(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_Zero(rName),
+				Config: testAccProjectConfig_environmentVariableZero(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project3),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.environment_variable.#", "0"),
@@ -532,7 +532,7 @@ func TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_Type(rName, codebuild.EnvironmentVariableTypePlaintext),
+				Config: testAccProjectConfig_environmentVariableType(rName, codebuild.EnvironmentVariableTypePlaintext),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.environment_variable.0.type", codebuild.EnvironmentVariableTypePlaintext),
@@ -545,7 +545,7 @@ func TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_Type(rName, codebuild.EnvironmentVariableTypeParameterStore),
+				Config: testAccProjectConfig_environmentVariableType(rName, codebuild.EnvironmentVariableTypeParameterStore),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.environment_variable.0.type", codebuild.EnvironmentVariableTypePlaintext),
@@ -553,7 +553,7 @@ func TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_Type(rName, codebuild.EnvironmentVariableTypeSecretsManager),
+				Config: testAccProjectConfig_environmentVariableType(rName, codebuild.EnvironmentVariableTypeSecretsManager),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.environment_variable.0.type", codebuild.EnvironmentVariableTypePlaintext),
@@ -576,7 +576,7 @@ func TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value(t *testing.T) 
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_One(rName, "KEY1", ""),
+				Config: testAccProjectConfig_environmentVariableOne(rName, "KEY1", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project1),
 				),
@@ -587,7 +587,7 @@ func TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_One(rName, "KEY1", "VALUE1"),
+				Config: testAccProjectConfig_environmentVariableOne(rName, "KEY1", "VALUE1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project2),
 				),
@@ -598,7 +598,7 @@ func TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Environment_EnvironmentVariable_One(rName, "KEY1", ""),
+				Config: testAccProjectConfig_environmentVariableOne(rName, "KEY1", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project3),
 				),
@@ -625,7 +625,7 @@ func TestAccCodeBuildProject_Environment_certificate(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Environment_Certificate(rName, oName),
+				Config: testAccProjectConfig_environmentCertificate(rName, oName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					testAccCheckProjectCertificate(&project, fmt.Sprintf("%s/%s", rName, oName)),
@@ -652,7 +652,7 @@ func TestAccCodeBuildProject_Logs_cloudWatchLogs(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_LogsConfig_CloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", ""),
+				Config: testAccProjectConfig_logsCloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -661,7 +661,7 @@ func TestAccCodeBuildProject_Logs_cloudWatchLogs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_LogsConfig_CloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", "stream-name"),
+				Config: testAccProjectConfig_logsCloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", "stream-name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -670,7 +670,7 @@ func TestAccCodeBuildProject_Logs_cloudWatchLogs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_LogsConfig_CloudWatchLogs(rName, codebuild.LogsConfigStatusTypeDisabled, "", ""),
+				Config: testAccProjectConfig_logsCloudWatchLogs(rName, codebuild.LogsConfigStatusTypeDisabled, "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", codebuild.LogsConfigStatusTypeDisabled),
@@ -697,7 +697,7 @@ func TestAccCodeBuildProject_Logs_s3Logs(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_LogsConfig_S3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", false),
+				Config: testAccProjectConfig_logsS3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -706,7 +706,7 @@ func TestAccCodeBuildProject_Logs_s3Logs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_LogsConfig_S3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", true),
+				Config: testAccProjectConfig_logsS3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -715,7 +715,7 @@ func TestAccCodeBuildProject_Logs_s3Logs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_LogsConfig_S3Logs(rName, codebuild.LogsConfigStatusTypeDisabled, "", false),
+				Config: testAccProjectConfig_logsS3Logs(rName, codebuild.LogsConfigStatusTypeDisabled, "", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", codebuild.LogsConfigStatusTypeDisabled),
@@ -746,7 +746,7 @@ func TestAccCodeBuildProject_buildBatch(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_BuildBatchConfig(rName, true, "BUILD_GENERAL1_SMALL", 10, 5),
+				Config: testAccProjectConfig_buildBatch(rName, true, "BUILD_GENERAL1_SMALL", 10, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.combine_artifacts", "true"),
@@ -763,7 +763,7 @@ func TestAccCodeBuildProject_buildBatch(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_BuildBatchConfig(rName, false, "BUILD_GENERAL1_MEDIUM", 20, 10),
+				Config: testAccProjectConfig_buildBatch(rName, false, "BUILD_GENERAL1_MEDIUM", 20, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.combine_artifacts", "false"),
@@ -790,7 +790,7 @@ func TestAccCodeBuildProject_Source_gitCloneDepth(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_GitCloneDepth(rName, 1),
+				Config: testAccProjectConfig_sourceGitCloneDepth(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.git_clone_depth", "1"),
@@ -802,7 +802,7 @@ func TestAccCodeBuildProject_Source_gitCloneDepth(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_GitCloneDepth(rName, 2),
+				Config: testAccProjectConfig_sourceGitCloneDepth(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.git_clone_depth", "2"),
@@ -824,7 +824,7 @@ func TestAccCodeBuildProject_SourceGitSubmodules_codeCommit(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_GitSubmodulesConfig_CodeCommit(rName, true),
+				Config: testAccProjectConfig_sourceGitSubmodulesCodeCommit(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.git_submodules_config.#", "1"),
@@ -837,7 +837,7 @@ func TestAccCodeBuildProject_SourceGitSubmodules_codeCommit(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_GitSubmodulesConfig_CodeCommit(rName, false),
+				Config: testAccProjectConfig_sourceGitSubmodulesCodeCommit(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.git_submodules_config.#", "1"),
@@ -860,7 +860,7 @@ func TestAccCodeBuildProject_SourceGitSubmodules_gitHub(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_GitSubmodulesConfig_GitHub(rName, true),
+				Config: testAccProjectConfig_sourceGitSubmodulesGitHub(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -871,7 +871,7 @@ func TestAccCodeBuildProject_SourceGitSubmodules_gitHub(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_GitSubmodulesConfig_GitHub(rName, false),
+				Config: testAccProjectConfig_sourceGitSubmodulesGitHub(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -892,7 +892,7 @@ func TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise(t *testing.T) 
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_GitSubmodulesConfig_GitHubEnterprise(rName, true),
+				Config: testAccProjectConfig_sourceGitSubmodulesGitHubEnterprise(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -903,7 +903,7 @@ func TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_GitSubmodulesConfig_GitHubEnterprise(rName, false),
+				Config: testAccProjectConfig_sourceGitSubmodulesGitHubEnterprise(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -924,7 +924,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit(t *testing
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_CodeCommit(rName, true),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesCodeCommit(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "2"),
@@ -946,7 +946,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit(t *testing
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_CodeCommit(rName, false),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesCodeCommit(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "2"),
@@ -963,7 +963,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit(t *testing
 				),
 			},
 			{
-				Config: testAccProjectConfig_SecondarySources_none(rName, false),
+				Config: testAccProjectConfig_secondarySourcesNone(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "0"),
@@ -985,7 +985,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub(t *testing.T) 
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_GitHub(rName, true),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesGitHub(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -996,7 +996,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_GitHub(rName, false),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesGitHub(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -1017,7 +1017,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise(t *t
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_GitHubEnterprise(rName, true),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesGitHubEnterprise(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -1028,7 +1028,7 @@ func TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise(t *t
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_GitHubEnterprise(rName, false),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesGitHubEnterprise(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -1049,7 +1049,7 @@ func TestAccCodeBuildProject_SecondarySourcesVersions(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondarySourceVersions_CodeCommit(rName),
+				Config: testAccProjectConfig_secondarySourceVersionsCodeCommit(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "2"),
@@ -1072,7 +1072,7 @@ func TestAccCodeBuildProject_SecondarySourcesVersions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondarySourceVersions_CodeCommitUpdated(rName),
+				Config: testAccProjectConfig_secondarySourceVersionsCodeCommitUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "2"),
@@ -1094,7 +1094,7 @@ func TestAccCodeBuildProject_SecondarySourcesVersions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_SecondarySourceVersions_CodeCommit(rName),
+				Config: testAccProjectConfig_secondarySourceVersionsCodeCommit(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "2"),
@@ -1112,7 +1112,7 @@ func TestAccCodeBuildProject_SecondarySourcesVersions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_SecondarySources_GitSubmodulesConfig_CodeCommit(rName, false),
+				Config: testAccProjectConfig_secondarySourcesGitSubmodulesCodeCommit(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.#", "2"),
@@ -1145,7 +1145,7 @@ func TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_BuildStatusConfig_GitHubEnterprise(rName),
+				Config: testAccProjectConfig_sourceBuildStatusGitHubEnterprise(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -1171,7 +1171,7 @@ func TestAccCodeBuildProject_Source_insecureSSL(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_InsecureSSL(rName, true),
+				Config: testAccProjectConfig_sourceInsecureSSL(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.insecure_ssl", "true"),
@@ -1183,7 +1183,7 @@ func TestAccCodeBuildProject_Source_insecureSSL(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_InsecureSSL(rName, false),
+				Config: testAccProjectConfig_sourceInsecureSSL(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.insecure_ssl", "false"),
@@ -1207,7 +1207,7 @@ func TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_ReportBuildStatus_Bitbucket(rName, sourceLocation, true),
+				Config: testAccProjectConfig_sourceReportBuildStatusBitbucket(rName, sourceLocation, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.report_build_status", "true"),
@@ -1219,7 +1219,7 @@ func TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_ReportBuildStatus_Bitbucket(rName, sourceLocation, false),
+				Config: testAccProjectConfig_sourceReportBuildStatusBitbucket(rName, sourceLocation, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.report_build_status", "false"),
@@ -1241,7 +1241,7 @@ func TestAccCodeBuildProject_SourceReportBuildStatus_gitHub(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_ReportBuildStatus_GitHub(rName, true),
+				Config: testAccProjectConfig_sourceReportBuildStatusGitHub(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.report_build_status", "true"),
@@ -1253,7 +1253,7 @@ func TestAccCodeBuildProject_SourceReportBuildStatus_gitHub(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_ReportBuildStatus_GitHub(rName, false),
+				Config: testAccProjectConfig_sourceReportBuildStatusGitHub(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.report_build_status", "false"),
@@ -1275,7 +1275,7 @@ func TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise(t *testing
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName, true),
+				Config: testAccProjectConfig_sourceReportBuildStatusGitHubEnterprise(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.report_build_status", "true"),
@@ -1287,7 +1287,7 @@ func TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise(t *testing
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName, false),
+				Config: testAccProjectConfig_sourceReportBuildStatusGitHubEnterprise(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.report_build_status", "false"),
@@ -1311,7 +1311,7 @@ func TestAccCodeBuildProject_SourceType_bitbucket(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_Type_Bitbucket(rName, sourceLocation),
+				Config: testAccProjectConfig_sourceTypeBitbucket(rName, sourceLocation),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.type", "BITBUCKET"),
@@ -1339,7 +1339,7 @@ func TestAccCodeBuildProject_SourceType_codeCommit(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_Type_CodeCommit(rName),
+				Config: testAccProjectConfig_sourceTypeCodeCommit(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.type", "CODECOMMIT"),
@@ -1366,7 +1366,7 @@ func TestAccCodeBuildProject_SourceType_codePipeline(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_Type_CodePipeline(rName),
+				Config: testAccProjectConfig_sourceTypeCodePipeline(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.type", "CODEPIPELINE"),
@@ -1393,7 +1393,7 @@ func TestAccCodeBuildProject_SourceType_gitHubEnterprise(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_Type_GitHubEnterprise(rName),
+				Config: testAccProjectConfig_sourceTypeGitHubEnterprise(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.type", "GITHUB_ENTERPRISE"),
@@ -1420,7 +1420,7 @@ func TestAccCodeBuildProject_SourceType_s3(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_Type_S3(rName),
+				Config: testAccProjectConfig_sourceTypeS3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -1453,7 +1453,7 @@ phases:
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Source_Type_NoSource(rName, "", rBuildspec),
+				Config: testAccProjectConfig_sourceTypeNoSource(rName, "", rBuildspec),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.type", "NO_SOURCE"),
@@ -1485,11 +1485,11 @@ phases:
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccProjectConfig_Source_Type_NoSource(rName, "", ""),
+				Config:      testAccProjectConfig_sourceTypeNoSource(rName, "", ""),
 				ExpectError: regexp.MustCompile("`buildspec` must be set when source's `type` is `NO_SOURCE`"),
 			},
 			{
-				Config:      testAccProjectConfig_Source_Type_NoSource(rName, "location", rBuildspec),
+				Config:      testAccProjectConfig_sourceTypeNoSource(rName, "location", rBuildspec),
 				ExpectError: regexp.MustCompile("`location` must be empty when source's `type` is `NO_SOURCE`"),
 			},
 		},
@@ -1508,7 +1508,7 @@ func TestAccCodeBuildProject_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Tags(rName, "tag2", "tag2value"),
+				Config: testAccProjectConfig_tags(rName, "tag2", "tag2value"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -1522,7 +1522,7 @@ func TestAccCodeBuildProject_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Tags(rName, "tag2", "tag2value-updated"),
+				Config: testAccProjectConfig_tags(rName, "tag2", "tag2value-updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -1546,7 +1546,7 @@ func TestAccCodeBuildProject_vpc(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_VPCConfig2(rName),
+				Config: testAccProjectConfig_vpc2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
@@ -1561,7 +1561,7 @@ func TestAccCodeBuildProject_vpc(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_VPCConfig1(rName),
+				Config: testAccProjectConfig_vpc1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
@@ -1593,7 +1593,7 @@ func TestAccCodeBuildProject_windowsServer2019Container(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_WindowsServer2019Container(rName),
+				Config: testAccProjectConfig_windowsServer2019Container(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "environment.#", "1"),
@@ -1626,7 +1626,7 @@ func TestAccCodeBuildProject_armContainer(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_ARMContainer(rName),
+				Config: testAccProjectConfig_armContainer(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -1655,7 +1655,7 @@ func TestAccCodeBuildProject_Artifacts_artifactIdentifier(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_ArtifactIdentifier(rName, artifactIdentifier1),
+				Config: testAccProjectConfig_artifactsArtifactIdentifier(rName, artifactIdentifier1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1668,7 +1668,7 @@ func TestAccCodeBuildProject_Artifacts_artifactIdentifier(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_ArtifactIdentifier(rName, artifactIdentifier2),
+				Config: testAccProjectConfig_artifactsArtifactIdentifier(rName, artifactIdentifier2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1691,7 +1691,7 @@ func TestAccCodeBuildProject_Artifacts_encryptionDisabled(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_EncryptionDisabled(rName, true),
+				Config: testAccProjectConfig_artifactsEncryptionDisabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1704,7 +1704,7 @@ func TestAccCodeBuildProject_Artifacts_encryptionDisabled(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_EncryptionDisabled(rName, false),
+				Config: testAccProjectConfig_artifactsEncryptionDisabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1728,7 +1728,7 @@ func TestAccCodeBuildProject_Artifacts_location(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_Location(rName1, rName1),
+				Config: testAccProjectConfig_artifactsLocation(rName1, rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1741,7 +1741,7 @@ func TestAccCodeBuildProject_Artifacts_location(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_Location(rName1, rName2),
+				Config: testAccProjectConfig_artifactsLocation(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1767,7 +1767,7 @@ func TestAccCodeBuildProject_Artifacts_name(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_Name(rName, name1),
+				Config: testAccProjectConfig_artifactsName(rName, name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1780,7 +1780,7 @@ func TestAccCodeBuildProject_Artifacts_name(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_Name(rName, name2),
+				Config: testAccProjectConfig_artifactsName(rName, name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1803,7 +1803,7 @@ func TestAccCodeBuildProject_Artifacts_namespaceType(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_NamespaceType(rName, codebuild.ArtifactNamespaceBuildId),
+				Config: testAccProjectConfig_artifactsNamespaceType(rName, codebuild.ArtifactNamespaceBuildId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1816,7 +1816,7 @@ func TestAccCodeBuildProject_Artifacts_namespaceType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_NamespaceType(rName, codebuild.ArtifactNamespaceNone),
+				Config: testAccProjectConfig_artifactsNamespaceType(rName, codebuild.ArtifactNamespaceNone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1839,7 +1839,7 @@ func TestAccCodeBuildProject_Artifacts_overrideArtifactName(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_OverrideArtifactName(rName, true),
+				Config: testAccProjectConfig_artifactsOverrideArtifactName(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1852,7 +1852,7 @@ func TestAccCodeBuildProject_Artifacts_overrideArtifactName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_OverrideArtifactName(rName, false),
+				Config: testAccProjectConfig_artifactsOverrideArtifactName(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1875,7 +1875,7 @@ func TestAccCodeBuildProject_Artifacts_packaging(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_Packaging(rName, codebuild.ArtifactPackagingZip),
+				Config: testAccProjectConfig_artifactsPackaging(rName, codebuild.ArtifactPackagingZip),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1888,7 +1888,7 @@ func TestAccCodeBuildProject_Artifacts_packaging(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_Packaging(rName, codebuild.ArtifactPackagingNone),
+				Config: testAccProjectConfig_artifactsPackaging(rName, codebuild.ArtifactPackagingNone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1911,7 +1911,7 @@ func TestAccCodeBuildProject_Artifacts_path(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_Path(rName, "path1"),
+				Config: testAccProjectConfig_artifactsPath(rName, "path1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1924,7 +1924,7 @@ func TestAccCodeBuildProject_Artifacts_path(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_Path(rName, "path2"),
+				Config: testAccProjectConfig_artifactsPath(rName, "path2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1950,7 +1950,7 @@ func TestAccCodeBuildProject_Artifacts_type(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_Type(rName, type1),
+				Config: testAccProjectConfig_artifactsType(rName, type1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1963,7 +1963,7 @@ func TestAccCodeBuildProject_Artifacts_type(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_Type(rName, type2),
+				Config: testAccProjectConfig_artifactsType(rName, type2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1986,7 +1986,7 @@ func TestAccCodeBuildProject_Artifacts_bucketOwnerAccess(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Artifacts_BucketOwnerAccess(rName, "FULL"),
+				Config: testAccProjectConfig_artifactsBucketOwnerAccess(rName, "FULL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -1999,7 +1999,7 @@ func TestAccCodeBuildProject_Artifacts_bucketOwnerAccess(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Artifacts_BucketOwnerAccess(rName, "READ_ONLY"),
+				Config: testAccProjectConfig_artifactsBucketOwnerAccess(rName, "READ_ONLY"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
@@ -2022,7 +2022,7 @@ func TestAccCodeBuildProject_secondaryArtifacts(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts(rName),
+				Config: testAccProjectConfig_secondaryArtifacts(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "2"),
@@ -2034,7 +2034,7 @@ func TestAccCodeBuildProject_secondaryArtifacts(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_none(rName),
+				Config: testAccProjectConfig_secondaryArtifactsNone(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "0"),
@@ -2059,7 +2059,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier(t *testing.T)
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_ArtifactIdentifier(rName, artifactIdentifier1),
+				Config: testAccProjectConfig_secondaryArtifactsArtifactIdentifier(rName, artifactIdentifier1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2074,7 +2074,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier(t *testing.T)
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_ArtifactIdentifier(rName, artifactIdentifier2),
+				Config: testAccProjectConfig_secondaryArtifactsArtifactIdentifier(rName, artifactIdentifier2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2099,7 +2099,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName(t *testing.
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_OverrideArtifactName(rName, true),
+				Config: testAccProjectConfig_secondaryArtifactsOverrideArtifactName(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2114,7 +2114,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName(t *testing.
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_OverrideArtifactName(rName, false),
+				Config: testAccProjectConfig_secondaryArtifactsOverrideArtifactName(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2139,7 +2139,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled(t *testing.T)
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_EncryptionDisabled(rName, true),
+				Config: testAccProjectConfig_secondaryArtifactsEncryptionDisabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2154,7 +2154,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled(t *testing.T)
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_EncryptionDisabled(rName, false),
+				Config: testAccProjectConfig_secondaryArtifactsEncryptionDisabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2180,7 +2180,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_location(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Location(rName1, rName1),
+				Config: testAccProjectConfig_secondaryArtifactsLocation(rName1, rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2195,7 +2195,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_location(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Location(rName1, rName2),
+				Config: testAccProjectConfig_secondaryArtifactsLocation(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2225,7 +2225,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_name(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Name(rName, name1),
+				Config: testAccProjectConfig_secondaryArtifactsName(rName, name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2240,7 +2240,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_name(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Name(rName, name2),
+				Config: testAccProjectConfig_secondaryArtifactsName(rName, name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2265,7 +2265,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_namespaceType(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_NamespaceType(rName, codebuild.ArtifactNamespaceBuildId),
+				Config: testAccProjectConfig_secondaryArtifactsNamespaceType(rName, codebuild.ArtifactNamespaceBuildId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2280,7 +2280,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_namespaceType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_NamespaceType(rName, codebuild.ArtifactNamespaceNone),
+				Config: testAccProjectConfig_secondaryArtifactsNamespaceType(rName, codebuild.ArtifactNamespaceNone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2305,7 +2305,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_packaging(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Packaging(rName, codebuild.ArtifactPackagingZip),
+				Config: testAccProjectConfig_secondaryArtifactsPackaging(rName, codebuild.ArtifactPackagingZip),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2320,7 +2320,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_packaging(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Packaging(rName, codebuild.ArtifactPackagingNone),
+				Config: testAccProjectConfig_secondaryArtifactsPackaging(rName, codebuild.ArtifactPackagingNone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2348,7 +2348,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_path(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Path(rName, path1),
+				Config: testAccProjectConfig_secondaryArtifactsPath(rName, path1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2363,7 +2363,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_path(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Path(rName, path2),
+				Config: testAccProjectConfig_secondaryArtifactsPath(rName, path2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2388,7 +2388,7 @@ func TestAccCodeBuildProject_SecondaryArtifacts_type(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondaryArtifacts_Type(rName, codebuild.ArtifactsTypeS3),
+				Config: testAccProjectConfig_secondaryArtifactsType(rName, codebuild.ArtifactsTypeS3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
@@ -2418,7 +2418,7 @@ func TestAccCodeBuildProject_SecondarySources_codeCommit(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_SecondarySources_CodeCommit(rName),
+				Config: testAccProjectConfig_secondarySourcesCodeCommit(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.0.type", "CODECOMMIT"),
@@ -2472,7 +2472,7 @@ func TestAccCodeBuildProject_concurrentBuildLimit(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_ConcurrentBuildLimit(rName, 4),
+				Config: testAccProjectConfig_concurrentBuildLimit(rName, 4),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "concurrent_build_limit", "4"),
@@ -2484,7 +2484,7 @@ func TestAccCodeBuildProject_concurrentBuildLimit(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_ConcurrentBuildLimit(rName, 12),
+				Config: testAccProjectConfig_concurrentBuildLimit(rName, 12),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "concurrent_build_limit", "12"),
@@ -2506,7 +2506,7 @@ func TestAccCodeBuildProject_Environment_registryCredential(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_Environment_RegistryCredential1(rName),
+				Config: testAccProjectConfig_environmentRegistryCredential1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -2517,7 +2517,7 @@ func TestAccCodeBuildProject_Environment_registryCredential(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectConfig_Environment_RegistryCredential2(rName),
+				Config: testAccProjectConfig_environmentRegistryCredential2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 				),
@@ -2730,7 +2730,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, testAccGitHubSourceLocationFromEnv()))
 }
 
-func testAccProjectConfig_projectVisibility(rName, visibility string) string {
+func testAccProjectConfig_visibility(rName, visibility string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name               = %[1]q
@@ -2755,7 +2755,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, testAccGitHubSourceLocationFromEnv(), visibility))
 }
 
-func testAccProjectConfig_projectVisibility_resourceRole(rName, visibility string) string {
+func testAccProjectConfig_visibilityResourceRole(rName, visibility string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name                 = %[1]q
@@ -2781,7 +2781,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, testAccGitHubSourceLocationFromEnv(), visibility))
 }
 
-func testAccProjectConfig_BadgeEnabled(rName string, badgeEnabled bool) string {
+func testAccProjectConfig_badgeEnabled(rName string, badgeEnabled bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   badge_enabled = %[1]t
@@ -2806,7 +2806,7 @@ resource "aws_codebuild_project" "test" {
 `, badgeEnabled, rName))
 }
 
-func testAccProjectConfig_BuildTimeout(rName string, buildTimeout int) string {
+func testAccProjectConfig_buildTimeout(rName string, buildTimeout int) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   build_timeout = %[1]d
@@ -2831,7 +2831,7 @@ resource "aws_codebuild_project" "test" {
 `, buildTimeout, rName))
 }
 
-func testAccProjectConfig_QueuedTimeout(rName string, queuedTimeout int) string {
+func testAccProjectConfig_queuedTimeout(rName string, queuedTimeout int) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   queued_timeout = %[1]d
@@ -2856,7 +2856,7 @@ resource "aws_codebuild_project" "test" {
 `, queuedTimeout, rName))
 }
 
-func testAccProjectConfig_S3_ComputedLocation(rName string) string {
+func testAccProjectConfig_s3ComputedLocation(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket_prefix = "cache"
@@ -2889,7 +2889,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Cache(rName, cacheLocation, cacheType string) string {
+func testAccProjectConfig_cache(rName, cacheLocation, cacheType string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test1" {
   bucket        = "%[1]s-1"
@@ -2930,7 +2930,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, cacheLocation, cacheType))
 }
 
-func testAccProjectConfig_LocalCache(rName, modeType string) string {
+func testAccProjectConfig_localCache(rName, modeType string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -2959,7 +2959,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, modeType))
 }
 
-func testAccProjectConfig_Description(rName, description string) string {
+func testAccProjectConfig_description(rName, description string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   description  = %[1]q
@@ -2984,7 +2984,7 @@ resource "aws_codebuild_project" "test" {
 `, description, rName))
 }
 
-func testAccProjectConfig_SourceVersion(rName, sourceVersion string) string {
+func testAccProjectConfig_sourceVersion(rName, sourceVersion string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3010,7 +3010,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, sourceVersion))
 }
 
-func testAccProjectConfig_EncryptionKey(rName string) string {
+func testAccProjectConfig_encryptionKey(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -3040,7 +3040,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Environment_EnvironmentVariable_One(rName, key1, value1 string) string {
+func testAccProjectConfig_environmentVariableOne(rName, key1, value1 string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3069,7 +3069,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, key1, value1))
 }
 
-func testAccProjectConfig_Environment_EnvironmentVariable_Two(rName, key1, value1, key2, value2 string) string {
+func testAccProjectConfig_environmentVariableTwo(rName, key1, value1, key2, value2 string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3103,7 +3103,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, key1, value1, key2, value2))
 }
 
-func testAccProjectConfig_Environment_EnvironmentVariable_Zero(rName string) string {
+func testAccProjectConfig_environmentVariableZero(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3127,7 +3127,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Environment_EnvironmentVariable_Type(rName, environmentVariableType string) string {
+func testAccProjectConfig_environmentVariableType(rName, environmentVariableType string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3162,7 +3162,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, environmentVariableType))
 }
 
-func testAccProjectConfig_Environment_Certificate(rName string, oName string) string {
+func testAccProjectConfig_environmentCertificate(rName string, oName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -3200,7 +3200,7 @@ resource "aws_codebuild_project" "test" {
 `, oName, rName))
 }
 
-func testAccProjectConfig_Environment_RegistryCredential1(rName string) string {
+func testAccProjectConfig_environmentRegistryCredential1(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3240,7 +3240,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Environment_RegistryCredential2(rName string) string {
+func testAccProjectConfig_environmentRegistryCredential2(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3280,7 +3280,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_LogsConfig_CloudWatchLogs(rName, status, gName, sName string) string {
+func testAccProjectConfig_logsCloudWatchLogs(rName, status, gName, sName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3312,7 +3312,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, status, gName, sName))
 }
 
-func testAccProjectConfig_BuildBatchConfig(rName string, combineArtifacts bool, computeTypesAllowed string, maximumBuildsAllowed, timeoutInMins int) string {
+func testAccProjectConfig_buildBatch(rName string, combineArtifacts bool, computeTypesAllowed string, maximumBuildsAllowed, timeoutInMins int) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3348,7 +3348,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, combineArtifacts, computeTypesAllowed, maximumBuildsAllowed, timeoutInMins))
 }
 
-func testAccProjectConfig_LogsConfig_S3Logs(rName, status, location string, encryptionDisabled bool) string {
+func testAccProjectConfig_logsS3Logs(rName, status, location string, encryptionDisabled bool) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -3387,7 +3387,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, status, location, encryptionDisabled))
 }
 
-func testAccProjectConfig_Source_GitCloneDepth(rName string, gitCloneDepth int) string {
+func testAccProjectConfig_sourceGitCloneDepth(rName string, gitCloneDepth int) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3412,7 +3412,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, gitCloneDepth))
 }
 
-func testAccProjectConfig_Source_GitSubmodulesConfig_CodeCommit(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_sourceGitSubmodulesCodeCommit(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3440,7 +3440,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_Source_GitSubmodulesConfig_GitHub(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_sourceGitSubmodulesGitHub(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3468,7 +3468,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_Source_GitSubmodulesConfig_GitHubEnterprise(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_sourceGitSubmodulesGitHubEnterprise(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3496,7 +3496,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_SecondarySources_GitSubmodulesConfig_CodeCommit(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_secondarySourcesGitSubmodulesCodeCommit(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3544,7 +3544,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_SecondarySources_none(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_secondarySourcesNone(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3572,7 +3572,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_SecondarySources_GitSubmodulesConfig_GitHub(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_secondarySourcesGitSubmodulesGitHub(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3620,7 +3620,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_SecondarySources_GitSubmodulesConfig_GitHubEnterprise(rName string, fetchSubmodules bool) string {
+func testAccProjectConfig_secondarySourcesGitSubmodulesGitHubEnterprise(rName string, fetchSubmodules bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3668,7 +3668,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, fetchSubmodules))
 }
 
-func testAccProjectConfig_SecondarySourceVersions_CodeCommit(rName string) string {
+func testAccProjectConfig_secondarySourceVersionsCodeCommit(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3709,7 +3709,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_SecondarySourceVersions_CodeCommitUpdated(rName string) string {
+func testAccProjectConfig_secondarySourceVersionsCodeCommitUpdated(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3755,7 +3755,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Source_InsecureSSL(rName string, insecureSSL bool) string {
+func testAccProjectConfig_sourceInsecureSSL(rName string, insecureSSL bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3780,7 +3780,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, insecureSSL))
 }
 
-func testAccProjectConfig_Source_ReportBuildStatus_Bitbucket(rName, sourceLocation string, reportBuildStatus bool) string {
+func testAccProjectConfig_sourceReportBuildStatusBitbucket(rName, sourceLocation string, reportBuildStatus bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3805,7 +3805,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, sourceLocation, reportBuildStatus))
 }
 
-func testAccProjectConfig_Source_ReportBuildStatus_GitHub(rName string, reportBuildStatus bool) string {
+func testAccProjectConfig_sourceReportBuildStatusGitHub(rName string, reportBuildStatus bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3830,7 +3830,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, reportBuildStatus))
 }
 
-func testAccProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName string, reportBuildStatus bool) string {
+func testAccProjectConfig_sourceReportBuildStatusGitHubEnterprise(rName string, reportBuildStatus bool) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3855,7 +3855,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, reportBuildStatus))
 }
 
-func testAccProjectConfig_Source_Type_Bitbucket(rName, sourceLocation string) string {
+func testAccProjectConfig_sourceTypeBitbucket(rName, sourceLocation string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3879,7 +3879,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, sourceLocation))
 }
 
-func testAccProjectConfig_Source_Type_CodeCommit(rName string) string {
+func testAccProjectConfig_sourceTypeCodeCommit(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3903,7 +3903,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Source_Type_CodePipeline(rName string) string {
+func testAccProjectConfig_sourceTypeCodePipeline(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3926,7 +3926,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Source_Type_GitHubEnterprise(rName string) string {
+func testAccProjectConfig_sourceTypeGitHubEnterprise(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3950,7 +3950,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Source_Type_S3(rName string) string {
+func testAccProjectConfig_sourceTypeS3(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -3984,7 +3984,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Source_Type_NoSource(rName string, rLocation string, rBuildspec string) string {
+func testAccProjectConfig_sourceTypeNoSource(rName string, rLocation string, rBuildspec string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -4009,7 +4009,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, rLocation, rBuildspec))
 }
 
-func testAccProjectConfig_Tags(rName, tagKey, tagValue string) string {
+func testAccProjectConfig_tags(rName, tagKey, tagValue string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -4039,7 +4039,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, tagKey, tagValue))
 }
 
-func testAccProjectConfig_VPCConfig1(rName string) string {
+func testAccProjectConfig_vpc1(rName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -4097,7 +4097,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_VPCConfig2(rName string) string {
+func testAccProjectConfig_vpc2(rName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -4155,7 +4155,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_WindowsServer2019Container(rName string) string {
+func testAccProjectConfig_windowsServer2019Container(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -4179,7 +4179,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, testAccGitHubSourceLocationFromEnv()))
 }
 
-func testAccProjectConfig_ARMContainer(rName string) string {
+func testAccProjectConfig_armContainer(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -4203,7 +4203,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, testAccGitHubSourceLocationFromEnv()))
 }
 
-func testAccProjectConfig_Artifacts_ArtifactIdentifier(rName string, artifactIdentifier string) string {
+func testAccProjectConfig_artifactsArtifactIdentifier(rName string, artifactIdentifier string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4236,7 +4236,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, artifactIdentifier))
 }
 
-func testAccProjectConfig_Artifacts_EncryptionDisabled(rName string, encryptionDisabled bool) string {
+func testAccProjectConfig_artifactsEncryptionDisabled(rName string, encryptionDisabled bool) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4269,7 +4269,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, encryptionDisabled))
 }
 
-func testAccProjectConfig_Artifacts_Location(rName, bucketName string) string {
+func testAccProjectConfig_artifactsLocation(rName, bucketName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4301,7 +4301,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, bucketName))
 }
 
-func testAccProjectConfig_Artifacts_Name(rName string, name string) string {
+func testAccProjectConfig_artifactsName(rName string, name string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4334,7 +4334,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, name))
 }
 
-func testAccProjectConfig_Artifacts_NamespaceType(rName, namespaceType string) string {
+func testAccProjectConfig_artifactsNamespaceType(rName, namespaceType string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4367,7 +4367,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, namespaceType))
 }
 
-func testAccProjectConfig_Artifacts_OverrideArtifactName(rName string, overrideArtifactName bool) string {
+func testAccProjectConfig_artifactsOverrideArtifactName(rName string, overrideArtifactName bool) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4400,7 +4400,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, overrideArtifactName))
 }
 
-func testAccProjectConfig_Artifacts_Packaging(rName, packaging string) string {
+func testAccProjectConfig_artifactsPackaging(rName, packaging string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4433,7 +4433,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, packaging))
 }
 
-func testAccProjectConfig_Artifacts_Path(rName, path string) string {
+func testAccProjectConfig_artifactsPath(rName, path string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4466,7 +4466,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, path))
 }
 
-func testAccProjectConfig_Artifacts_Type(rName string, artifactType string) string {
+func testAccProjectConfig_artifactsType(rName string, artifactType string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4498,7 +4498,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, artifactType))
 }
 
-func testAccProjectConfig_Artifacts_BucketOwnerAccess(rName string, typ string) string {
+func testAccProjectConfig_artifactsBucketOwnerAccess(rName string, typ string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4531,7 +4531,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, typ))
 }
 
-func testAccProjectConfig_SecondaryArtifacts(rName string) string {
+func testAccProjectConfig_secondaryArtifacts(rName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4575,7 +4575,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_none(rName string) string {
+func testAccProjectConfig_secondaryArtifactsNone(rName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4607,7 +4607,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_ArtifactIdentifier(rName string, artifactIdentifier string) string {
+func testAccProjectConfig_secondaryArtifactsArtifactIdentifier(rName string, artifactIdentifier string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4645,7 +4645,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, artifactIdentifier))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_EncryptionDisabled(rName string, encryptionDisabled bool) string {
+func testAccProjectConfig_secondaryArtifactsEncryptionDisabled(rName string, encryptionDisabled bool) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4684,7 +4684,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, encryptionDisabled))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_Location(rName, bucketName string) string {
+func testAccProjectConfig_secondaryArtifactsLocation(rName, bucketName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4722,7 +4722,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, bucketName))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_Name(rName string, name string) string {
+func testAccProjectConfig_secondaryArtifactsName(rName string, name string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4761,7 +4761,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, name))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_NamespaceType(rName, namespaceType string) string {
+func testAccProjectConfig_secondaryArtifactsNamespaceType(rName, namespaceType string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4800,7 +4800,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, namespaceType))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_OverrideArtifactName(rName string, overrideArtifactName bool) string {
+func testAccProjectConfig_secondaryArtifactsOverrideArtifactName(rName string, overrideArtifactName bool) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4839,7 +4839,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, overrideArtifactName))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_Packaging(rName, packaging string) string {
+func testAccProjectConfig_secondaryArtifactsPackaging(rName, packaging string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4878,7 +4878,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, packaging))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_Path(rName, path string) string {
+func testAccProjectConfig_secondaryArtifactsPath(rName, path string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4917,7 +4917,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, path))
 }
 
-func testAccProjectConfig_SecondaryArtifacts_Type(rName string, artifactType string) string {
+func testAccProjectConfig_secondaryArtifactsType(rName string, artifactType string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`
@@ -4955,7 +4955,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, artifactType))
 }
 
-func testAccProjectConfig_SecondarySources_CodeCommit(rName string) string {
+func testAccProjectConfig_secondarySourcesCodeCommit(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -4991,7 +4991,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_Source_BuildStatusConfig_GitHubEnterprise(rName string) string {
+func testAccProjectConfig_sourceBuildStatusGitHubEnterprise(rName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -5020,7 +5020,7 @@ resource "aws_codebuild_project" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_ConcurrentBuildLimit(rName string, concurrentBuildLimit int) string {
+func testAccProjectConfig_concurrentBuildLimit(rName string, concurrentBuildLimit int) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   concurrent_build_limit = %[1]d
@@ -5045,7 +5045,7 @@ resource "aws_codebuild_project" "test" {
 `, concurrentBuildLimit, rName))
 }
 
-func testAccProjectConfig_FileSystemLocations(rName, mountPoint string) string {
+func testAccProjectConfig_fileSystemLocations(rName, mountPoint string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		acctest.ConfigAvailableAZsNoOptIn(),

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -652,7 +652,7 @@ func TestAccCodeBuildProject_Logs_cloudWatchLogs(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_logsCloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", ""),
+				Config: testAccProjectConfig_cloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -661,7 +661,7 @@ func TestAccCodeBuildProject_Logs_cloudWatchLogs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_logsCloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", "stream-name"),
+				Config: testAccProjectConfig_cloudWatchLogs(rName, codebuild.LogsConfigStatusTypeEnabled, "group-name", "stream-name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -670,7 +670,7 @@ func TestAccCodeBuildProject_Logs_cloudWatchLogs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_logsCloudWatchLogs(rName, codebuild.LogsConfigStatusTypeDisabled, "", ""),
+				Config: testAccProjectConfig_cloudWatchLogs(rName, codebuild.LogsConfigStatusTypeDisabled, "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", codebuild.LogsConfigStatusTypeDisabled),
@@ -697,7 +697,7 @@ func TestAccCodeBuildProject_Logs_s3Logs(t *testing.T) {
 		CheckDestroy:      testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_logsS3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", false),
+				Config: testAccProjectConfig_s3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -706,7 +706,7 @@ func TestAccCodeBuildProject_Logs_s3Logs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_logsS3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", true),
+				Config: testAccProjectConfig_s3Logs(rName, codebuild.LogsConfigStatusTypeEnabled, rName+"/build-log", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", codebuild.LogsConfigStatusTypeEnabled),
@@ -715,7 +715,7 @@ func TestAccCodeBuildProject_Logs_s3Logs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectConfig_logsS3Logs(rName, codebuild.LogsConfigStatusTypeDisabled, "", false),
+				Config: testAccProjectConfig_s3Logs(rName, codebuild.LogsConfigStatusTypeDisabled, "", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", codebuild.LogsConfigStatusTypeDisabled),
@@ -3280,7 +3280,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName))
 }
 
-func testAccProjectConfig_logsCloudWatchLogs(rName, status, gName, sName string) string {
+func testAccProjectConfig_cloudWatchLogs(rName, status, gName, sName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -3348,7 +3348,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, combineArtifacts, computeTypesAllowed, maximumBuildsAllowed, timeoutInMins))
 }
 
-func testAccProjectConfig_logsS3Logs(rName, status, location string, encryptionDisabled bool) string {
+func testAccProjectConfig_s3Logs(rName, status, location string, encryptionDisabled bool) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`

--- a/internal/service/codebuild/report_group_test.go
+++ b/internal/service/codebuild/report_group_test.go
@@ -25,7 +25,7 @@ func TestAccCodeBuildReportGroup_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckReportGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReportGroupBasicConfig(rName),
+				Config: testAccReportGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -57,7 +57,7 @@ func TestAccCodeBuildReportGroup_Export_s3(t *testing.T) {
 		CheckDestroy:      testAccCheckReportGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReportGroupS3ExportConfig(rName),
+				Config: testAccReportGroupConfig_s3Export(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -78,7 +78,7 @@ func TestAccCodeBuildReportGroup_Export_s3(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 			{
-				Config: testAccReportGroupS3ExportUpdatedConfig(rName),
+				Config: testAccReportGroupConfig_s3ExportUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -107,7 +107,7 @@ func TestAccCodeBuildReportGroup_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckReportGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReportGroupTags1Config(rName, "key1", "value1"),
+				Config: testAccReportGroupConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -121,7 +121,7 @@ func TestAccCodeBuildReportGroup_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 			{
-				Config: testAccReportGroupTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccReportGroupConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -130,7 +130,7 @@ func TestAccCodeBuildReportGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccReportGroupTags1Config(rName, "key2", "value2"),
+				Config: testAccReportGroupConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -153,7 +153,7 @@ func TestAccCodeBuildReportGroup_deleteReports(t *testing.T) {
 		CheckDestroy:      testAccCheckReportGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReportGroupDeleteReportsConfig(rName),
+				Config: testAccReportGroupConfig_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -181,7 +181,7 @@ func TestAccCodeBuildReportGroup_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckReportGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReportGroupBasicConfig(rName),
+				Config: testAccReportGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportGroupExists(resourceName, &reportGroup),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceReportGroup(), resourceName),
@@ -253,7 +253,7 @@ func testAccCheckReportGroupExists(name string, reportGroup *codebuild.ReportGro
 	}
 }
 
-func testAccReportGroupBasicConfig(rName string) string {
+func testAccReportGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
   name = %[1]q
@@ -297,7 +297,7 @@ resource "aws_s3_bucket" "test" {
 `, rName)
 }
 
-func testAccReportGroupS3ExportConfig(rName string) string {
+func testAccReportGroupConfig_s3Export(rName string) string {
 	return testAccReportGroupBasicS3ExportBaseConfig(rName) +
 		fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
@@ -319,7 +319,7 @@ resource "aws_codebuild_report_group" "test" {
 `, rName)
 }
 
-func testAccReportGroupS3ExportUpdatedConfig(rName string) string {
+func testAccReportGroupConfig_s3ExportUpdated(rName string) string {
 	return testAccReportGroupBasicS3ExportBaseConfig(rName) +
 		fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
@@ -341,7 +341,7 @@ resource "aws_codebuild_report_group" "test" {
 `, rName)
 }
 
-func testAccReportGroupTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccReportGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
   name = %[1]q
@@ -358,7 +358,7 @@ resource "aws_codebuild_report_group" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccReportGroupTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccReportGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
   name = %[1]q
@@ -376,7 +376,7 @@ resource "aws_codebuild_report_group" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccReportGroupDeleteReportsConfig(rName string) string {
+func testAccReportGroupConfig_delete(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
   name           = %[1]q

--- a/internal/service/codebuild/resource_policy_test.go
+++ b/internal/service/codebuild/resource_policy_test.go
@@ -26,7 +26,7 @@ func TestAccCodeBuildResourcePolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyBasicConfig(rName),
+				Config: testAccResourcePolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_codebuild_report_group.test", "arn"),
@@ -54,7 +54,7 @@ func TestAccCodeBuildResourcePolicy_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyBasicConfig(rName),
+				Config: testAccResourcePolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName, &reportGroup),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceResourcePolicy(), resourceName),
@@ -78,7 +78,7 @@ func TestAccCodeBuildResourcePolicy_disappears_resource(t *testing.T) {
 		CheckDestroy:      testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePolicyBasicConfig(rName),
+				Config: testAccResourcePolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName, &reportGroup),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceReportGroup(), resourceName),
@@ -139,7 +139,7 @@ func testAccCheckResourcePolicyExists(name string, policy *codebuild.GetResource
 	}
 }
 
-func testAccResourcePolicyBasicConfig(rName string) string {
+func testAccResourcePolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_report_group" "test" {
   name = %[1]q

--- a/internal/service/codebuild/source_credential_test.go
+++ b/internal/service/codebuild/source_credential_test.go
@@ -27,7 +27,7 @@ func TestAccCodeBuildSourceCredential_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSourceCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB", token),
+				Config: testAccSourceCredentialConfig_basic("PERSONAL_ACCESS_TOKEN", "GITHUB", token),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codebuild", regexp.MustCompile(`token/github`)),
@@ -36,7 +36,7 @@ func TestAccCodeBuildSourceCredential_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB_ENTERPRISE", token),
+				Config: testAccSourceCredentialConfig_basic("PERSONAL_ACCESS_TOKEN", "GITHUB_ENTERPRISE", token),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codebuild", regexp.MustCompile(`token/github_enterprise`)),
@@ -66,7 +66,7 @@ func TestAccCodeBuildSourceCredential_basicAuth(t *testing.T) {
 		CheckDestroy:      testAccCheckSourceCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSourceCredential_BasicAuth(token, "user1"),
+				Config: testAccSourceCredentialConfig_basicAuth(token, "user1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codebuild", regexp.MustCompile(`token/bitbucket`)),
@@ -76,7 +76,7 @@ func TestAccCodeBuildSourceCredential_basicAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSourceCredential_BasicAuth(token, "user2"),
+				Config: testAccSourceCredentialConfig_basicAuth(token, "user2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					resource.TestCheckResourceAttr(resourceName, "user_name", "user2"),
@@ -104,7 +104,7 @@ func TestAccCodeBuildSourceCredential_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckSourceCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB_ENTERPRISE", token),
+				Config: testAccSourceCredentialConfig_basic("PERSONAL_ACCESS_TOKEN", "GITHUB_ENTERPRISE", token),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceSourceCredential(), resourceName),
@@ -163,7 +163,7 @@ func testAccCheckSourceCredentialExists(name string, sourceCredential *codebuild
 	}
 }
 
-func testAccSourceCredential_Basic(authType, serverType, token string) string {
+func testAccSourceCredentialConfig_basic(authType, serverType, token string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_source_credential" "test" {
   auth_type   = "%s"
@@ -173,7 +173,7 @@ resource "aws_codebuild_source_credential" "test" {
 `, authType, serverType, token)
 }
 
-func testAccSourceCredential_BasicAuth(token, userName string) string {
+func testAccSourceCredentialConfig_basicAuth(token, userName string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_source_credential" "test" {
   auth_type   = "BASIC_AUTH"

--- a/internal/service/codebuild/webhook_test.go
+++ b/internal/service/codebuild/webhook_test.go
@@ -29,7 +29,7 @@ func TestAccCodeBuildWebhook_bitbucket(t *testing.T) {
 		CheckDestroy:      testAccCheckWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebhookConfig_Bitbucket(rName, sourceLocation),
+				Config: testAccWebhookConfig_bitbucket(rName, sourceLocation),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", ""),
@@ -61,7 +61,7 @@ func TestAccCodeBuildWebhook_gitHub(t *testing.T) {
 		CheckDestroy:      testAccCheckWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebhookConfig_GitHub(rName),
+				Config: testAccWebhookConfig_gitHub(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", ""),
@@ -93,7 +93,7 @@ func TestAccCodeBuildWebhook_gitHubEnterprise(t *testing.T) {
 		CheckDestroy:      testAccCheckWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebhookConfig_GitHubEnterprise(rName, "dev"),
+				Config: testAccWebhookConfig_gitHubEnterprise(rName, "dev"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", "dev"),
@@ -110,7 +110,7 @@ func TestAccCodeBuildWebhook_gitHubEnterprise(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"secret"},
 			},
 			{
-				Config: testAccWebhookConfig_GitHubEnterprise(rName, "master"),
+				Config: testAccWebhookConfig_gitHubEnterprise(rName, "master"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", "master"),
@@ -142,21 +142,21 @@ func TestAccCodeBuildWebhook_buildType(t *testing.T) {
 		CheckDestroy:      testAccCheckWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebhookConfig_BuildType(rName, "BUILD"),
+				Config: testAccWebhookConfig_buildType(rName, "BUILD"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "build_type", "BUILD"),
 				),
 			},
 			{
-				Config: testAccWebhookConfig_GitHub(rName),
+				Config: testAccWebhookConfig_gitHub(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccWebhookConfig_BuildType(rName, "BUILD_BATCH"),
+				Config: testAccWebhookConfig_buildType(rName, "BUILD_BATCH"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "build_type", "BUILD_BATCH"),
@@ -184,14 +184,14 @@ func TestAccCodeBuildWebhook_branchFilter(t *testing.T) {
 		CheckDestroy:      testAccCheckWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebhookConfig_BranchFilter(rName, "master"),
+				Config: testAccWebhookConfig_branchFilter(rName, "master"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", "master"),
 				),
 			},
 			{
-				Config: testAccWebhookConfig_BranchFilter(rName, "dev"),
+				Config: testAccWebhookConfig_branchFilter(rName, "dev"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", "dev"),
@@ -219,7 +219,7 @@ func TestAccCodeBuildWebhook_filterGroup(t *testing.T) {
 		CheckDestroy:      testAccCheckWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebhookConfig_FilterGroup(rName),
+				Config: testAccWebhookConfig_filterGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebhookExists(resourceName, &webhook),
 					testAccCheckWebhookFilter(&webhook, [][]*codebuild.WebhookFilter{
@@ -333,9 +333,9 @@ func testAccCheckWebhookExists(name string, webhook *codebuild.Webhook) resource
 	}
 }
 
-func testAccWebhookConfig_Bitbucket(rName, sourceLocation string) string {
+func testAccWebhookConfig_bitbucket(rName, sourceLocation string) string {
 	return acctest.ConfigCompose(
-		testAccProjectConfig_Source_Type_Bitbucket(rName, sourceLocation),
+		testAccProjectConfig_sourceTypeBitbucket(rName, sourceLocation),
 		`
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
@@ -343,7 +343,7 @@ resource "aws_codebuild_webhook" "test" {
 `)
 }
 
-func testAccWebhookConfig_GitHub(rName string) string {
+func testAccWebhookConfig_gitHub(rName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_basic(rName),
 		`
@@ -353,7 +353,7 @@ resource "aws_codebuild_webhook" "test" {
 `)
 }
 
-func testAccWebhookConfig_GitHubEnterprise(rName string, branchFilter string) string {
+func testAccWebhookConfig_gitHubEnterprise(rName string, branchFilter string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
@@ -382,7 +382,7 @@ resource "aws_codebuild_webhook" "test" {
 `, rName, branchFilter))
 }
 
-func testAccWebhookConfig_BuildType(rName, branchFilter string) string {
+func testAccWebhookConfig_buildType(rName, branchFilter string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_basic(rName), fmt.Sprintf(`
 resource "aws_codebuild_webhook" "test" {
   build_type   = %[1]q
@@ -391,7 +391,7 @@ resource "aws_codebuild_webhook" "test" {
 `, branchFilter))
 }
 
-func testAccWebhookConfig_BranchFilter(rName, branchFilter string) string {
+func testAccWebhookConfig_branchFilter(rName, branchFilter string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_basic(rName), fmt.Sprintf(`
 resource "aws_codebuild_webhook" "test" {
   branch_filter = %[1]q
@@ -400,7 +400,7 @@ resource "aws_codebuild_webhook" "test" {
 `, branchFilter))
 }
 
-func testAccWebhookConfig_FilterGroup(rName string) string {
+func testAccWebhookConfig_filterGroup(rName string) string {
 	return acctest.ConfigCompose(
 		testAccProjectConfig_basic(rName),
 		`


### PR DESCRIPTION
- ci: semgrep clean up
- codebuild: Fix test configs names
- codebuild: Fix configs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
