### PR TITLE
r/aws_launch_configuration: No default for `associate_public_ip_address`

### DIFF
--- a/.changelog/25450.txt
+++ b/.changelog/25450.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ resource/aws_launch_configuration: Remove default value for `associate_public_ip_address` argument and mark as Computed. This fixes a regression introduced in [v4.17.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4170-june--3-2022) via [#17695](https://github.com/hashicorp/terraform-provider-aws/issues/17695) when no value is configured, whilst honoring any configured value
+ ```

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -41,8 +41,8 @@ func ResourceLaunchConfiguration() *schema.Resource {
 			"associate_public_ip_address": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
-				Default:  false,
 			},
 			"ebs_block_device": {
 				Type:     schema.TypeSet,
@@ -326,11 +326,15 @@ func resourceLaunchConfigurationCreate(d *schema.ResourceData, meta interface{})
 
 	lcName := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := autoscaling.CreateLaunchConfigurationInput{
-		AssociatePublicIpAddress: aws.Bool(d.Get("associate_public_ip_address").(bool)),
-		EbsOptimized:             aws.Bool(d.Get("ebs_optimized").(bool)),
-		ImageId:                  aws.String(d.Get("image_id").(string)),
-		InstanceType:             aws.String(d.Get("instance_type").(string)),
-		LaunchConfigurationName:  aws.String(lcName),
+		EbsOptimized:            aws.Bool(d.Get("ebs_optimized").(bool)),
+		ImageId:                 aws.String(d.Get("image_id").(string)),
+		InstanceType:            aws.String(d.Get("instance_type").(string)),
+		LaunchConfigurationName: aws.String(lcName),
+	}
+
+	associatePublicIPAddress := d.GetRawConfig().GetAttr("associate_public_ip_address")
+	if associatePublicIPAddress.IsKnown() && !associatePublicIPAddress.IsNull() {
+		input.AssociatePublicIpAddress = aws.Bool(associatePublicIPAddress.True())
 	}
 
 	if v, ok := d.GetOk("vpc_classic_link_id"); ok {

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -299,7 +299,6 @@ func TestAccAutoScalingLaunchConfiguration_encryptedRootBlockDevice(t *testing.T
 				Config: testAccLaunchConfigurationConfig_encryptedRootBlockDevice(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "root_block_device.*", map[string]string{
 						"encrypted":   "true",
@@ -394,7 +393,6 @@ func TestAccAutoScalingLaunchConfiguration_withIAMProfile(t *testing.T) {
 				Config: testAccLaunchConfigurationConfig_iamProfile(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "iam_instance_profile"),
 				),
 			},
@@ -1035,10 +1033,9 @@ resource "aws_launch_configuration" "test" {
 func testAccLaunchConfigurationConfig_encryptedRootBlockDevice(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name_prefix                 = %[1]q
-  image_id                    = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = "t3.nano"
-  associate_public_ip_address = false
+  name_prefix   = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = "t3.nano"
 
   root_block_device {
     encrypted   = true
@@ -1123,8 +1120,6 @@ resource "aws_launch_configuration" "test" {
   image_id             = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type        = "t2.nano"
   iam_instance_profile = aws_iam_instance_profile.test.name
-
-  associate_public_ip_address = true
 }
 `, rName))
 }

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -612,7 +612,7 @@ func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseC
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckGroupExists(groupResourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 1),
-					testAccCheckInstanceHasPublicIpAddress(&group, 0, false),
+					testAccCheckInstanceHasPublicIPAddress(&group, 0, false),
 				),
 			},
 			{
@@ -643,7 +643,7 @@ func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseC
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckGroupExists(groupResourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 1),
-					testAccCheckInstanceHasPublicIpAddress(&group, 0, false),
+					testAccCheckInstanceHasPublicIPAddress(&group, 0, false),
 				),
 			},
 			{
@@ -674,7 +674,7 @@ func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseC
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckGroupExists(groupResourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 1),
-					testAccCheckInstanceHasPublicIpAddress(&group, 0, true),
+					testAccCheckInstanceHasPublicIPAddress(&group, 0, true),
 				),
 			},
 			{
@@ -705,7 +705,7 @@ func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueCo
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckGroupExists(groupResourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 1),
-					testAccCheckInstanceHasPublicIpAddress(&group, 0, true),
+					testAccCheckInstanceHasPublicIPAddress(&group, 0, true),
 				),
 			},
 			{
@@ -736,7 +736,7 @@ func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueCo
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckGroupExists(groupResourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 1),
-					testAccCheckInstanceHasPublicIpAddress(&group, 0, false),
+					testAccCheckInstanceHasPublicIPAddress(&group, 0, false),
 				),
 			},
 			{
@@ -767,7 +767,7 @@ func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueCo
 					testAccCheckLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckGroupExists(groupResourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 1),
-					testAccCheckInstanceHasPublicIpAddress(&group, 0, true),
+					testAccCheckInstanceHasPublicIPAddress(&group, 0, true),
 				),
 			},
 			{
@@ -853,7 +853,7 @@ func testAccCheckAMIExists(n string, v *ec2.Image) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckInstanceHasPublicIpAddress(group *autoscaling.Group, idx int, expected bool) resource.TestCheckFunc {
+func testAccCheckInstanceHasPublicIPAddress(group *autoscaling.Group, idx int, expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -594,6 +595,192 @@ func TestAccAutoScalingLaunchConfiguration_userData(t *testing.T) {
 	})
 }
 
+func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigNull(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	var group autoscaling.Group
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_launch_configuration.test"
+	groupResourceName := "aws_autoscaling_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationConfig_associatePublicIPAddress(rName, false, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckGroupExists(groupResourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 1),
+					testAccCheckInstanceHasPublicIpAddress(&group, 0, false),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigFalse(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	var group autoscaling.Group
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_launch_configuration.test"
+	groupResourceName := "aws_autoscaling_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationConfig_associatePublicIPAddress(rName, false, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckGroupExists(groupResourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 1),
+					testAccCheckInstanceHasPublicIpAddress(&group, 0, false),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigTrue(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	var group autoscaling.Group
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_launch_configuration.test"
+	groupResourceName := "aws_autoscaling_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationConfig_associatePublicIPAddress(rName, false, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckGroupExists(groupResourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 1),
+					testAccCheckInstanceHasPublicIpAddress(&group, 0, true),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigNull(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	var group autoscaling.Group
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_launch_configuration.test"
+	groupResourceName := "aws_autoscaling_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationConfig_associatePublicIPAddress(rName, true, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckGroupExists(groupResourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 1),
+					testAccCheckInstanceHasPublicIpAddress(&group, 0, true),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigFalse(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	var group autoscaling.Group
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_launch_configuration.test"
+	groupResourceName := "aws_autoscaling_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationConfig_associatePublicIPAddress(rName, true, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckGroupExists(groupResourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 1),
+					testAccCheckInstanceHasPublicIpAddress(&group, 0, false),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigTrue(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	var group autoscaling.Group
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_launch_configuration.test"
+	groupResourceName := "aws_autoscaling_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationConfig_associatePublicIPAddress(rName, true, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckGroupExists(groupResourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 1),
+					testAccCheckInstanceHasPublicIpAddress(&group, 0, true),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckLaunchConfigurationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingConn
 
@@ -663,6 +850,27 @@ func testAccCheckAMIExists(n string, v *ec2.Image) resource.TestCheckFunc {
 		}
 
 		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckInstanceHasPublicIpAddress(group *autoscaling.Group, idx int, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+		instanceID := aws.StringValue(group.Instances[idx].InstanceId)
+		instance, err := tfec2.FindInstanceByID(conn, instanceID)
+
+		if err != nil {
+			return err
+		}
+
+		hasPublicIPAddress := aws.StringValue(instance.PublicIpAddress) != ""
+
+		if hasPublicIPAddress != expected {
+			return fmt.Errorf("%s has public IP address; got %t, expected %t", instanceID, hasPublicIPAddress, expected)
+		}
 
 		return nil
 	}
@@ -1016,4 +1224,57 @@ resource "aws_launch_configuration" "test" {
   user_data_base64 = base64encode("hello world")
 }
 `, rName))
+}
+
+func testAccLaunchConfigurationConfig_associatePublicIPAddress(rName string, subnetMapPublicIPOnLaunch bool, associatePublicIPAddress string) string {
+	if associatePublicIPAddress == "" {
+		associatePublicIPAddress = "null"
+	}
+
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
+		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[1]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = aws_vpc.test.id
+  availability_zone       = data.aws_availability_zones.available.names[1]
+  map_public_ip_on_launch = %[2]t
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_launch_configuration" "test" {
+  name                        = %[1]q
+  image_id                    = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
+  associate_public_ip_address = %[3]s
+}
+
+resource "aws_autoscaling_group" "test" {
+  vpc_zone_identifier  = [aws_subnet.test.id]
+  max_size             = 1
+  min_size             = 1
+  desired_capacity     = 1
+  name                 = %[1]q
+  launch_configuration = aws_launch_configuration.test.name
+
+  tag {
+    key                 = "Name"
+    value               = %[1]q
+    propagate_at_launch = true
+  }
+}
+`, rName, subnetMapPublicIPOnLaunch, associatePublicIPAddress))
 }

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -1033,7 +1033,7 @@ resource "aws_launch_configuration" "test" {
 func testAccLaunchConfigurationConfig_encryptedRootBlockDevice(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name_prefix   = %[1]q
+  name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t3.nano"
 
@@ -1187,7 +1187,7 @@ resource "aws_launch_configuration" "test" {
 func testAccLaunchConfigurationConfig_ebsNoDevice(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name_prefix   = %[1]q
+  name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "m1.small"
 
@@ -1202,7 +1202,7 @@ resource "aws_launch_configuration" "test" {
 func testAccLaunchConfigurationConfig_userData(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name_prefix   = %[1]q
+  name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
   user_data     = "foo:-with-character's"
@@ -1213,7 +1213,7 @@ resource "aws_launch_configuration" "test" {
 func testAccLaunchConfigurationConfig_userDataBase64(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name_prefix      = %[1]q
+  name             = %[1]q
   image_id         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type    = "t2.micro"
   user_data_base64 = base64encode("hello world")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25244.
Closes #25252.
Relates #17695.

Removes the default value for `associate_public_ip_address` argument and marks it as Computed.
This allows the pre-**v4.17.0** behavior of no configured value triggering the [API default behavior](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_CreateLaunchConfiguration.html#API_CreateLaunchConfiguration_RequestParameters) to be restored whilst also allowing a configured value of `false` to override the subnet's setting.

```console
% make testacc TESTARGS='-run=TestAccAutoScalingLaunchConfiguration_' PKG=autoscaling ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 3  -run=TestAccAutoScalingLaunchConfiguration_ -timeout 180m
=== RUN   TestAccAutoScalingLaunchConfiguration_basic
=== PAUSE TestAccAutoScalingLaunchConfiguration_basic
=== RUN   TestAccAutoScalingLaunchConfiguration_disappears
=== PAUSE TestAccAutoScalingLaunchConfiguration_disappears
=== RUN   TestAccAutoScalingLaunchConfiguration_Name_generated
=== PAUSE TestAccAutoScalingLaunchConfiguration_Name_generated
=== RUN   TestAccAutoScalingLaunchConfiguration_namePrefix
=== PAUSE TestAccAutoScalingLaunchConfiguration_namePrefix
=== RUN   TestAccAutoScalingLaunchConfiguration_withBlockDevices
=== PAUSE TestAccAutoScalingLaunchConfiguration_withBlockDevices
=== RUN   TestAccAutoScalingLaunchConfiguration_withInstanceStoreAMI
=== PAUSE TestAccAutoScalingLaunchConfiguration_withInstanceStoreAMI
=== RUN   TestAccAutoScalingLaunchConfiguration_RootBlockDevice_amiDisappears
=== PAUSE TestAccAutoScalingLaunchConfiguration_RootBlockDevice_amiDisappears
=== RUN   TestAccAutoScalingLaunchConfiguration_RootBlockDevice_volumeSize
=== PAUSE TestAccAutoScalingLaunchConfiguration_RootBlockDevice_volumeSize
=== RUN   TestAccAutoScalingLaunchConfiguration_encryptedRootBlockDevice
=== PAUSE TestAccAutoScalingLaunchConfiguration_encryptedRootBlockDevice
=== RUN   TestAccAutoScalingLaunchConfiguration_withSpotPrice
=== PAUSE TestAccAutoScalingLaunchConfiguration_withSpotPrice
=== RUN   TestAccAutoScalingLaunchConfiguration_withVPCClassicLink
=== PAUSE TestAccAutoScalingLaunchConfiguration_withVPCClassicLink
=== RUN   TestAccAutoScalingLaunchConfiguration_withIAMProfile
=== PAUSE TestAccAutoScalingLaunchConfiguration_withIAMProfile
=== RUN   TestAccAutoScalingLaunchConfiguration_withGP3
=== PAUSE TestAccAutoScalingLaunchConfiguration_withGP3
=== RUN   TestAccAutoScalingLaunchConfiguration_encryptedEBSBlockDevice
=== PAUSE TestAccAutoScalingLaunchConfiguration_encryptedEBSBlockDevice
=== RUN   TestAccAutoScalingLaunchConfiguration_metadataOptions
=== PAUSE TestAccAutoScalingLaunchConfiguration_metadataOptions
=== RUN   TestAccAutoScalingLaunchConfiguration_EBS_noDevice
=== PAUSE TestAccAutoScalingLaunchConfiguration_EBS_noDevice
=== RUN   TestAccAutoScalingLaunchConfiguration_userData
=== PAUSE TestAccAutoScalingLaunchConfiguration_userData
=== RUN   TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigNull
=== PAUSE TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigNull
=== RUN   TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigFalse
=== PAUSE TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigFalse
=== RUN   TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigTrue
=== PAUSE TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigTrue
=== RUN   TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigNull
=== PAUSE TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigNull
=== RUN   TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigFalse
=== PAUSE TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigFalse
=== RUN   TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigTrue
=== PAUSE TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigTrue
=== CONT  TestAccAutoScalingLaunchConfiguration_basic
=== CONT  TestAccAutoScalingLaunchConfiguration_withGP3
=== CONT  TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigFalse
--- PASS: TestAccAutoScalingLaunchConfiguration_withGP3 (51.95s)
=== CONT  TestAccAutoScalingLaunchConfiguration_EBS_noDevice
--- PASS: TestAccAutoScalingLaunchConfiguration_basic (52.84s)
=== CONT  TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigNull
--- PASS: TestAccAutoScalingLaunchConfiguration_EBS_noDevice (48.63s)
=== CONT  TestAccAutoScalingLaunchConfiguration_userData
--- PASS: TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigFalse (171.74s)
=== CONT  TestAccAutoScalingLaunchConfiguration_RootBlockDevice_amiDisappears
--- PASS: TestAccAutoScalingLaunchConfiguration_userData (89.17s)
=== CONT  TestAccAutoScalingLaunchConfiguration_withIAMProfile
--- PASS: TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigNull (155.48s)
=== CONT  TestAccAutoScalingLaunchConfiguration_withVPCClassicLink
--- PASS: TestAccAutoScalingLaunchConfiguration_withIAMProfile (56.83s)
=== CONT  TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigFalse
--- PASS: TestAccAutoScalingLaunchConfiguration_withVPCClassicLink (54.83s)
=== CONT  TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigTrue
--- PASS: TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigFalse (172.01s)
=== CONT  TestAccAutoScalingLaunchConfiguration_metadataOptions
--- PASS: TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigTrue (183.60s)
=== CONT  TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigNull
--- PASS: TestAccAutoScalingLaunchConfiguration_metadataOptions (51.27s)
=== CONT  TestAccAutoScalingLaunchConfiguration_encryptedEBSBlockDevice
--- PASS: TestAccAutoScalingLaunchConfiguration_encryptedEBSBlockDevice (87.86s)
=== CONT  TestAccAutoScalingLaunchConfiguration_encryptedRootBlockDevice
--- PASS: TestAccAutoScalingLaunchConfiguration_RootBlockDevice_amiDisappears (408.65s)
=== CONT  TestAccAutoScalingLaunchConfiguration_withSpotPrice
--- PASS: TestAccAutoScalingLaunchConfiguration_encryptedRootBlockDevice (47.18s)
=== CONT  TestAccAutoScalingLaunchConfiguration_RootBlockDevice_volumeSize
--- PASS: TestAccAutoScalingLaunchConfiguration_withSpotPrice (46.38s)
=== CONT  TestAccAutoScalingLaunchConfiguration_namePrefix
--- PASS: TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetTrueConfigNull (183.17s)
=== CONT  TestAccAutoScalingLaunchConfiguration_withInstanceStoreAMI
--- PASS: TestAccAutoScalingLaunchConfiguration_namePrefix (48.83s)
=== CONT  TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigTrue
--- PASS: TestAccAutoScalingLaunchConfiguration_withInstanceStoreAMI (63.24s)
=== CONT  TestAccAutoScalingLaunchConfiguration_Name_generated
--- PASS: TestAccAutoScalingLaunchConfiguration_RootBlockDevice_volumeSize (90.73s)
=== CONT  TestAccAutoScalingLaunchConfiguration_withBlockDevices
--- PASS: TestAccAutoScalingLaunchConfiguration_Name_generated (50.08s)
=== CONT  TestAccAutoScalingLaunchConfiguration_disappears
--- PASS: TestAccAutoScalingLaunchConfiguration_withBlockDevices (51.07s)
--- PASS: TestAccAutoScalingLaunchConfiguration_disappears (41.80s)
--- PASS: TestAccAutoScalingLaunchConfiguration_AssociatePublicIPAddress_subnetFalseConfigTrue (159.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	839.362s
```