### PR TITLE
fix(doc): wrong example for aws_imagebuilder_distribution_configuration

### DIFF
--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -24,13 +24,13 @@ resource "aws_imagebuilder_distribution_configuration" "example" {
 
       name = "example-{{ imagebuilder:buildDate }}"
 
-      launch_template_configuration {
-        launch_template_id = "lt-0aaa1bcde2ff3456"
-      }
-
       launch_permission {
         user_ids = ["123456789012"]
       }
+    }
+
+    launch_template_configuration {
+      launch_template_id = "lt-0aaa1bcde2ff3456"
     }
 
     region = "us-east-1"


### PR DESCRIPTION
Fix wrong example in aws_imagebuilder_distribution_configuration.
launch_template_configuration must be defined under the distribution block.
