### PR TITLE
r/vpc_endpoint - add `dns_options` and `ip_address_type` argument

### DIFF
--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -68,6 +68,7 @@ func ResourceVPCEndpoint() *schema.Resource {
 			"dns_options": {
 				Type:             schema.TypeList,
 				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 				MaxItems:         1,
 				Elem: &schema.Resource{
@@ -83,6 +84,7 @@ func ResourceVPCEndpoint() *schema.Resource {
 			"ip_address_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice(ec2.IpAddressType_Values(), false),
 			},
 			"network_interface_ids": {

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -65,6 +65,11 @@ func ResourceVPCEndpoint() *schema.Resource {
 					},
 				},
 			},
+			"ip_address_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.IpAddressType_Values(), false),
+			},
 			"network_interface_ids": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -176,6 +181,10 @@ func resourceVPCEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		req.PolicyDocument = aws.String(policy)
 	}
 
+	if v, ok := d.GetOk("ip_address_type"); ok {
+		req.IpAddressType = aws.String(v.(string))
+	}
+
 	setVPCEndpointCreateList(d, "route_table_ids", &req.RouteTableIds)
 	setVPCEndpointCreateList(d, "subnet_ids", &req.SubnetIds)
 	setVPCEndpointCreateList(d, "security_group_ids", &req.SecurityGroupIds)
@@ -234,6 +243,7 @@ func resourceVPCEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("service_name", serviceName)
 	d.Set("state", vpce.State)
 	d.Set("vpc_id", vpce.VpcId)
+	d.Set("ip_address_type", vpce.IpAddressType)
 
 	respPl, err := conn.DescribePrefixLists(&ec2.DescribePrefixListsInput{
 		Filters: BuildAttributeFilterList(map[string]string{

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -66,9 +66,10 @@ func ResourceVPCEndpoint() *schema.Resource {
 				},
 			},
 			"dns_options": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+				MaxItems:         1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"dns_record_ip_type": {

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -120,12 +120,18 @@ The following arguments are supported:
 * `policy` - (Optional) A policy to attach to the endpoint that controls access to the service. This is a JSON formatted string. Defaults to full access. All `Gateway` and some `Interface` endpoints support policies - see the [relevant AWS documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-access.html) for more details. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 * `private_dns_enabled` - (Optional; AWS services and AWS Marketplace partner services only) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
 Defaults to `false`.
+* `dns_options` - (Optional) The DNS options for the endpoint. See dns_options below.
+* `ip_address_type` - (Optional) The IP address type for the endpoint. Valid values are `ipv4`, `dualstack`, and `ipv6`.
 * `route_table_ids` - (Optional) One or more route table IDs. Applicable for endpoints of type `Gateway`.
 * `subnet_ids` - (Optional) The ID of one or more subnets in which to create a network interface for the endpoint. Applicable for endpoints of type `GatewayLoadBalancer` and `Interface`.
 * `security_group_ids` - (Optional) The ID of one or more security groups to associate with the network interface. Applicable for endpoints of type `Interface`.
 If no security groups are specified, the VPC's [default security group](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#DefaultSecurityGroup) is associated with the endpoint.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_endpoint_type` - (Optional) The VPC endpoint type, `Gateway`, `GatewayLoadBalancer`, or `Interface`. Defaults to `Gateway`.
+
+### dns_options
+
+* `dns_record_ip_type` - (Optional) The DNS records created for the endpoint. Valid values are `ipv4`, `dualstack`, `service-defined`, and `ipv6`.
 
 ### Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/24784

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCEndpoint_ PKG=ec2
--- PASS: TestAccVPCEndpoint_disappears (44.99s)
--- PASS: TestAccVPCEndpoint_gatewayBasic (51.87s)
--- PASS: TestAccVPCEndpoint_ignoreEquivalent (67.38s)
--- PASS: TestAccVPCEndpoint_gatewayPolicy (84.57s)
--- PASS: TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy (98.01s)
--- PASS: TestAccVPCEndpoint_tags (99.39s)
--- PASS: TestAccVPCEndpoint_interfaceBasic (151.59s)
--- PASS: TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate (277.36s)
--- PASS: TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate (347.46s)
--- PASS: TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup (484.52s)
```
