### PR TITLE
resource/aws_db_instance_role_association & aws_rds_cluster_role_association: Extend timeouts

### DIFF
--- a/.changelog/25145.txt
+++ b/.changelog/25145.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_rds_cluster_role_association: Extend timeout to 10 minutes
+```
+
+```release-note:bug
+resource/aws_db_instance_role_association: Extend timeout to 10 minutes
+```

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -331,7 +331,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceClusterInstanceCreateUpdatePendingStates,
 		Target:     []string{"available"},
-		Refresh:    resourceInstanceStateRefreshFunc(d.Id(), conn),
+		Refresh:    resourceDbInstanceStateRefreshFunc(d.Id(), conn),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -604,7 +604,7 @@ func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		stateConf := &resource.StateChangeConf{
 			Pending:    resourceClusterInstanceCreateUpdatePendingStates,
 			Target:     []string{"available"},
-			Refresh:    resourceInstanceStateRefreshFunc(d.Id(), conn),
+			Refresh:    resourceDbInstanceStateRefreshFunc(d.Id(), conn),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -880,7 +880,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		stateConf := &resource.StateChangeConf{
 			Pending:    resourceInstanceCreatePendingStates,
 			Target:     []string{"available", "storage-optimization"},
-			Refresh:    resourceInstanceStateRefreshFunc(d.Id(), conn),
+			Refresh:    resourceDbInstanceStateRefreshFunc(d.Id(), conn),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting
@@ -1379,7 +1379,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceInstanceCreatePendingStates,
 		Target:     []string{"available", "storage-optimization"},
-		Refresh:    resourceInstanceStateRefreshFunc(d.Id(), conn),
+		Refresh:    resourceDbInstanceStateRefreshFunc(d.Id(), conn),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
@@ -1609,7 +1609,7 @@ func waitUntilDBInstanceAvailableAfterUpdate(id string, conn *rds.RDS, timeout t
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceInstanceUpdatePendingStates,
 		Target:     []string{"available", "storage-optimization"},
-		Refresh:    resourceInstanceStateRefreshFunc(id, conn),
+		Refresh:    resourceDbInstanceStateRefreshFunc(id, conn),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
@@ -1881,11 +1881,11 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceInstanceRead(d, meta)
 }
 
-// resourceInstanceRetrieve fetches DBInstance information from the AWS
+// resourceDbInstanceRetrieve fetches DBInstance information from the AWS
 // API. It returns an error if there is a communication problem or unexpected
 // error with AWS. When the DBInstance is not found, it returns no error and a
 // nil pointer.
-func resourceInstanceRetrieve(id string, conn *rds.RDS) (*rds.DBInstance, error) {
+func resourceDbInstanceRetrieve(id string, conn *rds.RDS) (*rds.DBInstance, error) {
 	opts := rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String(id),
 	}
@@ -1917,12 +1917,11 @@ func resourceInstanceImport(
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceInstanceStateRefreshFunc(id string, conn *rds.RDS) resource.StateRefreshFunc {
+func resourceDbInstanceStateRefreshFunc(id string, conn *rds.RDS) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		v, err := resourceInstanceRetrieve(id, conn)
+		v, err := resourceDbInstanceRetrieve(id, conn)
 
 		if err != nil {
-			log.Printf("Error on retrieving DB Instance when waiting: %s", err)
 			return nil, "", err
 		}
 
@@ -1930,11 +1929,7 @@ func resourceInstanceStateRefreshFunc(id string, conn *rds.RDS) resource.StateRe
 			return nil, "", nil
 		}
 
-		if v.DBInstanceStatus != nil {
-			log.Printf("[DEBUG] DB Instance status for instance %s: %s", id, *v.DBInstanceStatus)
-		}
-
-		return v, *v.DBInstanceStatus, nil
+		return v, aws.StringValue(v.DBInstanceStatus), nil
 	}
 }
 

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -69,13 +69,13 @@ func resourceInstanceRoleAssociationCreate(d *schema.ResourceData, meta interfac
 	_, err := conn.AddRoleToDBInstance(input)
 
 	if err != nil {
-		return fmt.Errorf("error associating RDS DB Instance (%s) IAM Role (%s): %s", dbInstanceIdentifier, roleArn, err)
+		return fmt.Errorf("error associating RDS DB Instance (%s) IAM Role (%s): %w", dbInstanceIdentifier, roleArn, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s,%s", dbInstanceIdentifier, roleArn))
 
 	if err := waitForDBInstanceRoleAssociation(conn, dbInstanceIdentifier, roleArn); err != nil {
-		return fmt.Errorf("error waiting for RDS DB Instance (%s) IAM Role (%s) association: %s", dbInstanceIdentifier, roleArn, err)
+		return fmt.Errorf("error waiting for RDS DB Instance (%s) IAM Role (%s) association: %w", dbInstanceIdentifier, roleArn, err)
 	}
 
 	return resourceInstanceRoleAssociationRead(d, meta)
@@ -87,7 +87,7 @@ func resourceInstanceRoleAssociationRead(d *schema.ResourceData, meta interface{
 	dbInstanceIdentifier, roleArn, err := InstanceRoleAssociationDecodeID(d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error reading resource ID: %s", err)
+		return fmt.Errorf("error reading resource ID: %w", err)
 	}
 
 	dbInstanceRole, err := DescribeInstanceRole(conn, dbInstanceIdentifier, roleArn)
@@ -99,7 +99,7 @@ func resourceInstanceRoleAssociationRead(d *schema.ResourceData, meta interface{
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading RDS DB Instance (%s) IAM Role (%s) association: %s", dbInstanceIdentifier, roleArn, err)
+		return fmt.Errorf("error reading RDS DB Instance (%s) IAM Role (%s) association: %w", dbInstanceIdentifier, roleArn, err)
 	}
 
 	if dbInstanceRole == nil {
@@ -121,7 +121,7 @@ func resourceInstanceRoleAssociationDelete(d *schema.ResourceData, meta interfac
 	dbInstanceIdentifier, roleArn, err := InstanceRoleAssociationDecodeID(d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error reading resource ID: %s", err)
+		return fmt.Errorf("error reading resource ID: %w", err)
 	}
 
 	input := &rds.RemoveRoleFromDBInstanceInput{
@@ -142,11 +142,11 @@ func resourceInstanceRoleAssociationDelete(d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return fmt.Errorf("error disassociating RDS DB Instance (%s) IAM Role (%s): %s", dbInstanceIdentifier, roleArn, err)
+		return fmt.Errorf("error disassociating RDS DB Instance (%s) IAM Role (%s): %w", dbInstanceIdentifier, roleArn, err)
 	}
 
 	if err := WaitForInstanceRoleDisassociation(conn, dbInstanceIdentifier, roleArn); err != nil {
-		return fmt.Errorf("error waiting for RDS DB Instance (%s) IAM Role (%s) disassociation: %s", dbInstanceIdentifier, roleArn, err)
+		return fmt.Errorf("error waiting for RDS DB Instance (%s) IAM Role (%s) disassociation: %w", dbInstanceIdentifier, roleArn, err)
 	}
 
 	return nil

--- a/internal/service/rds/instance_role_association_test.go
+++ b/internal/service/rds/instance_role_association_test.go
@@ -192,6 +192,9 @@ data "aws_rds_orderable_db_instance" "test" {
 resource "aws_iam_role" "test" {
   assume_role_policy = data.aws_iam_policy_document.rds_assume_role_policy.json
   name               = %[1]q
+
+  # ensure IAM role is created just before association to exercise IAM eventual consistency
+  depends_on = [aws_db_instance.test]
 }
 
 data "aws_iam_policy_document" "rds_assume_role_policy" {

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	dbClusterRoleAssociationCreatedTimeout = 5 * time.Minute
-	dbClusterRoleAssociationDeletedTimeout = 5 * time.Minute
+	dbClusterRoleAssociationCreatedTimeout = 10 * time.Minute
+	dbClusterRoleAssociationDeletedTimeout = 10 * time.Minute
 
 	dbClusterActivityStreamStartedTimeout = 30 * time.Minute
 	dbClusterActivityStreamStoppedTimeout = 30 * time.Minute


### PR DESCRIPTION
Extends the timeouts for `aws_db_instance_role_association` and `aws_rds_cluster_role_association`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24963

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=rds TESTS='TestAccRDSInstanceRoleAssociation|TestAccRDSClusterRoleAssociation'

--- PASS: TestAccRDSClusterRoleAssociation_Disappears_cluster (184.79s)
--- PASS: TestAccRDSClusterRoleAssociation_Disappears_role (187.39s)
--- PASS: TestAccRDSClusterRoleAssociation_disappears (190.88s)
--- PASS: TestAccRDSClusterRoleAssociation_basic (205.95s)
--- PASS: TestAccRDSInstanceRoleAssociation_disappears (901.54s)
--- PASS: TestAccRDSInstanceRoleAssociation_basic (972.91s)
```
