### PR TITLE
r/synthetics_canary - add `delete_lambda` argument

### DIFF
--- a/.changelog/25284.txt
+++ b/.changelog/25284.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_synthetics_canary: Add `delete_lambda` argument
+```

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -74,6 +74,11 @@ func ResourceCanary() *schema.Resource {
 					return strings.TrimPrefix(new, "s3://") == old
 				},
 			},
+			"delete_lambda": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"engine_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -549,7 +554,8 @@ func resourceCanaryDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting Synthetics Canary: (%s)", d.Id())
 	_, err := conn.DeleteCanary(&synthetics.DeleteCanaryInput{
-		Name: aws.String(d.Id()),
+		Name:         aws.String(d.Id()),
+		DeleteLambda: aws.Bool(d.Get("delete_lambda").(bool)),
 	})
 
 	if tfawserr.ErrCodeEquals(err, synthetics.ErrCodeResourceNotFoundException) {

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -400,6 +400,7 @@ func TestAccSyntheticsCanary_runEnvironmentVariables(t *testing.T) {
 				Config: testAccCanaryConfig_runEnvVariables1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test1", "result1"),
 				),
 			},
@@ -413,15 +414,9 @@ func TestAccSyntheticsCanary_runEnvironmentVariables(t *testing.T) {
 				Config: testAccCanaryConfig_runEnvVariables2(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test1", "result1"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.test2", "result2"),
-				),
-			},
-			{
-				Config: testAccCanaryConfig_basic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCanaryExists(resourceName, &conf),
-					resource.TestCheckNoResourceAttr(resourceName, "run_config.0.environment_variables"),
 				),
 			},
 		},

--- a/website/docs/r/synthetics_canary.html.markdown
+++ b/website/docs/r/synthetics_canary.html.markdown
@@ -42,6 +42,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `delete_lambda` - (Optional)  Specifies whether to also delete the Lambda functions and layers used by this canary. The default is `false`.
 * `vpc_config` - (Optional) Configuration block. Detailed below.
 * `failure_retention_period` - (Optional) Number of days to retain data about failed runs of this canary. If you omit this field, the default of 31 days is used. The valid range is 1 to 455 days.
 * `run_config` - (Optional) Configuration block for individual canary runs. Detailed below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19288

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSyntheticsCanary_ PKG=synthetics
--- PASS: TestAccSyntheticsCanary_disappears (84.28s)
--- PASS: TestAccSyntheticsCanary_s3 (93.01s)
--- PASS: TestAccSyntheticsCanary_artifactEncryption (106.73s)
--- PASS: TestAccSyntheticsCanary_runtimeVersion (130.89s)
--- PASS: TestAccSyntheticsCanary_basic (133.96s)
--- PASS: TestAccSyntheticsCanary_runTracing (137.44s)
--- PASS: TestAccSyntheticsCanary_tags (150.96s)
--- PASS: TestAccSyntheticsCanary_startCanary (158.98s)
--- PASS: TestAccSyntheticsCanary_run (178.02s)
--- PASS: TestAccSyntheticsCanary_vpc (1441.25s)
```
