### PR TITLE
resource/aws_iam_policy: Do not iterate over all IAM Policies when ARN supplied

### DIFF
--- a/.changelog/25538.txt
+++ b/.changelog/25538.txt
@@ -3,5 +3,5 @@ data-source/aws_iam_policy: Add validation to prevent setting incompatible param
 ```
 
 ```release-note:bug
- data-source/aws_iam_policy: Now loads tags.
- ```
+data-source/aws_iam_policy: Now loads tags.
+```

--- a/.changelog/25538.txt
+++ b/.changelog/25538.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_iam_policy: Add validation to prevent setting incompatible parameters.
+```
+
+```release-note:bug
+ data-source/aws_iam_policy: Now loads tags.
+ ```

--- a/internal/service/iam/find.go
+++ b/internal/service/iam/find.go
@@ -79,16 +79,64 @@ func FindUserAttachedPolicy(conn *iam.IAM, userName string, policyARN string) (*
 	return result, nil
 }
 
-// FindPolicies returns the FindPolicies corresponding to the specified ARN, name, and/or path-prefix.
-func FindPolicies(conn *iam.IAM, arn, name, pathPrefix string) ([]*iam.Policy, error) {
-	input := &iam.ListPoliciesInput{}
+// FindPolicyByArn returns the Policy corresponding to the specified ARN.
+func FindPolicyByArn(conn *iam.IAM, arn string) (*iam.Policy, error) {
+	input := &iam.GetPolicyInput{
+		PolicyArn: aws.String(arn),
+	}
 
+	output, err := conn.GetPolicy(input)
+	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Policy == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Policy, nil
+}
+
+// FindPolicyByName returns the Policy corresponding to the name and/or path-prefix.
+func FindPolicyByName(conn *iam.IAM, name, pathPrefix string) (*iam.Policy, error) {
+	input := &iam.ListPoliciesInput{}
 	if pathPrefix != "" {
 		input.PathPrefix = aws.String(pathPrefix)
 	}
 
-	var results []*iam.Policy
+	all, err := FindPolicies(conn, input)
+	if err != nil {
+		return nil, err
+	}
 
+	var results []*iam.Policy
+	for _, p := range all {
+		if name != "" && name != aws.StringValue(p.PolicyName) {
+			continue
+		}
+
+		results = append(results, p)
+	}
+
+	if len(results) == 0 || results[0] == nil {
+		return nil, tfresource.NewEmptyResultError(nil)
+	}
+	if l := len(results); l > 1 {
+		return nil, tfresource.NewTooManyResultsError(1, nil)
+	}
+
+	return results[0], nil
+}
+
+// FindPolicies returns the Policies matching the parameters in the iam.ListPoliciesInput.
+func FindPolicies(conn *iam.IAM, input *iam.ListPoliciesInput) ([]*iam.Policy, error) {
+	var results []*iam.Policy
 	err := conn.ListPoliciesPages(input, func(page *iam.ListPoliciesOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
@@ -96,14 +144,6 @@ func FindPolicies(conn *iam.IAM, arn, name, pathPrefix string) ([]*iam.Policy, e
 
 		for _, p := range page.Policies {
 			if p == nil {
-				continue
-			}
-
-			if arn != "" && arn != aws.StringValue(p.Arn) {
-				continue
-			}
-
-			if name != "" && name != aws.StringValue(p.PolicyName) {
 				continue
 			}
 

--- a/internal/service/iam/find.go
+++ b/internal/service/iam/find.go
@@ -79,8 +79,8 @@ func FindUserAttachedPolicy(conn *iam.IAM, userName string, policyARN string) (*
 	return result, nil
 }
 
-// FindPolicyByArn returns the Policy corresponding to the specified ARN.
-func FindPolicyByArn(conn *iam.IAM, arn string) (*iam.Policy, error) {
+// FindPolicyByARN returns the Policy corresponding to the specified ARN.
+func FindPolicyByARN(conn *iam.IAM, arn string) (*iam.Policy, error) {
 	input := &iam.GetPolicyInput{
 		PolicyArn: aws.String(arn),
 	}

--- a/internal/service/iam/policy_data_source.go
+++ b/internal/service/iam/policy_data_source.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -22,27 +23,30 @@ func DataSourcePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidARN,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  verify.ValidARN,
+				ConflictsWith: []string{"name", "path_prefix"},
 			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"arn"},
 			},
 			"path": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"path_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"arn"},
 			},
 			"policy": {
 				Type:     schema.TypeString,
@@ -65,46 +69,37 @@ func dataSourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	pathPrefix := d.Get("path_prefix").(string)
 
-	var results []*iam.Policy
+	if arn == "" {
+		raw, err := tfresource.RetryWhenNotFound(propagationTimeout,
+			func() (interface{}, error) {
+				return FindPolicyByName(conn, name, pathPrefix)
+			},
+		)
 
-	// Handle IAM eventual consistency
-	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
-		var err error
-		results, err = FindPolicies(conn, arn, name, pathPrefix)
-
-		if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			return resource.RetryableError(err)
+		if errors.Is(err, tfresource.ErrEmptyResult) {
+			return fmt.Errorf("no IAM policy found matching criteria (%s); try different search", PolicySearchDetails(name, pathPrefix))
 		}
-
+		if errors.Is(err, tfresource.ErrTooManyResults) {
+			return fmt.Errorf("multiple IAM policies found matching criteria (%s); try different search. %w", PolicySearchDetails(name, pathPrefix), err)
+		}
 		if err != nil {
-			return resource.NonRetryableError(err)
+			return fmt.Errorf("error reading IAM policy (%s): %w", PolicySearchDetails(name, pathPrefix), err)
 		}
 
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		results, err = FindPolicies(conn, arn, name, pathPrefix)
+		arn = aws.StringValue((raw.(*iam.Policy)).Arn)
 	}
 
+	// We need to make a call to `iam.GetPolicy` because `iam.ListPolicies` doesn't return all values
+	policy, err := FindPolicyByArn(conn, arn)
 	if err != nil {
-		return fmt.Errorf("error reading IAM policy (%s): %w", PolicySearchDetails(arn, name, pathPrefix), err)
+		return fmt.Errorf("error reading IAM policy (%s): %w", arn, err)
 	}
 
-	if len(results) == 0 {
-		return fmt.Errorf("no IAM policy found matching criteria (%s); try different search", PolicySearchDetails(arn, name, pathPrefix))
-	}
-
-	if len(results) > 1 {
-		return fmt.Errorf("multiple IAM policies found matching criteria (%s); try different search", PolicySearchDetails(arn, name, pathPrefix))
-	}
-
-	policy := results[0]
 	policyArn := aws.StringValue(policy.Arn)
 
 	d.SetId(policyArn)
-
 	d.Set("arn", policyArn)
+	d.Set("description", policy.Description)
 	d.Set("name", policy.PolicyName)
 	d.Set("path", policy.Path)
 	d.Set("policy_id", policy.PolicyId)
@@ -112,23 +107,6 @@ func dataSourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("tags", KeyValueTags(policy.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
-
-	// Retrieve policy description
-	policyInput := &iam.GetPolicyInput{
-		PolicyArn: policy.Arn,
-	}
-
-	policyOutput, err := conn.GetPolicy(policyInput)
-
-	if err != nil {
-		return fmt.Errorf("error reading IAM policy (%s): %w", policyArn, err)
-	}
-
-	if policyOutput == nil || policyOutput.Policy == nil {
-		return fmt.Errorf("error reading IAM policy (%s): empty output", policyArn)
-	}
-
-	d.Set("description", policyOutput.Policy.Description)
 
 	// Retrieve policy
 	policyVersionInput := &iam.GetPolicyVersionInput{
@@ -181,11 +159,8 @@ func dataSourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 // PolicySearchDetails returns the configured search criteria as a printable string
-func PolicySearchDetails(arn, name, pathPrefix string) string {
+func PolicySearchDetails(name, pathPrefix string) string {
 	var policyDetails []string
-	if arn != "" {
-		policyDetails = append(policyDetails, fmt.Sprintf("ARN: %s", arn))
-	}
 	if name != "" {
 		policyDetails = append(policyDetails, fmt.Sprintf("Name: %s", name))
 	}

--- a/internal/service/iam/policy_data_source.go
+++ b/internal/service/iam/policy_data_source.go
@@ -90,7 +90,7 @@ func dataSourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// We need to make a call to `iam.GetPolicy` because `iam.ListPolicies` doesn't return all values
-	policy, err := FindPolicyByArn(conn, arn)
+	policy, err := FindPolicyByARN(conn, arn)
 	if err != nil {
 		return fmt.Errorf("error reading IAM policy (%s): %w", arn, err)
 	}

--- a/internal/service/iam/policy_data_source_test.go
+++ b/internal/service/iam/policy_data_source_test.go
@@ -104,26 +104,6 @@ func TestAccIAMPolicyDataSource_arnTags(t *testing.T) {
 	})
 }
 
-func TestAccIAMPolicyDataSource_awsManagedArn(t *testing.T) {
-	datasourceName := "data.aws_iam_policy.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPolicyDataSourceConfig_awsManagedArn("service-role/AmazonElasticMapReduceforAutoScalingRole"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(datasourceName, "name", "AmazonElasticMapReduceforAutoScalingRole"),
-					resource.TestCheckResourceAttr(datasourceName, "path", "/service-role/"),
-					acctest.CheckResourceAttrGlobalARNAccountID(datasourceName, "arn", "aws", "iam", "policy/service-role/AmazonElasticMapReduceforAutoScalingRole"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccIAMPolicyDataSource_name(t *testing.T) {
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
@@ -319,16 +299,6 @@ data "aws_iam_policy" "test" {
   arn = aws_iam_policy.test.arn
 }
 `)
