### PR TITLE
Fix example for Selecting Backups By Conditions

### DIFF
--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -72,7 +72,8 @@ resource "aws_backup_selection" "example" {
   iam_role_arn = aws_iam_role.example.arn
   name         = "tf_example_backup_selection"
   plan_id      = aws_backup_plan.example.id
-
+  resources = ["*"]
+  
   condition {
     string_equals {
       key   = "aws:ResourceTag/Component"

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -72,8 +72,8 @@ resource "aws_backup_selection" "example" {
   iam_role_arn = aws_iam_role.example.arn
   name         = "tf_example_backup_selection"
   plan_id      = aws_backup_plan.example.id
-  resources = ["*"]
-  
+  resources    = ["*"]
+
   condition {
     string_equals {
       key   = "aws:ResourceTag/Component"


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


### Description
When using aws_backup_selection the resources field is needed in order to work.

Previously this example would give the following error:

```
resource "aws_backup_selection" "example" {
  iam_role_arn = aws_iam_role.example.arn
  name         = "tf_example_backup_selection"
  plan_id      = aws_backup_plan.example.id

  condition {
    string_equals {
      key   = "aws:ResourceTag/Component"
      value = "rds"
    }
    string_like {
      key   = "aws:ResourceTag/Application"
      value = "app*"
    }
    string_not_equals {
      key   = "aws:ResourceTag/Backup"
      value = "false"
    }
    string_not_like {
      key   = "aws:ResourceTag/Environment"
      value = "test*"
    }
  }
}
```

```
Error: error creating Backup Selection: InvalidParameterValueException: Invalid backup selection. Either 'ListOfTags' or 'Resources' section must be non-empty.
```

The correct would be to add the `resources` field, either by using `*` or more specific: `resources = "arn:aws:rds:*:*:db:*"`
```
resource "aws_backup_selection" "example" {
  iam_role_arn = aws_iam_role.example.arn
  name         = "tf_example_backup_selection"
  plan_id      = aws_backup_plan.example.id
  resources = ["*"]

  condition {
    string_equals {
      key   = "aws:ResourceTag/Component"
      value = "rds"
    }
    string_like {
      key   = "aws:ResourceTag/Application"
      value = "app*"
    }
    string_not_equals {
      key   = "aws:ResourceTag/Backup"
      value = "false"
    }
    string_not_like {
      key   = "aws:ResourceTag/Environment"
      value = "test*"
    }
  }
}
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes  #24235
