### PR TITLE
efs: Fix test configs names

### DIFF
--- a/.semgrep-caps-aws-config.yml
+++ b/.semgrep-caps-aws-config.yml
@@ -381,7 +381,6 @@ rules:
         - internal/service/ecr
         - internal/service/ecrpublic
         - internal/service/ecs
-        - internal/service/efs
         - internal/service/elasticache
         - internal/service/elasticbeanstalk
         - internal/service/elasticsearch

--- a/internal/service/efs/access_point_data_source_test.go
+++ b/internal/service/efs/access_point_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccEFSAccessPointDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointDataSourceConfig(rName),
+				Config: testAccAccessPointDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
@@ -35,7 +35,7 @@ func TestAccEFSAccessPointDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccAccessPointDataSourceConfig(rName string) string {
+func testAccAccessPointDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"

--- a/internal/service/efs/access_point_test.go
+++ b/internal/service/efs/access_point_test.go
@@ -29,7 +29,7 @@ func TestAccEFSAccessPoint_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointConfig(rName),
+				Config: testAccAccessPointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttrPair(resourceName, "file_system_arn", fsResourceName, "arn"),
@@ -63,7 +63,7 @@ func TestAccEFSAccessPoint_Root_directory(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointRootDirectoryConfig(rName, "/home/test"),
+				Config: testAccAccessPointConfig_rootDirectory(rName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.#", "1"),
@@ -92,7 +92,7 @@ func TestAccEFSAccessPoint_RootDirectoryCreation_info(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointRootDirectoryCreationInfoConfig(rName, "/home/test"),
+				Config: testAccAccessPointConfig_rootDirectoryCreationInfo(rName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "root_directory.#", "1"),
@@ -124,7 +124,7 @@ func TestAccEFSAccessPoint_POSIX_user(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointPOSIXUserConfig(rName),
+				Config: testAccAccessPointConfig_posixUser(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "1"),
@@ -154,7 +154,7 @@ func TestAccEFSAccessPoint_POSIXUserSecondary_gids(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointPOSIXUserSecondaryGidsConfig(rName),
+				Config: testAccAccessPointConfig_posixUserSecondaryGids(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "1"),
@@ -183,7 +183,7 @@ func TestAccEFSAccessPoint_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointTags1Config(rName, "key1", "value1"),
+				Config: testAccAccessPointConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -196,7 +196,7 @@ func TestAccEFSAccessPoint_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAccessPointTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAccessPointConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -205,7 +205,7 @@ func TestAccEFSAccessPoint_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAccessPointTags1Config(rName, "key2", "value2"),
+				Config: testAccAccessPointConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -228,7 +228,7 @@ func TestAccEFSAccessPoint_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointConfig(rName),
+				Config: testAccAccessPointConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(resourceName, &ap),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceAccessPoint(), resourceName),
@@ -298,7 +298,7 @@ func testAccCheckAccessPointExists(resourceID string, mount *efs.AccessPointDesc
 	}
 }
 
-func testAccAccessPointConfig(rName string) string {
+func testAccAccessPointConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"
@@ -310,7 +310,7 @@ resource "aws_efs_access_point" "test" {
 `, rName)
 }
 
-func testAccAccessPointRootDirectoryConfig(rName, dir string) string {
+func testAccAccessPointConfig_rootDirectory(rName, dir string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -325,7 +325,7 @@ resource "aws_efs_access_point" "test" {
 `, rName, dir)
 }
 
-func testAccAccessPointRootDirectoryCreationInfoConfig(rName, dir string) string {
+func testAccAccessPointConfig_rootDirectoryCreationInfo(rName, dir string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -345,7 +345,7 @@ resource "aws_efs_access_point" "test" {
 `, rName, dir)
 }
 
-func testAccAccessPointPOSIXUserConfig(rName string) string {
+func testAccAccessPointConfig_posixUser(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"
@@ -361,7 +361,7 @@ resource "aws_efs_access_point" "test" {
 `, rName)
 }
 
-func testAccAccessPointPOSIXUserSecondaryGidsConfig(rName string) string {
+func testAccAccessPointConfig_posixUserSecondaryGids(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"
@@ -378,7 +378,7 @@ resource "aws_efs_access_point" "test" {
 `, rName)
 }
 
-func testAccAccessPointTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccAccessPointConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -394,7 +394,7 @@ resource "aws_efs_access_point" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAccessPointTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAccessPointConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q

--- a/internal/service/efs/access_points_data_source_test.go
+++ b/internal/service/efs/access_points_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccEFSAccessPointsDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointsDataSourceConfig(),
+				Config: testAccAccessPointsDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
@@ -38,7 +38,7 @@ func TestAccEFSAccessPointsDataSource_empty(t *testing.T) {
 		CheckDestroy:      testAccCheckAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessPointsEmptyDataSourceConfig(),
+				Config: testAccAccessPointsDataSourceConfig_empty(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "0"),
@@ -48,7 +48,7 @@ func TestAccEFSAccessPointsDataSource_empty(t *testing.T) {
 	})
 }
 
-func testAccAccessPointsDataSourceConfig() string {
+func testAccAccessPointsDataSourceConfig_basic() string {
 	return `
 resource "aws_efs_file_system" "test" {}
 
@@ -62,7 +62,7 @@ data "aws_efs_access_points" "test" {
 `
 }
 
-func testAccAccessPointsEmptyDataSourceConfig() string {
+func testAccAccessPointsDataSourceConfig_empty() string {
 	return `
 resource "aws_efs_file_system" "test" {}
 

--- a/internal/service/efs/backup_policy_test.go
+++ b/internal/service/efs/backup_policy_test.go
@@ -27,7 +27,7 @@ func TestAccEFSBackupPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPolicyConfig(rName, "ENABLED"),
+				Config: testAccBackupPolicyConfig_basic(rName, "ENABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
@@ -56,7 +56,7 @@ func TestAccEFSBackupPolicy_Disappears_fs(t *testing.T) {
 		CheckDestroy:      testAccCheckBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPolicyConfig(rName, "ENABLED"),
+				Config: testAccBackupPolicyConfig_basic(rName, "ENABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBackupPolicyExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystem(), fsResourceName),
@@ -79,7 +79,7 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 		CheckDestroy:      testAccCheckBackupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPolicyConfig(rName, "DISABLED"),
+				Config: testAccBackupPolicyConfig_basic(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
@@ -92,7 +92,7 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupPolicyConfig(rName, "ENABLED"),
+				Config: testAccBackupPolicyConfig_basic(rName, "ENABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
@@ -100,7 +100,7 @@ func TestAccEFSBackupPolicy_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupPolicyConfig(rName, "DISABLED"),
+				Config: testAccBackupPolicyConfig_basic(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBackupPolicyExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.#", "1"),
@@ -164,7 +164,7 @@ func testAccCheckBackupPolicyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccBackupPolicyConfig(rName, status string) string {
+func testAccBackupPolicyConfig_basic(rName, status string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q

--- a/internal/service/efs/file_system_data_source_test.go
+++ b/internal/service/efs/file_system_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccEFSFileSystemDataSource_id(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemIDDataSourceConfig,
+				Config: testAccFileSystemDataSourceConfig_id,
 				Check: resource.ComposeTestCheckFunc(
 					testAccFileSystemCheckDataSource(dataSourceName, resourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -52,7 +52,7 @@ func TestAccEFSFileSystemDataSource_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemTagsDataSourceConfig,
+				Config: testAccFileSystemDataSourceConfig_tags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccFileSystemCheckDataSource(dataSourceName, resourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -82,7 +82,7 @@ func TestAccEFSFileSystemDataSource_name(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemNameDataSourceConfig,
+				Config: testAccFileSystemDataSourceConfig_name,
 				Check: resource.ComposeTestCheckFunc(
 					testAccFileSystemCheckDataSource(dataSourceName, resourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -112,7 +112,7 @@ func TestAccEFSFileSystemDataSource_availabilityZone(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemAvailabilityZoneDataSourceConfig,
+				Config: testAccFileSystemDataSourceConfig_availabilityZone,
 				Check: resource.ComposeTestCheckFunc(
 					testAccFileSystemCheckDataSource(dataSourceName, resourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_id", resourceName, "availability_zone_id"),
@@ -130,7 +130,7 @@ func TestAccEFSFileSystemDataSource_nonExistent_fileSystemID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccFileSystemIDDataSourceConfig_NonExistent,
+				Config:      testAccFileSystemDataSourceConfig_idNonExistent,
 				ExpectError: regexp.MustCompile(`error reading EFS FileSystem`),
 			},
 		},
@@ -148,13 +148,13 @@ func TestAccEFSFileSystemDataSource_nonExistent_tags(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemConfig(rName),
+				Config: testAccFileSystemConfig_dataSourceBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 				),
 			},
 			{
-				Config:      testAccFileSystemTagsDataSourceConfig_NonExistent(rName),
+				Config:      testAccFileSystemDataSourceConfig_tagsNonExistent(rName),
 				ExpectError: regexp.MustCompile(`Search returned 0 results`),
 			},
 		},
@@ -195,15 +195,15 @@ func testAccFileSystemCheckDataSource(dName, rName string) resource.TestCheckFun
 	}
 }
 
-const testAccFileSystemIDDataSourceConfig_NonExistent = `
+const testAccFileSystemDataSourceConfig_idNonExistent = `
 data "aws_efs_file_system" "test" {
   file_system_id = "fs-nonexistent"
 }
 `
 
-func testAccFileSystemTagsDataSourceConfig_NonExistent(rName string) string {
+func testAccFileSystemDataSourceConfig_tagsNonExistent(rName string) string {
 	return acctest.ConfigCompose(
-		testAccFileSystemConfig(rName),
+		testAccFileSystemConfig_dataSourceBasic(rName),
 		`
 data "aws_efs_file_system" "test" {
   tags = {
@@ -213,7 +213,7 @@ data "aws_efs_file_system" "test" {
 `)
 }
 
-const testAccFileSystemNameDataSourceConfig = `
+const testAccFileSystemDataSourceConfig_name = `
 resource "aws_efs_file_system" "test" {}
 
 data "aws_efs_file_system" "test" {
@@ -221,7 +221,7 @@ data "aws_efs_file_system" "test" {
 }
 `
 
-const testAccFileSystemIDDataSourceConfig = `
+const testAccFileSystemDataSourceConfig_id = `
 resource "aws_efs_file_system" "test" {}
 
 data "aws_efs_file_system" "test" {
@@ -229,7 +229,7 @@ data "aws_efs_file_system" "test" {
 }
 `
 
-const testAccFileSystemTagsDataSourceConfig = `
+const testAccFileSystemDataSourceConfig_tags = `
 resource "aws_efs_file_system" "test" {
   tags = {
     Name        = "default-efs"
@@ -250,7 +250,7 @@ data "aws_efs_file_system" "test" {
 }
 `
 
-const testAccFileSystemAvailabilityZoneDataSourceConfig = `
+const testAccFileSystemDataSourceConfig_availabilityZone = `
 data "aws_availability_zones" "available" {
   state = "available"
 

--- a/internal/service/efs/file_system_policy_test.go
+++ b/internal/service/efs/file_system_policy_test.go
@@ -26,7 +26,7 @@ func TestAccEFSFileSystemPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemPolicyConfig(rName),
+				Config: testAccFileSystemPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -39,7 +39,7 @@ func TestAccEFSFileSystemPolicy_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccFileSystemPolicyUpdatedConfig(rName),
+				Config: testAccFileSystemPolicyConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
@@ -61,7 +61,7 @@ func TestAccEFSFileSystemPolicy_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemPolicyConfig(rName),
+				Config: testAccFileSystemPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystemPolicy(), resourceName),
@@ -84,7 +84,7 @@ func TestAccEFSFileSystemPolicy_policyBypass(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemPolicyConfig(rName),
+				Config: testAccFileSystemPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
@@ -97,7 +97,7 @@ func TestAccEFSFileSystemPolicy_policyBypass(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"bypass_policy_lockout_safety_check"},
 			},
 			{
-				Config: testAccFileSystemPolicyBypassConfig(rName, true),
+				Config: testAccFileSystemPolicyConfig_bypass(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
@@ -120,14 +120,14 @@ func TestAccEFSFileSystemPolicy_equivalentPolicies(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemPolicyFirstEquivalentConfig(rName),
+				Config: testAccFileSystemPolicyConfig_firstEquivalent(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
 			{
-				Config:   testAccFileSystemPolicySecondEquivalentConfig(rName),
+				Config:   testAccFileSystemPolicyConfig_secondEquivalent(rName),
 				PlanOnly: true,
 			},
 		},
@@ -147,14 +147,14 @@ func TestAccEFSFileSystemPolicy_equivalentPoliciesIAMPolicyDoc(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemPolicyEquivalentIAMPolicyDocConfig(rName),
+				Config: testAccFileSystemPolicyConfig_equivalentIAMDoc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
 			{
-				Config:   testAccFileSystemPolicyEquivalentIAMPolicyDocConfig(rName),
+				Config:   testAccFileSystemPolicyConfig_equivalentIAMDoc(rName),
 				PlanOnly: true,
 			},
 		},
@@ -210,7 +210,7 @@ func testAccCheckFileSystemPolicyExists(n string, v *efs.DescribeFileSystemPolic
 	}
 }
 
-func testAccFileSystemPolicyConfig(rName string) string {
+func testAccFileSystemPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -248,7 +248,7 @@ POLICY
 `, rName)
 }
 
-func testAccFileSystemPolicyUpdatedConfig(rName string) string {
+func testAccFileSystemPolicyConfig_updated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -283,7 +283,7 @@ POLICY
 `, rName)
 }
 
-func testAccFileSystemPolicyBypassConfig(rName string, bypass bool) string {
+func testAccFileSystemPolicyConfig_bypass(rName string, bypass bool) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -323,7 +323,7 @@ POLICY
 `, rName, bypass)
 }
 
-func testAccFileSystemPolicyFirstEquivalentConfig(rName string) string {
+func testAccFileSystemPolicyConfig_firstEquivalent(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -357,7 +357,7 @@ resource "aws_efs_file_system_policy" "test" {
 `, rName)
 }
 
-func testAccFileSystemPolicySecondEquivalentConfig(rName string) string {
+func testAccFileSystemPolicyConfig_secondEquivalent(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -391,7 +391,7 @@ resource "aws_efs_file_system_policy" "test" {
 `, rName)
 }
 
-func testAccFileSystemPolicyEquivalentIAMPolicyDocConfig(rName string) string {
+func testAccFileSystemPolicyConfig_equivalentIAMDoc(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -27,7 +27,7 @@ func TestAccEFSFileSystem_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemConfig(rName),
+				Config: testAccFileSystemConfig_dataSourceBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
@@ -52,7 +52,7 @@ func TestAccEFSFileSystem_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFileSystemWithPerformanceModeConfig,
+				Config: testAccFileSystemConfig_performanceMode,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem("aws_efs_file_system.test2", &desc),
 					resource.TestCheckResourceAttr("aws_efs_file_system.test2", "creation_token", "supercalifragilisticexpialidocious"),
@@ -75,7 +75,7 @@ func TestAccEFSFileSystem_availabilityZoneName(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemAvailabilityZoneNameConfig(rName),
+				Config: testAccFileSystemConfig_availabilityZoneName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone_id", "data.aws_availability_zones.available", "zone_ids.0"),
@@ -103,7 +103,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemTags1Config(rName, "key1", "value1"),
+				Config: testAccFileSystemConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -116,7 +116,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFileSystemTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccFileSystemConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -125,7 +125,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemTags1Config(rName, "key2", "value2"),
+				Config: testAccFileSystemConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -133,7 +133,7 @@ func TestAccEFSFileSystem_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemWithMaxTagsConfig(rName),
+				Config: testAccFileSystemConfig_maxTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "50"),
@@ -158,7 +158,7 @@ func TestAccEFSFileSystem_pagedTags(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemPagedTagsConfig(rInt),
+				Config: testAccFileSystemConfig_pagedTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "10"),
@@ -186,7 +186,7 @@ func TestAccEFSFileSystem_kmsKey(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemWithKMSKeyConfig(rInt, true),
+				Config: testAccFileSystemConfig_kmsKey(rInt, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
@@ -212,7 +212,7 @@ func TestAccEFSFileSystem_kmsWithoutEncryption(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccFileSystemWithKMSKeyConfig(rInt, false),
+				Config:      testAccFileSystemConfig_kmsKey(rInt, false),
 				ExpectError: regexp.MustCompile(`encrypted must be set to true when kms_key_id is specified`),
 			},
 		},
@@ -230,7 +230,7 @@ func TestAccEFSFileSystem_provisionedThroughputInMibps(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemConfig_ProvisionedThroughputInMibps(1.0),
+				Config: testAccFileSystemConfig_provisionedThroughputInMibps(1.0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "1"),
@@ -238,7 +238,7 @@ func TestAccEFSFileSystem_provisionedThroughputInMibps(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemConfig_ProvisionedThroughputInMibps(2.0),
+				Config: testAccFileSystemConfig_provisionedThroughputInMibps(2.0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "2"),
@@ -265,7 +265,7 @@ func TestAccEFSFileSystem_throughputMode(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemConfig_ProvisionedThroughputInMibps(1.0),
+				Config: testAccFileSystemConfig_provisionedThroughputInMibps(1.0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "1"),
@@ -273,7 +273,7 @@ func TestAccEFSFileSystem_throughputMode(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemConfig_ThroughputMode(efs.ThroughputModeBursting),
+				Config: testAccFileSystemConfig_throughputMode(efs.ThroughputModeBursting),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "provisioned_throughput_in_mibps", "0"),
@@ -334,7 +334,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemRemovedLifecyclePolicyConfig,
+				Config: testAccFileSystemConfig_removedLifecyclePolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "0"),
@@ -370,7 +370,7 @@ func TestAccEFSFileSystem_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemConfig(rName),
+				Config: testAccFileSystemConfig_dataSourceBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(resourceName, &desc),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceFileSystem(), resourceName),
@@ -430,7 +430,7 @@ func testAccCheckFileSystem(resourceID string, fDesc *efs.FileSystemDescription)
 	}
 }
 
-func testAccFileSystemConfig(rName string) string {
+func testAccFileSystemConfig_dataSourceBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %q
@@ -438,7 +438,7 @@ resource "aws_efs_file_system" "test" {
 `, rName)
 }
 
-func testAccFileSystemAvailabilityZoneNameConfig(rName string) string {
+func testAccFileSystemConfig_availabilityZoneName(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -456,7 +456,7 @@ resource "aws_efs_file_system" "test" {
 `, rName)
 }
 
-func testAccFileSystemTags1Config(rName, tagKey1, tagValue1 string) string {
+func testAccFileSystemConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -467,7 +467,7 @@ resource "aws_efs_file_system" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccFileSystemTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccFileSystemConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -479,7 +479,7 @@ resource "aws_efs_file_system" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccFileSystemPagedTagsConfig(rInt int) string {
+func testAccFileSystemConfig_pagedTags(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   tags = {
@@ -498,7 +498,7 @@ resource "aws_efs_file_system" "test" {
 `, rInt)
 }
 
-func testAccFileSystemWithMaxTagsConfig(rName string) string {
+func testAccFileSystemConfig_maxTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   tags = {
@@ -557,14 +557,14 @@ resource "aws_efs_file_system" "test" {
 `, rName)
 }
 
-const testAccFileSystemWithPerformanceModeConfig = `
+const testAccFileSystemConfig_performanceMode = `
 resource "aws_efs_file_system" "test2" {
   creation_token   = "supercalifragilisticexpialidocious"
   performance_mode = "maxIO"
 }
 `
 
-func testAccFileSystemWithKMSKeyConfig(rInt int, enable bool) string {
+func testAccFileSystemConfig_kmsKey(rInt int, enable bool) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = "Terraform acc test %[1]d"
@@ -577,7 +577,7 @@ resource "aws_efs_file_system" "test" {
 `, rInt, enable)
 }
 
-func testAccFileSystemConfig_ThroughputMode(throughputMode string) string {
+func testAccFileSystemConfig_throughputMode(throughputMode string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   throughput_mode = %q
@@ -585,7 +585,7 @@ resource "aws_efs_file_system" "test" {
 `, throughputMode)
 }
 
-func testAccFileSystemConfig_ProvisionedThroughputInMibps(provisionedThroughputInMibps float64) string {
+func testAccFileSystemConfig_provisionedThroughputInMibps(provisionedThroughputInMibps float64) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   provisioned_throughput_in_mibps = %f
@@ -618,6 +618,6 @@ resource "aws_efs_file_system" "test" {
 `, lpName1, lpVal1, lpName2, lpVal2)
 }
 
-const testAccFileSystemRemovedLifecyclePolicyConfig = `
+const testAccFileSystemConfig_removedLifecyclePolicy = `
 resource "aws_efs_file_system" "test" {}
 `

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -300,14 +300,14 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemWithLifecyclePolicyConfig(
+				Config: testAccFileSystemConfig_lifecyclePolicy(
 					"transition_to_ia",
 					"invalid_value",
 				),
 				ExpectError: regexp.MustCompile(`got invalid_value`),
 			},
 			{
-				Config: testAccFileSystemWithLifecyclePolicyConfig(
+				Config: testAccFileSystemConfig_lifecyclePolicy(
 					"transition_to_ia",
 					efs.TransitionToIARulesAfter30Days,
 				),
@@ -323,7 +323,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFileSystemWithLifecyclePolicyConfig(
+				Config: testAccFileSystemConfig_lifecyclePolicy(
 					"transition_to_primary_storage_class",
 					efs.TransitionToPrimaryStorageClassRulesAfter1Access,
 				),
@@ -341,7 +341,7 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemWithLifecyclePolicyMultiConfig(
+				Config: testAccFileSystemConfig_lifecyclePolicyMulti(
 					"transition_to_primary_storage_class",
 					efs.TransitionToPrimaryStorageClassRulesAfter1Access,
 					"transition_to_ia",
@@ -594,7 +594,7 @@ resource "aws_efs_file_system" "test" {
 `, provisionedThroughputInMibps)
 }
 
-func testAccFileSystemWithLifecyclePolicyConfig(lpName, lpVal string) string {
+func testAccFileSystemConfig_lifecyclePolicy(lpName, lpVal string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   lifecycle_policy {
@@ -604,7 +604,7 @@ resource "aws_efs_file_system" "test" {
 `, lpName, lpVal)
 }
 
-func testAccFileSystemWithLifecyclePolicyMultiConfig(lpName1, lpVal1, lpName2, lpVal2 string) string {
+func testAccFileSystemConfig_lifecyclePolicyMulti(lpName1, lpVal1, lpName2, lpVal2 string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   lifecycle_policy {

--- a/internal/service/efs/mount_target_data_source_test.go
+++ b/internal/service/efs/mount_target_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccEFSMountTargetDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetByMountTargetIDConfig(rName),
+				Config: testAccMountTargetDataSourceConfig_byID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_id", resourceName, "file_system_id"),
@@ -51,7 +51,7 @@ func TestAccEFSMountTargetDataSource_byAccessPointID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetByAccessPointIDConfig(rName),
+				Config: testAccMountTargetDataSourceConfig_byAccessPointID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_id", resourceName, "file_system_id"),
@@ -81,7 +81,7 @@ func TestAccEFSMountTargetDataSource_byFileSystemID(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetByFileSystemIDConfig(rName),
+				Config: testAccMountTargetDataSourceConfig_byFileSystemID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_id", resourceName, "file_system_id"),
@@ -135,7 +135,7 @@ resource "aws_subnet" "test" {
 `, rName))
 }
 
-func testAccMountTargetByMountTargetIDConfig(rName string) string {
+func testAccMountTargetDataSourceConfig_byID(rName string) string {
 	return acctest.ConfigCompose(testAccMountTargetBaseDataSourceConfig(rName), `
 data "aws_efs_mount_target" "test" {
   mount_target_id = aws_efs_mount_target.test.id
@@ -143,7 +143,7 @@ data "aws_efs_mount_target" "test" {
 `)
 }
 
-func testAccMountTargetByAccessPointIDConfig(rName string) string {
+func testAccMountTargetDataSourceConfig_byAccessPointID(rName string) string {
 	return acctest.ConfigCompose(testAccMountTargetBaseDataSourceConfig(rName), `
 resource "aws_efs_access_point" "test" {
   file_system_id = aws_efs_file_system.test.id
@@ -155,7 +155,7 @@ data "aws_efs_mount_target" "test" {
 `)
 }
 
-func testAccMountTargetByFileSystemIDConfig(rName string) string {
+func testAccMountTargetDataSourceConfig_byFileSystemID(rName string) string {
 	return acctest.ConfigCompose(testAccMountTargetBaseDataSourceConfig(rName), `
 data "aws_efs_mount_target" "test" {
   file_system_id = aws_efs_file_system.test.id

--- a/internal/service/efs/mount_target_test.go
+++ b/internal/service/efs/mount_target_test.go
@@ -31,7 +31,7 @@ func TestAccEFSMountTarget_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMountTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetConfig(ct),
+				Config: testAccMountTargetConfig_basic(ct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMountTarget(resourceName, &mount),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_id"),
@@ -50,7 +50,7 @@ func TestAccEFSMountTarget_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMountTargetModifiedConfig(ct),
+				Config: testAccMountTargetConfig_modified(ct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMountTarget(resourceName, &mount),
 					testAccCheckMountTarget(resourceName2, &mount),
@@ -74,7 +74,7 @@ func TestAccEFSMountTarget_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckVPNGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetConfig(ct),
+				Config: testAccMountTargetConfig_basic(ct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMountTarget(resourceName, &mount),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceMountTarget(), resourceName),
@@ -97,7 +97,7 @@ func TestAccEFSMountTarget_ipAddress(t *testing.T) {
 		CheckDestroy:      testAccCheckMountTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetIPAddressConfig(rName, "10.0.0.100"),
+				Config: testAccMountTargetConfig_ipAddress(rName, "10.0.0.100"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMountTarget(resourceName, &mount),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "10.0.0.100"),
@@ -125,7 +125,7 @@ func TestAccEFSMountTarget_IPAddress_emptyString(t *testing.T) {
 		CheckDestroy:      testAccCheckMountTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMountTargetIPAddressConfigNullIP(rName),
+				Config: testAccMountTargetConfig_ipAddressNullIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMountTarget(resourceName, &mount),
 					resource.TestMatchResourceAttr(resourceName, "ip_address", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
@@ -219,7 +219,7 @@ func testAccCheckMountTarget(resourceID string, mount *efs.MountTargetDescriptio
 	}
 }
 
-func testAccMountTargetConfig(ct string) string {
+func testAccMountTargetConfig_basic(ct string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -263,7 +263,7 @@ resource "aws_subnet" "test" {
 `, ct)
 }
 
-func testAccMountTargetModifiedConfig(ct string) string {
+func testAccMountTargetConfig_modified(ct string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -322,7 +322,7 @@ resource "aws_subnet" "test2" {
 `, ct)
 }
 
-func testAccMountTargetIPAddressConfig(rName, ipAddress string) string {
+func testAccMountTargetConfig_ipAddress(rName, ipAddress string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -365,7 +365,7 @@ resource "aws_efs_mount_target" "test" {
 `, rName, ipAddress)
 }
 
-func testAccMountTargetIPAddressConfigNullIP(rName string) string {
+func testAccMountTargetConfig_ipAddressNullIP(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/efs/replication_configuration_test.go
+++ b/internal/service/efs/replication_configuration_test.go
@@ -32,7 +32,7 @@ func TestAccEFSReplicationConfiguration_basic(t *testing.T) {
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckReplicationConfigurationDestroy, &providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicationConfigurationConfig(region),
+				Config: testAccReplicationConfigurationConfig_basic(region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationConfigurationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
@@ -70,7 +70,7 @@ func TestAccEFSReplicationConfiguration_disappears(t *testing.T) {
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckReplicationConfigurationDestroy, &providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicationConfigurationConfig(region),
+				Config: testAccReplicationConfigurationConfig_basic(region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationConfigurationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfefs.ResourceReplicationConfiguration(), resourceName),
@@ -102,7 +102,7 @@ func TestAccEFSReplicationConfiguration_allAttributes(t *testing.T) {
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckReplicationConfigurationDestroy, &providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicationConfigurationFullConfig(alternateRegion),
+				Config: testAccReplicationConfigurationConfig_full(alternateRegion),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationConfigurationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
@@ -169,7 +169,7 @@ func testAccCheckReplicationConfigurationDestroy(s *terraform.State, provider *s
 	return nil
 }
 
-func testAccReplicationConfigurationConfig(region string) string {
+func testAccReplicationConfigurationConfig_basic(region string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {}
 
@@ -183,7 +183,7 @@ resource "aws_efs_replication_configuration" "test" {
 `, region)
 }
 
-func testAccReplicationConfigurationFullConfig(region string) string {
+func testAccReplicationConfigurationConfig_full(region string) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   provider = "awsalternate"


### PR DESCRIPTION
- efs: Fix test configs names
- efs: Fix test config names

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
