### PR TITLE
add data resources aws_outposts_outposts + aws_outposts_asset

### DIFF
--- a/.changelog/25475.txt
+++ b/.changelog/25475.txt
@@ -1,0 +1,4 @@
+```release-note:new-data-source
+aws_outposts_assets
+aws_outposts_asset
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -780,6 +780,8 @@ func Provider() *schema.Provider {
 			"aws_organizations_organizational_units":     organizations.DataSourceOrganizationalUnits(),
 			"aws_organizations_resource_tags":            organizations.DataSourceResourceTags(),
 
+			"aws_outposts_asset":                  outposts.DataSourceOutpostAsset(),
+			"aws_outposts_assets":                 outposts.DataSourceOutpostAssets(),
 			"aws_outposts_outpost":                outposts.DataSourceOutpost(),
 			"aws_outposts_outpost_instance_type":  outposts.DataSourceOutpostInstanceType(),
 			"aws_outposts_outpost_instance_types": outposts.DataSourceOutpostInstanceTypes(),

--- a/internal/service/outposts/outpost_asset_data_source.go
+++ b/internal/service/outposts/outpost_asset_data_source.go
@@ -1,0 +1,88 @@
+package outposts
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceOutpostAsset() *schema.Resource {
+	return &schema.Resource{
+		Read: DataSourceOutpostAssetRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"asset_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"asset_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rack_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DataSourceOutpostAssetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).OutpostsConn
+
+	outpost_id := aws.String(d.Get("id").(string))
+
+	input := &outposts.ListAssetsInput{
+		OutpostIdentifier: outpost_id,
+	}
+
+	var results []*outposts.AssetInfo
+
+	err := conn.ListAssetsPages(input, func(page *outposts.ListAssetsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, asset := range page.Assets {
+
+			if asset == nil {
+				continue
+			}
+
+			if v, ok := d.GetOk("asset_id"); ok && v.(string) != aws.StringValue(asset.AssetId) {
+				continue
+			}
+			results = append(results, asset)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error listing Outposts asset: %w", err)
+	}
+
+	if len(results) == 0 {
+		return fmt.Errorf("no Outposts asset found matching criteria; try different search")
+	}
+
+	asset := results[0]
+
+	d.SetId(aws.StringValue(outpost_id))
+	d.Set("asset_id", asset.AssetId)
+	d.Set("asset_type", asset.AssetType)
+	d.Set("host_id", asset.ComputeAttributes.HostId)
+	d.Set("rack_id", asset.RackId)
+	return nil
+}

--- a/internal/service/outposts/outpost_asset_data_source_test.go
+++ b/internal/service/outposts/outpost_asset_data_source_test.go
@@ -1,0 +1,47 @@
+package outposts_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccOutpostsAssetDataSource_id(t *testing.T) {
+	dataSourceName := "data.aws_outposts_asset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, outposts.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOutpostAssetDataSourceConfig_id(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^op-.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "asset_id", regexp.MustCompile(`^(\w+)$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "asset_type", regexp.MustCompile(`COMPUTE`)),
+					resource.TestMatchResourceAttr(dataSourceName, "rack_id", regexp.MustCompile(`^[\S \n]+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccOutpostAssetDataSourceConfig_id() string {
+	return `
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_assets" "test" {
+	id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+data "aws_outposts_asset" "test" {
+	id       = tolist(data.aws_outposts_outposts.test.ids)[0]
+	asset_id = data.aws_outposts_assets.test.asset_ids[0]
+}
+`
+}

--- a/internal/service/outposts/outpost_assets_data_source.go
+++ b/internal/service/outposts/outpost_assets_data_source.go
@@ -1,0 +1,68 @@
+package outposts
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceOutpostAssets() *schema.Resource {
+	return &schema.Resource{
+		Read: DataSourceOutpostAssetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"asset_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func DataSourceOutpostAssetsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).OutpostsConn
+
+	outpost_id := aws.String(d.Get("id").(string))
+
+	input := &outposts.ListAssetsInput{
+		OutpostIdentifier: outpost_id,
+	}
+	var asset_ids []string
+
+	err := conn.ListAssetsPages(input, func(page *outposts.ListAssetsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, asset := range page.Assets {
+
+			if asset == nil {
+				continue
+			}
+			asset_ids = append(asset_ids, aws.StringValue(asset.AssetId))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error listing Outposts assets: %w", err)
+	}
+
+	if len(asset_ids) == 0 {
+		return fmt.Errorf("no Outposts assets found matching criteria; try different search")
+	}
+
+	d.SetId(aws.StringValue(outpost_id))
+	d.Set("asset_ids", asset_ids)
+
+	return nil
+}

--- a/internal/service/outposts/outpost_assets_data_source_test.go
+++ b/internal/service/outposts/outpost_assets_data_source_test.go
@@ -1,0 +1,39 @@
+package outposts_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccOutpostsAssetsDataSource_id(t *testing.T) {
+	dataSourceName := "data.aws_outposts_assets.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, outposts.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOutpostAssetsDataSourceConfig_id(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^op-.+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccOutpostAssetsDataSourceConfig_id() string {
+	return `
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_assets" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+`
+}

--- a/website/docs/d/outposts_asset.html.markdown
+++ b/website/docs/d/outposts_asset.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Outposts"
+layout: "aws"
+page_title: "AWS: aws_outposts_asset"
+description: |-
+  Information about hardware assets in an Outpost.
+---
+
+# Data Source: aws_outposts_asset
+
+Information about a specific hardware asset in an Outpost.
+
+## Example Usage
+
+```terraform
+data "aws_outposts_assets" "example" {
+  id = data.aws_outposts_outpost.example.id
+}
+
+data "aws_outposts_asset" "example" {
+  count    = length(data.aws_outposts_assets.example.asset_ids)
+  id       = data.aws_outposts_outpost.example.id
+  asset_id = element(data.aws_outposts_assets.this.asset_ids, count.index)
+}
+
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `id` - (Required) Outpost identifier.
+* `asset_id` - (Required) The ID of the asset.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `asset_type` - The type of the asset.
+* `host_id` - The host ID of the Dedicated Hosts on the asset, if a Dedicated Host is provisioned. 
+* `rack_id` - The rack ID of the asset.

--- a/website/docs/d/outposts_assets.html.markdown
+++ b/website/docs/d/outposts_assets.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Outposts"
+layout: "aws"
+page_title: "AWS: aws_outposts_assets"
+description: |-
+  Information about hardware assets in an Outpost.
+---
+
+# Data Source: aws_outposts_assets
+
+Information about hardware assets in an Outpost.
+
+## Example Usage
+
+```terraform
+data "aws_outposts_assets" "example" {
+  id = data.aws_outposts_outpost.example.id
+}
+
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `id` - (Required) Outpost identifier.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `asset_ids` - A list of all the subnet ids found. This data source will fail if none are found.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #25475

Output from acceptance testing:

```
$ make testacc TESTS='TestAccOutpostsAssetsDataSource_id' PKG=outposts TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/outposts/... -v -count 1 -parallel 20 -run='TestAccOutpostsAssetsDataSource_id' -short -timeout 180m
=== RUN   TestAccOutpostsAssetsDataSource_id
=== PAUSE TestAccOutpostsAssetsDataSource_id
=== CONT  TestAccOutpostsAssetsDataSource_id
--- PASS: TestAccOutpostsAssetsDataSource_id (12.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/outposts	15.090s


$ make testacc TESTS='TestAccOutpostsAssetDataSource_id' PKG=outposts TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/outposts/... -v -count 1 -parallel 20 -run='TestAccOutpostsAssetDataSource_id' -short -timeout 180m
=== RUN   TestAccOutpostsAssetDataSource_id
=== PAUSE TestAccOutpostsAssetDataSource_id
=== CONT  TestAccOutpostsAssetDataSource_id
--- PASS: TestAccOutpostsAssetDataSource_id (14.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/outposts	16.782s

...
```
