### PR TITLE
Updates `actions/setup-go` to use `go-version-file`

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2
@@ -41,11 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -59,11 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -64,11 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - name: go mod
         run: |
           echo "==> Checking source code with go mod tidy..."

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,11 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -29,11 +29,9 @@ jobs:
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     - name: go build
       run: go build -o terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 .
     - name: override plugin

--- a/.github/workflows/skaff.yml
+++ b/.github/workflows/skaff.yml
@@ -18,11 +18,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       # See also: https://github.com/actions/setup-go/issues/54
       - name: go env
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,11 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -34,11 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     - uses: actions/cache@v3
       continue-on-error: true
       id: cache-go-pkg-mod
@@ -62,12 +60,10 @@ jobs:
       with:
         path: terraform-plugin-dir
         key: ${{ runner.os }}-terraform-plugin-dir-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - if: steps.cache-terraform-plugin-dir.outputs.cache-hit != 'true' || steps.cache-terraform-plugin-dir.outcome == 'failure'
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     # See also: https://github.com/actions/setup-go/issues/54
     - if: steps.cache-terraform-plugin-dir.outputs.cache-hit != 'true' || steps.cache-terraform-plugin-dir.outcome == 'failure'
       name: go env
@@ -128,11 +124,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     # See also: https://github.com/actions/setup-go/issues/54
     - name: go env
       run: |
@@ -159,11 +153,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     # See also: https://github.com/actions/setup-go/issues/54
     - name: go env
       run: |
@@ -195,11 +187,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     # See also: https://github.com/actions/setup-go/issues/54
     - name: go env
       run: |
@@ -281,11 +271,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     # See also: https://github.com/actions/setup-go/issues/54
     - name: go env
       run: |
@@ -311,11 +299,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     # See also: https://github.com/actions/setup-go/issues/54
     - name: go env
       run: |
@@ -340,11 +326,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # See also: https://github.com/actions/setup-go/pull/62
-    - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
@@ -376,11 +360,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       # See also: https://github.com/actions/setup-go/issues/54
       - name: go env
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -74,11 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2
@@ -91,11 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2
@@ -108,11 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # See also: https://github.com/actions/setup-go/pull/62
-      - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - name: Install actionlint
         run: cd tools && go install github.com/rhysd/actionlint/cmd/actionlint
       - name: Run actionlint on workflow files


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24937

Now that actions/setup-go#62 has been merged, the GitHub action `setup-go` can now read the Go version from the `.go-version` file. Update uses of the `setup-go` action to use this feature.

Output from acceptance testing:

N/A