### PR TITLE
elasticache/replication_group: Add nil guards for endpoints

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -685,7 +685,10 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("port", rgp.ConfigurationEndpoint.Port)
 		d.Set("configuration_endpoint_address", rgp.ConfigurationEndpoint.Address)
 	} else {
+		log.Printf("[DEBUG] ElastiCache Replication Group (%s) Configuration Endpoint is nil", d.Id())
+
 		if rgp.NodeGroups[0].PrimaryEndpoint != nil {
+			log.Printf("[DEBUG] ElastiCache Replication Group (%s) Primary Endpoint is not nil", d.Id())
 			if rgp.NodeGroups[0].PrimaryEndpoint.Port != nil {
 				d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
 			}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -685,9 +685,19 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("port", rgp.ConfigurationEndpoint.Port)
 		d.Set("configuration_endpoint_address", rgp.ConfigurationEndpoint.Address)
 	} else {
-		d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
-		d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
-		d.Set("reader_endpoint_address", rgp.NodeGroups[0].ReaderEndpoint.Address)
+		if rgp.NodeGroups[0].PrimaryEndpoint != nil {
+			if rgp.NodeGroups[0].PrimaryEndpoint.Port != nil {
+				d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
+			}
+
+			if rgp.NodeGroups[0].PrimaryEndpoint.Address != nil {
+				d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+			}
+		}
+
+		if rgp.NodeGroups[0].ReaderEndpoint != nil && rgp.NodeGroups[0].ReaderEndpoint.Address != nil {
+			d.Set("reader_endpoint_address", rgp.NodeGroups[0].ReaderEndpoint.Address)
+		}
 	}
 
 	d.Set("user_group_ids", rgp.UserGroupIds)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #25430 (maybe closes)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccElastiCacheReplicationGroup_vpc PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_vpc'  -timeout 180m
--- PASS: TestAccElastiCacheReplicationGroup_vpc (722.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	723.454s
```
