### PR TITLE
Update `aws_sns_platform_application` argument descriptions

### DIFF
--- a/website/docs/r/sns_platform_application.html.markdown
+++ b/website/docs/r/sns_platform_application.html.markdown
@@ -40,14 +40,14 @@ The following arguments are supported:
 * `name` - (Required) The friendly name for the SNS platform application
 * `platform` - (Required) The platform that the app is registered with. See [Platform][1] for supported platforms.
 * `platform_credential` - (Required) Application Platform credential. See [Credential][1] for type of credential required for platform. The value of this attribute when stored into the Terraform state is only a hash of the real value, so therefore it is not practical to use this as an attribute for other resources.
-* `event_delivery_failure_topic_arn` - (Optional) SNS Topic triggered when a delivery to any of the platform endpoints associated with your platform application encounters a permanent failure.
-* `event_endpoint_created_topic_arn` - (Optional) SNS Topic triggered when a new platform endpoint is added to your platform application.
-* `event_endpoint_deleted_topic_arn` - (Optional) SNS Topic triggered when an existing platform endpoint is deleted from your platform application.
-* `event_endpoint_updated_topic_arn` - (Optional) SNS Topic triggered when an existing platform endpoint is changed from your platform application.
-* `failure_feedback_role_arn` - (Optional) The IAM role permitted to receive failure feedback for this application.
+* `event_delivery_failure_topic_arn` - (Optional) The ARN of the SNS Topic triggered when a delivery to any of the platform endpoints associated with your platform application encounters a permanent failure.
+* `event_endpoint_created_topic_arn` - (Optional) The ARN of the SNS Topic triggered when a new platform endpoint is added to your platform application.
+* `event_endpoint_deleted_topic_arn` - (Optional) The ARN of the SNS Topic triggered when an existing platform endpoint is deleted from your platform application.
+* `event_endpoint_updated_topic_arn` - (Optional) The ARN of the SNS Topic triggered when an existing platform endpoint is changed from your platform application.
+* `failure_feedback_role_arn` - (Optional) The IAM role ARN permitted to receive failure feedback for this application and give SNS write access to use CloudWatch logs on your behalf.
 * `platform_principal` - (Optional) Application Platform principal. See [Principal][2] for type of principal required for platform. The value of this attribute when stored into the Terraform state is only a hash of the real value, so therefore it is not practical to use this as an attribute for other resources.
-* `success_feedback_role_arn` - (Optional) The IAM role permitted to receive success feedback for this application.
-* `success_feedback_sample_rate` - (Optional) The percentage of success to sample (0-100)
+* `success_feedback_role_arn` - (Optional) The IAM role ARN permitted to receive success feedback for this application and give SNS write access to use CloudWatch logs on your behalf.
+* `success_feedback_sample_rate` - (Optional) The sample rate percentage (0-100) of successfully delivered messages.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #24760

Output from acceptance testing: n/a, docs

### Information

The linked issue points out that the descriptions for the arguments for the `aws_sns_platform_application` resource didn't quite describe what some of the arguments did. This PR aims to add a bit of additional clarity to the arguments.

### References

- `aws_sns_platform_application` uses [`sns.CreatePlatformApplication`](https://github.com/hashicorp/terraform-provider-aws/blob/ffe763e4e03ce85c6d0a5165b7584dfefec3533c/internal/service/sns/platform_application.go#L105)
- [`sns.CreatePlatformApplicationInput` reference](https://docs.aws.amazon.com/sdk-for-go/api/service/sns/#CreatePlatformApplicationInput)
- `sns.CreatePlatformApplicationInput` links to [`SetPlatformApplicationAttributes`](https://docs.aws.amazon.com/sns/latest/api/API_SetPlatformApplicationAttributes.html) for descriptions of the attributes, which is where I pulled the descriptions from.