### PR TITLE
Revert aws_rds_instance engine_version conflict for replica instances

### DIFF
--- a/.changelog/25439
+++ b/.changelog/25439
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Revert engine_version conflict for read replica instances
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -194,10 +194,9 @@ func ResourceInstance() *schema.Resource {
 				ConflictsWith: []string{"replicate_source_db"},
 			},
 			"engine_version": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"replicate_source_db"},
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"engine_version_actual": {
 				Type:     schema.TypeString,

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -120,7 +120,7 @@ in the Amazon RDS User Guide.
 is enabled, you can provide a prefix of the version such as `5.7` (for `5.7.10`).
 The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below.
 For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
-Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'. Cannot be specified for a replica.
+Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
 when this DB instance is deleted. Must be provided if `skip_final_snapshot` is
 set to `false`. The value must begin with a letter, only contain alphanumeric characters and hyphens, and not end with a hyphen or contain two consecutive hyphens. Must not be provided when deleting a read replica.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24887

Reverts the `aws_rds_instance` resource's `engine_version` -> `ConflictsWith: []string{"replicate_source_db"}` schema added in https://github.com/hashicorp/terraform-provider-aws/pull/22178

This fixes https://github.com/hashicorp/terraform-provider-aws/issues/24887 AWS RDS PostgreSQL minor version upgrades for primary / replica instances.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->



Output from ~acceptance~ testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -v github.com/hashicorp/terraform-provider-aws/internal/service/rds
...
PASS
```
