### PR TITLE
Prevent iso-tagging precautions from eating legit errors

### DIFF
--- a/.changelog/25549.txt
+++ b/.changelog/25549.txt
@@ -1,0 +1,151 @@
+```release-note:bug
+resource/aws_cloudwatch_composite_alarm: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_cloudwatch_metric_alarm: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_cloudwatch_metric_stream: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_ecr_repository: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+data-source/aws_ecr_repository: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_ecs_capacity_provider: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_ecs_cluster: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_ecs_service: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_ecs_task_definition: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_ecs_task_set: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_elasticache_cluster: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+data-source/aws_elasticache_cluster: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_elasticache_parameter_group: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_elasticache_replication_group: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_elasticache_subnet_group: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_elasticache_user: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_elasticache_user_group: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_lb_listener: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+data-source/aws_lb_listener: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_lb_listener_rule: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_lb: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+data-source/aws_lb: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_lb_target_group: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+data-source/aws_lb_target_group: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_cloudwatch_event_bus: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_cloudwatch_event_rule: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_instance_profile: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_openid_connect_provider: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_policy: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_role: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_saml_provider: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_server_certificate: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_service_linked_role: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_user: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_iam_virtual_mfa_device: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_sns_topic: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+resource/aws_sqs_queue: Prevent ISO-partition tagging precautions from eating legit errors
+```
+
+```release-note:bug
+data-source/aws_sqs_queue: Prevent ISO-partition tagging precautions from eating legit errors
+```

--- a/internal/service/cloudwatch/metric_stream.go
+++ b/internal/service/cloudwatch/metric_stream.go
@@ -203,7 +203,7 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.PutMetricStreamWithContext(ctx, &params)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating CloudWatch Metric Stream (%s) with tags: %s. Trying create without tags.", name, err)
 		params.Tags = nil
 
