### PR TITLE
r/redshift_endpoint_access - new resource

### DIFF
--- a/.changelog/25073.txt
+++ b/.changelog/25073.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_redshift_endpoint_access
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1766,6 +1766,7 @@ func Provider() *schema.Provider {
 
 			"aws_redshift_authentication_profile":        redshift.ResourceAuthenticationProfile(),
 			"aws_redshift_cluster":                       redshift.ResourceCluster(),
+			"aws_redshift_endpoint_access":               redshift.ResourceEndpointAccess(),
 			"aws_redshift_event_subscription":            redshift.ResourceEventSubscription(),
 			"aws_redshift_hsm_client_certificate":        redshift.ResourceHSMClientCertificate(),
 			"aws_redshift_parameter_group":               redshift.ResourceParameterGroup(),

--- a/internal/service/redshift/consts.go
+++ b/internal/service/redshift/consts.go
@@ -70,8 +70,14 @@ func clusterAvailabilityZoneRelocationStatus_PendingValues() []string {
 		clusterAvailabilityZoneRelocationStatusPendingEnabling,
 		clusterAvailabilityZoneRelocationStatusPendingDisabling,
 	}
-
 }
+
+const (
+	endpointAccessStatusActive    = "active"
+	endpointAccessStatusCreating  = "creating"
+	endpointAccessStatusDeleting  = "deleting"
+	endpointAccessStatusModifying = "modifying"
+)
 
 const (
 	propagationTimeout = 2 * time.Minute

--- a/internal/service/redshift/endpoint_access.go
+++ b/internal/service/redshift/endpoint_access.go
@@ -102,6 +102,7 @@ func ResourceEndpointAccess() *schema.Resource {
 			"vpc_security_group_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
@@ -195,6 +196,10 @@ func resourceEndpointAccessUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		if err != nil {
 			return fmt.Errorf("error updating Redshift endpoint access (%s): %w", d.Id(), err)
+		}
+
+		if _, err := waitEndpointAccessActive(conn, d.Id()); err != nil {
+			return fmt.Errorf("error waiting for Redshift Endpoint Access (%s) to be active: %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/redshift/endpoint_access.go
+++ b/internal/service/redshift/endpoint_access.go
@@ -33,7 +33,7 @@ func ResourceEndpointAccess() *schema.Resource {
 			"cluster_identifier": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Optional: true,
+				Required: true,
 			},
 			"endpoint_name": {
 				Type:     schema.TypeString,

--- a/internal/service/redshift/endpoint_access.go
+++ b/internal/service/redshift/endpoint_access.go
@@ -52,6 +52,7 @@ func ResourceEndpointAccess() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
+				Computed: true,
 			},
 			"subnet_group_name": {
 				Type:     schema.TypeString,
@@ -119,11 +120,11 @@ func resourceEndpointAccessCreate(d *schema.ResourceData, meta interface{}) erro
 		createOpts.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("cluster_identifier"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("cluster_identifier"); ok {
 		createOpts.ClusterIdentifier = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("resource_owner"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("resource_owner"); ok {
 		createOpts.ResourceOwner = aws.String(v.(string))
 	}
 

--- a/internal/service/redshift/endpoint_access.go
+++ b/internal/service/redshift/endpoint_access.go
@@ -1,0 +1,168 @@
+package redshift
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceEndpointAccess() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceEndpointAccessCreate,
+		Read:   resourceEndpointAccessRead,
+		Update: resourceEndpointAccessUpdate,
+		Delete: resourceEndpointAccessDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_identifier": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"endpoint_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 30),
+					validation.StringMatch(regexp.MustCompile(`^[0-9a-z-]+$`), "must contain only lowercase alphanumeric characters and hyphens"),
+				),
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"resource_owner": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"subnet_group_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"vpc_security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceEndpointAccessCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).RedshiftConn
+
+	createOpts := redshift.CreateEndpointAccessInput{
+		EndpointName:    aws.String(d.Get("endpoint_name").(string)),
+		SubnetGroupName: aws.String(d.Get("subnet_group_name").(string)),
+	}
+
+	if v, ok := d.GetOk("vpc_security_group_ids"); ok && v.(*schema.Set).Len() > 0 {
+		createOpts.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("cluster_identifier"); ok && v.(string) != "" {
+		createOpts.ClusterIdentifier = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("resource_owner"); ok && v.(string) != "" {
+		createOpts.ResourceOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.CreateEndpointAccess(&createOpts)
+	if err != nil {
+		return fmt.Errorf("error creating Redshift endpoint access: %w", err)
+	}
+
+	d.SetId(aws.StringValue(createOpts.EndpointName))
+	log.Printf("[INFO] Redshift endpoint access ID: %s", d.Id())
+	return resourceEndpointAccessRead(d, meta)
+}
+
+func resourceEndpointAccessRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).RedshiftConn
+
+	endpoint, err := FindEndpointAccessByName(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Redshift endpoint access (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Redshift endpoint access (%s): %w", d.Id(), err)
+	}
+
+	d.Set("endpoint_name", endpoint.EndpointName)
+	d.Set("subnet_group_name", endpoint.SubnetGroupName)
+	d.Set("vpc_security_group_ids", vpcSgsIdsToSlice(endpoint.VpcSecurityGroups))
+	d.Set("resource_owner", endpoint.ResourceOwner)
+	d.Set("cluster_identifier", endpoint.ClusterIdentifier)
+	d.Set("port", endpoint.Port)
+
+	return nil
+}
+
+func resourceEndpointAccessUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).RedshiftConn
+
+	if d.HasChanges("vpc_security_group_ids") {
+		_, n := d.GetChange("vpc_security_group_ids")
+		if n == nil {
+			n = new(schema.Set)
+		}
+		ns := n.(*schema.Set)
+
+		var sIds []*string
+		for _, s := range ns.List() {
+			sIds = append(sIds, aws.String(s.(string)))
+		}
+
+		_, err := conn.ModifyEndpointAccess(&redshift.ModifyEndpointAccessInput{
+			EndpointName:        aws.String(d.Id()),
+			VpcSecurityGroupIds: sIds,
+		})
+
+		if err != nil {
+			return fmt.Errorf("error updating Redshift endpoint access (%s): %w", d.Id(), err)
+		}
+	}
+
+	return resourceEndpointAccessRead(d, meta)
+}
+
+func resourceEndpointAccessDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).RedshiftConn
+
+	_, err := conn.DeleteEndpointAccess(&redshift.DeleteEndpointAccessInput{
+		EndpointName: aws.String(d.Id()),
+	})
+	if err != nil && tfawserr.ErrCodeEquals(err, redshift.ErrCodeEndpointNotFoundFault) {
+		return nil
+	}
+
+	return err
+}
+
+func vpcSgsIdsToSlice(vpsSgsIds []*redshift.VpcSecurityGroupMembership) []string {
+	VpcSgsSlice := make([]string, 0, len(vpsSgsIds))
+	for _, s := range vpsSgsIds {
+		VpcSgsSlice = append(VpcSgsSlice, *s.VpcSecurityGroupId)
+	}
+	return VpcSgsSlice
+}

--- a/internal/service/redshift/endpoint_access.go
+++ b/internal/service/redshift/endpoint_access.go
@@ -166,7 +166,7 @@ func resourceEndpointAccessRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("port", endpoint.Port)
 	d.Set("address", endpoint.Address)
 
-	if err := d.Set("vpc_endpoint", flattenVpcEndpoint(endpoint.VpcEndpoint)); err != nil {
+	if err := d.Set("vpc_endpoint", flattenVPCEndpoint(endpoint.VpcEndpoint)); err != nil {
 		return fmt.Errorf("setting vpc_endpoint: %w", err)
 	}
 
@@ -230,7 +230,7 @@ func vpcSgsIdsToSlice(vpsSgsIds []*redshift.VpcSecurityGroupMembership) []string
 	return VpcSgsSlice
 }
 
-func flattenVpcEndpoint(apiObject *redshift.VpcEndpoint) []interface{} {
+func flattenVPCEndpoint(apiObject *redshift.VpcEndpoint) []interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/redshift/endpoint_access_test.go
+++ b/internal/service/redshift/endpoint_access_test.go
@@ -132,7 +132,7 @@ func testAccCheckEndpointAccessDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_redshift_subnet_group" {
+		if rs.Type != "aws_redshift_endpoint_access" {
 			continue
 		}
 
@@ -146,7 +146,7 @@ func testAccCheckEndpointAccessDestroy(s *terraform.State) error {
 			return err
 		}
 
-		return fmt.Errorf("Redshift Subent Group %s still exists", rs.Primary.ID)
+		return fmt.Errorf("Redshift Endpoint Access %s still exists", rs.Primary.ID)
 	}
 
 	return nil
@@ -160,7 +160,7 @@ func testAccCheckEndpointAccessExists(n string, v *redshift.EndpointAccess) reso
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Redshift Subnet Group ID is set")
+			return fmt.Errorf("No Redshift Endpoint Access ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn

--- a/internal/service/redshift/endpoint_access_test.go
+++ b/internal/service/redshift/endpoint_access_test.go
@@ -1,0 +1,173 @@
+package redshift_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/redshift"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccRedshiftEndpointAccess_basic(t *testing.T) {
+	var v redshift.EndpointAccess
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(18))
+	resourceName := "aws_redshift_endpoint_access.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEndpointAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointAccessConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointAccessExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "5439"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint.#", "1"),
+					acctest.CheckResourceAttrAccountID(resourceName, "resource_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_group_name", "aws_redshift_subnet_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_identifier", "aws_redshift_cluster.test", "cluster_identifier"),
+					resource.TestCheckResourceAttrSet(resourceName, "address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftEndpointAccess_disappears(t *testing.T) {
+	var v redshift.EndpointAccess
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(18))
+	resourceName := "aws_redshift_endpoint_access.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEndpointAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointAccessConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointAccessExists(resourceName, &v),
+					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceEndpointAccess(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftEndpointAccess_disappears_cluster(t *testing.T) {
+	var v redshift.EndpointAccess
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(18))
+	resourceName := "aws_redshift_endpoint_access.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckEndpointAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointAccessConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointAccessExists(resourceName, &v),
+					acctest.CheckResourceDisappears(acctest.Provider, tfredshift.ResourceCluster(), "aws_redshift_cluster.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEndpointAccessDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_redshift_subnet_group" {
+			continue
+		}
+
+		_, err := tfredshift.FindEndpointAccessByName(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Redshift Subent Group %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckEndpointAccessExists(n string, v *redshift.EndpointAccess) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Redshift Subnet Group ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn
+
+		output, err := tfredshift.FindEndpointAccessByName(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccEndpointAccessConfig_basic(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_redshift_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test[*].id
+}
+
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier                   = %[1]q
+  availability_zone                    = data.aws_availability_zones.available.names[0]
+  database_name                        = "mydb"
+  master_username                      = "foo_test"
+  master_password                      = "Mustbe8characters"
+  node_type                            = "ra3.xlplus"
+  automated_snapshot_retention_period  = 1
+  allow_version_upgrade                = false
+  skip_final_snapshot                  = true
+  availability_zone_relocation_enabled = true
+  publicly_accessible                  = false
+}
+
+resource "aws_redshift_endpoint_access" "test" {
+  endpoint_name      = %[1]q
+  subnet_group_name  = aws_redshift_subnet_group.test.id
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
+}
+`, rName))
+}

--- a/internal/service/redshift/endpoint_access_test.go
+++ b/internal/service/redshift/endpoint_access_test.go
@@ -221,7 +221,7 @@ resource "aws_redshift_endpoint_access" "test" {
   endpoint_name          = %[1]q
   subnet_group_name      = aws_redshift_subnet_group.test.id
   cluster_identifier     = aws_redshift_cluster.test.cluster_identifier
-  vpc_security_group_ids = [aws_security_group.test.id]  
+  vpc_security_group_ids = [aws_security_group.test.id]
 }
 `, rName))
 }
@@ -242,7 +242,7 @@ resource "aws_redshift_endpoint_access" "test" {
   endpoint_name          = %[1]q
   subnet_group_name      = aws_redshift_subnet_group.test.id
   cluster_identifier     = aws_redshift_cluster.test.cluster_identifier
-  vpc_security_group_ids = [aws_security_group.test.id, aws_security_group.test2.id]  
+  vpc_security_group_ids = [aws_security_group.test.id, aws_security_group.test2.id]
 }
 `, rName))
 }

--- a/internal/service/redshift/status.go
+++ b/internal/service/redshift/status.go
@@ -86,3 +86,19 @@ func statusScheduleAssociation(conn *redshift.Redshift, id string) resource.Stat
 		return output, aws.StringValue(output.ScheduleAssociationState), nil
 	}
 }
+
+func statusEndpointAccess(conn *redshift.Redshift, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindEndpointAccessByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.EndpointStatus), nil
+	}
+}

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -174,7 +174,7 @@ func waitScheduleAssociationDeleted(conn *redshift.Redshift, id string) (*redshi
 	return nil, err
 }
 
-func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
+func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "modifying"},
 		Target:     []string{"active"},
@@ -195,7 +195,7 @@ func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.End
 	return nil, err
 }
 
-func waitEndpointAccessDeleted(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
+func waitEndpointAccessDeleted(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting"},
 		Target:     []string{},

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -195,7 +195,7 @@ func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.End
 	return nil, err
 }
 
-func waitEndpointAccessDeleted(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) { //nolint:unparam
+func waitEndpointAccessDeleted(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting"},
 		Target:     []string{},

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -173,3 +173,45 @@ func waitScheduleAssociationDeleted(conn *redshift.Redshift, id string) (*redshi
 
 	return nil, err
 }
+
+func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"active"},
+		Refresh:    statusEndpointAccess(conn, id),
+		Timeout:    10 * time.Minute,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*redshift.EndpointAccess); ok {
+		tfresource.SetLastError(err, errors.New(aws.StringValue(output.EndpointStatus)))
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitEndpointAccessDeleted(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting"},
+		Target:     []string{},
+		Refresh:    statusEndpointAccess(conn, id),
+		Timeout:    10 * time.Minute,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*redshift.EndpointAccess); ok {
+		tfresource.SetLastError(err, errors.New(aws.StringValue(output.EndpointStatus)))
+
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -176,8 +176,8 @@ func waitScheduleAssociationDeleted(conn *redshift.Redshift, id string) (*redshi
 
 func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"creating", "modifying"},
-		Target:     []string{"active"},
+		Pending:    []string{endpointAccessStatusCreating, endpointAccessStatusModifying},
+		Target:     []string{endpointAccessStatusActive},
 		Refresh:    statusEndpointAccess(conn, id),
 		Timeout:    10 * time.Minute,
 		MinTimeout: 10 * time.Second,
@@ -197,7 +197,7 @@ func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.End
 
 func waitEndpointAccessDeleted(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"deleting"},
+		Pending:    []string{endpointAccessStatusDeleting},
 		Target:     []string{},
 		Refresh:    statusEndpointAccess(conn, id),
 		Timeout:    10 * time.Minute,

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -176,7 +176,7 @@ func waitScheduleAssociationDeleted(conn *redshift.Redshift, id string) (*redshi
 
 func waitEndpointAccessActive(conn *redshift.Redshift, id string) (*redshift.EndpointAccess, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"creating"},
+		Pending:    []string{"creating", "modifying"},
 		Target:     []string{"active"},
 		Refresh:    statusEndpointAccess(conn, id),
 		Timeout:    10 * time.Minute,

--- a/website/docs/r/redshift_endpoint_access.html.markdown
+++ b/website/docs/r/redshift_endpoint_access.html.markdown
@@ -54,7 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Redshift endpoint accesss can be imported using the `name`, e.g.,
+Redshift endpoint access can be imported using the `name`, e.g.,
 
 ```
 $ terraform import aws_redshift_endpoint_access.example example

--- a/website/docs/r/redshift_endpoint_access.html.markdown
+++ b/website/docs/r/redshift_endpoint_access.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshift_endpoint_access"
+description: |-
+  Provides a Redshift Endpoint Access resource.
+---
+
+# Resource: aws_redshift_endpoint_access
+
+Creates a new Amazon Redshift endpoint access.
+
+## Example Usage
+
+```terraform
+resource "aws_redshift_endpoint_access" "example" {
+  endpoint_name      = "example"
+  subnet_group_name  = aws_redshift_subnet_group.example.id
+  cluster_identifier = aws_redshift_cluster.example.cluster_identifier
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_identifier` - (Required) The cluster identifier of the cluster to access.
+* `endpoint_name` - (Required) The Redshift-managed VPC endpoint name.
+* `resource_owner` - (Optional) The Amazon Web Services account ID of the owner of the cluster. This is only required if the cluster is in another Amazon Web Services account.
+* `subnet_group_name` - (Required) The subnet group from which Amazon Redshift chooses the subnet to deploy the endpoint.
+* `vpc_security_group_ids` - (Optional) The security group that defines the ports, protocols, and sources for inbound traffic that you are authorizing into your endpoint.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `address` - The DNS address of the endpoint.
+* `id` - The Redshift-managed VPC endpoint name.
+* `port` - The port number on which the cluster accepts incoming connections.
+* `vpc_endpoint` - The connection endpoint for connecting to an Amazon Redshift cluster through the proxy. See details below.
+
+### VPC Endpoint
+
+* `network_interface` - One or more network interfaces of the endpoint. Also known as an interface endpoint. See details below.
+* `vpc_endpoint_id` - The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy.
+* `vpc_id` - The VPC identifier that the endpoint is associated.
+
+### Network Interface
+
+* `availability_zone` - The Availability Zone.
+* `network_interface_id` - The network interface identifier.
+* `private_ip_address` - The IPv4 address of the network interface within the subnet.
+* `subnet_id` - The subnet identifier.
+
+## Import
+
+Redshift endpoint accesss can be imported using the `name`, e.g.,
+
+```
+$ terraform import aws_redshift_endpoint_access.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22113

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRedshiftEndpointAccess_ PKG=redshift
--- PASS: TestAccRedshiftEndpointAccess_disappears_cluster (695.53s)
--- PASS: TestAccRedshiftEndpointAccess_disappears (760.81s)
--- PASS: TestAccRedshiftEndpointAccess_basic (1163.36s)
--- PASS: TestAccRedshiftEndpointAccess_sgs (1164.01s)
```
