### PR TITLE
resource/aws_elasticache_global_replication_group: Support upgrading version

### DIFF
--- a/.changelog/25077.txt
+++ b/.changelog/25077.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_global_replication_group: Add support for upgrading `engine_version`.
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -535,8 +534,12 @@ func setFromCacheCluster(d *schema.ResourceData, c *elasticache.CacheCluster) er
 	d.Set("node_type", c.CacheNodeType)
 
 	d.Set("engine", c.Engine)
-	if err := setEngineVersionFromCacheCluster(d, c); err != nil {
-		return err
+	if aws.StringValue(c.Engine) == engineRedis {
+		if err := setEngineVersionRedis(d, c.EngineVersion); err != nil {
+			return err
+		}
+	} else {
+		setEngineVersionMemcached(d, c.EngineVersion)
 	}
 	d.Set("auto_minor_version_upgrade", strconv.FormatBool(aws.BoolValue(c.AutoMinorVersionUpgrade)))
 
@@ -553,27 +556,6 @@ func setFromCacheCluster(d *schema.ResourceData, c *elasticache.CacheCluster) er
 	}
 
 	d.Set("maintenance_window", c.PreferredMaintenanceWindow)
-
-	return nil
-}
-
-func setEngineVersionFromCacheCluster(d *schema.ResourceData, c *elasticache.CacheCluster) error {
-	engineVersion, err := gversion.NewVersion(aws.StringValue(c.EngineVersion))
-	if err != nil {
-		return fmt.Errorf("error reading ElastiCache Cache Cluster (%s) engine version: %w", d.Id(), err)
-	}
-	if engineVersion.Segments()[0] < 6 {
-		d.Set("engine_version", engineVersion.String())
-	} else {
-		// Handle major-only version number
-		configVersion := d.Get("engine_version").(string)
-		if t, _ := regexp.MatchString(`[6-9]\.x`, configVersion); t {
-			d.Set("engine_version", fmt.Sprintf("%d.x", engineVersion.Segments()[0]))
-		} else {
-			d.Set("engine_version", fmt.Sprintf("%d.%d", engineVersion.Segments()[0], engineVersion.Segments()[1]))
-		}
-	}
-	d.Set("engine_version_actual", engineVersion.String())
 
 	return nil
 }

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -133,8 +133,8 @@ func normalizeEngineVersion(version string) (*gversion.Version, error) {
 }
 
 func setEngineVersionMemcached(d *schema.ResourceData, version *string) {
-	d.Set("engine_version", aws.StringValue(version))
-	d.Set("engine_version_actual", aws.StringValue(version))
+	d.Set("engine_version", version)
+	d.Set("engine_version_actual", version)
 }
 
 func setEngineVersionRedis(d *schema.ResourceData, version *string) error {

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -167,3 +167,30 @@ func setEngineVersionRedis(d *schema.ResourceData, version *string) error {
 
 	return nil
 }
+
+type versionDiff [3]int
+
+// diffVersion returns a diff of the versions, component by component.
+// Only reports the first diff, since subsequent segments are unimportant for us.
+func diffVersion(n, o *gversion.Version) (result versionDiff) {
+	if n.String() == o.String() {
+		return
+	}
+
+	segmentsNew := n.Segments64()
+	segmentsOld := o.Segments64()
+
+	for i := 0; i < 3; i++ {
+		lhs := segmentsNew[i]
+		rhs := segmentsOld[i]
+		if lhs < rhs {
+			result[i] = -1
+			break
+		} else if lhs > rhs {
+			result[i] = 1
+			break
+		}
+	}
+
+	return
+}

--- a/internal/service/elasticache/engine_version_test.go
+++ b/internal/service/elasticache/engine_version_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 func TestValidMemcachedVersionString(t *testing.T) {
@@ -523,5 +525,42 @@ func TestNormalizeEngineVersion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestVersionDiff(t *testing.T) {
+	cases := []struct {
+		v1       string
+		v2       string
+		expected versionDiff
+	}{
+		{"1.2.3", "1.2.3", versionDiff{0, 0, 0}},
+		{"1.2.3", "1.1.7", versionDiff{0, 1, 0}},
+		{"1.2.3", "1.4.5", versionDiff{0, -1, 0}},
+		{"2.0.0", "1.2.3", versionDiff{1, 0, 0}},
+		{"1.2.3", "2.0.0", versionDiff{-1, 0, 0}},
+		{"1.2.3", "1.2.1", versionDiff{0, 0, 1}},
+		{"1.2.3", "1.2.4", versionDiff{0, 0, -1}},
+	}
+
+	for _, tc := range cases {
+		v1, err := version.NewVersion(tc.v1)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		v2, err := version.NewVersion(tc.v2)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := diffVersion(v1, v2)
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf(
+				"%s <=> %s\nexpected: %d\nactual: %d",
+				tc.v1, tc.v2,
+				expected, actual)
+		}
 	}
 }

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -187,6 +187,8 @@ func resourceGlobalReplicationGroupCreate(d *schema.ResourceData, meta interface
 			if err != nil {
 				return fmt.Errorf("error updating ElastiCache Global Replication Group (%s) engine version on creation: %w", d.Id(), err)
 			}
+		} else if requestedVersion.LessThan(engineVersion) {
+			return fmt.Errorf("error updating ElastiCache Global Replication Group (%s) engine version on creation: cannot downgrade version when creating, is %s, want %s", d.Id(), engineVersion.String(), requestedVersion.String())
 		}
 	}
 

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -341,6 +341,28 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgr
 	})
 }
 
