### PR TITLE
F/#25314 - Return the public key material for a `aws_key_pair`

### DIFF
--- a/.changelog/25371.txt
+++ b/.changelog/25371.txt
@@ -3,5 +3,5 @@ resource/aws_key_pair: Added 2 new attributes - `key_type` and `create_time`
 ```
 
 ```release-note:enhancement
-data/aws_key_pair: Get the public key material by setting the attribute `include_public_key`
+data/aws_key_pair: New attribute `public_key` populated by setting the new `include_public_key` argument
 ```

--- a/.changelog/25371.txt
+++ b/.changelog/25371.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_key_pair: Added 2 new attributes - `key_type` and `create_time`
+```
+
+```release-note:enhancement
+data/aws_key_pair: Get the public key material by setting the attribute `include_public_key`
+```

--- a/internal/service/ec2/ec2_key_pair.go
+++ b/internal/service/ec2/ec2_key_pair.go
@@ -1,9 +1,12 @@
 package ec2
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"strings"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -176,4 +179,22 @@ func resourceKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+// OpenSSHPublicKeysEqual returns whether or not two OpenSSH public key format strings represent the same key.
+// Any key comment is ignored when comparing values.
+func OpenSSHPublicKeysEqual(v1, v2 string) bool {
+	key1, _, _, _, err := ssh.ParseAuthorizedKey([]byte(v1))
+
+	if err != nil {
+		return false
+	}
+
+	key2, _, _, _, err := ssh.ParseAuthorizedKey([]byte(v2))
+
+	if err != nil {
+		return false
+	}
+
+	return key1.Type() == key2.Type() && bytes.Equal(key1.Marshal(), key2.Marshal())
 }

