### PR TITLE
fix opensearch_domain documentation

### DIFF
--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -59,7 +59,7 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_opensearch_domain" "example" {
+resource "aws_opensearch_domain_policy" "example" {
   domain_name = var.domain
 
   # ... other configuration ...


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This PR is only fix documentation.  

Target URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain#access-policy

The part that should be `aws_opensearch_domain_policy` was `aws_opensearch_domain`.