@@ -222,7 +222,7 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 		err := UpdateTags(conn, aws.StringValue(output.Arn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 			return resourceMetricStreamRead(ctx, d, meta)
 		}
@@ -287,7 +287,7 @@ func resourceMetricStreamRead(ctx context.Context, d *schema.ResourceData, meta 
 	tags, err := ListTags(conn, aws.StringValue(output.Arn))
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -137,7 +137,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	out, err := conn.CreateRepository(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ECR Repository (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
@@ -159,7 +159,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(repository.RepositoryArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}
@@ -237,7 +237,7 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}
@@ -327,7 +327,7 @@ func resourceRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, arn, o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -116,7 +116,7 @@ func dataSourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -126,7 +126,7 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 	output, err := conn.CreateCapacityProvider(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Capacity Provider (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
@@ -143,7 +143,7 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)
@@ -239,7 +239,7 @@ func resourceCapacityProviderUpdate(d *schema.ResourceData, meta interface{}) er
 		err := UpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)
 		}

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -203,7 +203,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	out, err := retryClusterCreate(conn, input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Cluster (%s) with tags: %s. Trying create without tags.", clusterName, err)
 		input.Tags = nil
 
@@ -226,7 +226,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Cluster (%s): %s", d.Id(), err)
 			return resourceClusterRead(d, meta)
@@ -366,7 +366,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Cluster (%s): %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -21,7 +21,7 @@ func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider
 	output, err := conn.DescribeCapacityProviders(input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Capacity Provider (%s) with tags: %s; retrying without tags", arn, err)
 
 		input.Include = nil
@@ -60,7 +60,7 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	output, err := conn.DescribeClustersWithContext(ctx, input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed describing ECS Cluster (%s) including tags: %s; retrying without tags", nameOrARN, err)
 
 		input.Include = aws.StringSlice([]string{ecs.ClusterFieldConfigurations, ecs.ClusterFieldSettings})
@@ -68,7 +68,7 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	}
 
 	// Some partitions (i.e., ISO) may not support describe including configuration, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed describing ECS Cluster (%s) including configuration: %s; retrying without configuration", nameOrARN, err)
 
 		input.Include = aws.StringSlice([]string{ecs.ClusterFieldSettings})

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -518,7 +518,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 	out, err := conn.RegisterTaskDefinition(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Task Definition (%s) with tags: %s. Trying create without tags.", d.Get("family").(string), err)
 		input.Tags = nil
 
@@ -542,7 +542,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 		err := UpdateTags(conn, aws.StringValue(taskDefinition.TaskDefinitionArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Task Definition (%s): %s", d.Id(), err)
 			return resourceTaskDefinitionRead(d, meta)
 		}
@@ -570,7 +570,7 @@ func resourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error 
 	out, err := conn.DescribeTaskDefinition(&input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Task Definition (%s) with tags: %s; retrying without tags", d.Id(), err)
 
 		input.Include = nil
@@ -732,7 +732,7 @@ func resourceTaskDefinitionUpdate(d *schema.ResourceData, meta interface{}) erro
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Task Definition (%s): %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -435,7 +435,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, arn, nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache Cache Cluster (%s): %w", d.Id(), err)
 			}
@@ -506,7 +506,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(c.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("error listing tags for ElastiCache Cache Cluster (%s): %w", d.Id(), err)
 	}
 
@@ -706,7 +706,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// ISO partitions may not support tagging, giving error
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Cache Cluster (%s) tags: %w", d.Get("arn").(string), err)
 			}
@@ -784,7 +784,7 @@ func createCacheCluster(conn *elasticache.ElastiCache, input *elasticache.Create
 	output, err := conn.CreateCacheCluster(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Cache Cluster with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -233,7 +233,7 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(cluster.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("error listing tags for Elasticache Cluster (%s): %w", d.Id(), err)
 	}
 

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -95,7 +95,7 @@ func resourceParameterGroupCreate(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Create ElastiCache Parameter Group: %#v", createOpts)
 	resp, err := conn.CreateCacheParameterGroup(&createOpts)
 
-	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Parameter Group with tags: %s. Trying create without tags.", err)
 
 		createOpts.Tags = nil
@@ -143,7 +143,7 @@ func resourceParameterGroupRead(d *schema.ResourceData, meta interface{}) error 
 
 	tags, err := ListTags(conn, aws.StringValue(parameterGroup.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("error listing tags for ElastiCache Parameter Group (%s): %w", d.Id(), err)
 	}
 
@@ -291,7 +291,7 @@ func resourceParameterGroupUpdate(d *schema.ResourceData, meta interface{}) erro
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Parameter Group (%s) tags: %w", d.Get("arn").(string), err)
 			}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -565,7 +565,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := conn.CreateReplicationGroup(params)
 
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Replication Group with tags: %s. Trying create without tags.", err)
 
 		params.Tags = nil
@@ -598,7 +598,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 		err := UpdateTags(conn, aws.StringValue(resp.ReplicationGroup.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache Replication Group (%s): %w", d.Id(), err)
 			}
@@ -717,7 +717,7 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 	tags, err := ListTags(conn, aws.StringValue(rgp.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache Replication Group (%s): %w", aws.StringValue(rgp.ARN), err)
 	}
 
@@ -970,7 +970,7 @@ func resourceReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Replication Group (%s) tags: %w", d.Id(), err)
 			}

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -103,7 +103,7 @@ func resourceSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	output, err := conn.CreateCacheSubnetGroup(req)
 
-	if req.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if req.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Subnet Group with tags: %s. Trying create without tags.", err)
 
 		req.Tags = nil
@@ -125,7 +125,7 @@ func resourceSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(output.CacheSubnetGroup.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache Subnet Group (%s): %w", d.Id(), err)
 			}
@@ -183,7 +183,7 @@ func resourceSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Get("arn").(string))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache Subnet Group (%s): %w", d.Id(), err)
 	}
 
@@ -236,7 +236,7 @@ func resourceSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Subnet Group (%s) tags: %w", d.Id(), err)
 			}

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -100,7 +100,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	out, err := conn.CreateUser(input)
 
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache User with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil
@@ -118,7 +118,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(out.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache User (%s): %w", d.Id(), err)
 			}
@@ -154,7 +154,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(resp.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache User (%s): %w", aws.StringValue(resp.ARN), err)
 	}
 
@@ -222,7 +222,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache User (%s) tags: %w", d.Get("arn").(string), err)
 			}

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -85,7 +85,7 @@ func resourceUserGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	out, err := conn.CreateUserGroup(input)
 
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache User Group with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil
@@ -118,7 +118,7 @@ func resourceUserGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(out.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache User Group (%s): %w", d.Id(), err)
 			}
@@ -153,7 +153,7 @@ func resourceUserGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(resp.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(err) {
+	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache User Group (%s): %w", aws.StringValue(resp.ARN), err)
 	}
 
@@ -230,7 +230,7 @@ func resourceUserGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache User Group (%s) tags: %w", d.Get("arn").(string), err)
 			}

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -435,7 +435,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryListenerCreate(conn, params)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
 		params.Tags = nil
 		output, err = retryListenerCreate(conn, params)
@@ -451,7 +451,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	if params.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for ELBv2 Listener (%s): %s", d.Id(), err)
 			return resourceListenerRead(d, meta)
@@ -534,7 +534,7 @@ func resourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return nil
 	}
@@ -643,7 +643,7 @@ func resourceListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Listener %s: %s", d.Id(), err)
 			return resourceListenerRead(d, meta)
 		}

--- a/internal/service/elbv2/listener_data_source.go
+++ b/internal/service/elbv2/listener_data_source.go
@@ -341,7 +341,7 @@ func dataSourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -361,7 +361,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 	resp, err := conn.CreateLoadBalancer(elbOpts)
 
 	// Some partitions may not support tag-on-create
-	if elbOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if elbOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Load Balancer (%s) create failed (%s) with tags. Trying create without tags.", name, err)
 		elbOpts.Tags = nil
 		resp, err = conn.CreateLoadBalancer(elbOpts)
@@ -389,7 +389,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for ELBv2 Load Balancer (%s): %s", d.Id(), err)
 			return resourceLoadBalancerUpdate(d, meta)
 		}
@@ -624,7 +624,7 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 
 			_, err := waitLoadBalancerActive(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
@@ -914,7 +914,7 @@ func flattenResource(d *schema.ResourceData, meta interface{}, lb *elbv2.LoadBal
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -306,7 +306,7 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -368,7 +368,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.CreateTargetGroup(params)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Target Group (%s) create failed (%s) with tags. Trying create without tags.", groupName, err)
 		params.Tags = nil
 		resp, err = conn.CreateTargetGroup(params)
@@ -521,7 +521,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for ELBv2 Target Group (%s): %s", d.Id(), err)
 			return resourceTargetGroupRead(d, meta)
 		}
@@ -778,7 +778,7 @@ func resourceTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Target Group %s: %s", d.Id(), err)
 			return resourceTargetGroupRead(d, meta)
 		}
@@ -967,7 +967,7 @@ func flattenTargetGroupResource(d *schema.ResourceData, meta interface{}, target
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/target_group_data_source.go
+++ b/internal/service/elbv2/target_group_data_source.go
@@ -268,7 +268,7 @@ func dataSourceTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -71,7 +71,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateEventBus(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] EventBridge Bus (%s) create failed (%s) with tags. Trying create without tags.", eventBusName, err)
 		input.Tags = nil
 		output, err = conn.CreateEventBus(input)
@@ -89,7 +89,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, aws.StringValue(output.EventBusArn), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for EventBridge Bus (%s): %s", d.Id(), err)
 			return resourceBusRead(d, meta)
 		}
@@ -127,7 +127,7 @@ func resourceBusRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, aws.StringValue(output.Arn))
 
 	// ISO partitions may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for EventBridge Bus %s: %s", d.Id(), err)
 		return nil
 	}