--- a/internal/service/ec2/ec2_key_pair.go
+++ b/internal/service/ec2/ec2_key_pair.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"strings"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -19,6 +17,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"golang.org/x/crypto/ssh"
 )
 
 func ResourceKeyPair() *schema.Resource {

--- a/internal/service/ec2/ec2_key_pair.go
+++ b/internal/service/ec2/ec2_key_pair.go
@@ -66,6 +66,10 @@ func ResourceKeyPair() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"key_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"public_key": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -137,6 +141,7 @@ func resourceKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("fingerprint", keyPair.KeyFingerprint)
 	d.Set("key_name", keyPair.KeyName)
 	d.Set("key_name_prefix", create.NamePrefixFromName(aws.StringValue(keyPair.KeyName)))
+	d.Set("key_type", keyPair.KeyType)
 	d.Set("key_pair_id", keyPair.KeyPairId)
 
 	tags := KeyValueTags(keyPair.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/ec2/ec2_key_pair_data_source.go
+++ b/internal/service/ec2/ec2_key_pair_data_source.go
@@ -34,6 +34,15 @@ func DataSourceKeyPair() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"include_public_key": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"public_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
@@ -57,6 +66,10 @@ func dataSourceKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 		input.KeyPairIds = aws.StringSlice([]string{v.(string)})
 	}
 
+	if v, ok := d.GetOk("include_public_key"); ok {
+		input.IncludePublicKey = aws.Bool(v.(bool))
+	}
+
 	keyPair, err := FindKeyPair(conn, input)
 
 	if err != nil {
@@ -77,6 +90,8 @@ func dataSourceKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("fingerprint", keyPair.KeyFingerprint)
 	d.Set("key_name", keyName)
 	d.Set("key_pair_id", keyPair.KeyPairId)
+	d.Set("include_public_key", input.IncludePublicKey)
+	d.Set("public_key", keyPair.PublicKey)
 
 	if err := d.Set("tags", KeyValueTags(keyPair.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/internal/service/ec2/ec2_key_pair_data_source.go
+++ b/internal/service/ec2/ec2_key_pair_data_source.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -21,6 +22,10 @@ func DataSourceKeyPair() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"filter": DataSourceFiltersSchema(),
 			"fingerprint": {
 				Type:     schema.TypeString,
@@ -33,6 +38,10 @@ func DataSourceKeyPair() *schema.Resource {
 			"key_pair_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"key_type": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"include_public_key": {
 				Type:     schema.TypeBool,
@@ -87,9 +96,11 @@ func dataSourceKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 		Resource:  fmt.Sprintf("key-pair/%s", keyName),
 	}.String()
 	d.Set("arn", arn)
+	d.Set("create_time", aws.TimeValue(keyPair.CreateTime).Format(time.RFC3339))
 	d.Set("fingerprint", keyPair.KeyFingerprint)
 	d.Set("key_name", keyName)
 	d.Set("key_pair_id", keyPair.KeyPairId)
+	d.Set("key_type", keyPair.KeyType)
 	d.Set("include_public_key", input.IncludePublicKey)
 	d.Set("public_key", keyPair.PublicKey)
 

--- a/internal/service/ec2/ec2_key_pair_data_source_test.go
+++ b/internal/service/ec2/ec2_key_pair_data_source_test.go
@@ -114,7 +114,7 @@ resource "aws_key_pair" "test" {
 func testAccKeyPairDataSourceConfig_includePublicKey(rName, publicKey string) string {
 	return fmt.Sprintf(`
 data "aws_key_pair" "by_name" {
-  key_name = aws_key_pair.test.key_name
+  key_name           = aws_key_pair.test.key_name
   include_public_key = true
 }
 

--- a/internal/service/ec2/ec2_key_pair_data_source_test.go
+++ b/internal/service/ec2/ec2_key_pair_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
 func TestAccEC2KeyPairDataSource_basic(t *testing.T) {
@@ -75,7 +76,13 @@ func TestAccEC2KeyPairDataSource_includePublicKey(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSource1Name, "fingerprint", resourceName, "fingerprint"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "key_name", resourceName, "key_name"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "key_pair_id", resourceName, "key_pair_id"),
-					resource.TestCheckResourceAttrPair(dataSource1Name, "public_key", resourceName, "public_key"),
+					resource.TestCheckResourceAttrWith(dataSource1Name, "public_key", func(v string) error {
+						if !tfec2.OpenSSHPublicKeysEqual(v, publicKey) {
+							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
+						}
+
+						return nil
+					}),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "tags.%", resourceName, "tags.%"),
 				),
 			},

--- a/website/docs/d/key_pair.html.markdown
+++ b/website/docs/d/key_pair.html.markdown
@@ -12,11 +12,13 @@ Use this data source to get information about a specific EC2 Key Pair.
 
 ## Example Usage
 
-The following example shows how to get a EC2 Key Pair from its name.
+The following example shows how to get a EC2 Key Pair including the public key material from its name.
 
 ```terraform
 data "aws_key_pair" "example" {
-  key_name = "test"
+  key_name           = "test"
+  include_public_key = true
+
   filter {
     name   = "tag:Component"
     values = ["web"]
@@ -44,6 +46,7 @@ whose data will be exported as attributes.
 
 * `key_pair_id` - (Optional) The Key Pair ID.
 * `key_name` - (Optional) The Key Pair name.
+* `include_public_key` - (Optional) Whether to include the public key material in the response.
 * `filter` -  (Optional) Custom filter block as described below.
 
 ### filter Configuration Block
@@ -60,4 +63,5 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - ID of the Key Pair.
 * `arn` - The ARN of the Key Pair.
 * `fingerprint` - The SHA-1 digest of the DER encoded private key.
+* `public_key` - The public key material.
 * `tags` - Any tags assigned to the Key Pair.

--- a/website/docs/d/key_pair.html.markdown
+++ b/website/docs/d/key_pair.html.markdown
@@ -62,6 +62,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the Key Pair.
 * `arn` - The ARN of the Key Pair.
+* `create_time` - The timestamp for when the key pair was created in ISO 8601 format.
 * `fingerprint` - The SHA-1 digest of the DER encoded private key.
+* `key_type` - The type of key pair.
 * `public_key` - The public key material.
 * `tags` - Any tags assigned to the Key Pair.

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -44,6 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The key pair ARN.
 * `key_name` - The key pair name.
 * `key_pair_id` - The key pair ID.
+* `key_type` - The type of key pair.
 * `fingerprint` - The MD5 public key fingerprint as specified in section 4 of RFC 4716.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25314 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
bruno@pop-os ~/G/terraform-provider-aws (f/#25314-aws-key-pair-public-key)> make testacc TESTS=TestAccEC2KeyPairDataSource_ PKG=ec2                                                                                                     (base) 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2KeyPairDataSource_'  -timeout 180m
=== RUN   TestAccEC2KeyPairDataSource_basic
=== PAUSE TestAccEC2KeyPairDataSource_basic
=== RUN   TestAccEC2KeyPairDataSource_includePublicKey
=== PAUSE TestAccEC2KeyPairDataSource_includePublicKey
=== CONT  TestAccEC2KeyPairDataSource_basic
=== CONT  TestAccEC2KeyPairDataSource_includePublicKey
--- PASS: TestAccEC2KeyPairDataSource_includePublicKey (7.51s)
--- PASS: TestAccEC2KeyPairDataSource_basic (8.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        8.177s
bruno@pop-os ~/G/terraform-provider-aws (f/#25314-aws-key-pair-public-key)> make testacc TESTS=TestAccEC2KeyPair_ PKG=ec2                                                                                                               (base) 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2KeyPair_'  -timeout 180m
=== RUN   TestAccEC2KeyPair_basic
=== PAUSE TestAccEC2KeyPair_basic
=== RUN   TestAccEC2KeyPair_tags
=== PAUSE TestAccEC2KeyPair_tags
=== RUN   TestAccEC2KeyPair_nameGenerated
=== PAUSE TestAccEC2KeyPair_nameGenerated
=== RUN   TestAccEC2KeyPair_namePrefix
=== PAUSE TestAccEC2KeyPair_namePrefix
=== RUN   TestAccEC2KeyPair_disappears
=== PAUSE TestAccEC2KeyPair_disappears
=== CONT  TestAccEC2KeyPair_basic
=== CONT  TestAccEC2KeyPair_namePrefix
=== CONT  TestAccEC2KeyPair_disappears
=== CONT  TestAccEC2KeyPair_nameGenerated
=== CONT  TestAccEC2KeyPair_tags
--- PASS: TestAccEC2KeyPair_disappears (6.91s)
--- PASS: TestAccEC2KeyPair_basic (9.71s)
--- PASS: TestAccEC2KeyPair_namePrefix (9.83s)
--- PASS: TestAccEC2KeyPair_nameGenerated (9.83s)
--- PASS: TestAccEC2KeyPair_tags (21.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        21.230s
```