-}
-
-func testAccPolicyDataSourceConfig_awsManagedArn(arnResource string) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-
-data "aws_iam_policy" "test" {
-  arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/%[1]s"
-}
-`, arnResource)
 }
 
 func testAccPolicyDataSourceConfig_name(policyName, policyPath string) string {

--- a/internal/service/iam/policy_data_source_test.go
+++ b/internal/service/iam/policy_data_source_test.go
@@ -297,7 +297,7 @@ resource "aws_iam_policy" "test" {
 }
 EOF
 
-tags = {
+  tags = {
     "key" = "value"
   }
 }`, policyName, policyPath)

--- a/internal/service/iam/policy_data_source_test.go
+++ b/internal/service/iam/policy_data_source_test.go
@@ -14,64 +14,35 @@ import (
 
 func TestPolicySearchDetails(t *testing.T) {
 	testCases := []struct {
-		Arn        string
 		Name       string
 		PathPrefix string
 		Expected   string
 	}{
 		{
-			Arn:        "",
 			Name:       "",
 			PathPrefix: "",
 			Expected:   "",
 		},
 		{
-			Arn:        "arn:aws:iam::aws:policy/TestPolicy", //lintignore:AWSAT005
-			Name:       "",
-			PathPrefix: "",
-			Expected:   "ARN: arn:aws:iam::aws:policy/TestPolicy", //lintignore:AWSAT005
-		},
-		{
-			Arn:        "",
 			Name:       "tf-acc-test-policy",
 			PathPrefix: "",
 			Expected:   "Name: tf-acc-test-policy",
 		},
 		{
-			Arn:        "",
 			Name:       "",
 			PathPrefix: "/test-prefix/",
 			Expected:   "PathPrefix: /test-prefix/",
 		},
 		{
-			Arn:        "arn:aws:iam::aws:policy/TestPolicy", //lintignore:AWSAT005
-			Name:       "tf-acc-test-policy",
-			PathPrefix: "",
-			Expected:   "ARN: arn:aws:iam::aws:policy/TestPolicy, Name: tf-acc-test-policy", //lintignore:AWSAT005
-		},
-		{
-			Arn:        "arn:aws:iam::aws:policy/TestPolicy", //lintignore:AWSAT005
-			Name:       "",
-			PathPrefix: "/test-prefix/",
-			Expected:   "ARN: arn:aws:iam::aws:policy/TestPolicy, PathPrefix: /test-prefix/", //lintignore:AWSAT005
-		},
-		{
-			Arn:        "",
 			Name:       "tf-acc-test-policy",
 			PathPrefix: "/test-prefix/",
 			Expected:   "Name: tf-acc-test-policy, PathPrefix: /test-prefix/",
-		},
-		{
-			Arn:        "arn:aws:iam::aws:policy/TestPolicy", //lintignore:AWSAT005
-			Name:       "tf-acc-test-policy",
-			PathPrefix: "/test-prefix/",
-			Expected:   "ARN: arn:aws:iam::aws:policy/TestPolicy, Name: tf-acc-test-policy, PathPrefix: /test-prefix/", //lintignore:AWSAT005
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := tfiam.PolicySearchDetails(testCase.Arn, testCase.Name, testCase.PathPrefix)
+			got := tfiam.PolicySearchDetails(testCase.Name, testCase.PathPrefix)
 
 			if got != testCase.Expected {
 				t.Errorf("got %s, expected %s", got, testCase.Expected)
@@ -83,7 +54,7 @@ func TestPolicySearchDetails(t *testing.T) {
 func TestAccIAMPolicyDataSource_arn(t *testing.T) {
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
-	policyName := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -92,6 +63,32 @@ func TestAccIAMPolicyDataSource_arn(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPolicyDataSourceConfig_arn(policyName, "/"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttrPair(datasourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(datasourceName, "policy_id", resourceName, "policy_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDataSource_arnTags(t *testing.T) {
+	datasourceName := "data.aws_iam_policy.test"
+	resourceName := "aws_iam_policy.test"
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDataSourceConfig_arnTags(policyName, "/"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
@@ -99,7 +96,28 @@ func TestAccIAMPolicyDataSource_arn(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "policy", resourceName, "policy"),
 					resource.TestCheckResourceAttrPair(datasourceName, "policy_id", resourceName, "policy_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(datasourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.key", resourceName, "tags.key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDataSource_awsManagedArn(t *testing.T) {
+	datasourceName := "data.aws_iam_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDataSourceConfig_awsManagedArn("service-role/AmazonElasticMapReduceforAutoScalingRole"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "name", "AmazonElasticMapReduceforAutoScalingRole"),
+					resource.TestCheckResourceAttr(datasourceName, "path", "/service-role/"),
+					acctest.CheckResourceAttrGlobalARNAccountID(datasourceName, "arn", "aws", "iam", "policy/service-role/AmazonElasticMapReduceforAutoScalingRole"),
 				),
 			},
 		},
@@ -109,7 +127,7 @@ func TestAccIAMPolicyDataSource_arn(t *testing.T) {
 func TestAccIAMPolicyDataSource_name(t *testing.T) {
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
-	policyName := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -118,14 +136,41 @@ func TestAccIAMPolicyDataSource_name(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPolicyDataSourceConfig_name(policyName, "/"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(datasourceName, "path", resourceName, "path"),
 					resource.TestCheckResourceAttrPair(datasourceName, "policy", resourceName, "policy"),
 					resource.TestCheckResourceAttrPair(datasourceName, "policy_id", resourceName, "policy_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(datasourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDataSource_nameTags(t *testing.T) {
+	datasourceName := "data.aws_iam_policy.test"
+	resourceName := "aws_iam_policy.test"
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDataSourceConfig_nameTags(policyName, "/"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttrPair(datasourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(datasourceName, "policy_id", resourceName, "policy_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.key", resourceName, "tags.key"),
 				),
 			},
 		},
@@ -136,7 +181,7 @@ func TestAccIAMPolicyDataSource_nameAndPathPrefix(t *testing.T) {
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
 
-	policyName := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyPath := "/test-path/"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -146,14 +191,43 @@ func TestAccIAMPolicyDataSource_nameAndPathPrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPolicyDataSourceConfig_pathPrefix(policyName, policyPath),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(datasourceName, "path", resourceName, "path"),
 					resource.TestCheckResourceAttrPair(datasourceName, "policy", resourceName, "policy"),
 					resource.TestCheckResourceAttrPair(datasourceName, "policy_id", resourceName, "policy_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(datasourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDataSource_nameAndPathPrefixTags(t *testing.T) {
+	datasourceName := "data.aws_iam_policy.test"
+	resourceName := "aws_iam_policy.test"
+
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyPath := "/test-path/"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDataSourceConfig_pathPrefixTags(policyName, policyPath),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttrPair(datasourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(datasourceName, "policy_id", resourceName, "policy_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.key", resourceName, "tags.key"),
 				),
 			},
 		},
@@ -161,7 +235,7 @@ func TestAccIAMPolicyDataSource_nameAndPathPrefix(t *testing.T) {
 }
 
 func TestAccIAMPolicyDataSource_nonExistent(t *testing.T) {
-	policyName := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyPath := "/test-path/"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -201,20 +275,74 @@ EOF
 }`, policyName, policyPath)
 }
 
+func testAccPolicyBaseDataSourceTagsConfig(policyName, policyPath string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name        = %[1]q
+  path        = %[2]q
+  description = "My test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+tags = {
+    "key" = "value"
+  }
+}`, policyName, policyPath)
+}
+
 func testAccPolicyDataSourceConfig_arn(policyName, policyPath string) string {
 	return acctest.ConfigCompose(
-		testAccPolicyBaseDataSourceConfig(policyName, policyPath),
-		`
+		testAccPolicyBaseDataSourceConfig(policyName, policyPath), `
 data "aws_iam_policy" "test" {
   arn = aws_iam_policy.test.arn
 }
 `)
 }
 
+func testAccPolicyDataSourceConfig_arnTags(policyName, policyPath string) string {
+	return acctest.ConfigCompose(
+		testAccPolicyBaseDataSourceTagsConfig(policyName, policyPath), `
+data "aws_iam_policy" "test" {
+  arn = aws_iam_policy.test.arn
+}
+`)
+}
+
+func testAccPolicyDataSourceConfig_awsManagedArn(arnResource string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_iam_policy" "test" {
+  arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/%[1]s"
+}
+`, arnResource)
+}
+
 func testAccPolicyDataSourceConfig_name(policyName, policyPath string) string {
 	return acctest.ConfigCompose(
-		testAccPolicyBaseDataSourceConfig(policyName, policyPath),
-		`
+		testAccPolicyBaseDataSourceConfig(policyName, policyPath), `
+data "aws_iam_policy" "test" {
+  name = aws_iam_policy.test.name
+}
+`)
+}
+
+func testAccPolicyDataSourceConfig_nameTags(policyName, policyPath string) string {
+	return acctest.ConfigCompose(
+		testAccPolicyBaseDataSourceTagsConfig(policyName, policyPath), `
 data "aws_iam_policy" "test" {
   name = aws_iam_policy.test.name
 }
@@ -224,6 +352,17 @@ data "aws_iam_policy" "test" {
 func testAccPolicyDataSourceConfig_pathPrefix(policyName, policyPath string) string {
 	return acctest.ConfigCompose(
 		testAccPolicyBaseDataSourceConfig(policyName, policyPath),
+		fmt.Sprintf(`
+data "aws_iam_policy" "test" {
+  name        = aws_iam_policy.test.name
+  path_prefix = %q
+}
+`, policyPath))
+}
+
+func testAccPolicyDataSourceConfig_pathPrefixTags(policyName, policyPath string) string {
+	return acctest.ConfigCompose(
+		testAccPolicyBaseDataSourceTagsConfig(policyName, policyPath),
 		fmt.Sprintf(`
 data "aws_iam_policy" "test" {
   name        = aws_iam_policy.test.name

--- a/website/docs/d/iam_policy.html.markdown
+++ b/website/docs/d/iam_policy.html.markdown
@@ -32,8 +32,12 @@ data "aws_iam_policy" "example" {
 ## Argument Reference
 
 * `arn` - (Optional) The ARN of the IAM policy.
+  Conflicts with `name` and `path_prefix`.
 * `name` - (Optional) The name of the IAM policy.
-* `path_prefix` - (Optional) The prefix of the path to the IAM policy. Defaults to a slash (`/`).
+  Conflicts with `arn`.
+* `path_prefix` - (Optional) The prefix of the path to the IAM policy.
+  Defaults to a slash (`/`).
+  Conflicts with `arn`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
No longer iterates over all IAM Policies in `aws_iam_policy` data source when ARN is supplied. Also fixes bug where tags are not retrieved.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25533.
Closes #25537.
Closes #19878.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=iam TESTS=TestAccIAMPolicyDataSource_

--- PASS: TestAccIAMPolicyDataSource_awsManagedArn (26.32s)
--- PASS: TestAccIAMPolicyDataSource_arnTags (29.29s)
--- PASS: TestAccIAMPolicyDataSource_arn (30.15s)
--- PASS: TestAccIAMPolicyDataSource_nameAndPathPrefixTags (30.17s)
--- PASS: TestAccIAMPolicyDataSource_nameAndPathPrefix (30.49s)
--- PASS: TestAccIAMPolicyDataSource_nameTags (39.02s)
--- PASS: TestAccIAMPolicyDataSource_name (40.39s)
--- PASS: TestAccIAMPolicyDataSource_nonExistent (126.49s)
```
