### PR TITLE
r/ram_resource_share - add `permission_arns` argument

### DIFF
--- a/.changelog/25113.txt
+++ b/.changelog/25113.txt
@@ -1,0 +1,2 @@
+```release-note:enhancement
+resource/aws_ram_resource_share: Add `permission_arns` argument.

--- a/internal/service/ram/resource_share.go
+++ b/internal/service/ram/resource_share.go
@@ -41,15 +41,14 @@ func ResourceResourceShare() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 			"permission_arns": {
 				Type:     schema.TypeSet,
-				ForceNew: true,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: verify.ValidARN,
@@ -68,30 +67,31 @@ func resourceResourceShareCreate(d *schema.ResourceData, meta interface{}) error
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	request := &ram.CreateResourceShareInput{
-		Name:                    aws.String(d.Get("name").(string)),
+	name := d.Get("name").(string)
+	input := &ram.CreateResourceShareInput{
 		AllowExternalPrincipals: aws.Bool(d.Get("allow_external_principals").(bool)),
+		Name:                    aws.String(name),
 	}
 
 	if v, ok := d.GetOk("permission_arns"); ok && v.(*schema.Set).Len() > 0 {
-		request.PermissionArns = flex.ExpandStringSet(v.(*schema.Set))
+		input.PermissionArns = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	if len(tags) > 0 {
-		request.Tags = Tags(tags.IgnoreAWS())
+		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	log.Println("[DEBUG] Create RAM resource share request:", request)
-	createResp, err := conn.CreateResourceShare(request)
+	log.Printf("[DEBUG] Creating RAM Resource Share: %s", input)
+	output, err := conn.CreateResourceShare(input)
+
 	if err != nil {
-		return fmt.Errorf("Error creating RAM resource share: %s", err)
+		return fmt.Errorf("creating RAM Resource Share (%s): %w", name, err)
 	}
 
-	d.SetId(aws.StringValue(createResp.ResourceShare.ResourceShareArn))
+	d.SetId(aws.StringValue(output.ResourceShare.ResourceShareArn))
 
-	_, err = WaitResourceShareOwnedBySelfActive(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return fmt.Errorf("Error waiting for RAM resource share (%s) to become ready: %s", d.Id(), err)
+	if _, err = WaitResourceShareOwnedBySelfActive(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("waiting for RAM Resource Share (%s) to become ready: %w", d.Id(), err)
 	}
 
 	return resourceResourceShareRead(d, meta)
@@ -103,13 +103,15 @@ func resourceResourceShareRead(d *schema.ResourceData, meta interface{}) error {
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	resourceShare, err := FindResourceShareOwnerSelfByARN(conn, d.Id())
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+		log.Printf("[WARN] RAM Resource Share (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
-			log.Printf("[WARN] RAM Resource Share (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error reading RAM resource share %s: %w", d.Id(), err)
+		return fmt.Errorf("reading RAM Resource Share (%s): %w", d.Id(), err)
 	}
 
 	if !d.IsNewResource() && aws.StringValue(resourceShare.Status) != ram.ResourceShareStatusActive {
@@ -118,37 +120,36 @@ func resourceResourceShareRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	d.Set("allow_external_principals", resourceShare.AllowExternalPrincipals)
 	d.Set("arn", resourceShare.ResourceShareArn)
 	d.Set("name", resourceShare.Name)
-	d.Set("allow_external_principals", resourceShare.AllowExternalPrincipals)
 
 	tags := KeyValueTags(resourceShare.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
-	permsInput := &ram.ListResourceSharePermissionsInput{
+	perms, err := conn.ListResourceSharePermissions(&ram.ListResourceSharePermissionsInput{
 		ResourceShareArn: aws.String(d.Id()),
-	}
+	})
 
-	perms, err := conn.ListResourceSharePermissions(permsInput)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing RAM Resource Share (%s) permissions: %w", d.Id(), err)
 	}
 
-	permArns := make([]*string, 0, len(perms.Permissions))
+	permissionARNs := make([]*string, 0, len(perms.Permissions))
 
-	for _, perm := range perms.Permissions {
-		permArns = append(permArns, perm.Arn)
+	for _, v := range perms.Permissions {
+		permissionARNs = append(permissionARNs, v.Arn)
 	}
 
-	d.Set("permission_arns", flex.FlattenStringSet(permArns))
+	d.Set("permission_arns", aws.StringValueSlice(permissionARNs))
 
 	return nil
 }
@@ -157,15 +158,17 @@ func resourceResourceShareUpdate(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*conns.AWSClient).RAMConn
 
 	if d.HasChanges("name", "allow_external_principals") {
-		request := &ram.UpdateResourceShareInput{
-			ResourceShareArn:        aws.String(d.Id()),
-			Name:                    aws.String(d.Get("name").(string)),
+		input := &ram.UpdateResourceShareInput{
 			AllowExternalPrincipals: aws.Bool(d.Get("allow_external_principals").(bool)),
+			Name:                    aws.String(d.Get("name").(string)),
+			ResourceShareArn:        aws.String(d.Id()),
 		}
 
-		_, err := conn.UpdateResourceShare(request)
+		log.Printf("[DEBUG] Updating RAM Resource Share: %s", input)
+		_, err := conn.UpdateResourceShare(input)
+
 		if err != nil {
-			return fmt.Errorf("error updating RAM resource share %s: %w", d.Id(), err)
+			return fmt.Errorf("updating RAM Resource Share (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -173,7 +176,7 @@ func resourceResourceShareUpdate(d *schema.ResourceData, meta interface{}) error
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating RAM resource share (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("updating RAM Resource Share (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -183,23 +186,21 @@ func resourceResourceShareUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceResourceShareDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).RAMConn
 
-	deleteResourceShareInput := &ram.DeleteResourceShareInput{
+	log.Printf("[DEBUG] Delete RAM Resource Share: %s", d.Id())
+	_, err := conn.DeleteResourceShare(&ram.DeleteResourceShareInput{
 		ResourceShareArn: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+		return nil
 	}
 
-	log.Println("[DEBUG] Delete RAM resource share request:", deleteResourceShareInput)
-	_, err := conn.DeleteResourceShare(deleteResourceShareInput)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
-			return nil
-		}
-		return fmt.Errorf("Error deleting RAM resource share %s: %s", d.Id(), err)
+		return fmt.Errorf("deleting RAM Resource Share (%s): %w", d.Id(), err)
 	}
 
-	_, err = WaitResourceShareOwnedBySelfDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-
-	if err != nil {
-		return fmt.Errorf("Error waiting for RAM resource share (%s) to become ready: %s", d.Id(), err)
+	if _, err = WaitResourceShareOwnedBySelfDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("waiting for RAM Resource Share (%s) delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ram/resource_share_test.go
+++ b/internal/service/ram/resource_share_test.go
@@ -252,6 +252,7 @@ func testAccCheckResourceShareDestroy(s *terraform.State) error {
 		}
 
 		resourceShare, err := tfram.FindResourceShareOwnerSelfByARN(conn, rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}

--- a/internal/service/ram/resource_share_test.go
+++ b/internal/service/ram/resource_share_test.go
@@ -214,7 +214,7 @@ func TestAccRAMResourceShare_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceShareExists(resourceName string, resourceShare *ram.ResourceShare) resource.TestCheckFunc {
+func testAccCheckResourceShareExists(resourceName string, v *ram.ResourceShare) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RAMConn
 
@@ -227,14 +227,17 @@ func testAccCheckResourceShareExists(resourceName string, resourceShare *ram.Res
 			return fmt.Errorf("No ID is set")
 		}
 
-		resourceShare, err := tfram.FindResourceShareOwnerSelfByARN(conn, rs.Primary.ID)
+		output, err := tfram.FindResourceShareOwnerSelfByARN(conn, rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
 
-		if aws.StringValue(resourceShare.Status) != ram.ResourceShareStatusActive {
+		if aws.StringValue(output.Status) != ram.ResourceShareStatusActive {
 			return fmt.Errorf("RAM resource share (%s) delet(ing|ed)", rs.Primary.ID)
 		}
+
+		*v = *output
 
 		return nil
 	}

--- a/website/docs/r/ram_resource_share.markdown
+++ b/website/docs/r/ram_resource_share.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource share.
 * `allow_external_principals` - (Optional) Indicates whether principals outside your organization can be associated with a resource share.
+* `permission_arns` - (Optional) Specifies the Amazon Resource Names (ARNs) of the RAM permission to associate with the resource share. If you do not specify an ARN for the permission, RAM automatically attaches the default version of the permission for each resource type. You can associate only one permission with each resource type included in the resource share.
 * `tags` - (Optional) A map of tags to assign to the resource share. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20499

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRAMResourceShare_ PKG=ram
--- PASS: TestAccRAMResourceShare_permission (35.57s)
--- PASS: TestAccRAMResourceShare_basic (35.62s)
--- PASS: TestAccRAMResourceShare_allowExternalPrincipals (56.72s)
--- PASS: TestAccRAMResourceShare_name (57.08s)
--- PASS: TestAccRAMResourceShare_tags (77.97s)
```
