### PR TITLE
bugfix: validate `embed_host_domains` correctly

### DIFF
--- a/.changelog/25372.txt
+++ b/.changelog/25372.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_appstream_stack: Fix crash when setting `embed_host_domains`
+```

--- a/.changelog/25372.txt
+++ b/.changelog/25372.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_appstream_stack: Fix crash when setting `embed_host_domains`
+resource/aws_appstream_stack: Fix crash when setting `embed_host_domains`
 ```

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -211,7 +211,7 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("embed_host_domains"); ok {
-		input.EmbedHostDomains = flex.ExpandStringList(v.([]interface{}))
+		input.EmbedHostDomains = flex.ExpandStringList(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("feedback_url"); ok {

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -95,6 +95,9 @@ func TestAccAppStreamStack_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
+					resource.TestCheckResourceAttr(resourceName, "embed_host_domains.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "embed_host_domains.*", "example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "embed_host_domains.*", "subdomain.example.com"),
 				),
 			},
 			{
@@ -214,6 +217,8 @@ func testAccStackCompleteConfig(name, description string) string {
 resource "aws_appstream_stack" "test" {
   name        = %[1]q
   description = %[2]q
+
+  embed_host_domains = ["example.com", "subdomain.example.com"]
 
   storage_connectors {
     connector_type = "HOMEFOLDERS"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25205

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppStreamStack PKG=appstream 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamStack'  -timeout 180m
=== RUN   TestAccAppStreamStack_basic
=== PAUSE TestAccAppStreamStack_basic
=== RUN   TestAccAppStreamStack_disappears
=== PAUSE TestAccAppStreamStack_disappears
=== RUN   TestAccAppStreamStack_complete
=== PAUSE TestAccAppStreamStack_complete
=== RUN   TestAccAppStreamStack_withTags
=== PAUSE TestAccAppStreamStack_withTags
=== CONT  TestAccAppStreamStack_basic
=== CONT  TestAccAppStreamStack_complete
=== CONT  TestAccAppStreamStack_disappears
=== CONT  TestAccAppStreamStack_withTags
--- PASS: TestAccAppStreamStack_disappears (6.92s)
--- PASS: TestAccAppStreamStack_basic (12.82s)
--- PASS: TestAccAppStreamStack_withTags (24.32s)
--- PASS: TestAccAppStreamStack_complete (25.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  27.388s
```

The `embed_host_domains` path was validated incorrectly, and any plan that used it crashed. This fixes it so that it validates the paths as a set, not a list.