### PR TITLE
fix(beanstalk-env): polling_interval validation

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -162,7 +162,7 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 						errors = append(errors, fmt.Errorf(
 							"%q cannot be parsed as a duration: %s", k, err))
 					}
-					if duration < 10*time.Second || duration > 60*time.Second {
+					if duration < 10*time.Second || duration > 180*time.Second {
 						errors = append(errors, fmt.Errorf(
 							"%q must be between 10s and 180s", k))
 					}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25082

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
I'm not sure how to run the test here of if they need to be modified
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