+func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "6.2", "6.0"),
+				ExpectError: regexp.MustCompile(`cannot downgrade version when creating, is 6.2.[[:digit:]]+, want 6.0.[[:digit:]]+`),
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -44,7 +44,7 @@ func TestAccElastiCacheGlobalReplicationGroup_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_basic(rName, primaryReplicationGroupId),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
 					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					testAccCheckReplicationGroupParameterGroup(&primaryReplicationGroup, &pg),
@@ -54,7 +54,7 @@ func TestAccElastiCacheGlobalReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "cache_node_type", primaryReplicationGroupResourceName, "node_type"),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_enabled", primaryReplicationGroupResourceName, "cluster_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "engine", primaryReplicationGroupResourceName, "engine"),
-					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version_actual"),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_id_suffix", rName),
 					resource.TestMatchResourceAttr(resourceName, "global_replication_group_id", regexp.MustCompile(tfelasticache.GlobalReplicationGroupRegionPrefixFormat+rName)),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_description", tfelasticache.EmptyDescription),
@@ -91,7 +91,7 @@ func TestAccElastiCacheGlobalReplicationGroup_description(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_description(rName, primaryReplicationGroupId, description1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_description", description1),
 				),
@@ -103,7 +103,7 @@ func TestAccElastiCacheGlobalReplicationGroup_description(t *testing.T) {
 			},
 			{
 				Config: testAccGlobalReplicationGroupConfig_description(rName, primaryReplicationGroupId, description2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_description", description2),
 				),
@@ -130,7 +130,7 @@ func TestAccElastiCacheGlobalReplicationGroup_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_basic(rName, primaryReplicationGroupId),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
 					acctest.CheckResourceDisappears(acctest.Provider, tfelasticache.ResourceGlobalReplicationGroup(), resourceName),
 				),
@@ -161,7 +161,7 @@ func TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_MultipleSecondaries(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplcationGroup),
 				),
 			},
@@ -190,13 +190,13 @@ func TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion(t
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_ReplaceSecondary_DifferentRegion_Setup(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplcationGroup),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_ReplaceSecondary_DifferentRegion_Move(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplcationGroup),
 				),
 			},
@@ -225,7 +225,7 @@ func TestAccElastiCacheGlobalReplicationGroup_clusterMode(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_ClusterMode(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
 					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -351,10 +351,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgr
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "6.0", "6.2"),
@@ -491,10 +491,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDown
 	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "6.2", "6.0"),
@@ -509,10 +509,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersio
 	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGlobalReplicationGroupConfig_ParamGroup(rName, primaryReplicationGroupId, "6.2", "default.redis6.x"),
@@ -528,10 +528,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpg
 	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGlobalReplicationGroupConfig_EngineVersionParamGroup(rName, primaryReplicationGroupId, "6.0", "6.2", "default.redis6.x"),
@@ -751,10 +751,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersio
 	resourceName := "aws_elasticache_global_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersion_Inherit(rName, primaryReplicationGroupId, "6.2"),
