### PR TITLE
r/aws_kendra_thesaurus - New attribute thesaurus_id

### DIFF
--- a/internal/service/kendra/thesaurus.go
+++ b/internal/service/kendra/thesaurus.go
@@ -82,6 +82,10 @@ func ResourceThesaurus() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"thesaurus_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -185,6 +189,7 @@ func resourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("name", out.Name)
 	d.Set("role_arn", out.RoleArn)
 	d.Set("status", out.Status)
+	d.Set("thesaurus_id", out.Id)
 
 	if err := d.Set("source_s3_path", flattenSourceS3Path(out.SourceS3Path)); err != nil {
 		return diag.Errorf("setting complex argument: %s", err)

--- a/internal/service/kendra/thesaurus_test.go
+++ b/internal/service/kendra/thesaurus_test.go
@@ -45,6 +45,7 @@ func testAccThesaurus_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "source_s3_path.0.bucket", "aws_s3_bucket.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "source_s3_path.0.key", "aws_s3_object.test", "key"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "thesaurus_id"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kendra", regexp.MustCompile(`index/.+/thesaurus/.+$`)),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #25199

`thesaurus_id` attribute is used with `index_id` in the `aws_kendra_thesaurus` data source. Tagging @anGie44 for visibility. Thanks Angie! 

Commented out other tests locally to just run the `basic` test.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKendra_serial/Thesaurus' PKG=kendra
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kendra/... -v -count 1 -parallel 20  -run=TestAccKendra_serial/Thesaurus -timeout 180m
=== RUN   TestAccKendra_serial
=== RUN   TestAccKendra_serial/Thesaurus
=== RUN   TestAccKendra_serial/Thesaurus/basic
=== PAUSE TestAccKendra_serial/Thesaurus/basic
=== CONT  TestAccKendra_serial/Thesaurus/basic
--- PASS: TestAccKendra_serial (2479.43s)
    --- PASS: TestAccKendra_serial/Thesaurus (0.00s)
        --- PASS: TestAccKendra_serial/Thesaurus/basic (2479.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kendra     2479.494s

...
```
