### PR TITLE
docs(route53_record): add references to block descriptions

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -127,37 +127,42 @@ The following arguments are supported:
 * `set_identifier` - (Optional) Unique identifier to differentiate records with routing policies from one another. Required if using `failover`, `geolocation`, `latency`, `multivalue_answer`, or `weighted` routing policies documented below.
 * `health_check_id` - (Optional) The health check the record should be associated with.
 * `alias` - (Optional) An alias block. Conflicts with `ttl` & `records`.
-  Alias record documented below.
-* `failover_routing_policy` - (Optional) A block indicating the routing behavior when associated health check fails. Conflicts with any other routing policy. Documented below.
-* `geolocation_routing_policy` - (Optional) A block indicating a routing policy based on the geolocation of the requestor. Conflicts with any other routing policy. Documented below.
-* `latency_routing_policy` - (Optional) A block indicating a routing policy based on the latency between the requestor and an AWS region. Conflicts with any other routing policy. Documented below.
-* `weighted_routing_policy` - (Optional) A block indicating a weighted routing policy. Conflicts with any other routing policy. Documented below.
+  [Documented below](#alias).
+* `failover_routing_policy` - (Optional) A block indicating the routing behavior when associated health check fails. Conflicts with any other routing policy. [Documented below](#failover-routing-policy).
+* `geolocation_routing_policy` - (Optional) A block indicating a routing policy based on the geolocation of the requestor. Conflicts with any other routing policy. [Documented below](#geolocation-routing-policy).
+* `latency_routing_policy` - (Optional) A block indicating a routing policy based on the latency between the requestor and an AWS region. Conflicts with any other routing policy. [Documented below](#latency-routing-policy).
+* `weighted_routing_policy` - (Optional) A block indicating a weighted routing policy. Conflicts with any other routing policy. [Documented below](#weighted-routing-policy).
 * `multivalue_answer_routing_policy` - (Optional) Set to `true` to indicate a multivalue answer routing policy. Conflicts with any other routing policy.
 * `allow_overwrite` - (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual Route 53 changes outside Terraform from overwriting this record. `false` by default. This configuration is not recommended for most environments.
 
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 
-Alias records support ([`alias`](/docs/providers/aws/r/route53_record/#alias)) the following:
+### Alias
+Alias records support the following:
 
 * `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
 * `zone_id` - (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, or Route 53 hosted zone. See [`resource_elb.zone_id`](/docs/providers/aws/r/elb.html#zone_id) for example.
 * `evaluate_target_health` - (Required) Set to `true` if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, see [related part of documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health).
 
-Failover routing policies ([`failover_routing_policy`](/docs/providers/aws/r/route53_record/#failover_routing_policy)) support the following:
+### Failover routing policies
+Failover routing policiessupport the following:
 
 * `type` - (Required) `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
 
-Geolocation routing policies ([`geolocation_routing_policy`](/docs/providers/aws/r/route53_record/#geolocation_routing_policy)) support the following:
+### Geolocation routing policies
+Geolocation routing policies support the following:
 
 * `continent` - A two-letter continent code. See http://docs.aws.amazon.com/Route53/latest/APIReference/API_GetGeoLocation.html for code details. Either `continent` or `country` must be specified.
 * `country` - A two-character country code or `*` to indicate a default resource record set.
 * `subdivision` - (Optional) A subdivision code for a country.
 
-Latency routing policies ([`latency_routing_policy`](/docs/providers/aws/r/route53_record/#latency_routing_policy)) support the following:
+### Latency routing policies
+Latency routing policies support the following:
 
 * `region` - (Required) An AWS region from which to measure latency. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-latency
 
-Weighted routing policies ([`weighted_routing_policy`](/docs/providers/aws/r/route53_record/#weighted_routing_policy)) support the following:
+### Weighted routing policies 
+Weighted routing policies support the following:
 
 * `weight` - (Required) A numeric value indicating the relative weight of the record. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-weighted.
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -137,27 +137,27 @@ The following arguments are supported:
 
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 
-Alias records support the following:
+Alias records support ([`alias`](/docs/providers/aws/r/route53_record/#alias)) the following:
 
 * `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
 * `zone_id` - (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, or Route 53 hosted zone. See [`resource_elb.zone_id`](/docs/providers/aws/r/elb.html#zone_id) for example.
 * `evaluate_target_health` - (Required) Set to `true` if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, see [related part of documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health).
 
-Failover routing policies support the following:
+Failover routing policies ([`failover_routing_policy`](/docs/providers/aws/r/route53_record/#failover_routing_policy)) support the following:
 
 * `type` - (Required) `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
 
-Geolocation routing policies support the following:
+Geolocation routing policies ([`geolocation_routing_policy`](/docs/providers/aws/r/route53_record/#geolocation_routing_policy)) support the following:
 
 * `continent` - A two-letter continent code. See http://docs.aws.amazon.com/Route53/latest/APIReference/API_GetGeoLocation.html for code details. Either `continent` or `country` must be specified.
 * `country` - A two-character country code or `*` to indicate a default resource record set.
 * `subdivision` - (Optional) A subdivision code for a country.
 
-Latency routing policies support the following:
+Latency routing policies ([`latency_routing_policy`](/docs/providers/aws/r/route53_record/#latency_routing_policy)) support the following:
 
 * `region` - (Required) An AWS region from which to measure latency. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-latency
 
-Weighted routing policies support the following:
+Weighted routing policies ([`weighted_routing_policy`](/docs/providers/aws/r/route53_record/#weighted_routing_policy)) support the following:
 
 * `weight` - (Required) A numeric value indicating the relative weight of the record. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-weighted.
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -147,13 +147,13 @@ Alias records support the following:
 * `zone_id` - (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, or Route 53 hosted zone. See [`resource_elb.zone_id`](/docs/providers/aws/r/elb.html#zone_id) for example.
 * `evaluate_target_health` - (Required) Set to `true` if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, see [related part of documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health).
 
-### Failover routing policies
+### Failover Routing Policy
 
 Failover routing policiessupport the following:
 
 * `type` - (Required) `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
 
-### Geolocation routing policies
+### Geolocation Routing Policy
 
 Geolocation routing policies support the following:
 
@@ -161,13 +161,13 @@ Geolocation routing policies support the following:
 * `country` - A two-character country code or `*` to indicate a default resource record set.
 * `subdivision` - (Optional) A subdivision code for a country.
 
-### Latency routing policies
+### Latency Routing Policy
 
 Latency routing policies support the following:
 
 * `region` - (Required) An AWS region from which to measure latency. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-latency
 
-### Weighted routing policies
+### Weighted Routing Policy
 
 Weighted routing policies support the following:
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -25,6 +25,7 @@ resource "aws_route53_record" "www" {
 ```
 
 ### Weighted routing policy
+
 Other routing policies are configured similarly. See [Amazon Route 53 Developer Guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html) for details.
 
 ```terraform
@@ -58,6 +59,7 @@ resource "aws_route53_record" "www-live" {
 ```
 
 ### Alias record
+
 See [related part of Amazon Route 53 Developer Guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html)
 to understand differences between alias and non-alias records.
 
@@ -138,6 +140,7 @@ The following arguments are supported:
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 
 ### Alias
+
 Alias records support the following:
 
 * `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
@@ -145,11 +148,13 @@ Alias records support the following:
 * `evaluate_target_health` - (Required) Set to `true` if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, see [related part of documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health).
 
 ### Failover routing policies
+
 Failover routing policiessupport the following:
 
 * `type` - (Required) `PRIMARY` or `SECONDARY`. A `PRIMARY` record will be served if its healthcheck is passing, otherwise the `SECONDARY` will be served. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html#dns-failover-failover-rrsets
 
 ### Geolocation routing policies
+
 Geolocation routing policies support the following:
 
 * `continent` - A two-letter continent code. See http://docs.aws.amazon.com/Route53/latest/APIReference/API_GetGeoLocation.html for code details. Either `continent` or `country` must be specified.
@@ -157,11 +162,13 @@ Geolocation routing policies support the following:
 * `subdivision` - (Optional) A subdivision code for a country.
 
 ### Latency routing policies
+
 Latency routing policies support the following:
 
 * `region` - (Required) An AWS region from which to measure latency. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-latency
 
-### Weighted routing policies 
+### Weighted routing policies
+
 Weighted routing policies support the following:
 
 * `weight` - (Required) A numeric value indicating the relative weight of the record. See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-weighted.
@@ -172,7 +179,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `name` - The name of the record.
 * `fqdn` - [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) built using the zone domain and `name`.
-
 
 ## Import
 


### PR DESCRIPTION
To find with CMD+F the documentation of following config blocks:
* `alias`
* `failover_routing_policy`
* `geolocation_routing_policy`
* `latency_routing_policy`
* `weighted_routing_policy`

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
