### PR TITLE
r/ec2_vpc_endpoint_service - add `supported_ip_address_types` argument

### DIFF
--- a/internal/service/ec2/vpc_endpoint_service_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_test.go
@@ -68,9 +68,8 @@ func TestAccVPCEndpointService_ipTypes(t *testing.T) {
 				Config: testAccVPCEndpointServiceConfig_ipTypes(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointServiceExists(resourceName, &svcCfg),
-					resource.TestCheckResourceAttr(resourceName, "supported_ip_address_types.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "supported_ip_address_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "supported_ip_address_types.*", "ipv4"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "supported_ip_address_types.*", "ipv6"),
 				),
 			},
 			{
@@ -471,7 +470,7 @@ resource "aws_vpc_endpoint_service" "test" {
     aws_lb.test1.arn,
   ]
 
-  supported_ip_address_types = ["ipv4", "ipv6"]
+  supported_ip_address_types = ["ipv4"]
 }
 `)
 }

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 * `network_load_balancer_arns` - (Optional) Amazon Resource Names (ARNs) of one or more Network Load Balancers for the endpoint service.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `private_dns_name` - (Optional) The private DNS name for the service.
+* `supported_ip_address_types` - (Optional) The supported IP address types. The possible values are `ipv4` and `ipv6`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #24784

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCEndpointService_ PKG=ec2

...
```
