### PR TITLE
Add multi-key/multi-value `conditional` example to `aws_iam_policy_document` data source documentation

### DIFF
--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -75,6 +75,61 @@ resource "aws_iam_policy" "example" {
 }
 ```
 
+### Example Multiple Condition Keys
+
+You can specify a [condition with multiple keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html) by supplying multiple `condition` blocks with the same `test` value, but differing `variable` values.
+
+```terraform
+data "aws_iam_policy_document" "example_multiple_condition_keys" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "kms:EncryptionContext:service"
+      values   = ["pi"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "kms:EncryptionContext:aws:pi:service"
+      values   = ["rds"]
+    }
+
+  }
+}
+```
+
+`data.aws_iam_policy_document.example_multiple_condition_keys.json` will evaluate to:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "kms:GenerateDataKey",
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "ForAnyValue:StringEquals": {
+          "kms:EncryptionContext:aws:pi:service": "rds",
+          "kms:EncryptionContext:service": "pi"
+        }
+      }
+    }
+  ]
+}
+```
+
 ### Example Assume-Role Policy with Multiple Principals
 
 You can specify multiple principal blocks with different types. You can also use this data source to generate an assume-role policy.

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -75,12 +75,12 @@ resource "aws_iam_policy" "example" {
 }
 ```
 
-### Example Multiple Condition Keys
+### Example Multiple Condition Keys and Values
 
-You can specify a [condition with multiple keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html) by supplying multiple `condition` blocks with the same `test` value, but differing `variable` values.
+You can specify a [condition with multiple keys and values](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html) by supplying multiple `condition` blocks with the same `test` value, but differing `variable` and `values` values.
 
 ```terraform
-data "aws_iam_policy_document" "example_multiple_condition_keys" {
+data "aws_iam_policy_document" "example_multiple_condition_keys_and_values" {
   statement {
     actions = [
       "kms:Decrypt",
@@ -101,11 +101,17 @@ data "aws_iam_policy_document" "example_multiple_condition_keys" {
       values   = ["rds"]
     }
 
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "kms:EncryptionContext:aws:rds:db-id"
+      values   = ["db-AAAAABBBBBCCCCCDDDDDEEEEE", "db-EEEEEDDDDDCCCCCBBBBBAAAAA"]
+    }
+
   }
 }
 ```
 
-`data.aws_iam_policy_document.example_multiple_condition_keys.json` will evaluate to:
+`data.aws_iam_policy_document.example_multiple_condition_keys_and_values.json` will evaluate to:
 
 ```json
 {
@@ -122,6 +128,10 @@ data "aws_iam_policy_document" "example_multiple_condition_keys" {
       "Condition": {
         "ForAnyValue:StringEquals": {
           "kms:EncryptionContext:aws:pi:service": "rds",
+          "kms:EncryptionContext:aws:rds:db-id": [
+            "db-AAAAABBBBBCCCCCDDDDDEEEEE",
+            "db-EEEEEDDDDDCCCCCBBBBBAAAAA"
+          ],
           "kms:EncryptionContext:service": "pi"
         }
       }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25071

Output from acceptance testing: n/a, docs

### Information

It's possible to create IAM policy documents with [conditions with multiple keys/values](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html), however, it wasn't clear in the documentation how to do so. This PR adds an example displaying how to do so.