### PR TITLE
Allow Eventbridge API Destination Invocation Rate Limit to be greater than 300

### DIFF
--- a/.changelog/25277.txt
+++ b/.changelog/25277.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_api_destination: Remove validation of a maximum value for the `invocation_rate_limit_per_second` argument
+```

--- a/internal/service/events/api_destination.go
+++ b/internal/service/events/api_destination.go
@@ -46,7 +46,7 @@ func ResourceAPIDestination() *schema.Resource {
 			"invocation_rate_limit_per_second": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, 300),
+				ValidateFunc: validation.IntAtLeast(1),
 				Default:      300,
 			},
 			"http_method": {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25276
