### PR TITLE
Ec2host outpostarn

### DIFF
--- a/.changelog/25464.txt
+++ b/.changelog/25464.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+ resource/aws_ec2_host: Add `outpost_arn` argument
+ ```
+
+ ```release-note:enhancement
+ data-source/aws_ec2_host: Add `outpost_arn` attribute
+ ```

--- a/internal/service/ec2/ec2_host.go
+++ b/internal/service/ec2/ec2_host.go
@@ -61,6 +61,10 @@ func ResourceHost() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: []string{"instance_family", "instance_type"},
 			},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -91,6 +95,9 @@ func resourceHostCreate(d *schema.ResourceData, meta interface{}) error {
 		input.InstanceType = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("outpost_arn"); ok {
+		input.OutpostArn = aws.String(v.(string))
+	}
 	if len(tags) > 0 {
 		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeDedicatedHost)
 	}
@@ -141,6 +148,7 @@ func resourceHostRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("host_recovery", host.HostRecovery)
 	d.Set("instance_family", host.HostProperties.InstanceFamily)
 	d.Set("instance_type", host.HostProperties.InstanceType)
+	d.Set("outpost_arn", host.OutpostArn)
 	d.Set("owner_id", host.OwnerId)
 
 	tags := KeyValueTags(host.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/ec2/ec2_host.go
+++ b/internal/service/ec2/ec2_host.go
@@ -64,6 +64,7 @@ func ResourceHost() *schema.Resource {
 			"outpost_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"owner_id": {
 				Type:     schema.TypeString,
@@ -98,6 +99,7 @@ func resourceHostCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("outpost_arn"); ok {
 		input.OutpostArn = aws.String(v.(string))
 	}
+
 	if len(tags) > 0 {
 		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeDedicatedHost)
 	}

--- a/internal/service/ec2/ec2_host_data_source.go
+++ b/internal/service/ec2/ec2_host_data_source.go
@@ -51,6 +51,10 @@ func DataSourceHost() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -95,6 +99,7 @@ func dataSourceHostRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("host_recovery", host.HostRecovery)
 	d.Set("instance_family", host.HostProperties.InstanceFamily)
 	d.Set("instance_type", host.HostProperties.InstanceType)
+	d.Set("outpost_arn", host.OutpostArn)
 	d.Set("owner_id", host.OwnerId)
 	d.Set("sockets", host.HostProperties.Sockets)
 	d.Set("total_vcpus", host.HostProperties.TotalVCpus)

--- a/internal/service/ec2/ec2_host_data_source_test.go
+++ b/internal/service/ec2/ec2_host_data_source_test.go
@@ -74,38 +74,6 @@ func TestAccEC2HostDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccEC2HostDataSource_outpost(t *testing.T) {
-	dataSourceName := "data.aws_ec2_host.test"
-	resourceName := "aws_ec2_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccHostDataSourceConfig_outpost(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "auto_placement", resourceName, "auto_placement"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone", resourceName, "availability_zone"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "cores"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "host_id", resourceName, "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "host_recovery", resourceName, "host_recovery"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instance_family", resourceName, "instance_family"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instance_type", resourceName, "instance_type"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_id", resourceName, "outpost_id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "sockets"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "total_vcpus"),
-				),
-			},
-		},
-	})
-}
-
 func testAccHostDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
@@ -149,30 +117,6 @@ data "aws_ec2_host" "test" {
     name   = "tag-key"
     values = [%[1]q]
   }
-}
-`, rName))
-}
-
-func testAccHostDataSourceConfig_outpost(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-data "aws_outposts_outposts" "test" {}
-
-data "aws_outposts_outpost" "test" {
-	id = tolist(data.aws_outposts_outposts.test.ids)[0]
-}
-
-resource "aws_ec2_host" "test" {
-	instance_family   = "r5d"
-	availability_zone = "us-west-2b"
-	outpost_arn       = data.aws_outposts_outpost.test.arn
-
-	tags = {
-		Name = %[1]q
-	}
-	}
-
-data "aws_ec2_host" "test" {
-  host_id = aws_ec2_host.test.id
 }
 `, rName))
 }

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -34,6 +34,7 @@ func TestAccEC2Host_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "host_recovery", "off"),
 					resource.TestCheckResourceAttr(resourceName, "instance_family", ""),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "a1.large"),
+					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -161,6 +162,33 @@ func TestAccEC2Host_tags(t *testing.T) {
 	})
 }
 
+func TestAccHost_outpost(t *testing.T) {
+	var host ec2.Host
+	outpostDataSourceName := "data.aws_outposts_outpost.test"
+	rName := "sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHost_outpost(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostExists(rName, &host),
+					resource.TestCheckResourceAttrPair(rName, "outpost_arn", outpostDataSourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckHostExists(n string, v *ec2.Host) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -274,4 +302,24 @@ resource "aws_ec2_host" "test" {
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccHost_outpost(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+	data "aws_outposts_outposts" "test" {}
+
+	data "aws_outposts_outpost" "test" {
+	  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+	}
+	
+	resource "aws_ec2_host" "test" {
+		instance_family   = "r5d"
+		availability_zone = "us-west-2b"
+		outpost_arn       = data.aws_outposts_outpost.test.arn
+
+		tags = {
+			Name = %[1]q
+		}
+	  }
+`, rName))
 }

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -312,7 +312,7 @@ data "aws_outposts_outposts" "test" {}
 data "aws_outposts_outpost" "test" {
   id = tolist(data.aws_outposts_outposts.test.ids)[0]
 }