@@ -159,7 +159,7 @@ func resourceBusUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, arn, o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for EventBridge Bus %s: %s", d.Id(), err)
 			return resourceBusRead(d, meta)
 		}

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -123,7 +123,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	arn, err := retryPutRule(conn, input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] EventBridge Rule (%s) create failed (%s) with tags. Trying create without tags.", name, err)
 		input.Tags = nil
 		arn, err = retryPutRule(conn, input)
@@ -139,7 +139,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, arn, nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for EventBridge Rule (%s): %s", d.Id(), err)
 			return resourceRuleRead(d, meta)
 		}
@@ -202,7 +202,7 @@ func resourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// ISO partitions may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for EventBridge Rule %s: %s", d.Id(), err)
 		return nil
 	}
@@ -269,7 +269,7 @@ func resourceRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, arn, o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for EventBridge Rule %s: %s", d.Id(), err)
 			return resourceRuleRead(d, meta)
 		}

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -104,7 +104,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 	response, err := conn.CreateInstanceProfile(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Instance Profile (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -135,7 +135,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 		err := instanceProfileUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Instance Profile (%s): %s", d.Id(), err)
 			return resourceInstanceProfileUpdate(d, meta)
 		}
@@ -228,7 +228,7 @@ func resourceInstanceProfileUpdate(d *schema.ResourceData, meta interface{}) err
 		err := instanceProfileUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Instance Profile (%s): %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -80,7 +80,7 @@ func resourceOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{
 	out, err := conn.CreateOpenIDConnectProvider(input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM OIDC Provider with tags: %s. Trying create without tags.", err)
 		input.Tags = nil
 
@@ -98,7 +98,7 @@ func resourceOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{
 		err := openIDConnectProviderUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM OIDC Provider (%s): %s", d.Id(), err)
 			return resourceOpenIDConnectProviderRead(d, meta)
 		}
@@ -169,7 +169,7 @@ func resourceOpenIDConnectProviderUpdate(d *schema.ResourceData, meta interface{
 		err := openIDConnectProviderUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM OIDC Provider (%s): %s", d.Id(), err)
 			return resourceOpenIDConnectProviderRead(d, meta)
 		}

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -115,7 +115,7 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	response, err := conn.CreatePolicy(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Policy (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -133,7 +133,7 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 		err := policyUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Policy (%s): %s", d.Id(), err)
 			return resourcePolicyRead(d, meta)
 		}
@@ -307,7 +307,7 @@ func resourcePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := policyUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Policy (%s): %s", d.Id(), err)
 			return resourcePolicyRead(d, meta)
 		}

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -202,7 +202,7 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryCreateRole(conn, request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Role (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -236,7 +236,7 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		err := roleUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Role (%s): %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}
@@ -485,7 +485,7 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := roleUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Role %s: %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -78,7 +78,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.CreateSAMLProvider(input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM SAML Provider (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
@@ -96,7 +96,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 		err := samlProviderUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM SAML Provider (%s): %s", d.Id(), err)
 			return resourceSAMLProviderRead(ctx, d, meta)
 		}
@@ -178,7 +178,7 @@ func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, met
 		err := samlProviderUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM SAML Provider (%s): %s", d.Id(), err)
 			return resourceSAMLProviderRead(ctx, d, meta)
 		}

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -139,7 +139,7 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 	resp, err := conn.UploadServerCertificate(createOpts)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Server Certificate (%s) with tags: %s. Trying create without tags.", sslCertName, err)
 		createOpts.Tags = nil
 
@@ -158,7 +158,7 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 		err := serverCertificateUpdateTags(conn, d.Get("name").(string), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Server Certificate (%s): %s", d.Id(), err)
 			return resourceServerCertificateRead(d, meta)
 		}
@@ -233,7 +233,7 @@ func resourceServerCertificateUpdate(d *schema.ResourceData, meta interface{}) e
 		err := serverCertificateUpdateTags(conn, d.Get("name").(string), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Server Certificate (%s): %s", d.Id(), err)
 			return resourceServerCertificateRead(d, meta)
 		}

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -115,7 +115,7 @@ func resourceServiceLinkedRoleCreate(d *schema.ResourceData, meta interface{}) e
 		err = roleUpdateTags(conn, roleName, nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Service Linked Role (%s): %s", d.Id(), err)
 			return resourceServiceLinkedRoleRead(d, meta)
 		}
@@ -207,7 +207,7 @@ func resourceServiceLinkedRoleUpdate(d *schema.ResourceData, meta interface{}) e
 		err := roleUpdateTags(conn, roleName, o, n)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Service Linked Role (%s): %s", d.Id(), err)
 			return resourceServiceLinkedRoleRead(d, meta)
 		}

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -103,7 +103,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 	createResp, err := conn.CreateUser(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM User (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -121,7 +121,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 		err := userUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM User (%s): %s", d.Id(), err)
 			return resourceUserRead(d, meta)
 		}
@@ -251,7 +251,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := userUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM User (%s): %s", d.Id(), err)
 			return resourceUserRead(d, meta)
 		}

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -80,7 +80,7 @@ func resourceVirtualMFADeviceCreate(d *schema.ResourceData, meta interface{}) er
 	output, err := conn.CreateVirtualMFADevice(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Virtual MFA Device (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -102,7 +102,7 @@ func resourceVirtualMFADeviceCreate(d *schema.ResourceData, meta interface{}) er
 		err := virtualMFAUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Virtual MFA Device (%s): %s", d.Id(), err)
 			return resourceVirtualMFADeviceRead(d, meta)
 		}
@@ -166,7 +166,7 @@ func resourceVirtualMFADeviceUpdate(d *schema.ResourceData, meta interface{}) er
 	err := virtualMFAUpdateTags(conn, d.Id(), o, n)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed updating tags for IAM Virtual MFA Device (%s): %s", d.Id(), err)
 		return resourceVirtualMFADeviceRead(d, meta)
 	}

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -250,7 +250,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateTopic(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating SNS Topic (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 		output, err = conn.CreateTopic(input)
@@ -272,7 +272,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] failed adding tags after create for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)
@@ -325,7 +325,7 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		// ISO partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SNS Topic (%s): %s", d.Id(), err)
 		return nil
@@ -371,7 +371,7 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// ISO partitions may not support tagging, giving error
 			log.Printf("[WARN] failed updating tags for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -219,7 +219,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}, sqs.ErrCodeQueueDeletedRecently)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating SQS Queue (%s) with tags: %s. Trying create without tags.", name, err)
 
 		input.Tags = nil
@@ -244,7 +244,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] failed adding tags after create for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)
@@ -308,7 +308,7 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return ListTags(conn, d.Id())
 	}, sqs.ErrCodeQueueDoesNotExist)
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
 		return nil
