### PR TITLE
Add additional compute types to aws_workspaces_workspace list of valid values

### DIFF
--- a/website/docs/r/workspaces_workspace.html.markdown
+++ b/website/docs/r/workspaces_workspace.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 `workspace_properties` supports the following:
 
-* `compute_type_name` – (Optional) The compute type. For more information, see [Amazon WorkSpaces Bundles](http://aws.amazon.com/workspaces/details/#Amazon_WorkSpaces_Bundles). Valid values are `VALUE`, `STANDARD`, `PERFORMANCE`, `POWER`, `GRAPHICS`, `POWERPRO` and `GRAPHICSPRO`.
+* `compute_type_name` – (Optional) The compute type. For more information, see [Amazon WorkSpaces Bundles](http://aws.amazon.com/workspaces/details/#Amazon_WorkSpaces_Bundles). Valid values are `VALUE`, `STANDARD`, `PERFORMANCE`, `POWER`, `GRAPHICS`, `POWERPRO`, `GRAPHICSPRO`, `GRAPHICS_G4DN`, and `GRAPHICSPRO_G4DN`.
 * `root_volume_size_gib` – (Optional) The size of the root volume.
 * `running_mode` – (Optional) The running mode. For more information, see [Manage the WorkSpace Running Mode](https://docs.aws.amazon.com/workspaces/latest/adminguide/running-mode.html). Valid values are `AUTO_STOP` and `ALWAYS_ON`.
 * `running_mode_auto_stop_timeout_in_minutes` – (Optional) The time after a user logs off when WorkSpaces are automatically stopped. Configured in 60-minute intervals.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates  #25112

Output from acceptance testing: n/a, docs

### Information

This PR adds a couple of additional valid values to the list of accepted values for `aws_workspaces_workspace.workspace_properties.compute_type_name`.

### References

- `ValidateFunc` uses [`workspaces.Compute_Values()`](https://github.com/hashicorp/terraform-provider-aws/blob/e70faae038841b83dc077de02ab7a07bb7c6726e/internal/service/workspaces/workspace.go#L82)
- [AWS Go SDK definition for `workspaces.Compute_Values()`](https://github.com/aws/aws-sdk-go/blob/4c3c501c0c5ae8aabc7ee678698569d643d47517/service/workspaces/api.go#L15742-L15784)