### PR TITLE
sweeper/aws_location_place_index - new sweeper

### DIFF
--- a/internal/service/location/sweep.go
+++ b/internal/service/location/sweep.go
@@ -20,6 +20,11 @@ func init() {
 		Name: "aws_location_map",
 		F:    sweepMaps,
 	})
+
+	resource.AddTestSweepers("aws_location_place_index", &resource.Sweeper{
+		Name: "aws_location_place_index",
+		F:    sweepPlaceIndexes,
+	})
 }
 
 func sweepMaps(region string) error {
@@ -63,6 +68,53 @@ func sweepMaps(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping Location Service Map sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepPlaceIndexes(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).LocationConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+
+	input := &locationservice.ListPlaceIndexesInput{}
+
+	err = conn.ListPlaceIndexesPages(input, func(page *locationservice.ListPlaceIndexesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, entry := range page.Entries {
+			r := ResourceMap()
+			d := r.Data(nil)
+
+			id := aws.StringValue(entry.IndexName)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Location Service Place Index for %s: %w", region, err))
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Location Service Place Index for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Location Service Place Index sweep for %s: %s", region, errs)
 		return nil
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ SWEEPARGS=-sweep-run=aws_location_place_index make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_location_place_index -timeout 60m
2022/06/22 23:23:13 Completed Sweepers for region (us-west-2) in 2.930648125s
2022/06/22 23:23:13 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_location_place_index
2022/06/22 23:23:15 Completed Sweepers for region (us-east-1) in 2.19906275s
2022/06/22 23:23:15 Sweeper Tests for region (us-east-1) ran successfully:
        - aws_location_place_index
2022/06/22 23:23:17 Completed Sweepers for region (us-east-2) in 1.899514917s
2022/06/22 23:23:17 Sweeper Tests for region (us-east-2) ran successfully:
        - aws_location_place_index
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      8.705s
```
