### PR TITLE
Add sweeper for spot instance requests

### DIFF
--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -180,6 +180,11 @@ func init() {
 		F:    sweepSpotFleetRequests,
 	})
 
+	resource.AddTestSweepers("aws_spot_instance_request", &resource.Sweeper{
+		Name: "aws_spot_instance_request",
+		F:    sweepSpotInstanceRequests,
+	})
+
 	resource.AddTestSweepers("aws_subnet", &resource.Sweeper{
 		Name: "aws_subnet",
 		F:    sweepSubnets,
@@ -1530,6 +1535,57 @@ func sweepSpotFleetRequests(region string) error {
 
 	if sweep.SkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping EC2 Spot Fleet Requests sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepSpotInstanceRequests(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).EC2Conn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+
+	err = conn.DescribeSpotInstanceRequestsPages(&ec2.DescribeSpotInstanceRequestsInput{}, func(page *ec2.DescribeSpotInstanceRequestsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		if len(page.SpotInstanceRequests) == 0 {
+			log.Print("[DEBUG] No Spot Instance Requests to sweep")
+			return false
+		}
+
+		for _, config := range page.SpotInstanceRequests {
+			id := aws.StringValue(config.SpotInstanceRequestId)
+
+			r := ResourceSpotInstanceRequest()
+			d := r.Data(nil)
+			d.SetId(id)
+			d.Set("instance_interruption_behavior", ec2.InstanceInterruptionBehaviorTerminate)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing EC2 Spot Instance Requests for %s: %w", region, err))
+	}
+
+	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 Spot Instance Requests for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping EC2 Spot Instance Requests sweep for %s: %s", region, errs)
 		return nil
 	}
 

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -98,6 +98,7 @@ func init() {
 		Dependencies: []string{
 			"aws_autoscaling_group",
 			"aws_spot_fleet_request",
+			"aws_spot_instance_request",
 		},
 	})
 
@@ -115,6 +116,7 @@ func init() {
 			"aws_elastic_beanstalk_environment",
 			"aws_instance",
 			"aws_spot_fleet_request",
+			"aws_spot_instance_request",
 		},
 		F: sweepKeyPairs,
 	})
@@ -159,6 +161,7 @@ func init() {
 			"aws_instance",
 			"aws_launch_template",
 			"aws_spot_fleet_request",
+			"aws_spot_instance_request",
 		},
 	})
 
@@ -227,6 +230,7 @@ func init() {
 			"aws_route53_resolver_endpoint",
 			"aws_sagemaker_notebook_instance",
 			"aws_spot_fleet_request",
+			"aws_spot_instance_request",
 			"aws_vpc_endpoint",
 		},
 	})

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1572,7 +1572,7 @@ func sweepSpotInstanceRequests(region string) error {
 			r := ResourceSpotInstanceRequest()
 			d := r.Data(nil)
 			d.SetId(id)
-			d.Set("instance_interruption_behavior", ec2.InstanceInterruptionBehaviorTerminate)
+			d.Set("spot_instance_id", config.InstanceId)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25193

Sweeper appears to cancel spot instance requests as desired:
```bash
❯ SWEEPARGS=-sweep-run=aws_spot_instance_request make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_spot_instance_request -timeout 60m
2022/06/10 14:26:09 [DEBUG] Running Sweepers for region (us-east-2):
2022/06/10 14:26:09 [DEBUG] Running Sweeper (aws_spot_instance_request) in region (us-east-2)
2022/06/10 14:26:09 [INFO] Retrieved credentials from "SharedConfigCredentials: /home/zhelding/.aws/credentials"
2022/06/10 14:26:09 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/06/10 14:26:09 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/06/10 14:26:09 [DEBUG] Waiting for state to become: [success]
2022/06/10 14:26:09 [INFO] Cancelling spot request: sir-8i2ye2xj
2022/06/10 14:26:09 [DEBUG] Completed Sweeper (aws_spot_instance_request) in region (us-east-2) in 544.03105ms
2022/06/10 14:26:09 Completed Sweepers for region (us-east-2) in 544.051742ms
2022/06/10 14:26:09 Sweeper Tests for region (us-east-2) ran successfully:
        - aws_spot_instance_request
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      2.440s
```