### PR TITLE
r/servicecatalog_provisioned_product: fix error when in the `TAINTED` state

### DIFF
--- a/.changelog/25130.txt
+++ b/.changelog/25130.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_servicecatalog_provisioned_product: Correctly handle resources in a `TAINTED` state
+```

--- a/website/docs/r/servicecatalog_provisioned_product.html.markdown
+++ b/website/docs/r/servicecatalog_provisioned_product.html.markdown
@@ -105,6 +105,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ### status Meanings
 
+~> **NOTE:** [Enable logging](https://www.terraform.io/plugin/log/managing) to `WARN` verbosity to further investigate error messages associated with a provisioned product in the `ERROR` or `TAINTED` state which can occur during resource creation or update.
+
 * `AVAILABLE` - Stable state, ready to perform any operation. The most recent operation succeeded and completed.
 * `UNDER_CHANGE` - Transitive state. Operations performed might not have
 valid results. Wait for an `AVAILABLE` status before performing operations.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24574

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccServiceCatalogProvisionedProduct_' PKG=servicecatalog
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20  -run=TestAccServiceCatalogProvisionedProduct_ -timeout 180m
=== RUN   TestAccServiceCatalogProvisionedProduct_basic
=== PAUSE TestAccServiceCatalogProvisionedProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_update
=== PAUSE TestAccServiceCatalogProvisionedProduct_update
=== RUN   TestAccServiceCatalogProvisionedProduct_disappears
=== PAUSE TestAccServiceCatalogProvisionedProduct_disappears
=== RUN   TestAccServiceCatalogProvisionedProduct_tags
=== PAUSE TestAccServiceCatalogProvisionedProduct_tags
=== RUN   TestAccServiceCatalogProvisionedProduct_tainted
=== PAUSE TestAccServiceCatalogProvisionedProduct_tainted
=== CONT  TestAccServiceCatalogProvisionedProduct_basic
=== CONT  TestAccServiceCatalogProvisionedProduct_tags
=== CONT  TestAccServiceCatalogProvisionedProduct_tainted
=== CONT  TestAccServiceCatalogProvisionedProduct_disappears
=== CONT  TestAccServiceCatalogProvisionedProduct_update
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (134.41s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (139.38s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tainted (213.92s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (228.76s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (229.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	232.687s
```
