### PR TITLE
F aws accessanayzer archive rule

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -900,7 +900,8 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"aws_accessanalyzer_analyzer": accessanalyzer.ResourceAnalyzer(),
+			"aws_accessanalyzer_analyzer":    accessanalyzer.ResourceAnalyzer(),
+			"aws_accessanalyzer_archiverule": accessanalyzer.ResourceArchiveRule(),
 
 			"aws_account_alternate_contact": account.ResourceAlternateContact(),
 

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -112,7 +112,6 @@ func resourceArchiveRuleRead(ctx context.Context, d *schema.ResourceData, meta i
 	analyzerName, ruleName := DecodeRuleID(d.Id())
 	out, err := FindArchiveRule(ctx, conn, analyzerName, ruleName)
 
-	// TIP: -- 3. Set ID to empty where resource is not new and not found
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] AccessAnalyzer ArchiveRule (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -205,7 +204,6 @@ func flattenFilter(filter map[string]*accessanalyzer.Criterion) []interface{} {
 		return nil
 	}
 
-	// m := map[string]interface{}{}
 	l := make([]interface{}, 0, 0)
 
 	for key, value := range filter {

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -1,0 +1,254 @@
+package accessanalyzer
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/accessanalyzer"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceArchiveRule() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceArchiveRuleCreate,
+		ReadWithoutTimeout:   resourceArchiveRuleRead,
+		UpdateWithoutTimeout: resourceArchiveRuleUpdate,
+		DeleteWithoutTimeout: resourceArchiveRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"analyzer_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"filter": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"contains": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     schema.TypeString,
+						},
+						"eq": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Elem:     schema.TypeString,
+						},
+						"exists": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"neq": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     schema.TypeString,
+						},
+					},
+				},
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceArchiveRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AccessAnalyzerConn
+
+	analyzerName := d.Get("analyzer_name").(string)
+	ruleName := d.Get("rule_name").(string)
+
+	in := &accessanalyzer.CreateArchiveRuleInput{
+		AnalyzerName: aws.String(analyzerName),
+		ClientToken:  aws.String(resource.UniqueId()),
+		RuleName:     aws.String(ruleName),
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		in.Filter = expandFilter(v.(map[string]interface{}))
+	}
+
+	_, err := conn.CreateArchiveRuleWithContext(ctx, in)
+	if err != nil {
+		return diag.Errorf("creating AWS IAM Access Analyzer ArchiveRule (%s): %s", d.Get("rule_name").(string), err)
+	}
+
+	id := EncodeRuleID(analyzerName, ruleName)
+	d.SetId(id)
+
+	return resourceArchiveRuleRead(ctx, d, meta)
+}
+
+func resourceArchiveRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AccessAnalyzerConn
+
+	analyzerName, ruleName := DecodeRuleID(d.Id())
+	out, err := FindArchiveRule(ctx, conn, analyzerName, ruleName)
+
+	// TIP: -- 3. Set ID to empty where resource is not new and not found
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] AccessAnalyzer ArchiveRule (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("reading AccessAnalyzer ArchiveRule (%s): %s", d.Id(), err)
+	}
+
+	d.Set("filter", flattenFilter(out.Filter))
+
+	return nil
+}
+
+func resourceArchiveRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AccessAnalyzerConn
+
+	analyzerName, ruleName := DecodeRuleID(d.Id())
+	in := &accessanalyzer.UpdateArchiveRuleInput{
+		AnalyzerName: aws.String(analyzerName),
+		ClientToken:  aws.String(resource.UniqueId()),
+		RuleName:     aws.String(ruleName),
+	}
+
+	if d.HasChanges("filter") {
+		in.Filter = expandFilter(d.Get("filter").(map[string]interface{}))
+
+	}
+
+	log.Printf("[DEBUG] Updating AccessAnalyzer ArchiveRule (%s): %#v", d.Id(), in)
+	_, err := conn.UpdateArchiveRuleWithContext(ctx, in)
+	if err != nil {
+		return diag.Errorf("updating AccessAnalyzer ArchiveRule (%s): %s", d.Id(), err)
+	}
+
+	return resourceArchiveRuleRead(ctx, d, meta)
+}
+
+func resourceArchiveRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AccessAnalyzerConn
+
+	log.Printf("[INFO] Deleting AccessAnalyzer ArchiveRule %s", d.Id())
+
+	analyzerName, ruleName := DecodeRuleID(d.Id())
+	_, err := conn.DeleteArchiveRuleWithContext(ctx, &accessanalyzer.DeleteArchiveRuleInput{
+		AnalyzerName: aws.String(analyzerName),
+		ClientToken:  aws.String(resource.UniqueId()),
+		RuleName:     aws.String(ruleName),
+	})
+
+	if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("deleting AccessAnalyzer ArchiveRule (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func FindArchiveRule(ctx context.Context, conn *accessanalyzer.AccessAnalyzer, analyzerName, ruleName string) (*accessanalyzer.ArchiveRuleSummary, error) {
+	in := &accessanalyzer.GetArchiveRuleInput{
+		AnalyzerName: aws.String(analyzerName),
+		RuleName:     aws.String(ruleName),
+	}
+
+	out, err := conn.GetArchiveRuleWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.ArchiveRule == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.ArchiveRule, nil
+}
+
+func flattenFilter(filter map[string]*accessanalyzer.Criterion) map[string]interface{} {
+	if filter == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	for key, value := range filter {
+		val := make(map[string]interface{})
+		val["contains"] = aws.ToStringSlice(value.Contains)
+		val["eq"] = aws.ToStringSlice(value.Eq)
+		val["exists"] = aws.ToBool(value.Exists)
+		val["neq"] = aws.ToStringSlice(value.Neq)
+
+		m[key] = val
+	}
+
+	return m
+}
+
+func expandFilter(tfMap map[string]interface{}) map[string]*accessanalyzer.Criterion {
+	if tfMap == nil {
+		return nil
+	}
+
+	a := make(map[string]*accessanalyzer.Criterion)
+
+	for key, value := range tfMap {
+		c := &accessanalyzer.Criterion{}
+		if v, ok := value.(map[string]interface{})["contains"]; ok {
+			c.Contains = aws.StringSlice(v.([]string))
+		}
+		if v, ok := value.(map[string]interface{})["eq"]; ok {
+			c.Eq = aws.StringSlice(v.([]string))
+		}
+		if v, ok := value.(map[string]interface{})["exists"]; ok {
+			c.Exists = aws.Bool(v.(bool))
+		}
+		if v, ok := value.(map[string]interface{})["neq"]; ok {
+			c.Neq = aws.StringSlice(v.([]string))
+		}
+
+		a[key] = c
+	}
+
+	return a
+}
+
+func EncodeRuleID(analyzerName, ruleName string) string {
+	return fmt.Sprintf("%s/%s", analyzerName, ruleName)
+}
+
+func DecodeRuleID(id string) (string, string) {
+	parts := strings.Split(id, "/")
+
+	return parts[0], parts[1]
+}

