### PR TITLE
r/aws_api_gateway_model: suppress schema whitespace differences

### DIFF
--- a/.changelog/25245.txt
+++ b/.changelog/25245.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_model: Surpress whitespace differences between model schemas
+```

--- a/internal/service/apigateway/model.go
+++ b/internal/service/apigateway/model.go
@@ -9,7 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceModel() *schema.Resource {
@@ -67,6 +70,15 @@ func ResourceModel() *schema.Resource {
 			"schema": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 32768),
+					validation.StringIsJSON,
+				),
+				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"content_type": {


### PR DESCRIPTION
### Community Note
* Please vote on this pull request by adding a +1 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Resolves an issue with API Gateway Schema models being marked as having changed when differences solely consist of irrelevant characters such as whitespace.

Implementation ported from [service/apigatewayv2/model.go](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/apigatewayv2/model.go) which already handles this issue.

Replaces previous PR [#20299](https://github.com/hashicorp/terraform-provider-aws/pull/20299).