### PR TITLE
r/aws_sagemaker_domain: in-place update for default user settings

### DIFF
--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -93,7 +93,6 @@ func ResourceDomain() *schema.Resource {
 						"sharing_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -118,7 +117,6 @@ func ResourceDomain() *schema.Resource {
 						"tensor_board_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -157,7 +155,6 @@ func ResourceDomain() *schema.Resource {
 						"jupyter_server_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -204,7 +201,6 @@ func ResourceDomain() *schema.Resource {
 						"kernel_gateway_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -45,6 +45,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"kms":                                                    testAccDomain_kms,
 			"securityGroup":                                          testAccDomain_securityGroup,
 			"sharingSettings":                                        testAccDomain_sharingSettings,
+			"defaultUserSettingsUpdated":                             testAccDomain_defaultUserSettingsUpdated,
 		},
 		"FlowDefinition": {
 			"basic":                          testAccFlowDefinition_basic,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25266

```
bug:

resource/aws_sagemaker_domain: Fix update behaviour for `default_user_settings`
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSageMaker_serial/Domain PKG=sagemaker                                  <aws:default>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMaker_serial/Domain'  -timeout 180m
=== RUN   TestAccSageMaker_serial
=== RUN   TestAccSageMaker_serial/Domain
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings
=== RUN   TestAccSageMaker_serial/Domain/defaultUserSettingsUpdated
=== RUN   TestAccSageMaker_serial/Domain/tensorboardAppSettingsWithImage
=== RUN   TestAccSageMaker_serial/Domain/disappears
=== RUN   TestAccSageMaker_serial/Domain/tags
=== RUN   TestAccSageMaker_serial/Domain/tensorboardAppSettings
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_customImage
    domain_test.go:331: Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set
=== RUN   TestAccSageMaker_serial/Domain/securityGroup
=== RUN   TestAccSageMaker_serial/Domain/basic
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_defaultResourceAndCustomImage
    domain_test.go:370: Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set
=== RUN   TestAccSageMaker_serial/Domain/kms
=== RUN   TestAccSageMaker_serial/Domain/sharingSettings
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_lifecycleConfig
=== RUN   TestAccSageMaker_serial/Domain/jupyterServerAppSettings
--- PASS: TestAccSageMaker_serial (3613.64s)
    --- PASS: TestAccSageMaker_serial/Domain (3613.64s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings (293.75s)
        --- PASS: TestAccSageMaker_serial/Domain/defaultUserSettingsUpdated (333.19s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettingsWithImage (347.15s)
        --- PASS: TestAccSageMaker_serial/Domain/disappears (370.60s)
        --- PASS: TestAccSageMaker_serial/Domain/tags (274.02s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettings (290.70s)
        --- SKIP: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_customImage (0.00s)
        --- PASS: TestAccSageMaker_serial/Domain/securityGroup (318.27s)
        --- PASS: TestAccSageMaker_serial/Domain/basic (276.42s)
        --- SKIP: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_defaultResourceAndCustomImage (0.00s)
        --- PASS: TestAccSageMaker_serial/Domain/kms (277.37s)
        --- PASS: TestAccSageMaker_serial/Domain/sharingSettings (279.50s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_lifecycleConfig (276.60s)
        --- PASS: TestAccSageMaker_serial/Domain/jupyterServerAppSettings (276.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  3616.057s
```
