### PR TITLE
r/aws_msk_cluster - support multi update

### DIFF
--- a/.changelog/25062.txt
+++ b/.changelog/25062.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_msk_cluster: Support multiple attribute updates by refreshing `current_version` after each update
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -661,6 +662,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
 		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+		}
 	}
 
 	if d.HasChanges("broker_node_group_info.0.ebs_volume_size", "broker_node_group_info.0.storage_info") {
@@ -710,6 +716,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
 			}
 		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("broker_node_group_info.0.connectivity_info") {
@@ -735,6 +746,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
 		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("number_of_broker_nodes") {
@@ -756,6 +772,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
 		}
 	}
 
@@ -787,6 +808,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
 		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("configuration_info") && !d.HasChange("kafka_version") {
@@ -811,6 +837,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
 		}
 	}
 
@@ -839,6 +870,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
 		}
 	}
 
@@ -878,6 +914,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if err != nil {
 			return diag.Errorf("waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
 		}
 	}
 
@@ -1698,4 +1739,18 @@ func flattenNodeExporter(apiObject *kafka.NodeExporter) map[string]interface{} {
 	}
 
 	return tfMap
+}
+
+func refreshClusterVersion(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).KafkaConn
+
+	cluster, err := FindClusterByARN(ctx, conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("reading MSK Cluster (%s): %s", d.Id(), err)
+	}
+
+	d.Set("current_version", cluster.CurrentVersion)
+
+	return nil
 }

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -665,7 +665,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -719,7 +719,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -749,7 +749,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -776,7 +776,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -811,7 +811,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -841,7 +841,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -874,7 +874,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -918,7 +918,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
-			return diag.Errorf("error refreshing current_version attribute for MSK Cluster (%s): %s ", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -1747,7 +1747,7 @@ func refreshClusterVersion(ctx context.Context, d *schema.ResourceData, meta int
 	cluster, err := FindClusterByARN(ctx, conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("reading MSK Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("reading MSK Cluster (%s): %w", d.Id(), err)
 	}
 
 	d.Set("current_version", cluster.CurrentVersion)

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -233,18 +233,7 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo(t 
 				PlanOnly: true,
 			},
 			{
-				// upgrade the instance type first. Multiple updates would cause a "The version of the cluster isn’t current. Check the current version and try again." error
-				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeOnlyConfig(rName, original_volume_size, "kafka.m5.4xlarge"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(resourceName, &cluster1),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.0.volume_size", strconv.Itoa(original_volume_size)),
-				),
-			},
-			{
-				// update storage and enable provisioned throughput
+				// upgrade the instance type, update storage, and enable provisioned throughput
 				Config: testAccClusterBrokerNodeGroupInfoStorageInfoVolumeSizeSetAndProvThroughputEnabledConfig(rName, updated_volume_size, "kafka.m5.4xlarge"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster2),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25061

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKafkaCluster_BrokerNodeGroupInfo' PKG=kafka
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafka/... -v -count 1 -parallel 20  -run=TestAccKafkaCluster_BrokerNodeGroupInfo -timeout 180m
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSaslIam
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSaslIam
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSaslIam
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize (2282.41s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo (2282.49s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEbsVolumeSizeToStorageInfo (4733.92s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSaslIam (6193.48s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType (6893.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      6893.163s
...
```
