### PR TITLE
d/cloudwatch_logs_groups - make `log_group_name_prefix` optional

### DIFF
--- a/internal/service/logs/groups_data_source.go
+++ b/internal/service/logs/groups_data_source.go
@@ -21,7 +21,7 @@ func DataSourceGroups() *schema.Resource {
 			},
 			"log_group_name_prefix": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"log_group_names": {
 				Type:     schema.TypeSet,
@@ -35,8 +35,10 @@ func DataSourceGroups() *schema.Resource {
 func dataSourceGroupsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).LogsConn
 
-	input := &cloudwatchlogs.DescribeLogGroupsInput{
-		LogGroupNamePrefix: aws.String(d.Get("log_group_name_prefix").(string)),
+	input := &cloudwatchlogs.DescribeLogGroupsInput{}
+
+	if v, ok := d.GetOk("log_group_name_prefix"); ok {
+		input.LogGroupNamePrefix = aws.String(v.(string))
 	}
 
 	var results []*cloudwatchlogs.LogGroup

--- a/internal/service/logs/groups_data_source_test.go
+++ b/internal/service/logs/groups_data_source_test.go
@@ -34,6 +34,28 @@ func TestAccLogsGroupsDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccLogsGroupsDataSource_noPrefix(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "data.aws_cloudwatch_log_groups.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, cloudwatchlogs.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupsDataSourceConfig_noPrefix(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "arns.*", "aws_cloudwatch_log_group.test1", "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "arns.*", "aws_cloudwatch_log_group.test2", "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_group_names.*", "aws_cloudwatch_log_group.test1", "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_group_names.*", "aws_cloudwatch_log_group.test2", "name"),
+				),
+			},
+		},
+	})
+}
+
 func testAccGroupsDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource aws_cloudwatch_log_group "test1" {
@@ -47,6 +69,22 @@ resource aws_cloudwatch_log_group "test2" {
 data aws_cloudwatch_log_groups "test" {
   log_group_name_prefix = %[1]q
 
+  depends_on = [aws_cloudwatch_log_group.test1,aws_cloudwatch_log_group.test2]
+}
+`, rName)
+}
+
+func testAccGroupsDataSourceConfig_noPrefix(rName string) string {
+	return fmt.Sprintf(`
+resource aws_cloudwatch_log_group "test1" {
+  name = "%[1]s/1"
+}
+
+resource aws_cloudwatch_log_group "test2" {
+  name = "%[1]s/2"
+}
+
+data aws_cloudwatch_log_groups "test" {
   depends_on = [aws_cloudwatch_log_group.test1,aws_cloudwatch_log_group.test2]
 }
 `, rName)

--- a/website/docs/d/cloudwatch_log_groups.html.markdown
+++ b/website/docs/d/cloudwatch_log_groups.html.markdown
@@ -22,7 +22,7 @@ data "aws_cloudwatch_log_groups" "example" {
 
 The following arguments are supported:
 
-* `log_group_name_prefix` - (Required) The group prefix of the Cloudwatch log groups to list
+* `log_group_name_prefix` - (Optional) The group prefix of the Cloudwatch log groups to list
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25155

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccLogsGroupsDataSource_ PKG=logs

--- PASS: TestAccLogsGroupsDataSource_noPrefix (26.84s)
--- PASS: TestAccLogsGroupsDataSource_basic (27.02s)
```
