### PR TITLE
vpc: Problem creating multiple managed prefix list entries

### DIFF
--- a/.changelog/25046.txt
+++ b/.changelog/25046.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_managed_prefix_list_entry: Fix error when attempting to create or delete multiple list entries
+```

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -69,7 +69,9 @@ func resourceManagedPrefixListEntryCreate(d *schema.ResourceData, meta interface
 		PrefixListId:   aws.String(plID),
 	}
 
-	_, err = conn.ModifyManagedPrefixList(input)
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+		return conn.ModifyManagedPrefixList(input)
+	}, "IncorrectState")
 
 	if err != nil {
 		return fmt.Errorf("error creating EC2 Managed Prefix List Entry (%s): %w", id, err)

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -51,36 +51,40 @@ func resourceManagedPrefixListEntryCreate(d *schema.ResourceData, meta interface
 	plID := d.Get("prefix_list_id").(string)
 	id := ManagedPrefixListEntryCreateID(plID, cidr)
 
-	pl, err := FindManagedPrefixListByID(conn, plID)
-
-	if err != nil {
-		return fmt.Errorf("error reading EC2 Managed Prefix List (%s): %w", plID, err)
-	}
-
 	addPrefixListEntry := &ec2.AddPrefixListEntry{Cidr: aws.String(cidr)}
 
 	if v, ok := d.GetOk("description"); ok {
 		addPrefixListEntry.Description = aws.String(v.(string))
 	}
 
-	input := &ec2.ModifyManagedPrefixListInput{
-		AddEntries:     []*ec2.AddPrefixListEntry{addPrefixListEntry},
-		CurrentVersion: pl.Version,
-		PrefixListId:   aws.String(plID),
-	}
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
+		conns.GlobalMutexKV.Lock(mutexKey)
+		defer conns.GlobalMutexKV.Unlock(mutexKey)
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+		pl, err := FindManagedPrefixListByID(conn, plID)
+
+		if err != nil {
+			return nil, fmt.Errorf("error reading VPC Managed Prefix List (%s): %w", plID, err)
+		}
+
+		input := &ec2.ModifyManagedPrefixListInput{
+			AddEntries:     []*ec2.AddPrefixListEntry{addPrefixListEntry},
+			CurrentVersion: pl.Version,
+			PrefixListId:   aws.String(plID),
+		}
+
 		return conn.ModifyManagedPrefixList(input)
-	}, "IncorrectState")
+	}, "IncorrectState", "PrefixListVersionMismatch")
 
 	if err != nil {
-		return fmt.Errorf("error creating EC2 Managed Prefix List Entry (%s): %w", id, err)
+		return fmt.Errorf("error creating VPC Managed Prefix List Entry (%s): %w", id, err)
 	}
 
 	d.SetId(id)
 
 	if _, err := WaitManagedPrefixListModified(conn, plID); err != nil {
-		return fmt.Errorf("error waiting for EC2 Managed Prefix List Entry (%s) create: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for VPC Managed Prefix List Entry (%s) create: %w", d.Id(), err)
 	}
 
 	return resourceManagedPrefixListEntryRead(d, meta)
@@ -100,13 +104,13 @@ func resourceManagedPrefixListEntryRead(d *schema.ResourceData, meta interface{}
 	}, d.IsNewResource())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] EC2 Managed Prefix List Entry (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] VPC Managed Prefix List Entry (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Managed Prefix List Entry (%s): %w", d.Id(), err)
+		return fmt.Errorf("error reading VPC Managed Prefix List Entry (%s): %w", d.Id(), err)
 	}
 
 	entry := outputRaw.(*ec2.PrefixListEntry)
@@ -123,31 +127,37 @@ func resourceManagedPrefixListEntryDelete(d *schema.ResourceData, meta interface
 	plID, cidr, err := ManagedPrefixListEntryParseID(d.Id())
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error parsing VPC Managed Prefix List Entry ID (%s): %w", d.Id(), err)
 	}
 
-	pl, err := FindManagedPrefixListByID(conn, plID)
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
+		conns.GlobalMutexKV.Lock(mutexKey)
+		defer conns.GlobalMutexKV.Unlock(mutexKey)
+
+		pl, err := FindManagedPrefixListByID(conn, plID)
+
+		if err != nil {
+			return nil, fmt.Errorf("error reading VPC Managed Prefix List (%s): %w", plID, err)
+		}
+
+		input := &ec2.ModifyManagedPrefixListInput{
+			CurrentVersion: pl.Version,
+			PrefixListId:   aws.String(plID),
+			RemoveEntries:  []*ec2.RemovePrefixListEntry{{Cidr: aws.String(cidr)}},
+		}
+
+		return conn.ModifyManagedPrefixList(input)
+	}, "IncorrectState", "PrefixListVersionMismatch")
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Managed Prefix List (%s): %w", plID, err)
-	}
-
-	input := &ec2.ModifyManagedPrefixListInput{
-		CurrentVersion: pl.Version,
-		PrefixListId:   aws.String(plID),
-		RemoveEntries:  []*ec2.RemovePrefixListEntry{{Cidr: aws.String(cidr)}},
-	}
-
-	_, err = conn.ModifyManagedPrefixList(input)
-
-	if err != nil {
-		return fmt.Errorf("error deleting EC2 Managed Prefix List Entry (%s): %w", d.Id(), err)
+		return fmt.Errorf("error deleting VPC Managed Prefix List Entry (%s): %w", d.Id(), err)
 	}
 
 	_, err = WaitManagedPrefixListModified(conn, plID)
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EC2 Managed Prefix List Entry (%s) delete: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for VPC Managed Prefix List Entry (%s) delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
@@ -46,6 +46,34 @@ func TestAccVPCManagedPrefixListEntry_ipv4(t *testing.T) {
 	})
 }
 
+func TestAccVPCManagedPrefixListEntry_ipv4Multiple(t *testing.T) {
+	var entry ec2.PrefixListEntry
+	resourceName1 := "aws_ec2_managed_prefix_list_entry.test1"
+	resourceName2 := "aws_ec2_managed_prefix_list_entry.test2"
+	resourceName3 := "aws_ec2_managed_prefix_list_entry.test3"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckManagedPrefixList(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckManagedPrefixListEntryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCManagedPrefixListEntryConfig_ipv4Multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckManagedPrefixListEntryExists(resourceName1, &entry),
+					testAccCheckManagedPrefixListEntryExists(resourceName2, &entry),
+					testAccCheckManagedPrefixListEntryExists(resourceName3, &entry),
+					resource.TestCheckResourceAttr(resourceName1, "cidr", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName2, "cidr", "10.0.1.0/24"),
+					resource.TestCheckResourceAttr(resourceName3, "cidr", "10.0.2.0/24"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCManagedPrefixListEntry_ipv6(t *testing.T) {
 	var entry ec2.PrefixListEntry
 	resourceName := "aws_ec2_managed_prefix_list_entry.test"
@@ -254,6 +282,34 @@ resource "aws_ec2_managed_prefix_list" "test" {
 
 resource "aws_ec2_managed_prefix_list_entry" "test" {
   cidr           = "10.0.0.0/8"
+  prefix_list_id = aws_ec2_managed_prefix_list.test.id
+}
+`, rName)
+}
+
+func testAccVPCManagedPrefixListEntryConfig_ipv4Multiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  name           = %[1]q
+  address_family = "IPv4"
+  max_entries    = 5
+}
+
+resource "aws_ec2_managed_prefix_list_entry" "test1" {
+  cidr           = "10.0.0.0/24"
+  description    = "description 1"
+  prefix_list_id = aws_ec2_managed_prefix_list.test.id
+}
+
+resource "aws_ec2_managed_prefix_list_entry" "test2" {
+  cidr           = "10.0.1.0/24"
+  description    = "description 2"  
+  prefix_list_id = aws_ec2_managed_prefix_list.test.id
+}
+
+resource "aws_ec2_managed_prefix_list_entry" "test3" {
+  cidr           = "10.0.2.0/24"
+  description    = "description 3"  
   prefix_list_id = aws_ec2_managed_prefix_list.test.id
 }
 `, rName)

--- a/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
@@ -303,13 +303,13 @@ resource "aws_ec2_managed_prefix_list_entry" "test1" {
 
 resource "aws_ec2_managed_prefix_list_entry" "test2" {
   cidr           = "10.0.1.0/24"
-  description    = "description 2"  
+  description    = "description 2"
   prefix_list_id = aws_ec2_managed_prefix_list.test.id
 }
 
 resource "aws_ec2_managed_prefix_list_entry" "test3" {
   cidr           = "10.0.2.0/24"
-  description    = "description 3"  
+  description    = "description 3"
   prefix_list_id = aws_ec2_managed_prefix_list.test.id
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21835

Seems like this should be straightforward but now it's giving a new error. Anyone have thoughts?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccVPCManagedPrefixListEntry_ipv4Multiple PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCManagedPrefixListEntry_ipv4Multiple'  -timeout 180m
=== RUN   TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== CONT  TestAccVPCManagedPrefixListEntry_ipv4Multiple
    vpc_managed_prefix_list_entry_test.go:56: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating EC2 Managed Prefix List Entry (pl-0a58f0e9573b85871,10.0.1.0/24): PrefixListVersionMismatch: The prefix list has the incorrect version number.
        	status code: 400, request id: 7b4c13b8-9faf-45ba-9164-ff79958af14b
        
          with aws_ec2_managed_prefix_list_entry.test2,
          on terraform_plugin_test.tf line 14, in resource "aws_ec2_managed_prefix_list_entry" "test2":
          14: resource "aws_ec2_managed_prefix_list_entry" "test2" {
        
        
        Error: error creating EC2 Managed Prefix List Entry (pl-0a58f0e9573b85871,10.0.2.0/24): PrefixListVersionMismatch: The prefix list has the incorrect version number.
        	status code: 400, request id: c786e1e0-dfbb-4ed8-ac37-5d7774de506c
        
          with aws_ec2_managed_prefix_list_entry.test3,
          on terraform_plugin_test.tf line 20, in resource "aws_ec2_managed_prefix_list_entry" "test3":
          20: resource "aws_ec2_managed_prefix_list_entry" "test3" {
        
--- FAIL: TestAccVPCManagedPrefixListEntry_ipv4Multiple (19.06s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	20.708s
```
