### PR TITLE
r/aws_dynamodb_table_item: fix to remove item elements on update

### DIFF
--- a/.changelog/25326.txt
+++ b/.changelog/25326.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ resource/aws_dynamodb_table_item: Fix to remove attribute from table item on update
+ ```

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -229,7 +229,12 @@ func resourceTableItemDelete(d *schema.ResourceData, meta interface{}) error {
 		Key:       queryKey,
 		TableName: aws.String(d.Get("table_name").(string)),
 	})
-	return fmt.Errorf("error deleting DynamoDB Table Item (%s): %w", d.Id(), err)
+
+	if err != nil {
+		return fmt.Errorf("error deleting DynamoDB Table Item (%s): %w", d.Id(), err)
+	}
+
+	return nil
 }
 
 // Helpers

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -10,8 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -179,25 +181,17 @@ func resourceTableItemRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	result, err := conn.GetItem(&dynamodb.GetItemInput{
-		TableName:      aws.String(tableName),
-		ConsistentRead: aws.Bool(true),
-		Key:            BuildTableItemqueryKey(attributes, hashKey, rangeKey),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
-			log.Printf("[WARN] Dynamodb Table Item (%s) not found, error code (404)", d.Id())
-			d.SetId("")
-			return nil
-		}
+	key := BuildTableItemqueryKey(attributes, hashKey, rangeKey)
+	result, err := FindTableItem(conn, tableName, key)
 
-		return fmt.Errorf("Error retrieving DynamoDB table item: %s", err)
-	}
-
-	if result.Item == nil {
-		log.Printf("[WARN] Dynamodb Table Item (%s) not found", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Dynamodb Table Item (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading DynamoDB Table Item (%s): %w", d.Id(), err)
 	}
 
 	// The record exists, now test if it differs from what is desired
@@ -238,6 +232,33 @@ func resourceTableItemDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 // Helpers
+
+func FindTableItem(conn *dynamodb.DynamoDB, tableName string, key map[string]*dynamodb.AttributeValue) (*dynamodb.GetItemOutput, error) {
+	in := &dynamodb.GetItemInput{
+		TableName:      aws.String(tableName),
+		ConsistentRead: aws.Bool(true),
+		Key:            key,
+	}
+
+	out, err := conn.GetItem(in)
+
+	if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.Item == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
 
 func BuildExpressionAttributeNames(attrs map[string]*dynamodb.AttributeValue) map[string]*string {
 	names := map[string]*string{}

--- a/internal/service/dynamodb/table_item_test.go
+++ b/internal/service/dynamodb/table_item_test.go
@@ -287,11 +287,11 @@ func testAccCheckItemDestroy(s *terraform.State) error {
 		}
 
 		result, err := conn.GetItem(&dynamodb.GetItemInput{
-			TableName:                aws.String(attrs["table_name"]),
-			ConsistentRead:           aws.Bool(true),
-			Key:                      tfdynamodb.BuildTableItemqueryKey(attributes, attrs["hash_key"], attrs["range_key"]),
-			ProjectionExpression:     tfdynamodb.BuildProjectionExpression(attributes),
-			ExpressionAttributeNames: tfdynamodb.BuildExpressionAttributeNames(attributes),
+			TableName:      aws.String(attrs["table_name"]),
+			ConsistentRead: aws.Bool(true),
+			Key:            tfdynamodb.BuildTableItemqueryKey(attributes, attrs["hash_key"], attrs["range_key"]),
+			//ProjectionExpression:     tfdynamodb.BuildProjectionExpression(attributes),
+			//ExpressionAttributeNames: tfdynamodb.BuildExpressionAttributeNames(attributes),
 		})
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {

--- a/internal/service/dynamodb/table_item_test.go
+++ b/internal/service/dynamodb/table_item_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccDynamoDBTableItem_basic(t *testing.T) {
+func TestAccTableItem_basic(t *testing.T) {
 	var conf dynamodb.GetItemOutput
 
-	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
 	itemContent := `{
 	"hashKey": {"S": "something"},
@@ -48,10 +48,10 @@ func TestAccDynamoDBTableItem_basic(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTableItem_rangeKey(t *testing.T) {
+func TestAccTableItem_rangeKey(t *testing.T) {
 	var conf dynamodb.GetItemOutput
 
-	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
 	rangeKey := "rangeKey"
 	itemContent := `{
@@ -84,11 +84,11 @@ func TestAccDynamoDBTableItem_rangeKey(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTableItem_withMultipleItems(t *testing.T) {
+func TestAccTableItem_withMultipleItems(t *testing.T) {
 	var conf1 dynamodb.GetItemOutput
 	var conf2 dynamodb.GetItemOutput
 
-	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
 	rangeKey := "rangeKey"
 	firstItem := `{
@@ -135,7 +135,7 @@ func TestAccDynamoDBTableItem_withMultipleItems(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTableItem_wonkyItems(t *testing.T) {
+func TestAccTableItem_wonkyItems(t *testing.T) {
 	var conf1 dynamodb.GetItemOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -172,10 +172,10 @@ func TestAccDynamoDBTableItem_wonkyItems(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTableItem_update(t *testing.T) {
+func TestAccTableItem_update(t *testing.T) {
 	var conf dynamodb.GetItemOutput
 
-	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
 
 	itemBefore := `{
@@ -222,10 +222,10 @@ func TestAccDynamoDBTableItem_update(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTableItem_updateWithRangeKey(t *testing.T) {
+func TestAccTableItem_updateWithRangeKey(t *testing.T) {
 	var conf dynamodb.GetItemOutput
 
-	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
 	rangeKey := "rangeKey"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15700

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccTableItem_ PKG=dynamodb

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccTableItem_'  -timeout 180m
=== RUN   TestAccTableItem_basic
=== PAUSE TestAccTableItem_basic
=== RUN   TestAccTableItem_rangeKey
=== PAUSE TestAccTableItem_rangeKey
=== RUN   TestAccTableItem_withMultipleItems
=== PAUSE TestAccTableItem_withMultipleItems
=== RUN   TestAccTableItem_wonkyItems
=== PAUSE TestAccTableItem_wonkyItems
=== RUN   TestAccTableItem_update
=== PAUSE TestAccTableItem_update
=== RUN   TestAccTableItem_updateWithRangeKey
=== PAUSE TestAccTableItem_updateWithRangeKey
=== RUN   TestAccTableItem_disappears
=== PAUSE TestAccTableItem_disappears
=== CONT  TestAccTableItem_basic
=== CONT  TestAccTableItem_update
=== CONT  TestAccTableItem_withMultipleItems
=== CONT  TestAccTableItem_wonkyItems
=== CONT  TestAccTableItem_disappears
=== CONT  TestAccTableItem_updateWithRangeKey
=== CONT  TestAccTableItem_rangeKey
--- PASS: TestAccTableItem_wonkyItems (17.43s)
--- PASS: TestAccTableItem_disappears (20.71s)
--- PASS: TestAccTableItem_withMultipleItems (21.02s)
--- PASS: TestAccTableItem_basic (21.02s)
--- PASS: TestAccTableItem_rangeKey (22.57s)
--- PASS: TestAccTableItem_updateWithRangeKey (27.90s)
--- PASS: TestAccTableItem_update (29.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	31.577s
...
```