@@ -785,10 +785,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpg
 	resourceName := "aws_elasticache_global_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersion_Inherit(rName, primaryReplicationGroupId, "6.0"),
@@ -820,10 +820,10 @@ func TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName(t *testin
 	resourceName := "aws_elasticache_global_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersionParamGroup(rName, primaryReplicationGroupId, "5.0.6", "6.2", "default.redis6.x"),

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -341,6 +341,44 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgr
 	})
 }
 
+func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	var rg elasticache.ReplicationGroup
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_global_replication_group.test"
+	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_EngineVersionParamGroup(rName, primaryReplicationGroupId, "5.0.6", "6.2", "default.redis6.x"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &rg),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.2\.[[:digit:]]+$`)),
+					testAccMatchReplicationGroupActualVersion(&rg, regexp.MustCompile(`^6\.2\.[[:digit:]]+$`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter_group_name"},
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -435,7 +473,7 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDown
 			},
 			// This step fails with: Error running pre-apply refresh
 			// {
-			// 	Config: testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "6.2", "6.0"),
+			// 	Config: testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "6.0", "6.0"),
 			// 	Taint: []string{
 			// 		resourceName,
 			// 		primaryReplicationGroupResourceName,
@@ -779,6 +817,32 @@ resource "aws_elasticache_replication_group" "test" {
   }
 }
 `, rName, primaryReplicationGroupId, repGroupEngineVersion, globalEngineVersion)
+}
+
+func testAccGlobalReplicationGroupConfig_EngineVersionParamGroup(rName, primaryReplicationGroupId, repGroupEngineVersion, globalEngineVersion, parameterGroup string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+
+  engine_version       = %[4]q
+  parameter_group_name = %[5]q
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[2]q
+  replication_group_description = "test"
+
+  engine                = "redis"
+  engine_version        = %[3]q
+  node_type             = "cache.m5.large"
+  number_cache_clusters = 1
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
+}
+`, rName, primaryReplicationGroupId, repGroupEngineVersion, globalEngineVersion, parameterGroup)
 }
 
 func testAccVPCBaseWithProvider(rName, name, provider string, subnetCount int) string {

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -251,10 +251,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_
 	resourceName := "aws_elasticache_global_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "6.2", "6.2"),
@@ -283,10 +283,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_
 	resourceName := "aws_elasticache_global_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersion(rName, primaryReplicationGroupId, "5.0.6", "5.0.6"),
@@ -316,10 +316,10 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgr
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlobalReplicationGroupDestroy,
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGlobalReplicationGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_EngineVersion_Inherit(rName, primaryReplicationGroupId, "6.0"),

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -159,6 +159,12 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
 				Config: testAccReplicationGroupConfig_EngineVersion(rName, "3.2.4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationGroupExists(resourceName, &v2),
@@ -182,7 +188,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 					testAccCheckReplicationGroupExists(resourceName, &v4),
 					testAccCheckReplicationGroupNotRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.0"),
-					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -191,8 +197,14 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 					testAccCheckReplicationGroupExists(resourceName, &v5),
 					testAccCheckReplicationGroupNotRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.2"),
-					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
 				Config: testAccReplicationGroupConfig_EngineVersion(rName, "5.0.6"),

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2191,46 +2191,6 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 	})
 }
 
-func testAccCheckReplicationGroupParameterGroup(rg *elasticache.ReplicationGroup, pg *elasticache.CacheParameterGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn
-
-		cacheCluster := rg.NodeGroups[0].NodeGroupMembers[0]
-		cluster, err := tfelasticache.FindCacheClusterByID(conn, aws.StringValue(cacheCluster.CacheClusterId))
-		if err != nil {
-			return fmt.Errorf("could not retrieve cache cluster (%s): %w", aws.StringValue(cacheCluster.CacheClusterId), err)
-		}
-
-		paramGroupName := aws.StringValue(cluster.CacheParameterGroup.CacheParameterGroupName)
-
-		group, err := tfelasticache.FindParameterGroupByName(conn, paramGroupName)
-		if err != nil {
-			return fmt.Errorf("error retrieving parameter group (%s): %w", paramGroupName, err)
-		}
-
-		*pg = *group
-
-		return nil
-	}
-}
-
-func testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(pg *elasticache.CacheParameterGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn
-
-		paramGroupName := aws.StringValue(pg.CacheParameterGroupName)
-
-		_, err := tfelasticache.FindParameterGroupByName(conn, paramGroupName)
-		if tfresource.NotFound(err) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("error finding parameter group (%s): %w", paramGroupName, err)
-		}
-		return fmt.Errorf("Cache Parameter Group (%s) still exists", paramGroupName)
-	}
-}
-
 func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -2526,6 +2486,46 @@ func testAccCheckReplicationGroupDestroy(s *terraform.State) error {
 		return fmt.Errorf("ElastiCache Replication Group (%s) still exists", rs.Primary.ID)
 	}
 	return nil
+}
+
+func testAccCheckReplicationGroupParameterGroup(rg *elasticache.ReplicationGroup, pg *elasticache.CacheParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn
+
+		cacheCluster := rg.NodeGroups[0].NodeGroupMembers[0]
+		cluster, err := tfelasticache.FindCacheClusterByID(conn, aws.StringValue(cacheCluster.CacheClusterId))
+		if err != nil {
+			return fmt.Errorf("could not retrieve cache cluster (%s): %w", aws.StringValue(cacheCluster.CacheClusterId), err)
+		}
+
+		paramGroupName := aws.StringValue(cluster.CacheParameterGroup.CacheParameterGroupName)
+
+		group, err := tfelasticache.FindParameterGroupByName(conn, paramGroupName)
+		if err != nil {
+			return fmt.Errorf("error retrieving parameter group (%s): %w", paramGroupName, err)
+		}
+
+		*pg = *group
+
+		return nil
+	}
+}
+
+func testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(pg *elasticache.CacheParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn
+
+		paramGroupName := aws.StringValue(pg.CacheParameterGroupName)
+
+		_, err := tfelasticache.FindParameterGroupByName(conn, paramGroupName)
+		if tfresource.NotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error finding parameter group (%s): %w", paramGroupName, err)
+		}
+		return fmt.Errorf("Cache Parameter Group (%s) still exists", paramGroupName)
+	}
 }
 
 func testAccCheckReplicationGroupUserGroup(resourceName, userGroupID string) resource.TestCheckFunc {

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -44,13 +44,65 @@ resource "aws_elasticache_replication_group" "secondary" {
 }
 ```
 
