### PR TITLE
d/aws_ram_resource_share - add `resource_share_status` argument

### DIFF
--- a/.changelog/25159.txt
+++ b/.changelog/25159.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ram_resource_share: Add `resource_share_status` argument.
+```

--- a/internal/service/ram/resource_share_data_source.go
+++ b/internal/service/ram/resource_share_data_source.go
@@ -35,12 +35,15 @@ func DataSourceResourceShare() *schema.Resource {
 			},
 
 			"resource_owner": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ram.ResourceOwnerOtherAccounts,
-					ram.ResourceOwnerSelf,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(ram.ResourceOwner_Values(), false),
+			},
+
+			"resource_share_status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ram.ResourceShareStatus_Values(), false),
 			},
 
 			"name": {
@@ -80,6 +83,10 @@ func dataSourceResourceShareRead(d *schema.ResourceData, meta interface{}) error
 	params := &ram.GetResourceSharesInput{
 		Name:          aws.String(name),
 		ResourceOwner: aws.String(owner),
+	}
+
+	if v, ok := d.GetOk("resource_share_status"); ok {
+		params.ResourceShareStatus = aws.String(v.(string))
 	}
 
 	if filtersOk {

--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -38,8 +38,9 @@ data "aws_ram_resource_share" "tag_filter" {
 The following Arguments are supported
 
 * `name` - (Required) The name of the resource share to retrieve.
-* `resource_owner` (Required) The owner of the resource share. Valid values are SELF or OTHER-ACCOUNTS
+* `resource_owner` (Required) The owner of the resource share. Valid values are `SELF` or `OTHER-ACCOUNTS`.
 
+* `resource_share_status` (Optional) Specifies that you want to retrieve details of only those resource shares that have this status. Valid values are `PENDING`, `ACTIVE`, `FAILED`, `DELETING`, and `DELETED`.
 * `filter` - (Optional) A filter used to scope the list e.g., by tags. See [related docs] (https://docs.aws.amazon.com/ram/latest/APIReference/API_TagFilter.html).
     * `name` - (Required) The name of the tag key to filter on.
     * `values` - (Required) The value of the tag key.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25157

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRAMResourceShareDataSource_ PKG=ram
--- PASS: TestAccRAMResourceShareDataSource_tags (35.06s)
--- PASS: TestAccRAMResourceShareDataSource_status (35.55s)
--- PASS: TestAccRAMResourceShareDataSource_basic (39.49s)
```