@@ -365,7 +365,7 @@ func resourceQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 			// Some partitions may not support tagging, giving error
 			log.Printf("[WARN] failed updating tags for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -62,7 +62,7 @@ func dataSourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, queueURL)
 
-	if verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
 		return nil

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"gopkg.in/yaml.v2"
 )
@@ -52,7 +53,11 @@ const (
 	ErrCodeValidationException         = "ValidationException"
 )
 
-func CheckISOErrorTagsUnsupported(err error) bool {
+func CheckISOErrorTagsUnsupported(partition string, err error) bool {
+	if partition == endpoints.AwsPartitionID {
+		return false
+	}
+
 	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) {
 		return true
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24930

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% go test ./...
?   	github.com/hashicorp/terraform-provider-aws	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	8.498s
?   	github.com/hashicorp/terraform-provider-aws/internal/attrmap	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/conns	1.184s
ok  	github.com/hashicorp/terraform-provider-aws/internal/create	1.779s
ok  	github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable	2.190s
?   	github.com/hashicorp/terraform-provider-aws/internal/experimental/sync	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/flex	2.153s
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/allowsubcats	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/checknames	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/customends	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/issuelabels	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/namescapslist	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters	2.460s
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/prlabels	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/servicelabels	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/servicesemgrep	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/generate/sweepimp	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider	0.543s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer	4.376s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	6.959s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acm	12.670s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	16.941s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	10.695s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	11.476s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	15.613s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	15.367s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling	13.071s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appconfig	11.576s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appflow	11.667s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appintegrations	13.052s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/applicationinsights	15.435s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appmesh	16.640s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apprunner	4.183s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	9.450s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appsync	10.871s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/athena	3.718s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	15.894s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans	8.098s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	17.129s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	18.102s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/budgets	6.354s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ce	11.944s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	13.663s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloud9	16.284s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol	15.079s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	17.554s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	21.184s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2	17.088s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	4.118s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail	11.064s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	19.889s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	13.523s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	12.171s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codecommit	6.511s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline	14.669s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections	8.528s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications	9.701s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity	18.655s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	19.949s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	15.154s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	16.856s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cur	17.761s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange	18.793s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline	18.865s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	4.010s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	2.581s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/deploy	8.493s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/detective	7.165s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm	10.032s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	10.567s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dlm	5.736s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	11.331s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	13.737s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	10.456s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	12.127s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	17.189s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	9.109s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic	12.597s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	5.352s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	3.263s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	8.915s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	5.199s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	4.976s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	6.478s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder	3.507s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	5.474s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	7.626s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emr	3.445s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrcontainers	7.848s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless	8.351s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	7.406s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	8.338s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fms	5.403s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	5.252s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/gamelift	4.002s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	6.513s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	7.823s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	8.653s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/grafana	10.669s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/greengrass	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/guardduty	9.380s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	9.120s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	11.778s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	12.914s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector	12.923s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	9.787s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotevents	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	7.996s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	11.466s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kendra	3.409s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces	2.373s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesis	10.205s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics	4.963s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	12.625s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo	6.629s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	5.748s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	11.530s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	2.558s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels	13.891s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager	14.057s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	10.705s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/location	6.962s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	11.163s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie	3.463s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie2	5.075s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert	8.911s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage	2.284s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediastore	6.181s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	7.454s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	10.383s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	11.538s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	12.550s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/neptune	4.915s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	13.431s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	13.451s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearch	3.243s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	5.182s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/organizations	7.126s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/outposts	4.612s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint	8.343s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pricing	3.041s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/qldb	6.158s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	7.443s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	3.419s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	5.359s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	2.966s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata	9.049s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups	10.463s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi	6.554s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	6.774s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	3.614s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	3.520s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	5.039s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver	7.534s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rum	1.926s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	14.538s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	9.169s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts	10.405s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	7.345s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/schemas	7.520s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	3.239s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	11.059s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	12.012s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	7.781s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	11.602s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	6.096s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	10.564s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	11.396s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	4.193s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/signer	9.191s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/simpledb	2.602s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	12.464s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	11.716s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	11.192s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	13.557s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	10.330s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	3.268s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/swf	13.956s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	1.874s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite	1.575s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	6.168s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/waf	3.048s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	3.860s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	6.962s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/worklink	4.505s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/workspaces	3.069s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	8.630s
ok  	github.com/hashicorp/terraform-provider-aws/internal/tags	1.087s
ok  	github.com/hashicorp/terraform-provider-aws/internal/tfresource	40.474s
ok  	github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys	2.644s
ok  	github.com/hashicorp/terraform-provider-aws/internal/vault/sdk/helper/jsonutil	0.954s
ok  	github.com/hashicorp/terraform-provider-aws/internal/verify	0.445s
ok  	github.com/hashicorp/terraform-provider-aws/names	1.597s
?   	github.com/hashicorp/terraform-provider-aws/version	[no test files]
% make testacc TESTS=TestAccIAMUser_tags PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_tags'  -timeout 180m
--- PASS: TestAccIAMUser_tags (58.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	59.753s
% make testacc TESTS=TestAccECRRepository_tags PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_tags'  -timeout 180m
--- PASS: TestAccECRRepository_tags (53.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	54.569s
% make testacc TESTS=TestAccCloudWatchMetricAlarm_tags PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_tags'  -timeout 180m
--- PASS: TestAccCloudWatchMetricAlarm_tags (83.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	84.884s
% make testacc TESTS=TestAccECSCluster_tags PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCluster_tags'  -timeout 180m
--- PASS: TestAccECSCluster_tags (93.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	94.490s
% make testacc TESTS=TestAccSQSQueue_tags PKG=sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue_tags'  -timeout 180m
--- PASS: TestAccSQSQueue_tags (125.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	127.064s
% make testacc TESTS=TestAccSNSTopic_tags PKG=sns
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopic_tags'  -timeout 180m
--- PASS: TestAccSNSTopic_tags (84.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	85.647s
% make testacc TESTS=TestAccEventsBus_tags PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBus_tags'  -timeout 180m
--- PASS: TestAccEventsBus_tags (107.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	108.511s
% make testacc TESTS=TestAccELBV2TargetGroup_tags PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_tags'  -timeout 180m
--- PASS: TestAccELBV2TargetGroup_tags (89.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	91.249s
% make testacc TESTS=TestAccElastiCacheUser_tags PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser_tags'  -timeout 180m
--- PASS: TestAccElastiCacheUser_tags (116.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	117.958s
```
