### PR TITLE
r/aws_msk_cluster: Fix crash when `tls` configuration block is empty

### DIFF
--- a/.changelog/25072.txt
+++ b/.changelog/25072.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_msk_cluster: Prevent crash on apply when `client_authentication.tls` is empty
+```

--- a/docs/contributing/data-handling-and-conversion.md
+++ b/docs/contributing/data-handling-and-conversion.md
@@ -619,7 +619,7 @@ To read:
 func expandStructure(tfMap map[string]interface{}) *service.Structure {
     // ...
 
-    if v, ok := tfMap["nested_attribute_name"].([]interface{}); ok && len(v) > 0 {
+    if v, ok := tfMap["nested_attribute_name"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
         apiObject.NestedAttributeName = expandStructure(v[0].(map[string]interface{}))
     }
 

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -973,7 +973,7 @@ func expandBrokerNodeGroupInfo(tfMap map[string]interface{}) *kafka.BrokerNodeGr
 		apiObject.ClientSubnets = flex.ExpandStringSet(v)
 	}
 
-	if v, ok := tfMap["connectivity_info"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["connectivity_info"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.ConnectivityInfo = expandConnectivityInfo(v[0].(map[string]interface{}))
 	}
 
@@ -993,7 +993,7 @@ func expandBrokerNodeGroupInfo(tfMap map[string]interface{}) *kafka.BrokerNodeGr
 		}
 	}
 
-	if v, ok := tfMap["storage_info"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["storage_info"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.StorageInfo = expandStorageInfo(v[0].(map[string]interface{}))
 	}
 
@@ -1007,7 +1007,7 @@ func expandConnectivityInfo(tfMap map[string]interface{}) *kafka.ConnectivityInf
 
 	apiObject := &kafka.ConnectivityInfo{}
 
-	if v, ok := tfMap["public_access"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["public_access"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.PublicAccess = expandPublicAccess(v[0].(map[string]interface{}))
 	}
 
@@ -1021,7 +1021,7 @@ func expandStorageInfo(tfMap map[string]interface{}) *kafka.StorageInfo {
 
 	apiObject := &kafka.StorageInfo{}
 
-	if v, ok := tfMap["ebs_storage_info"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["ebs_storage_info"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.EbsStorageInfo = expandEBSStorageInfo(v[0].(map[string]interface{}))
 	}
 
@@ -1035,7 +1035,7 @@ func expandEBSStorageInfo(tfMap map[string]interface{}) *kafka.EBSStorageInfo {
 
 	apiObject := &kafka.EBSStorageInfo{}
 
-	if v, ok := tfMap["provisioned_throughput"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["provisioned_throughput"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.ProvisionedThroughput = expandProvisionedThroughput(v[0].(map[string]interface{}))
 	}
 
@@ -1085,11 +1085,11 @@ func expandClientAuthentication(tfMap map[string]interface{}) *kafka.ClientAuthe
 
 	apiObject := &kafka.ClientAuthentication{}
 
-	if v, ok := tfMap["sasl"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sasl"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Sasl = expandSasl(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["tls"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tls"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Tls = expandTLS(v[0].(map[string]interface{}))
 	}
 
@@ -1166,7 +1166,7 @@ func expandEncryptionInfo(tfMap map[string]interface{}) *kafka.EncryptionInfo {
 
 	apiObject := &kafka.EncryptionInfo{}
 
-	if v, ok := tfMap["encryption_in_transit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["encryption_in_transit"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.EncryptionInTransit = expandEncryptionInTransit(v[0].(map[string]interface{}))
 	}
 
@@ -1204,7 +1204,7 @@ func expandLoggingInfo(tfMap map[string]interface{}) *kafka.LoggingInfo {
 
 	apiObject := &kafka.LoggingInfo{}
 
-	if v, ok := tfMap["broker_logs"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["broker_logs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.BrokerLogs = expandBrokerLogs(v[0].(map[string]interface{}))
 	}
 
@@ -1218,15 +1218,15 @@ func expandBrokerLogs(tfMap map[string]interface{}) *kafka.BrokerLogs {
 
 	apiObject := &kafka.BrokerLogs{}
 
-	if v, ok := tfMap["cloudwatch_logs"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cloudwatch_logs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.CloudWatchLogs = expandCloudWatchLogs(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["firehose"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["firehose"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Firehose = expandFirehose(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["s3"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["s3"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.S3 = expandS3(v[0].(map[string]interface{}))
 	}
 
@@ -1298,7 +1298,7 @@ func expandOpenMonitoringInfo(tfMap map[string]interface{}) *kafka.OpenMonitorin
 
 	apiObject := &kafka.OpenMonitoringInfo{}
 
-	if v, ok := tfMap["prometheus"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["prometheus"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Prometheus = expandPrometheusInfo(v[0].(map[string]interface{}))
 	}
 
@@ -1312,11 +1312,11 @@ func expandPrometheusInfo(tfMap map[string]interface{}) *kafka.PrometheusInfo {
 
 	apiObject := &kafka.PrometheusInfo{}
 
-	if v, ok := tfMap["jmx_exporter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["jmx_exporter"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.JmxExporter = expandJmxExporterInfo(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["node_exporter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["node_exporter"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.NodeExporter = expandNodeExporterInfo(v[0].(map[string]interface{}))
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #24881.

```
--- PASS: TestAccKafkaCluster_basic (1834.32s)
=== CONT  TestAccKafkaCluster_Info_revision
--- PASS: TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN (1834.56s)
=== CONT  TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication
--- PASS: TestAccKafkaCluster_ClientAuthenticationSASL_scram (3776.23s)
=== CONT  TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs
--- PASS: TestAccKafkaCluster_Info_revision (2719.22s)
=== CONT  TestAccKafkaCluster_ClientAuthenticationSASL_iam
--- PASS: TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs (1685.06s)
=== CONT  TestAccKafkaCluster_loggingInfo
--- PASS: TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication (4127.46s)
=== CONT  TestAccKafkaCluster_tags
--- PASS: TestAccKafkaCluster_tags (1579.31s)
=== CONT  TestAccKafkaCluster_kafkaVersionUpgradeWithInfo
--- PASS: TestAccKafkaCluster_loggingInfo (2236.75s)
=== CONT  TestAccKafkaCluster_kafkaVersionDowngrade
--- PASS: TestAccKafkaCluster_ClientAuthenticationSASL_iam (3860.76s)
=== CONT  TestAccKafkaCluster_kafkaVersionUpgrade
--- PASS: TestAccKafkaCluster_kafkaVersionDowngrade (3363.53s)
=== CONT  TestAccKafkaCluster_enhancedMonitoring
--- PASS: TestAccKafkaCluster_enhancedMonitoring (1907.71s)
=== CONT  TestAccKafkaCluster_openMonitoring
--- PASS: TestAccKafkaCluster_kafkaVersionUpgradeWithInfo (5716.31s)
=== CONT  TestAccKafkaCluster_numberOfBrokerNodes
--- PASS: TestAccKafkaCluster_kafkaVersionUpgrade (6208.73s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEBSVolumeSizeToStorageInfo
--- PASS: TestAccKafkaCluster_openMonitoring (1816.06s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSASLIAM
--- PASS: TestAccKafkaCluster_numberOfBrokerNodes (2236.92s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_storageInfo (2196.94s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_modifyEBSVolumeSizeToStorageInfo (4788.81s)
=== CONT  TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster
--- PASS: TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster (1886.54s)
=== CONT  TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSASLIAM (6606.06s)
```