### PR TITLE
r/aws_vpc_ipam_pool_cidr_allocation use AllocationId over filtering on `allocation-id`

### DIFF
--- a/.changelog/25257.txt
+++ b/.changelog/25257.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_ipam_pool_cidr_allocation: improve internal search mechanism
+```

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -187,13 +187,8 @@ func FindIPAMPoolCIDRAllocation(conn *ec2.EC2, id string) (*ec2.IpamPoolAllocati
 	}
 
 	input := &ec2.GetIpamPoolAllocationsInput{
-		IpamPoolId: aws.String(pool_id),
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("ipam-pool-allocation-id"),
-				Values: aws.StringSlice([]string{allocation_id}),
-			},
-		},
+		IpamPoolId:           aws.String(pool_id),
+		IpamPoolAllocationId: aws.String(allocation_id),
 	}
 
 	output, err := conn.GetIpamPoolAllocations(input)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #25256 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccIPAMPoolAllocation PKG=ec2                        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAMPoolAllocation'  -timeout 180m
=== RUN   TestAccIPAMPoolAllocation_ipv4Basic
=== PAUSE TestAccIPAMPoolAllocation_ipv4Basic
=== RUN   TestAccIPAMPoolAllocation_ipv4BasicNetmask
=== PAUSE TestAccIPAMPoolAllocation_ipv4BasicNetmask
=== RUN   TestAccIPAMPoolAllocation_ipv4DisallowedCIDR
=== PAUSE TestAccIPAMPoolAllocation_ipv4DisallowedCIDR
=== CONT  TestAccIPAMPoolAllocation_ipv4Basic
=== CONT  TestAccIPAMPoolAllocation_ipv4DisallowedCIDR
=== CONT  TestAccIPAMPoolAllocation_ipv4BasicNetmask
--- PASS: TestAccIPAMPoolAllocation_ipv4DisallowedCIDR (60.46s)
--- PASS: TestAccIPAMPoolAllocation_ipv4Basic (60.62s)
--- PASS: TestAccIPAMPoolAllocation_ipv4BasicNetmask (63.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        66.581s
```