-	
+
 resource "aws_ec2_host" "test" {
   instance_family   = "r5d"
   availability_zone = data.aws_availability_zones.available.names[1]

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -162,7 +162,7 @@ func TestAccEC2Host_tags(t *testing.T) {
 	})
 }
 
-func TestAccHost_outpost(t *testing.T) {
+func TestAccEC2Host_outpost(t *testing.T) {
 	var host ec2.Host
 	resourceName := "aws_ec2_host.test"
 	outpostDataSourceName := "data.aws_outposts_outpost.test"

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -164,8 +164,9 @@ func TestAccEC2Host_tags(t *testing.T) {
 
 func TestAccHost_outpost(t *testing.T) {
 	var host ec2.Host
+	resourceName := "aws_ec2_host.test"
 	outpostDataSourceName := "data.aws_outposts_outpost.test"
-	rName := "sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
@@ -174,10 +175,10 @@ func TestAccHost_outpost(t *testing.T) {
 		CheckDestroy:      testAccCheckHostDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHost_outpost(rName),
+				Config: testAccHostConfig_outpost(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHostExists(rName, &host),
-					resource.TestCheckResourceAttrPair(rName, "outpost_arn", outpostDataSourceName, "arn"),
+					testAccCheckHostExists(resourceName, &host),
+					resource.TestCheckResourceAttrPair(resourceName, "outpost_arn", outpostDataSourceName, "arn"),
 				),
 			},
 			{
@@ -304,22 +305,22 @@ resource "aws_ec2_host" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccHost_outpost(rName string) string {
+func testAccHostConfig_outpost(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-	data "aws_outposts_outposts" "test" {}
+data "aws_outposts_outposts" "test" {}
 
-	data "aws_outposts_outpost" "test" {
-	  id = tolist(data.aws_outposts_outposts.test.ids)[0]
-	}
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
 	
-	resource "aws_ec2_host" "test" {
-		instance_family   = "r5d"
-		availability_zone = "us-west-2b"
-		outpost_arn       = data.aws_outposts_outpost.test.arn
+resource "aws_ec2_host" "test" {
+  instance_family   = "r5d"
+  availability_zone = data.aws_availability_zones.available.names[1]
+  outpost_arn       = data.aws_outposts_outpost.test.arn
 
-		tags = {
-			Name = %[1]q
-		}
-	  }
+  tags = {
+    Name = %[1]q
+  }
+}
 `, rName))
 }

--- a/website/docs/d/ec2_host.html.markdown
+++ b/website/docs/d/ec2_host.html.markdown
@@ -1,7 +1,7 @@
 ---
-subcategory: "EC2 (Elastic Compute Cloud)"
-layout: "aws"
-page_title: "AWS: aws_ec2_host"
+subcategory: 'EC2 (Elastic Compute Cloud)'
+layout: 'aws'
+page_title: 'AWS: aws_ec2_host'
 description: |-
   Get information on an EC2 Host.
 ---
@@ -39,8 +39,8 @@ data "aws_ec2_host" "test" {
 The arguments of this data source act as filters for querying the available EC2 Hosts in the current region.
 The given filters must match exactly one host whose data will be exported as attributes.
 
-* `filter` - (Optional) Configuration block. Detailed below.
-* `host_id` - (Optional) The ID of the Dedicated Host.
+- `filter` - (Optional) Configuration block. Detailed below.
+- `host_id` - (Optional) The ID of the Dedicated Host.
 
 ### filter
 
@@ -48,21 +48,22 @@ This block allows for complex filters. You can use one or more `filter` blocks.
 
 The following arguments are required:
 
-* `name` - (Required) The name of the field to filter by, as defined by [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html).
-* `values` - (Required) Set of values that are accepted for the given field. A host will be selected if any one of the given values matches.
+- `name` - (Required) The name of the field to filter by, as defined by [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html).
+- `values` - (Required) Set of values that are accepted for the given field. A host will be selected if any one of the given values matches.
 
 ## Attributes Reference
 
 In addition to the attributes above, the following attributes are exported:
 
-* `id` - The ID of the Dedicated Host.
-* `arn` - The ARN of the Dedicated Host.
-* `auto_placement` - Whether auto-placement is on or off.
-* `availability_zone` - The Availability Zone of the Dedicated Host.
-* `cores` - The number of cores on the Dedicated Host.
-* `host_recovery` - Indicates whether host recovery is enabled or disabled for the Dedicated Host.
-* `instance_family` - The instance family supported by the Dedicated Host. For example, "m5".
-* `instance_type` - The instance type supported by the Dedicated Host. For example, "m5.large". If the host supports multiple instance types, no instanceType is returned.
-* `owner_id` - The ID of the AWS account that owns the Dedicated Host.
-* `sockets` - The number of sockets on the Dedicated Host.
-* `total_vcpus` - The total number of vCPUs on the Dedicated Host.
+- `id` - The ID of the Dedicated Host.
+- `arn` - The ARN of the Dedicated Host.
+- `auto_placement` - Whether auto-placement is on or off.
+- `availability_zone` - The Availability Zone of the Dedicated Host.
+- `cores` - The number of cores on the Dedicated Host.
+- `host_recovery` - Indicates whether host recovery is enabled or disabled for the Dedicated Host.
+- `instance_family` - The instance family supported by the Dedicated Host. For example, "m5".
+- `instance_type` - The instance type supported by the Dedicated Host. For example, "m5.large". If the host supports multiple instance types, no instanceType is returned.
+- `outpost_arn` - The Amazon Resource Name (ARN) of the AWS Outpost on which the Dedicated Host is allocated.
+- `owner_id` - The ID of the AWS account that owns the Dedicated Host.
+- `sockets` - The number of sockets on the Dedicated Host.
+- `total_vcpus` - The total number of vCPUs on the Dedicated Host.

--- a/website/docs/d/ec2_host.html.markdown
+++ b/website/docs/d/ec2_host.html.markdown
@@ -39,8 +39,8 @@ data "aws_ec2_host" "test" {
 The arguments of this data source act as filters for querying the available EC2 Hosts in the current region.
 The given filters must match exactly one host whose data will be exported as attributes.
 
-- `filter` - (Optional) Configuration block. Detailed below.
-- `host_id` - (Optional) The ID of the Dedicated Host.
+* `filter` - (Optional) Configuration block. Detailed below.
+* `host_id` - (Optional) The ID of the Dedicated Host.
 
 ### filter
 
@@ -48,22 +48,22 @@ This block allows for complex filters. You can use one or more `filter` blocks.
 
 The following arguments are required:
 
-- `name` - (Required) The name of the field to filter by, as defined by [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html).
-- `values` - (Required) Set of values that are accepted for the given field. A host will be selected if any one of the given values matches.
+* `name` - (Required) The name of the field to filter by, as defined by [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html).
+* `values` - (Required) Set of values that are accepted for the given field. A host will be selected if any one of the given values matches.
 
 ## Attributes Reference
 
 In addition to the attributes above, the following attributes are exported:
 
-- `id` - The ID of the Dedicated Host.
-- `arn` - The ARN of the Dedicated Host.
-- `auto_placement` - Whether auto-placement is on or off.
-- `availability_zone` - The Availability Zone of the Dedicated Host.
-- `cores` - The number of cores on the Dedicated Host.
-- `host_recovery` - Indicates whether host recovery is enabled or disabled for the Dedicated Host.
-- `instance_family` - The instance family supported by the Dedicated Host. For example, "m5".
-- `instance_type` - The instance type supported by the Dedicated Host. For example, "m5.large". If the host supports multiple instance types, no instanceType is returned.
-- `outpost_arn` - The Amazon Resource Name (ARN) of the AWS Outpost on which the Dedicated Host is allocated.
-- `owner_id` - The ID of the AWS account that owns the Dedicated Host.
-- `sockets` - The number of sockets on the Dedicated Host.
-- `total_vcpus` - The total number of vCPUs on the Dedicated Host.
+* `id` - The ID of the Dedicated Host.
+* `arn` - The ARN of the Dedicated Host.
+* `auto_placement` - Whether auto-placement is on or off.
+* `availability_zone` - The Availability Zone of the Dedicated Host.
+* `cores` - The number of cores on the Dedicated Host.
+* `host_recovery` - Indicates whether host recovery is enabled or disabled for the Dedicated Host.
+* `instance_family` - The instance family supported by the Dedicated Host. For example, "m5".
+* `instance_type` - The instance type supported by the Dedicated Host. For example, "m5.large". If the host supports multiple instance types, no instanceType is returned.
+* `outpost_arn` - The Amazon Resource Name (ARN) of the AWS Outpost on which the Dedicated Host is allocated.
+* `owner_id` - The ID of the AWS account that owns the Dedicated Host.
+* `sockets` - The number of sockets on the Dedicated Host.
+* `total_vcpus` - The total number of vCPUs on the Dedicated Host.

--- a/website/docs/d/ec2_host.html.markdown
+++ b/website/docs/d/ec2_host.html.markdown
@@ -1,7 +1,7 @@
 ---
-subcategory: 'EC2 (Elastic Compute Cloud)'
-layout: 'aws'
-page_title: 'AWS: aws_ec2_host'
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_host"
 description: |-
   Get information on an EC2 Host.
 ---

--- a/website/docs/r/ec2_host.html.markdown
+++ b/website/docs/r/ec2_host.html.markdown
@@ -27,22 +27,22 @@ resource "aws_ec2_host" "test" {
 
 The following arguments are supported:
 
-- `auto_placement` - (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: `on`, `off`. Default: `on`.
-- `availability_zone` - (Required) The Availability Zone in which to allocate the Dedicated Host.
-- `host_recovery` - (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Valid values: `on`, `off`. Default: `off`.
-- `instance_family` - (Optional) Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family. Exactly one of `instance_family` or `instance_type` must be specified.
-- `instance_type` - (Optional) Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. Exactly one of `instance_family` or `instance_type` must be specified.
-- `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the AWS Outpost on which to allocate the Dedicated Host.
-- `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `auto_placement` - (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: `on`, `off`. Default: `on`.
+* `availability_zone` - (Required) The Availability Zone in which to allocate the Dedicated Host.
+* `host_recovery` - (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Valid values: `on`, `off`. Default: `off`.
+* `instance_family` - (Optional) Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family. Exactly one of `instance_family` or `instance_type` must be specified.
+* `instance_type` - (Optional) Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. Exactly one of `instance_family` or `instance_type` must be specified.
+* `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the AWS Outpost on which to allocate the Dedicated Host.
+* `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The ID of the allocated Dedicated Host. This is used to launch an instance onto a specific host.
-- `arn` - The ARN of the Dedicated Host.
-- `owner_id` - The ID of the AWS account that owns the Dedicated Host.
-- `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
+* `id` - The ID of the allocated Dedicated Host. This is used to launch an instance onto a specific host.
+* `arn` - The ARN of the Dedicated Host.
+* `owner_id` - The ID of the AWS account that owns the Dedicated Host.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/ec2_host.html.markdown
+++ b/website/docs/r/ec2_host.html.markdown
@@ -1,7 +1,7 @@
 ---
-subcategory: "EC2 (Elastic Compute Cloud)"
-layout: "aws"
-page_title: "AWS: aws_ec2_host"
+subcategory: 'EC2 (Elastic Compute Cloud)'
+layout: 'aws'
+page_title: 'AWS: aws_ec2_host'
 description: |-
   Provides an EC2 Host resource. This allows Dedicated Hosts to be allocated, modified, and released.
 ---
@@ -27,21 +27,22 @@ resource "aws_ec2_host" "test" {
 
 The following arguments are supported:
 
-* `auto_placement` - (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: `on`, `off`. Default: `on`.
-* `availability_zone` - (Required) The Availability Zone in which to allocate the Dedicated Host.
-* `host_recovery` - (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Valid values: `on`, `off`. Default: `off`.
-* `instance_family` - (Optional) Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family. Exactly one of `instance_family` or `instance_type` must be specified.
-* `instance_type` - (Optional) Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only.  Exactly one of `instance_family` or `instance_type` must be specified.
-* `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+- `auto_placement` - (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: `on`, `off`. Default: `on`.
+- `availability_zone` - (Required) The Availability Zone in which to allocate the Dedicated Host.
+- `host_recovery` - (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Valid values: `on`, `off`. Default: `off`.
+- `instance_family` - (Optional) Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family. Exactly one of `instance_family` or `instance_type` must be specified.
+- `instance_type` - (Optional) Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. Exactly one of `instance_family` or `instance_type` must be specified.
+- `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the AWS Outpost on which to allocate the Dedicated Host.
+- `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the allocated Dedicated Host. This is used to launch an instance onto a specific host.
-* `arn` - The ARN of the Dedicated Host.
-* `owner_id` - The ID of the AWS account that owns the Dedicated Host.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
+- `id` - The ID of the allocated Dedicated Host. This is used to launch an instance onto a specific host.
+- `arn` - The ARN of the Dedicated Host.
+- `owner_id` - The ID of the AWS account that owns the Dedicated Host.
+- `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/ec2_host.html.markdown
+++ b/website/docs/r/ec2_host.html.markdown
@@ -1,7 +1,7 @@
 ---
-subcategory: 'EC2 (Elastic Compute Cloud)'
-layout: 'aws'
-page_title: 'AWS: aws_ec2_host'
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_host"
 description: |-
   Provides an EC2 Host resource. This allows Dedicated Hosts to be allocated, modified, and released.
 ---


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25410

Output from acceptance testing:

```
$ make testacc TESTS='TestAccHost_outpost' PKG=ec2 TESTARGS=-short                    2 ✘  16s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccHost_outpost' -short -timeout 180m
=== RUN   TestAccHost_outpost
=== PAUSE TestAccHost_outpost
=== CONT  TestAccHost_outpost
--- PASS: TestAccHost_outpost (20.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	22.960s



$ make testacc TESTS='TestAccEC2HostDataSource_outpost' PKG=ec2 TESTARGS=-short         ✔  17s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2HostDataSource_outpost' -short -timeout 180m
=== RUN   TestAccEC2HostDataSource_outpost
=== PAUSE TestAccEC2HostDataSource_outpost
=== CONT  TestAccEC2HostDataSource_outpost
--- PASS: TestAccEC2HostDataSource_outpost (16.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	18.959s

...
```
