### PR TITLE
Update upgrade guide to indicate lifecycle_rule id is required

### DIFF
--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -491,6 +491,8 @@ resource "aws_s3_bucket_cors_configuration" "example" {
 
 ### Migrating to `aws_s3_bucket_lifecycle_configuration`
 
+~> **Note:** In version `3.x` of the provider, the `lifecycle_rule.id` argument was an optional parameter, while in version `4.x`, the `aws_s3_bucket_lifecycle_configuration.rule.id` argument required.
+
 #### For Lifecycle Rules with no `prefix` previously configured
 
 ~> **Note:** When configuring the `rule.filter` configuration block in the new `aws_s3_bucket_lifecycle_configuration` resource, use the AWS CLI s3api [get-bucket-lifecycle-configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/get-bucket-lifecycle-configuration.html)

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -491,7 +491,7 @@ resource "aws_s3_bucket_cors_configuration" "example" {
 
 ### Migrating to `aws_s3_bucket_lifecycle_configuration`
 
-~> **Note:** In version `3.x` of the provider, the `lifecycle_rule.id` argument was an optional parameter, while in version `4.x`, the `aws_s3_bucket_lifecycle_configuration.rule.id` argument required.
+~> **Note:** In version `3.x` of the provider, the `lifecycle_rule.id` argument was optional, while in version `4.x`, the `aws_s3_bucket_lifecycle_configuration.rule.id` argument required. Use the AWS CLI s3api [get-bucket-lifecycle-configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/get-bucket-lifecycle-configuration.html) to get the source bucket's lifecycle configuration to determine the ID.
 
 #### For Lifecycle Rules with no `prefix` previously configured
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #24505

Output from acceptance testing: n/a, docs

### Information

This PR aims to clarify that the `id` of a lifecycle rule is a required argument in provider version `4.x`, whereas it was an optional argument in `3.x`.