### PR TITLE
r/ram_resource_share - Fix #25156

### DIFF
--- a/.changelog/25158.txt
+++ b/.changelog/25158.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ram_resource_share: Fix regression in 4.17.0 where `permission_arns` would get clobberd if already set.
+resource/aws_ram_resource_share: Fix regression in v4.17.0 where `permission_arns` would get clobbered if already set
 ```

--- a/.changelog/25158.txt
+++ b/.changelog/25158.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ram_resource_share: Fix regression in 4.17.0 where `permission_arns` would get clobberd if already set.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ ENHANCEMENTS:
 * resource/aws_dms_endpoint: Add ability to use AWS Secrets Manager with the `redshift` engine ([#25080](https://github.com/hashicorp/terraform-provider-aws/issues/25080))
 * resource/aws_dms_endpoint: Add ability to use AWS Secrets Manager with the `sqlserver` engine ([#22646](https://github.com/hashicorp/terraform-provider-aws/issues/22646))
 * resource/aws_guardduty_detector: Add `kubernetes` attribute to the `datasources` configuration block ([#22859](https://github.com/hashicorp/terraform-provider-aws/issues/22859))
+* resource/aws_ram_resource_share: Add `permission_arns` argument. ([#25113](https://github.com/hashicorp/terraform-provider-aws/issues/25113))
 * resource/aws_redshift_cluster: The `default_iam_role_arn` argument is now Computed ([#25096](https://github.com/hashicorp/terraform-provider-aws/issues/25096))
 
 BUG FIXES:

--- a/internal/service/ram/resource_share.go
+++ b/internal/service/ram/resource_share.go
@@ -48,6 +48,7 @@ func ResourceResourceShare() *schema.Resource {
 			"permission_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25156.
Relates #25113.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRAMResourceShare_ PKG=ram
--- PASS: TestAccRAMResourceShare_disappears (27.55s)
--- PASS: TestAccRAMResourceShare_basic (37.24s)
--- PASS: TestAccRAMResourceShare_permission (37.63s)
--- PASS: TestAccRAMResourceShare_allowExternalPrincipals (62.80s)
--- PASS: TestAccRAMResourceShare_name (62.83s)
--- PASS: TestAccRAMResourceShare_tags (97.13s)
```