--- a/internal/service/accessanalyzer/archive_rule_test.go
+++ b/internal/service/accessanalyzer/archive_rule_test.go
@@ -1,142 +1,74 @@
 package accessanalyzer_test
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
-//
-// Remember to register this new resource in the provider
-// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
-// know about it.
 
 import (
-	// TIP: ==== IMPORT ====
-    // This is a common set of imports but not customized to your code
-	// since your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
+	"context"
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
-	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types" // TIP: Some v2 packages use a separate package for types while some do not.
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go/service/accessanalyzer"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 
-	// TIP: You will often need to import the package that this test file lives
-    // in. Since it is in the "test" context, it must import the package to use
-    // any normal context constants, variables, or functions.
 	tfaccessanalyzer "github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this resource's maintainability by following this
-// outline.
+//func TestArchiveRuleExampleUnitTest(t *testing.T) {
+//	testCases := []struct {
+//		TestName string
+//		Input    string
+//		Expected string
+//		Error    bool
+//	}{
+//		{
+//			TestName: "empty",
+//			Input:    "",
+//			Expected: "",
+//			Error:    true,
+//		},
+//		{
+//			TestName: "descriptive name",
+//			Input:    "some input",
+//			Expected: "some output",
+//			Error:    false,
+//		},
+//		{
+//			TestName: "another descriptive name",
+//			Input:    "more input",
+//			Expected: "more output",
+//			Error:    false,
+//		},
+//	}
 //
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
+//	for _, testCase := range testCases {
+//		t.Run(testCase.TestName, func(t *testing.T) {
+//			got, err := tfaccessanalyzer.FunctionFromResource(testCase.Input)
 //
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
+//			if err != nil && !testCase.Error {
+//				t.Errorf("got error (%s), expected no error", err)
+//			}
 //
-// In designing a resource's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
+//			if err == nil && testCase.Error {
+//				t.Errorf("got (%s) and no error, expected error", got)
+//			}
 //
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestArchiveRuleExampleUnitTest(t *testing.T) {
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
+//			if got != testCase.Expected {
+//				t.Errorf("got %s, expected %s", got, testCase.Expected)
+//			}
+//		})
+//	}
+//}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			got, err := tfaccessanalyzer.FunctionFromResource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the resource as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// resource name.
-//
-// Acceptance test access AWS and cost money to run.
 func TestAccAccessAnalyzerArchiveRule_basic(t *testing.T) {
-    // TIP: This is a long-running test guard for tests that run longer than
-    // 300s (5 min) generally.
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var archiverule accessanalyzer.DescribeArchiveRuleResponse
+	var archiveRule accessanalyzer.ArchiveRuleSummary
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_archiverule.test"
 
@@ -144,16 +76,16 @@ func TestAccAccessAnalyzerArchiveRule_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(accessanalyzer.EndpointsID, t)
-			testAccPreCheck(t)
+			testAccArchiveRulePreCheck(t)
 		},
-		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckArchiveRuleDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckArchiveRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccArchiveRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(resourceName, &archiverule),
+					testAccCheckArchiveRuleExists(resourceName, &archiveRule),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
@@ -166,10 +98,9 @@ func TestAccAccessAnalyzerArchiveRule_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -180,7 +111,7 @@ func TestAccAccessAnalyzerArchiveRule_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var archiverule accessanalyzer.DescribeArchiveRuleResponse
+	var archiveRule accessanalyzer.ArchiveRuleSummary
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_archiverule.test"
 
@@ -188,16 +119,16 @@ func TestAccAccessAnalyzerArchiveRule_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(accessanalyzer.EndpointsID, t)
-			testAccPreCheck(t)
+			testAccArchiveRulePreCheck(t)
 		},
-		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckArchiveRuleDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckArchiveRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArchiveRuleConfig_basic(rName, testAccArchiveRuleVersionNewer),
+				Config: testAccArchiveRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(resourceName, &archiverule),
+					testAccCheckArchiveRuleExists(resourceName, &archiveRule),
 					acctest.CheckResourceDisappears(acctest.Provider, tfaccessanalyzer.ResourceArchiveRule(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -214,15 +145,14 @@ func testAccCheckArchiveRuleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		input := &accessanalyzer.DescribeArchiveRuleInput{
-			ArchiveRuleId: aws.String(rs.Primary.ID),
+		analyzerName, ruleName := tfaccessanalyzer.DecodeRuleID(rs.Primary.ID)
+		_, err := tfaccessanalyzer.FindArchiveRule(context.Background(), conn, analyzerName, ruleName)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		_, err := conn.DescribeArchiveRule(input)
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeNotFoundException) {
-				return nil
-			}
 			return err
 		}
 
@@ -232,7 +162,7 @@ func testAccCheckArchiveRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckArchiveRuleExists(name string, archiverule *accessanalyzer.DescribeArchiveRuleResponse) resource.TestCheckFunc {
+func testAccCheckArchiveRuleExists(name string, archiveRule *accessanalyzer.ArchiveRuleSummary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -244,21 +174,20 @@ func testAccCheckArchiveRuleExists(name string, archiverule *accessanalyzer.Desc
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn
-		resp, err := conn.DescribeArchiveRule(&accessanalyzer.DescribeArchiveRuleInput{
-			ArchiveRuleId: aws.String(rs.Primary.ID),
-		})
+		analyzerName, ruleName := tfaccessanalyzer.DecodeRuleID(rs.Primary.ID)
+		resp, err := tfaccessanalyzer.FindArchiveRule(context.Background(), conn, analyzerName, ruleName)
 
 		if err != nil {
 			return fmt.Errorf("Error describing AccessAnalyzer ArchiveRule: %s", err.Error())
 		}
 
-		*archiverule = *resp
+		*archiveRule = *resp
 
 		return nil
 	}
 }
 
-func testAccPreCheck(t *testing.T) {
+func testAccArchiveRulePreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn
 
 	input := &accessanalyzer.ListArchiveRulesInput{}
@@ -274,39 +203,11 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccCheckArchiveRuleNotRecreated(before, after *accessanalyzer.DescribeArchiveRuleResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if before, after := aws.StringValue(before.ArchiveRuleId), aws.StringValue(after.ArchiveRuleId); before != after {
-			return fmt.Errorf("AccessAnalyzer ArchiveRule (%s/%s) recreated", before, after)
-		}
-
-		return nil
-	}
-}
-
-func testAccArchiveRuleConfig_basic(rName, version string) string {
+func testAccArchiveRuleConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  name = %[1]q
-}
-
 resource "aws_accessanalyzer_archiverule" "test" {
-  archiverule_name             = %[1]q
-  engine_type             = "ActiveAccessAnalyzer"
-  engine_version          = %[2]q
-  host_instance_type      = "accessanalyzer.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
-
-  logs {
-    general = true
-  }
-
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
+  analyzer_name = aws_accessanalyzer_analyzer.test
+  rule_name     = %[1]q
 }
-`, rName, version)
+`, rName)
 }

--- a/internal/service/accessanalyzer/archive_rule_test.go
+++ b/internal/service/accessanalyzer/archive_rule_test.go
@@ -1,0 +1,312 @@
+package accessanalyzer_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+//
+// Remember to register this new resource in the provider
+// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
+// know about it.
+
+import (
+	// TIP: ==== IMPORT ====
+    // This is a common set of imports but not customized to your code
+	// since your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types" // TIP: Some v2 packages use a separate package for types while some do not.
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+
+	// TIP: You will often need to import the package that this test file lives
+    // in. Since it is in the "test" context, it must import the package to use
+    // any normal context constants, variables, or functions.
+	tfaccessanalyzer "github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestArchiveRuleExampleUnitTest(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tfaccessanalyzer.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccAccessAnalyzerArchiveRule_basic(t *testing.T) {
+    // TIP: This is a long-running test guard for tests that run longer than
+    // 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var archiverule accessanalyzer.DescribeArchiveRuleResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_accessanalyzer_archiverule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(accessanalyzer.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckArchiveRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArchiveRuleConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveRuleExists(resourceName, &archiverule),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "accessanalyzer", regexp.MustCompile(`archiverule:+.`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccAccessAnalyzerArchiveRule_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var archiverule accessanalyzer.DescribeArchiveRuleResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_accessanalyzer_archiverule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(accessanalyzer.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckArchiveRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArchiveRuleConfig_basic(rName, testAccArchiveRuleVersionNewer),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveRuleExists(resourceName, &archiverule),
+					acctest.CheckResourceDisappears(acctest.Provider, tfaccessanalyzer.ResourceArchiveRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckArchiveRuleDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_accessanalyzer_archiverule" {
+			continue
+		}
+
+		input := &accessanalyzer.DescribeArchiveRuleInput{
+			ArchiveRuleId: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeArchiveRule(input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeNotFoundException) {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Expected AccessAnalyzer ArchiveRule to be destroyed, %s found", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckArchiveRuleExists(name string, archiverule *accessanalyzer.DescribeArchiveRuleResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No AccessAnalyzer ArchiveRule is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn
+		resp, err := conn.DescribeArchiveRule(&accessanalyzer.DescribeArchiveRuleInput{
+			ArchiveRuleId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error describing AccessAnalyzer ArchiveRule: %s", err.Error())
+		}
+
+		*archiverule = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn
+
+	input := &accessanalyzer.ListArchiveRulesInput{}
+
+	_, err := conn.ListArchiveRules(input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckArchiveRuleNotRecreated(before, after *accessanalyzer.DescribeArchiveRuleResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.StringValue(before.ArchiveRuleId), aws.StringValue(after.ArchiveRuleId); before != after {
+			return fmt.Errorf("AccessAnalyzer ArchiveRule (%s/%s) recreated", before, after)
+		}
+
+		return nil
+	}
+}
+
+func testAccArchiveRuleConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_accessanalyzer_archiverule" "test" {
+  archiverule_name             = %[1]q
+  engine_type             = "ActiveAccessAnalyzer"
+  engine_version          = %[2]q
+  host_instance_type      = "accessanalyzer.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/website/docs/r/accessanalyzer_archive_rule.html.markdown
+++ b/website/docs/r/accessanalyzer_archive_rule.html.markdown
@@ -16,6 +16,23 @@ Terraform resource for managing an AWS AccessAnalyzer ArchiveRule.
 
 ```terraform
 resource "aws_accessanalyzer_archiverule" "example" {
+  analyser_name = "example-analyzer"
+  rule_name     = "example-rule"
+
+  filter {
+    criteria = "condition.aws:UserId"
+    eq       = ["userid"]
+  }
+
+  filter {
+    criteria = "error"
+    exists   = true
+  }
+
+  filter {
+    criteria = "isPublic"
+    eq       = ["false"]
+  }
 }
 ```
 
@@ -23,31 +40,29 @@ resource "aws_accessanalyzer_archiverule" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description.
+* `analyzer_name` - (Required) Analyzer name.
+* `filter` - (Required) The filter criteria for the archive rule. See [Filter](#filter) for more details.
+* `rule_name` - (Required) Rule name.
 
-The following arguments are optional:
+### Filter
 
-* `optional_arg` - (Optional) Concise argument description.
+* `criteria` - (Required) The filter criteria.
+* `contains` - (Optional) Contains comparator. 
+* `eq` - (Optional) Equals comparator.
+* `exists` - (Optional) Boolean comparator.
+* `neq` - (Optional) Not Equals comparator.
+
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the ArchiveRule.
-* `example_attribute` - Concise description.
-
-## Timeouts
-
-`aws_accessanalyzer_archiverule` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
-
-* `create` - (Optional, Default: `60m`)
-* `update` - (Optional, Default: `180m`)
-* `delete` - (Optional, Default: `90m`)
+* `id` - Resource ID in the format: `analyzer_name/rule_name`.
 
 ## Import
 
-AccessAnalyzer ArchiveRule can be imported using the `example_id_arg`, e.g.,
+AccessAnalyzer ArchiveRule can be imported using the `analyzer_name/rule_name`, e.g.,
 
 ```
-$ terraform import aws_accessanalyzer_archiverule.example rft-8012925589
+$ terraform import aws_accessanalyzer_archiverule.example example-analyzer/example-rule
 ```

--- a/website/docs/r/accessanalyzer_archive_rule.html.markdown
+++ b/website/docs/r/accessanalyzer_archive_rule.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "AccessAnalyzer"
+layout: "aws"
+page_title: "AWS: aws_accessanalyzer_archiverule"
+description: |-
+  Terraform resource for managing an AWS AccessAnalyzer ArchiveRule.
+---
+
+# Resource: aws_accessanalyzer_archiverule
+
+Terraform resource for managing an AWS AccessAnalyzer ArchiveRule.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_accessanalyzer_archiverule" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the ArchiveRule.
+* `example_attribute` - Concise description.
+
+## Timeouts
+
+`aws_accessanalyzer_archiverule` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Optional, Default: `60m`)
+* `update` - (Optional, Default: `180m`)
+* `delete` - (Optional, Default: `90m`)
+
+## Import
+
+AccessAnalyzer ArchiveRule can be imported using the `example_id_arg`, e.g.,
+
+```
+$ terraform import aws_accessanalyzer_archiverule.example rft-8012925589
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11102

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAccessAnalyzer_serial PKG=accessanalyzer

...
```
