### PR TITLE
sweeper/aws_vpc_ipam_pool_cidr_allocation: Add sweeper

### DIFF
--- a/internal/service/ec2/ipam_pool_cidr.go
+++ b/internal/service/ec2/ipam_pool_cidr.go
@@ -88,17 +88,16 @@ func resourceIPAMPoolCIDRCreate(d *schema.ResourceData, meta interface{}) error 
 		input.Cidr = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Provisioning IPAM Pool Cidr: %s", input)
 	output, err := conn.ProvisionIpamPoolCidr(input)
 	if err != nil {
-		return fmt.Errorf("Error provisioning ipam pool cidr in ipam pool (%s): %w", d.Get("ipam_pool_id").(string), err)
+		return fmt.Errorf("Error provisioning CIDR in IPAM pool (%s): %w", d.Get("ipam_pool_id").(string), err)
 	}
 
 	cidr := aws.StringValue(output.IpamPoolCidr.Cidr)
 	id := encodeIPAMPoolCIDRId(cidr, pool_id)
 
 	if _, err = WaitIPAMPoolCIDRAvailable(conn, id, ipamPoolCIDRCreateTimeout); err != nil {
-		return fmt.Errorf("error waiting for IPAM Pool Cidr (%s) to be provision: %w", id, err)
+		return fmt.Errorf("error waiting for IPAM Pool CIDR (%s) to be provisioned: %w", id, err)
 	}
 
 	d.SetId(id)
@@ -114,13 +113,13 @@ func resourceIPAMPoolCIDRRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if !d.IsNewResource() && cidr == nil {
-		log.Printf("[WARN] IPAM Pool Cidr (%s) not found or was deprovisioned, removing from state", cidr)
+		log.Printf("[WARN] IPAM Pool CIDR (%s) not found, removing from state", cidr)
 		d.SetId("")
 		return nil
 	}
 
 	if aws.StringValue(cidr.State) == ec2.IpamPoolCidrStateDeprovisioned {
-		log.Printf("[WARN] IPAM Pool Cidr (%s) not found or was deprovisioned, removing from state", cidr)
+		log.Printf("[WARN] IPAM Pool CIDR (%s) was deprovisioned, removing from state", cidr)
 		d.SetId("")
 		return nil
 	}
@@ -141,7 +140,6 @@ func resourceIPAMPoolCIDRDelete(d *schema.ResourceData, meta interface{}) error 
 		IpamPoolId: aws.String(pool_id),
 	}
 	return resource.Retry(ipamPoolCIDRDeleteTimeout, func() *resource.RetryError {
-		log.Printf("[DEBUG] Deprovisioning IPAM Pool Cidr: %s", input)
 		// releasing allocations is eventually consistent and can cause deprovisioning to fail
 		_, err = conn.DeprovisionIpamPoolCidr(input)
 
@@ -151,18 +149,18 @@ func resourceIPAMPoolCIDRDelete(d *schema.ResourceData, meta interface{}) error 
 				output, err := WaitIPAMPoolCIDRDeleted(conn, d.Id(), ipamPoolCIDRDeleteTimeout)
 				if err != nil {
 					// State = failed-deprovision
-					return resource.RetryableError(fmt.Errorf("Expected cidr to be deprovisioned but was in state %s", aws.StringValue(output.State)))
+					return resource.RetryableError(fmt.Errorf("Expected CIDR to be deprovisioned but was in state %s", aws.StringValue(output.State)))
 				}
 				// State = deprovisioned
 				return nil
 			}
-			return resource.NonRetryableError(fmt.Errorf("error deprovisioning ipam pool cidr: (%s): %w", cidr, err))
+			return resource.NonRetryableError(fmt.Errorf("error deprovisioning IPAM pool CIDR: (%s): %w", cidr, err))
 		}
 
 		output, err := WaitIPAMPoolCIDRDeleted(conn, d.Id(), ipamPoolCIDRDeleteTimeout)
 		if err != nil {
 			// State = failed-deprovision
-			return resource.RetryableError(fmt.Errorf("Expected cidr to be deprovisioned but was in state %s", aws.StringValue(output.State)))
+			return resource.RetryableError(fmt.Errorf("Expected CIDR to be deprovisioned but was in state %s", aws.StringValue(output.State)))
 		}
 		// State = deprovisioned
 		return nil

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -118,7 +118,7 @@ func resourceIPAMPoolCIDRAllocationCreate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Creating IPAM Pool Allocation: %s", input)
 	output, err := conn.AllocateIpamPoolCidr(input)
 	if err != nil {
-		return fmt.Errorf("Error allocating cidr from IPAM pool (%s): %w", d.Get("ipam_pool_id").(string), err)
+		return fmt.Errorf("Error allocating CIDR from IPAM Pool (%s): %w", d.Get("ipam_pool_id").(string), err)
 	}
 	d.SetId(encodeIPAMPoolCIDRAllocationID(aws.StringValue(output.IpamPoolAllocation.IpamPoolAllocationId), pool_id))
 
