### PR TITLE
r/waf_byte_match_set.byte_match_tuples.target_string (docs) fix example, spacing (fixes #25328)

### DIFF
--- a/website/docs/r/waf_byte_match_set.html.markdown
+++ b/website/docs/r/waf_byte_match_set.html.markdown
@@ -50,8 +50,7 @@ The following arguments are supported:
   e.g., `CONTAINS`, `CONTAINS_WORD` or `EXACTLY`.
   See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-PositionalConstraint)
   for all supported values.
-* `target_string` - (Optional) The value that you want to search for.
-  e.g., `badrefer1`.
+* `target_string` - (Optional) The value that you want to search for within the field specified by `field_to_match`, e.g., `badrefer1`.
   See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-TargetString)
   for all supported values.
 * `text_transformation` - (Required) Text transformations used to eliminate unusual formatting that attackers use in web requests in an effort to bypass AWS WAF.

--- a/website/docs/r/waf_byte_match_set.html.markdown
+++ b/website/docs/r/waf_byte_match_set.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
   See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-PositionalConstraint)
   for all supported values.
 * `target_string` - (Optional) The value that you want to search for within the field specified by `field_to_match`, e.g., `badrefer1`.
-  See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-TargetString)
+  See [docs](https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_ByteMatchTuple.html)
   for all supported values.
 * `text_transformation` - (Required) Text transformations used to eliminate unusual formatting that attackers use in web requests in an effort to bypass AWS WAF.
   If you specify a transformation, AWS WAF performs the transformation on `target_string` before inspecting a request for a match.

--- a/website/docs/r/waf_byte_match_set.html.markdown
+++ b/website/docs/r/waf_byte_match_set.html.markdown
@@ -50,7 +50,8 @@ The following arguments are supported:
   e.g., `CONTAINS`, `CONTAINS_WORD` or `EXACTLY`.
   See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-PositionalConstraint)
   for all supported values.
-* `target_string` - (Optional) The value that you want to search forE.g., `HEADER`, `METHOD` or `BODY`.
+* `target_string` - (Optional) The value that you want to search for.
+  e.g., `badrefer1`.
   See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-TargetString)
   for all supported values.
 * `text_transformation` - (Required) Text transformations used to eliminate unusual formatting that attackers use in web requests in an effort to bypass AWS WAF.


### PR DESCRIPTION
### Doc fix for `aws_waf_byte_match_set.byte_match_tuples.target_string`

Currently the description for this field docs gives a confusing example for this field (seems to have been copy/pasted from another field). This PR uses the example from the main example at the top of the page. It also makes the formatting consistent with the other descriptions.

Closes #25328