### PR TITLE
r/aws_location_place_index - set correct CheckDestroy

### DIFF
--- a/internal/service/location/place_index_test.go
+++ b/internal/service/location/place_index_test.go
@@ -57,7 +57,7 @@ func TestAccLocationPlaceIndex_disappears(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckMapDestroy,
+		CheckDestroy:      testAccCheckPlaceIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlaceIndexConfig_basic(rName),
@@ -79,7 +79,7 @@ func TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse(t *testing.T) 
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckMapDestroy,
+		CheckDestroy:      testAccCheckPlaceIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlaceIndexConfig_configurationIntendedUse(rName, locationservice.IntendedUseSingleUse),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationPlaceIndex_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationPlaceIndex_'  -timeout 180m
=== RUN   TestAccLocationPlaceIndex_basic
=== PAUSE TestAccLocationPlaceIndex_basic
=== RUN   TestAccLocationPlaceIndex_disappears
=== PAUSE TestAccLocationPlaceIndex_disappears
=== RUN   TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse
=== PAUSE TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse
=== RUN   TestAccLocationPlaceIndex_description
=== PAUSE TestAccLocationPlaceIndex_description
=== RUN   TestAccLocationPlaceIndex_tags
=== PAUSE TestAccLocationPlaceIndex_tags
=== CONT  TestAccLocationPlaceIndex_basic
=== CONT  TestAccLocationPlaceIndex_description
=== CONT  TestAccLocationPlaceIndex_tags
=== CONT  TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse
=== CONT  TestAccLocationPlaceIndex_disappears
--- PASS: TestAccLocationPlaceIndex_disappears (20.29s)
--- PASS: TestAccLocationPlaceIndex_basic (27.46s)
--- PASS: TestAccLocationPlaceIndex_dataSourceConfigurationIntendedUse (44.23s)
--- PASS: TestAccLocationPlaceIndex_description (44.41s)
--- PASS: TestAccLocationPlaceIndex_tags (61.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   63.860s
```
