### PR TITLE
r/aws_neptune_cluster: added `allow_major_version_upgrade` attribute

### DIFF
--- a/.changelog/25140.txt
+++ b/.changelog/25140.txt
@@ -1,0 +1,2 @@
+```release-note:enhancement
+resource/aws_neptune_cluster: Add `allow_major_version_upgrade` argument.

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -47,6 +47,14 @@ func ResourceCluster() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 
+			// allow_major_version_upgrade is used to indicate whether upgrades between different major versions
+			// are allowed.
+			"allow_major_version_upgrade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			// apply_immediately is used to determine when the update modifications
 			// take place.
 			"apply_immediately": {
@@ -560,8 +568,9 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	requestUpdate := false
 
 	req := &neptune.ModifyDBClusterInput{
-		ApplyImmediately:    aws.Bool(d.Get("apply_immediately").(bool)),
-		DBClusterIdentifier: aws.String(d.Id()),
+		AllowMajorVersionUpgrade: aws.Bool(d.Get("allow_major_version_upgrade").(bool)),
+		ApplyImmediately:         aws.Bool(d.Get("apply_immediately").(bool)),
+		DBClusterIdentifier:      aws.String(d.Id()),
 	}
 
 	if d.HasChange("copy_tags_to_snapshot") {

--- a/website/docs/r/neptune_cluster.html.markdown
+++ b/website/docs/r/neptune_cluster.html.markdown
@@ -39,6 +39,7 @@ See the AWS [Docs](https://docs.aws.amazon.com/neptune/latest/userguide/limits.h
 
 The following arguments are supported:
 
+* `allow_major_version_upgrade` - (Optional) Specifies whether upgrades between different major versions are allowed. You must set it to `true` when providing an `engine_version` parameter that uses a different major version than the DB cluster's current version. Default is `false`.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false`.
 * `availability_zones` - (Optional) A list of EC2 Availability Zones that instances in the Neptune cluster can be created in.
 * `backup_retention_period` - (Optional) The days to retain backups for. Default `1`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24512

Adding `allow_major_version_upgrade` attribute for AWS Neptune Cluster.

Output from acceptance testing:
Sorry, I'm not able to run Acceptance Tests right now, may I ask you to run them?

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccNeptuneCluster PKG=neptune

...
```
