### PR TITLE
d/redshift_cluster_credentials - new data source

### DIFF
--- a/.changelog/25092.txt
+++ b/.changelog/25092.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_redshift_cluster_credentials
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -805,10 +805,11 @@ func Provider() *schema.Provider {
 			"aws_rds_engine_version":        rds.DataSourceEngineVersion(),
 			"aws_rds_orderable_db_instance": rds.DataSourceOrderableInstance(),
 
-			"aws_redshift_cluster":           redshift.DataSourceCluster(),
-			"aws_redshift_orderable_cluster": redshift.DataSourceOrderableCluster(),
-			"aws_redshift_service_account":   redshift.DataSourceServiceAccount(),
-			"aws_redshift_subnet_group":      redshift.DataSourceSubnetGroup(),
+			"aws_redshift_cluster":             redshift.DataSourceCluster(),
+			"aws_redshift_cluster_credentials": redshift.DataSourceClusterCredentials(),
+			"aws_redshift_orderable_cluster":   redshift.DataSourceOrderableCluster(),
+			"aws_redshift_service_account":     redshift.DataSourceServiceAccount(),
+			"aws_redshift_subnet_group":        redshift.DataSourceSubnetGroup(),
 
 			"aws_resourcegroupstaggingapi_resources": resourcegroupstaggingapi.DataSourceResources(),
 

--- a/internal/service/redshift/cluster_credentials_data_source.go
+++ b/internal/service/redshift/cluster_credentials_data_source.go
@@ -25,22 +25,22 @@ func DataSourceClusterCredentials() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"db_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"db_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"db_user": {
-				Type:     schema.TypeString,
-				Required: true,
 			},
 			"db_password": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"db_groups": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"db_user": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"duration_seconds": {
 				Type:         schema.TypeInt,
@@ -59,32 +59,32 @@ func DataSourceClusterCredentials() *schema.Resource {
 func dataSourceClusterCredentialsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).RedshiftConn
 
-	clusterId := d.Get("cluster_identifier").(string)
+	clusterID := d.Get("cluster_identifier").(string)
 	input := &redshift.GetClusterCredentialsInput{
-		ClusterIdentifier: aws.String(clusterId),
-		DbUser:            aws.String(d.Get("db_user").(string)),
 		AutoCreate:        aws.Bool(d.Get("auto_create").(bool)),
+		ClusterIdentifier: aws.String(clusterID),
+		DbUser:            aws.String(d.Get("db_user").(string)),
 		DurationSeconds:   aws.Int64(int64(d.Get("duration_seconds").(int))),
-	}
-
-	if v, ok := d.GetOk("db_name"); ok {
-		input.DbName = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("db_groups"); ok && v.(*schema.Set).Len() > 0 {
 		input.DbGroups = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("db_name"); ok {
+		input.DbName = aws.String(v.(string))
+	}
+
 	creds, err := conn.GetClusterCredentials(input)
 
 	if err != nil {
-		return fmt.Errorf("reading Redshift Cluster Credentials for Cluster (%s): %w", clusterId, err)
+		return fmt.Errorf("reading Redshift Cluster Credentials for Cluster (%s): %w", clusterID, err)
 	}
 
-	d.SetId(clusterId)
+	d.SetId(clusterID)
 
-	d.Set("db_user", creds.DbUser)
 	d.Set("db_password", creds.DbPassword)
+	d.Set("db_user", creds.DbUser)
 	d.Set("expiration", aws.TimeValue(creds.Expiration).Format(time.RFC3339))
 
 	return nil

--- a/internal/service/redshift/cluster_credentials_data_source.go
+++ b/internal/service/redshift/cluster_credentials_data_source.go
@@ -35,8 +35,9 @@ func DataSourceClusterCredentials() *schema.Resource {
 				Optional: true,
 			},
 			"db_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"db_user": {
 				Type:     schema.TypeString,

--- a/internal/service/redshift/cluster_credentials_data_source.go
+++ b/internal/service/redshift/cluster_credentials_data_source.go
@@ -1,0 +1,91 @@
+package redshift
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+)
+
+func DataSourceClusterCredentials() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceClusterCredentialsRead,
+
+		Schema: map[string]*schema.Schema{
+			"auto_create": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"cluster_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"db_user": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"db_password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"duration_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      900,
+				ValidateFunc: validation.IntBetween(900, 3600),
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceClusterCredentialsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).RedshiftConn
+
+	clusterId := d.Get("cluster_identifier").(string)
+	input := &redshift.GetClusterCredentialsInput{
+		ClusterIdentifier: aws.String(clusterId),
+		DbUser:            aws.String(d.Get("db_user").(string)),
+		AutoCreate:        aws.Bool(d.Get("auto_create").(bool)),
+		DurationSeconds:   aws.Int64(int64(d.Get("duration_seconds").(int))),
+	}
+
+	if v, ok := d.GetOk("db_name"); ok {
+		input.DbName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("db_groups"); ok && v.(*schema.Set).Len() > 0 {
+		input.DbGroups = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	creds, err := conn.GetClusterCredentials(input)
+
+	if err != nil {
+		return fmt.Errorf("reading Redshift Cluster Credentials for Cluster (%s): %w", clusterId, err)
+	}
+
+	d.SetId(clusterId)
+
+	d.Set("db_user", creds.DbUser)
+	d.Set("db_password", creds.DbPassword)
+	d.Set("expiration", aws.TimeValue(creds.Expiration).Format(time.RFC3339))
+
+	return nil
+}

--- a/internal/service/redshift/cluster_credentials_data_source_test.go
+++ b/internal/service/redshift/cluster_credentials_data_source_test.go
@@ -1,0 +1,52 @@
+package redshift_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/redshift"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccRedshiftClusterCredentialsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_redshift_cluster_credentials.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterCredentialsDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_identifier", "aws_redshift_cluster.test", "cluster_identifier"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "db_password"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterCredentialsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier = %[1]q
+
+  database_name       = "testdb"
+  master_username     = "foo"
+  master_password     = "Password1"
+  node_type           = "dc2.large"
+  cluster_type        = "single-node"
+  skip_final_snapshot = true
+}
+
+data "aws_redshift_cluster_credentials" "test" {
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
+  db_user            = aws_redshift_cluster.test.master_username
+}
+`, rName)
+}

--- a/website/docs/d/redshift_cluster_credentials.html.markdown
+++ b/website/docs/d/redshift_cluster_credentials.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshift_cluster_credentials"
+description: |-
+  Provides redshift cluster credentials
+---
+
+# Data Source: aws_redshift_cluster_credentials
+
+Provides redshift subnet group.
+
+## Example Usage
+
+```terraform
+data "aws_redshift_cluster_credentials" "example" {
+  name = aws_redshift_cluster_credentials.example.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auto_create` - (Optional)  Create a database user with the name specified for the user named in `db_user` if one does not exist.
+* `cluster_identifier` - (Required) The unique identifier of the cluster that contains the database for which your are requesting credentials.
+* `db_name` - (Optional) The name of a database that DbUser is authorized to log on to. If `db_name` is not specified, `db_user` can log on to any existing database.
+* `db_user` - (Required) The name of a database user. If a user name matching `db_user` exists in the database, the temporary user credentials have the same permissions as the  existing user. If `db_user` doesn't exist in the database and `auto_create` is `True`, a new user is created using the value for `db_user` with `PUBLIC` permissions.  If a database user matching the value for `db_user` doesn't exist and `not` is `False`, then the command succeeds but the connection attempt will fail because the user doesn't exist in the database.
+* `db_groups` - (Optional) A list of the names of existing database groups that the user named in `db_user` will join for the current session, in addition to any group memberships for an existing user. If not specified, a new user is added only to `PUBLIC`.
+* `duration_seconds` - (Optional)  The number of seconds until the returned temporary password expires. Valid values are between `900` and `3600`. Default value is `900`.
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `db_password` - A temporary password that authorizes the user name returned by `db_user` to log on to the database `db_name`.
+* `expiration` - The date and time the password in `db_password` expires.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRedshiftClusterCredentialsDataSource_basic
--- PASS: TestAccRedshiftClusterCredentialsDataSource_basic (283.94s)
```
