### PR TITLE
skaff: resource generation template fixes

### DIFF
--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -393,7 +393,7 @@ func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if d.HasChanges("an_argument") {
-		in.AnArgument = d.Get("an_argument").(string)
+		in.AnArgument = aws.String(d.Get("an_argument").(string))
 		update = true
 	}
 
@@ -408,7 +408,7 @@ func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, 
 	// TIP: -- 3. Call the AWS modify/update function
 	{{- end }}
 	log.Printf("[DEBUG] Updating {{ .Service }} {{ .Resource }} (%s): %#v", d.Id(), in)
-	out, err := conn.Update{{ .Resource }}(ctx, in)
+	out, err := conn.Update{{ .Resource }}WithContext(ctx, in)
 	if err != nil {
 		return diag.Errorf("updating {{ .Service }} {{ .Resource }} (%s): %s", d.Id(), err)
 	}
@@ -585,7 +585,7 @@ func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Se
 			return nil, "", err
 		}
 
-		return out, out.Status, nil
+		return out, aws.ToString(out.Status), nil
 	}
 }
 {{ if .IncludeComments }}


### PR DESCRIPTION
This PR adds fixes to the `skaff` generated resource template. Issues are in regards to syntax when accessing the AWS SDK. 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #0000

Output from acceptance testing:

```
$ go test ./datasource 
ok      github.com/hashicorp/terraform-provider-aws/skaff/datasource    0.320s

$ go test ./resource  
ok      github.com/hashicorp/terraform-provider-aws/skaff/resource      0.265s
```