### PR TITLE
fix(glue_schema): check status of new version after update

### DIFF
--- a/.changelog/25469.txt
+++ b/.changelog/25469.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_schema: Fix status check of new glue schema version after update
+```

--- a/internal/service/glue/find.go
+++ b/internal/service/glue/find.go
@@ -111,6 +111,20 @@ func FindSchemaVersionByID(conn *glue.Glue, id string) (*glue.GetSchemaVersionOu
 	return output, nil
 }
 
+// FindSchemaVersionByVersionID returns the Schema corresponding to the schemaVersionID.
+func FindSchemaByVersionID(conn *glue.Glue, versionId string) (*glue.GetSchemaVersionOutput, error) {
+	input := &glue.GetSchemaVersionInput{
+		SchemaVersionId: &versionId,
+	}
+
+	output, err := conn.GetSchemaVersion(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
 // FindPartitionByValues returns the Partition corresponding to the specified Partition Values.
 func FindPartitionByValues(conn *glue.Glue, id string) (*glue.Partition, error) {
 

--- a/internal/service/glue/schema.go
+++ b/internal/service/glue/schema.go
@@ -238,12 +238,12 @@ func resourceSchemaUpdate(d *schema.ResourceData, meta interface{}) error {
 			SchemaDefinition: aws.String(d.Get("schema_definition").(string)),
 		}
 
-		_, err := conn.RegisterSchemaVersion(defInput)
+		schemaVersion, err := conn.RegisterSchemaVersion(defInput)
 		if err != nil {
 			return fmt.Errorf("error updating Glue Schema Definition (%s): %w", d.Id(), err)
 		}
 
-		_, err = waitSchemaVersionAvailable(conn, d.Id())
+		_, err = waitSchemaVersionAvailable(conn, *schemaVersion.SchemaVersionId)
 		if err != nil {
 			return fmt.Errorf("error waiting for Glue Schema Version (%s) to be Available: %w", d.Id(), err)
 		}

--- a/internal/service/glue/status.go
+++ b/internal/service/glue/status.go
@@ -69,9 +69,9 @@ func statusSchema(conn *glue.Glue, id string) resource.StateRefreshFunc {
 }
 
 // statusSchemaVersion fetches the Schema Version and its Status
-func statusSchemaVersion(conn *glue.Glue, id string) resource.StateRefreshFunc {
+func statusSchemaVersion(conn *glue.Glue, versionId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindSchemaVersionByID(conn, id)
+		output, err := FindSchemaByVersionID(conn, versionId)
 		if err != nil {
 			return nil, schemaVersionStatusUnknown, err
 		}

--- a/internal/service/glue/wait.go
+++ b/internal/service/glue/wait.go
@@ -94,11 +94,11 @@ func waitSchemaDeleted(conn *glue.Glue, registryID string) (*glue.GetSchemaOutpu
 }
 
 // waitSchemaVersionAvailable waits for a Schema to return Available
-func waitSchemaVersionAvailable(conn *glue.Glue, registryID string) (*glue.GetSchemaVersionOutput, error) {
+func waitSchemaVersionAvailable(conn *glue.Glue, schemaVersionId string) (*glue.GetSchemaVersionOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{glue.SchemaVersionStatusPending},
 		Target:  []string{glue.SchemaVersionStatusAvailable},
-		Refresh: statusSchemaVersion(conn, registryID),
+		Refresh: statusSchemaVersion(conn, schemaVersionId),
 		Timeout: schemaVersionAvailableTimeout,
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccGlueSchema PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueSchema' -short -timeout 180m
=== RUN   TestAccGlueSchema_basic
=== PAUSE TestAccGlueSchema_basic
=== RUN   TestAccGlueSchema_json
=== PAUSE TestAccGlueSchema_json
=== RUN   TestAccGlueSchema_protobuf
=== PAUSE TestAccGlueSchema_protobuf
=== RUN   TestAccGlueSchema_description
=== PAUSE TestAccGlueSchema_description
=== RUN   TestAccGlueSchema_compatibility
=== PAUSE TestAccGlueSchema_compatibility
=== RUN   TestAccGlueSchema_tags
=== PAUSE TestAccGlueSchema_tags
=== RUN   TestAccGlueSchema_schemaDefUpdated
=== PAUSE TestAccGlueSchema_schemaDefUpdated
=== RUN   TestAccGlueSchema_backwardCompatibilityBreakingChange
=== PAUSE TestAccGlueSchema_backwardCompatibilityBreakingChange
=== RUN   TestAccGlueSchema_disappears
=== PAUSE TestAccGlueSchema_disappears
=== RUN   TestAccGlueSchema_Disappears_registry
=== PAUSE TestAccGlueSchema_Disappears_registry
=== CONT  TestAccGlueSchema_basic
=== CONT  TestAccGlueSchema_tags
=== CONT  TestAccGlueSchema_description
=== CONT  TestAccGlueSchema_disappears
=== CONT  TestAccGlueSchema_compatibility
=== CONT  TestAccGlueSchema_Disappears_registry
=== CONT  TestAccGlueSchema_protobuf
=== CONT  TestAccGlueSchema_json
=== CONT  TestAccGlueSchema_backwardCompatibilityBreakingChange
=== CONT  TestAccGlueSchema_schemaDefUpdated
--- PASS: TestAccGlueSchema_Disappears_registry (13.92s)
--- PASS: TestAccGlueSchema_protobuf (26.47s)
--- PASS: TestAccGlueSchema_basic (28.08s)
--- PASS: TestAccGlueSchema_json (28.97s)
--- PASS: TestAccGlueSchema_disappears (31.82s)
--- PASS: TestAccGlueSchema_backwardCompatibilityBreakingChange (32.35s)
--- PASS: TestAccGlueSchema_description (35.43s)
--- PASS: TestAccGlueSchema_compatibility (39.84s)
--- PASS: TestAccGlueSchema_schemaDefUpdated (45.93s)
--- PASS: TestAccGlueSchema_tags (49.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       51.660s
```


