### PR TITLE
r/aws_location_tracker - new resource

### DIFF
--- a/.changelog/25466.txt
+++ b/.changelog/25466.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_location_tracker
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1643,6 +1643,7 @@ func Provider() *schema.Provider {
 
 			"aws_location_map":         location.ResourceMap(),
 			"aws_location_place_index": location.ResourcePlaceIndex(),
+			"aws_location_tracker":     location.ResourceTracker(),
 
 			"aws_macie_member_account_association": macie.ResourceMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":      macie.ResourceS3BucketAssociation(),

--- a/internal/service/location/tracker.go
+++ b/internal/service/location/tracker.go
@@ -1,0 +1,204 @@
+package location
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceTracker() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTrackerCreate,
+		Read:   resourceTrackerRead,
+		Update: resourceTrackerUpdate,
+		Delete: resourceTrackerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1000),
+			},
+			"kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 2048),
+			},
+			"position_filtering": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      locationservice.PositionFilteringTimeBased,
+				ValidateFunc: validation.StringInSlice(locationservice.PositionFiltering_Values(), false),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"tracker_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tracker_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceTrackerCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &locationservice.CreateTrackerInput{}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		input.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tracker_name"); ok {
+		input.TrackerName = aws.String(v.(string))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	output, err := conn.CreateTracker(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating Location Service Tracker: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error creating Location Service Tracker: empty result")
+	}
+
+	d.SetId(aws.StringValue(output.TrackerName))
+
+	return resourceTrackerRead(d, meta)
+}
+
+func resourceTrackerRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	input := &locationservice.DescribeTrackerInput{
+		TrackerName: aws.String(d.Id()),
+	}
+
+	output, err := conn.DescribeTracker(input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Location Service Tracker (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting Location Service Tracker (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Location Service Map (%s): empty response", d.Id())
+	}
+
+	d.Set("create_time", aws.TimeValue(output.CreateTime).Format(time.RFC3339))
+	d.Set("description", output.Description)
+	d.Set("kms_key_id", output.KmsKeyId)
+	d.Set("position_filtering", output.PositionFiltering)
+	d.Set("tracker_arn", output.TrackerArn)
+	d.Set("tracker_name", output.TrackerName)
+	d.Set("update_time", aws.TimeValue(output.UpdateTime).Format(time.RFC3339))
+
+	tags := KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceTrackerUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	if d.HasChanges("description", "position_filtering") {
+		input := &locationservice.UpdateTrackerInput{
+			TrackerName: aws.String(d.Id()),
+		}
+
+		if v, ok := d.GetOk("description"); ok {
+			input.Description = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("position_filtering"); ok {
+			input.PositionFiltering = aws.String(v.(string))
+		}
+
+		_, err := conn.UpdateTracker(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating Location Service Tracker (%s): %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("tracker_arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags for Location Service Tracker (%s): %w", d.Id(), err)
+		}
+	}
+
+	return resourceTrackerRead(d, meta)
+}
+
+func resourceTrackerDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.DeleteTrackerInput{
+		TrackerName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteTracker(input)
+
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Location Service Tracker (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/location/tracker_test.go
+++ b/internal/service/location/tracker_test.go
@@ -270,8 +270,8 @@ resource "aws_location_tracker" "test" {
 func testAccTrackerConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_location_tracker" "test" {
-  tracker_name    = %[1]q
-  description     = %[2]q
+  tracker_name = %[1]q
+  description  = %[2]q
 }
 `, rName, description)
 }
@@ -283,8 +283,8 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_location_tracker" "test" {
-  tracker_name    = %[1]q
-  kms_key_id      = aws_kms_key.test.arn
+  tracker_name = %[1]q
+  kms_key_id   = aws_kms_key.test.arn
 }
 `, rName)
 }

--- a/internal/service/location/tracker_test.go
+++ b/internal/service/location/tracker_test.go
@@ -1,0 +1,174 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
+)
+
+func TestAccLocationTracker_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_tracker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrackerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "create_time"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "position_filtering", locationservice.PositionFilteringTimeBased),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "tracker_arn", "geo", fmt.Sprintf("tracker/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "tracker_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "update_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationTracker_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_tracker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrackerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourceTracker(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationTracker_description(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_tracker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrackerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerConfig_description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTrackerConfig_description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckTrackerDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_location_tracker" {
+			continue
+		}
+
+		input := &locationservice.DescribeTrackerInput{
+			TrackerName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeTracker(input)
+
+		if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Location Service Tracker (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("Location Service Tracker (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckTrackerExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+		input := &locationservice.DescribeTrackerInput{
+			TrackerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeTracker(input)
+
+		if err != nil {
+			return fmt.Errorf("error getting Location Service Tracker (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccTrackerConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_tracker" "test" {
+  tracker_name = %[1]q
+}
+`, rName)
+}
+
+func testAccTrackerConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_location_tracker" "test" {
+  tracker_name    = %[1]q
+  description     = %[2]q
+}
+`, rName, description)
+}

--- a/website/docs/r/location_tracker.html.markdown
+++ b/website/docs/r/location_tracker.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_tracker"
+description: |-
+    Provides a Location Service Tracker.
+---
+
+# Resource: aws_location_tracker
+
+Provides a Location Service Tracker.
+
+## Example Usage
+
+```terraform
+resource "aws_location_tracker" "example" {
+  tracker_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `tracker_name` - (Required) The name of the tracker resource.
+
+The following arguments are optional:
+
+* `description` - (Optional) The optional description for the tracker resource.
+* `kms_key_id` - (Optional) A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
+* `position_filtering` - (Optional) The position filtering method of the tracker resource. Valid values: `TimeBased`, `DistanceBased`, `AccuracyBased`. Default: `TimeBased`.
+* `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `create_time` - The timestamp for when the tracker resource was created in ISO 8601 format.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
+* `tracker_arn` - The Amazon Resource Name (ARN) for the tracker resource. Used when you need to specify a resource across all AWS.
+* `update_time` - The timestamp for when the tracker resource was last update in ISO 8601 format.
+
+## Import
+
+`aws_location_tracker` resources can be imported using the tracker name, e.g.:
+
+```
+$ terraform import aws_location_tracker.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationTracker_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationTracker_'  -timeout 180m
=== RUN   TestAccLocationTracker_basic
=== PAUSE TestAccLocationTracker_basic
=== RUN   TestAccLocationTracker_disappears
=== PAUSE TestAccLocationTracker_disappears
=== RUN   TestAccLocationTracker_description
=== PAUSE TestAccLocationTracker_description
=== RUN   TestAccLocationTracker_kmsKeyID
=== PAUSE TestAccLocationTracker_kmsKeyID
=== RUN   TestAccLocationTracker_positionFiltering
=== PAUSE TestAccLocationTracker_positionFiltering
=== RUN   TestAccLocationTracker_tags
=== PAUSE TestAccLocationTracker_tags
=== CONT  TestAccLocationTracker_basic
=== CONT  TestAccLocationTracker_kmsKeyID
=== CONT  TestAccLocationTracker_tags
=== CONT  TestAccLocationTracker_description
=== CONT  TestAccLocationTracker_disappears
=== CONT  TestAccLocationTracker_positionFiltering
--- PASS: TestAccLocationTracker_disappears (21.11s)
--- PASS: TestAccLocationTracker_basic (28.40s)
--- PASS: TestAccLocationTracker_kmsKeyID (30.09s)
--- PASS: TestAccLocationTracker_description (45.55s)
--- PASS: TestAccLocationTracker_positionFiltering (45.91s)
--- PASS: TestAccLocationTracker_tags (63.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   65.480s
```
