### PR TITLE
resource/aws_ssm_parameter: Allow `Intelligent-Tiering` to upgrade to `Advanced`

### DIFF
--- a/.changelog/25174.txt
+++ b/.changelog/25174.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_parameter: Allow `Intelligent-Tiering` to upgrade to `Advanced` tier as needed.
+```

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -129,7 +129,6 @@ func resourceParameterCreate(d *schema.ResourceData, meta interface{}) error {
 		Name:           aws.String(name),
 		Type:           aws.String(d.Get("type").(string)),
 		Value:          aws.String(d.Get("value").(string)),
-		Overwrite:      aws.Bool(ShouldUpdateParameter(d)),
 		AllowedPattern: aws.String(d.Get("allowed_pattern").(string)),
 	}
 
@@ -149,33 +148,20 @@ func resourceParameterCreate(d *schema.ResourceData, meta interface{}) error {
 		paramInput.SetKeyId(keyID.(string))
 	}
 
-	// AWS SSM Service only supports PutParameter requests with Tags
-	// iff Overwrite is not provided or is false; in this resource's case,
-	// the Overwrite value is always set in the paramInput so we check for the value
-	if len(tags) > 0 && !aws.BoolValue(paramInput.Overwrite) {
+	if len(tags) > 0 {
 		paramInput.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	_, err := conn.PutParameter(paramInput)
 
 	if tfawserr.ErrMessageContains(err, "ValidationException", "Tier is not supported") {
+		log.Printf("[WARN] Creating SSM Parameter (%s): tier %q not supported, using default", name, d.Get("tier").(string))
 		paramInput.Tier = nil
 		_, err = conn.PutParameter(paramInput)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating SSM parameter (%s): %w", name, err)
-	}
-
-	// Since the AWS SSM Service does not support PutParameter requests with
-	// Tags and Overwrite set to true, we make an additional API call
-	// to Update the resource's tags if necessary
-	if d.HasChange("tags_all") && paramInput.Tags == nil {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(conn, name, ssm.ResourceTypeForTaggingParameter, o, n); err != nil {
-			return fmt.Errorf("error updating SSM Parameter (%s) tags: %w", name, err)
-		}
+		return fmt.Errorf("error creating SSM Parameter (%s): %w", name, err)
 	}
 
 	d.SetId(name)
@@ -312,12 +298,13 @@ func resourceParameterUpdate(d *schema.ResourceData, meta interface{}) error {
 		_, err := conn.PutParameter(paramInput)
 
 		if tfawserr.ErrMessageContains(err, "ValidationException", "Tier is not supported") {
+			log.Printf("[WARN] Updating SSM Parameter (%s): tier %q not supported, using default", d.Get("name").(string), d.Get("tier").(string))
 			paramInput.Tier = nil
 			_, err = conn.PutParameter(paramInput)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating SSM parameter (%s): %w", d.Id(), err)
+			return fmt.Errorf("error updating SSM Parameter (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -278,6 +278,7 @@ func resourceParameterUpdate(d *schema.ResourceData, meta interface{}) error {
 			AllowedPattern: aws.String(d.Get("allowed_pattern").(string)),
 		}
 
+		// Retrieve the value set in the config directly to counteract the DiffSuppressFunc above
 		tier := d.GetRawConfig().GetAttr("tier")
 		if tier.IsKnown() && !tier.IsNull() {
 			paramInput.Tier = aws.String(tier.AsString())

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -61,7 +61,11 @@ The following arguments are supported:
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of `type`. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the [Terraform v0.15 Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values).
 * `description` - (Optional) The description of the parameter.
-* `tier` - (Optional) The tier of the parameter. If not specified, will default to `Standard`. Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`. For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
+* `tier` - (Optional) The parameter tier to assign to the parameter.
+  If not specified, will use the default parameter tier for the region.
+  Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`.
+  Downgrading an `Advanced` tier parameter to `Standard` will recreate the resource.
+  For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
 * `key_id` - (Optional) The KMS key id or arn for encrypting a SecureString.
 * `overwrite` - (Optional) Overwrite an existing parameter. If not specified, will default to `false` if the resource has not been created by terraform to avoid overwrite of existing resource and will default to `true` otherwise (terraform lifecycle rules should then be used to manage the update behavior).
 * `allowed_pattern` - (Optional) A regular expression used to validate the parameter value.


### PR DESCRIPTION
AWS SSM Parameters with `Intelligent-Tiering` were not upgrading from `Standard` to `Advanced` if needed.

Removes hard-coded default of `Standard` to use the default configured for the account and region.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18521
Closes #25037

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ssm TESTS=TestAccSSMParameter

--- PASS: TestAccSSMParameter_disappears (106.85s)
--- PASS: TestAccSSMParametersByPathDataSource_withRecursion (130.32s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnCreation (137.32s)
--- PASS: TestAccSSMParameter_overwriteWithTags (146.87s)
--- PASS: TestAccSSMParameter_secure (146.89s)
--- PASS: TestAccSSMParameter_noOverwriteWithTags (147.05s)
--- PASS: TestAccSSMParameter_fullPath (147.11s)
--- PASS: TestAccSSMParameter_basic (149.06s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnUpdate (204.45s)
--- PASS: TestAccSSMParameterDataSource_basic (209.50s)
--- PASS: TestAccSSMParameter_updateType (216.19s)
--- PASS: TestAccSSMParameter_updateToOverwriteWithTags (220.86s)
--- PASS: TestAccSSMParametersByPathDataSource_basic (114.14s)
--- PASS: TestAccSSMParameter_overwrite (222.88s)
--- PASS: TestAccSSMParameter_updateDescription (223.01s)
--- PASS: TestAccSSMParameter_Secure_keyUpdate (223.90s)
--- PASS: TestAccSSMParameterDataSource_fullPath (95.61s)
--- PASS: TestAccSSMParameter_overwriteCascade (236.64s)
--- PASS: TestAccSSMParameter_secureWithKey (99.41s)
--- PASS: TestAccSSMParameter_DataType_ec2Image (97.65s)
--- PASS: TestAccSSMParameter_tier (246.33s)
--- PASS: TestAccSSMParameter_tags (246.96s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (247.06s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (248.32s)
--- PASS: TestAccSSMParameter_changeNameForcesNew (103.43s)
```
