### PR TITLE
Correct `aws_ce_anomaly_monitor` argument names

### DIFF
--- a/website/docs/r/ce_anomaly_monitor.html.markdown
+++ b/website/docs/r/ce_anomaly_monitor.html.markdown
@@ -19,8 +19,8 @@ There are two main types of a Cost Anomaly Monitor: `DIMENSIONAL` and `CUSTOM`.
 ```terraform
 resource "aws_ce_anomaly_monitor" "service_monitor" {
   name      = "AWSServiceMonitor"
-  type      = "DIMENSIONAL"
-  dimension = "SERVICE"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
 }
 ```
 
@@ -29,7 +29,7 @@ resource "aws_ce_anomaly_monitor" "service_monitor" {
 ```terraform
 resource "aws_ce_anomaly_monitor" "test" {
   name = "AWSCustomAnomalyMonitor"
-  type = "CUSTOM"
+  monitor_type = "CUSTOM"
 
   specification = <<JSON
 {
@@ -55,9 +55,9 @@ JSON
 The following arguments are required:
 
 * `name` - (Required) The name of the monitor.
-* `type` - (Required) The possible type values. Valid values: `DIMENSIONAL` | `CUSTOM`.
-* `dimension` - (Required, if `type` is `DIMENSIONAL`) The dimensions to evaluate. Valid values: `SERVICE`.
-* `specification` - (Required, if `type` is `CUSTOM`) A valid JSON representation for the [Expression](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html) object.
+* `monitor_type` - (Required) The possible type values. Valid values: `DIMENSIONAL` | `CUSTOM`.
+* `monitor_dimension` - (Required, if `monitor_type` is `DIMENSIONAL`) The dimensions to evaluate. Valid values: `SERVICE`.
+* `monitor_specification` - (Required, if `monitor_type` is `CUSTOM`) A valid JSON representation for the [Expression](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html) object.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/ce_anomaly_monitor.html.markdown
+++ b/website/docs/r/ce_anomaly_monitor.html.markdown
@@ -18,7 +18,7 @@ There are two main types of a Cost Anomaly Monitor: `DIMENSIONAL` and `CUSTOM`.
 
 ```terraform
 resource "aws_ce_anomaly_monitor" "service_monitor" {
-  name      = "AWSServiceMonitor"
+  name              = "AWSServiceMonitor"
   monitor_type      = "DIMENSIONAL"
   monitor_dimension = "SERVICE"
 }
@@ -28,7 +28,7 @@ resource "aws_ce_anomaly_monitor" "service_monitor" {
 
 ```terraform
 resource "aws_ce_anomaly_monitor" "test" {
-  name = "AWSCustomAnomalyMonitor"
+  name         = "AWSCustomAnomalyMonitor"
   monitor_type = "CUSTOM"
 
   specification = <<JSON


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25295

Output from acceptance testing: N/a, docs

### Information

It looks like just before the new `aws_ce_anomaly_monitor` resource was added, the argument names were changed, but the change didn't make it to the docs. This PR corrects the argument names in the documentation.

### References

- PR that added resource: #25177 (new in `4.18.0`)
- [Argument names](https://github.com/hashicorp/terraform-provider-aws/blob/fc8305ac6f5f665df3195f1a2dd8ac22e3adef91/internal/service/ce/anomaly_monitor.go#L36-L57)