+### Managing Redis Engine Versions
+
+The initial Redis version is deterined by the version set on the primary replication group.
+However, once it is part of a Global Replication Group,
+the Global Replication Group manages the version of all member replication groups.
+
+In this example,
+the primary replication group will be created with Redis 6.0,
+and then upgraded to Redis 6.2 once added to the Global Replication Group.
+The secondary replication group will be created with Redis 6.2.
+
+```terraform
+resource "aws_elasticache_global_replication_group" "example" {
+  global_replication_group_id_suffix = "example"
+  primary_replication_group_id       = aws_elasticache_replication_group.primary.id
+
+  engine_version = "6.2"
+}
+
+resource "aws_elasticache_replication_group" "primary" {
+  replication_group_id          = "example-primary"
+  replication_group_description = "primary replication group"
+
+  engine         = "redis"
+  engine_version = "6.0"
+  node_type      = "cache.m5.large"
+
+  number_cache_clusters = 1
+}
+
+resource "aws_elasticache_replication_group" "secondary" {
+  provider = aws.other_region
+
+  replication_group_id          = "example-secondary"
+  replication_group_description = "secondary replication group"
+  global_replication_group_id   = aws_elasticache_global_replication_group.example.global_replication_group_id
+
+  number_cache_clusters = 1
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
+* `engine_version` - (Optional) Redis version to use for the Global Replication Group.
+  When creating, by default the Global Replication Group inherits the version of the primary replication group.
+  If a version is specified, the Global Replication Group and all member replication groups will be upgraded to this version.
+  Cannot be downgraded without replacing the Global Replication Group and all member replication groups.
+  If the version is 6 or higher, the major and minor version can be set, e.g., `6.2`,
+  or the minor version can be unspecified which will use the latest version at creation time, e.g., `6.x`.
+  The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below.
 * `global_replication_group_id_suffix` – (Required) The suffix name of a Global Datastore. If `global_replication_group_id_suffix` is changed, creates a new resource.
 * `primary_replication_group_id` – (Required) The ID of the primary cluster that accepts writes and will replicate updates to the secondary cluster. If `primary_replication_group_id` is changed, creates a new resource.
 * `global_replication_group_description` – (Optional) A user-created description for the global replication group.
+* `parameter_group_name` - (Optional) An ElastiCache Parameter Group to use for the Global Replication Group.
+  Required when upgrading a major engine version, but will be ignored if left configured after the upgrade is complete.
+  Specifying without a major version upgrade will fail.
+  Note that ElastiCache creates a copy of this parameter group for each member replication group.
 
 ## Attributes Reference
 

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -46,7 +46,7 @@ resource "aws_elasticache_replication_group" "secondary" {
 
 ### Managing Redis Engine Versions
 
-The initial Redis version is deterined by the version set on the primary replication group.
+The initial Redis version is determined by the version set on the primary replication group.
 However, once it is part of a Global Replication Group,
 the Global Replication Group manages the version of all member replication groups.
 


### PR DESCRIPTION
Adds support for upgrading the `engine_version` for an `aws_elasticache_global_replication_group`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17696

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=elasticache TESTS='TestAccElastiCacheCluster|TestAccElastiCacheGlobalReplicationGroup|TestAccElastiCacheReplicationGroup'

--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (53.01s)
--- PASS: TestAccElastiCacheClusterDataSource_Data_basic (540.79s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (771.60s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (809.35s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (952.12s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1109.12s)
--- PASS: TestAccElastiCacheReplicationGroup_tagWithOtherModification (1162.58s)
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (1220.25s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1313.54s)
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (2.14s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1421.12s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1445.83s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1535.10s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1571.36s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (713.24s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1808.26s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1798.28s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1860.50s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (2.76s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (853.88s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (907.07s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (2076.22s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (917.51s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (1576.84s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (822.31s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (1433.17s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (1020.93s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1784.53s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2792.73s)
--- PASS: TestAccElastiCacheReplicationGroup_depecatedAvailabilityZones_vpc (795.88s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (1164.78s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (1190.58s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (1066.62s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (983.64s)
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (1177.72s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (1326.12s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1908.20s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1633.82s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_nonExistent (3.16s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (3539.52s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (1507.77s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3696.95s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (686.75s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (840.43s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (839.29s)
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1055.84s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzNotInVPC (1841.99s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (713.08s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2306.67s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (4008.96s)
--- PASS: TestAccElastiCacheReplicationGroup_basic_v5 (699.65s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion (2.75s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (698.71s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (748.86s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1605.81s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2643.41s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2811.50s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (800.22s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (920.82s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (3067.58s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1092.96s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade (955.33s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion (986.34s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade (1091.30s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName (1267.11s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade (978.38s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x (1070.76s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x (1014.12s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade (1429.59s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x (1607.22s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade (1549.79s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v5 (1265.41s)
--- PASS: TestAccElastiCacheCluster_tags (515.24s)
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (2.79s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade (1325.81s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (2.49s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6x (1175.01s)
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (606.32s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade (1488.41s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade (1595.89s)
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (498.64s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode (1266.06s)
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (504.22s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_disappears (1131.72s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_basic (984.45s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x (1903.21s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_description (1103.88s)
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (736.22s)
--- SKIP: TestAccElastiCacheCluster_SecurityGroup_ec2Classic (0.74s)
--- PASS: TestAccElastiCacheCluster_AZMode_redis (476.05s)
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (486.10s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6 (1755.26s)
--- PASS: TestAccElastiCacheCluster_Engine_None (1.96s)
--- PASS: TestAccElastiCacheCluster_port (485.10s)
--- PASS: TestAccElastiCacheCluster_vpc (499.24s)
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (513.54s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (1006.87s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (754.76s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (476.40s)
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (476.64s)
--- PASS: TestAccElastiCacheCluster_PortRedis_default (476.51s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1146.18s)
--- PASS: TestAccElastiCacheCluster_Engine_memcached (475.25s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1175.50s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1194.76s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1194.64s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (496.04s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1096.66s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (865.02s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (845.13s)
--- PASS: TestAccElastiCacheClusterDataSource_Engine_Redis_LogDeliveryConfigurations (735.68s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion (3311.65s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (2446.12s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries (3537.11s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (5199.80s)
```