@@ -135,7 +135,7 @@ func resourceIPAMPoolCIDRAllocationRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if !d.IsNewResource() && cidr_allocation == nil {
-		log.Printf("[WARN] IPAM Pool Cidr Allocation (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] IPAM Pool Allocation (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -167,13 +167,12 @@ func resourceIPAMPoolCIDRAllocationDelete(d *schema.ResourceData, meta interface
 		Cidr:                 aws.String(d.Get("cidr").(string)),
 	}
 
-	log.Printf("[DEBUG] Releasing IPAM Pool CIDR Allocation: %s", input)
 	output, err := conn.ReleaseIpamPoolAllocation(input)
 	if err != nil || !aws.BoolValue(output.Success) {
 		if tfawserr.ErrCodeEquals(err, InvalidIPAMPoolIDNotFound) {
 			return nil
 		}
-		return fmt.Errorf("error releasing IPAM CIDR Allocation: (%s): %w", d.Id(), err)
+		return fmt.Errorf("error releasing IPAM Pool Allocation (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -335,10 +335,16 @@ func init() {
 		},
 	})
 
+	resource.AddTestSweepers("aws_vpc_ipam_pool_cidr_allocation", &resource.Sweeper{
+		Name: "aws_vpc_ipam_pool_cidr_allocation",
+		F:    sweepIPAMPoolCIDRAllocations,
+	})
+
 	resource.AddTestSweepers("aws_vpc_ipam_pool_cidr", &resource.Sweeper{
 		Name: "aws_vpc_ipam_pool_cidr",
 		F:    sweepIPAMPoolCIDRs,
 		Dependencies: []string{
+			"aws_vpc_ipam_pool_cidr_allocation",
 			"aws_vpc",
 		},
 	})
@@ -2349,6 +2355,76 @@ func sweepCustomerGateways(region string) error {
 	return nil
 }
 
+func sweepIPAMPoolCIDRAllocations(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).EC2Conn
+	input := &ec2.DescribeIpamPoolsInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.IpamPools {
+			poolID := aws.StringValue(v.IpamPoolId)
+			input := &ec2.GetIpamPoolAllocationsInput{
+				IpamPoolId: v.IpamPoolId,
+			}
+
+			err := conn.GetIpamPoolAllocationsPages(input, func(page *ec2.GetIpamPoolAllocationsOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, v := range page.IpamPoolAllocations {
+					r := ResourceIPAMPoolCIDRAllocation()
+					d := r.Data(nil)
+					d.SetId(encodeIPAMPoolCIDRAllocationID(aws.StringValue(v.IpamPoolAllocationId), poolID))
+					d.Set("ipam_pool_id", poolID)
+					d.Set("ipam_pool_allocation_id", v.IpamPoolAllocationId)
+					d.Set("cidr", v.Cidr)
+
+					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
+
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IPAM Pool (%s) Allocations (%s): %w", poolID, region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping IPAM Pool Allocations sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IPAM Pools (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping IPAM Pool Allocations (%s): %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
 func sweepIPAMPoolCIDRs(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
@@ -2410,7 +2486,7 @@ func sweepIPAMPoolCIDRs(region string) error {
 	err = sweep.SweepOrchestrator(sweepResources)
 
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping IPAM Pools (%s): %w", region, err))
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping IPAM Pool CIDRs (%s): %w", region, err))
 	}
 
 	return sweeperErrs.ErrorOrNil()


### PR DESCRIPTION
Adds sweeper for `aws_vpc_ipam_pool_cidr_allocation` to unblock other IPAM sweepers.

Output from acceptance testing:

2022/06/21 12:26:07 [DEBUG] Running Sweeper (aws_vpc_ipam_pool_cidr_allocation) in region (us-west-2)
2022/06/21 12:26:09 [DEBUG] Waiting for state to become: [success]
2022/06/21 12:26:09 [DEBUG] Waiting for state to become: [success]
2022/06/21 12:26:09 [DEBUG] Waiting for state to become: [success]
2022/06/21 12:26:09 [DEBUG] Waiting for state to become: [success]
2022/06/21 12:26:10 [DEBUG] Completed Sweeper (aws_vpc_ipam_pool_cidr_allocation) in region (us-west-2) in 2.98451441s
