### PR TITLE
Fix parameter expansion and update values type to schema.TypeList

### DIFF
--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -121,7 +121,7 @@ func ResourceCostCategory() *schema.Resource {
 										ValidateFunc: validation.StringInSlice(costexplorer.CostCategorySplitChargeRuleParameterType_Values(), false),
 									},
 									"values": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Optional: true,
 										MinItems: 1,
 										MaxItems: 500,
@@ -129,7 +129,6 @@ func ResourceCostCategory() *schema.Resource {
 											Type:         schema.TypeString,
 											ValidateFunc: validation.StringLenBetween(0, 1024),
 										},
-										Set: schema.HashString,
 									},
 								},
 							},
@@ -694,8 +693,8 @@ func expandCostCategorySplitChargeRuleParameter(tfMap map[string]interface{}) *c
 	}
 
 	apiObject := &costexplorer.CostCategorySplitChargeRuleParameter{
-		Type:   aws.String(tfMap["method"].(string)),
-		Values: flex.ExpandStringSet(tfMap["values"].(*schema.Set)),
+		Type:   aws.String(tfMap["type"].(string)),
+		Values: flex.ExpandStringList(tfMap["values"].([]interface{})),
 	}
 
 	return apiObject
@@ -989,6 +988,6 @@ func costCategorySplitChargesParameter(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(m["type"].(string))
-	buf.WriteString(fmt.Sprintf("%+v", m["values"].(*schema.Set)))
+	buf.WriteString(fmt.Sprintf("%+v", m["values"].([]interface{})))
 	return schema.HashString(buf.String())
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This PR closes #25487  and fixes an issue where the `cost_category` schema (`split_charge_rule.parameter.values`) is of incorrect type as well as incorrect implementation of `expandCostCategorySplitChargeRuleParameter` where it's trying to expand non-existent field `method` while it should be expanding `type`

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCECostCategory_splitCharge PKG=ce

=== RUN   TestAccCECostCategory_splitCharge
=== PAUSE TestAccCECostCategory_splitCharge
=== CONT  TestAccCECostCategory_splitCharge
--- PASS: TestAccCECostCategory_splitCharge (49.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ce 51.593s
```
