### PR TITLE
d/aws_kendra_thesaurus

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -711,8 +711,9 @@ func Provider() *schema.Provider {
 			"aws_mskconnect_custom_plugin":        kafkaconnect.DataSourceCustomPlugin(),
 			"aws_mskconnect_worker_configuration": kafkaconnect.DataSourceWorkerConfiguration(),
 
-			"aws_kendra_faq":   kendra.DataSourceFaq(),
-			"aws_kendra_index": kendra.DataSourceIndex(),
+			"aws_kendra_faq":       kendra.DataSourceFaq(),
+			"aws_kendra_index":     kendra.DataSourceIndex(),
+			"aws_kendra_thesaurus": kendra.DataSourceThesaurus(),
 
 			"aws_kinesis_stream":          kinesis.DataSourceStream(),
 			"aws_kinesis_stream_consumer": kinesis.DataSourceStreamConsumer(),

--- a/internal/service/kendra/thesaurus_data_source.go
+++ b/internal/service/kendra/thesaurus_data_source.go
@@ -1,0 +1,96 @@
+package kendra
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceThesaurus() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_size_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"index_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`[a-zA-Z0-9][a-zA-Z0-9-]{35}`),
+					"Starts with an alphanumeric character. Subsequently, can contain alphanumeric characters and hyphens. Fixed length of 36.",
+				),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_s3_path": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"synonym_rule_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"term_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"thesaurus_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 100),
+					validation.StringMatch(
+						regexp.MustCompile(`[a-zA-Z0-9][a-zA-Z0-9_-]*`),
+						"Starts with an alphanumeric character. Subsequently, can contain alphanumeric characters and hyphens.",
+					),
+				),
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}

--- a/internal/service/kendra/thesaurus_data_source.go
+++ b/internal/service/kendra/thesaurus_data_source.go
@@ -1,15 +1,23 @@
 package kendra
 
 import (
+	"context"
+	"fmt"
 	"regexp"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
 func DataSourceThesaurus() *schema.Resource {
 	return &schema.Resource{
+		ReadContext: dataSourceThesaurusRead,
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -93,4 +101,62 @@ func DataSourceThesaurus() *schema.Resource {
 			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
+}
+
+func dataSourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).KendraConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	id := d.Get("thesaurus_id").(string)
+	indexId := d.Get("index_id").(string)
+
+	resp, err := FindThesaurusByID(ctx, conn, id, indexId)
+
+	if err != nil {
+		return diag.Errorf("getting Kendra Thesaurus (%s): %s", d.Id(), err)
+	}
+
+	if resp == nil {
+		return diag.Errorf("getting Kendra Thesaurus (%s): empty response", id)
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "kendra",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("index/%s/thesaurus/%s", indexId, id),
+	}.String()
+
+	d.Set("arn", arn)
+	d.Set("created_at", aws.ToTime(resp.CreatedAt).Format(time.RFC3339))
+	d.Set("description", resp.Description)
+	d.Set("error_message", resp.ErrorMessage)
+	d.Set("file_size_bytes", resp.FileSizeBytes)
+	d.Set("index_id", resp.IndexId)
+	d.Set("name", resp.Name)
+	d.Set("role_arn", resp.RoleArn)
+	d.Set("status", resp.Status)
+	d.Set("synonym_rule_count", resp.SynonymRuleCount)
+	d.Set("term_count", resp.TermCount)
+	d.Set("thesaurus_id", resp.Id)
+	d.Set("updated_at", aws.ToTime(resp.UpdatedAt).Format(time.RFC3339))
+
+	if err := d.Set("source_s3_path", flattenSourceS3Path(resp.SourceS3Path)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	tags, err := ListTags(ctx, conn, arn)
+	if err != nil {
+		return diag.Errorf("error listing tags for resource (%s): %s", arn, err)
+	}
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", id, indexId))
+
+	return nil
 }

--- a/internal/service/kendra/thesaurus_data_source_test.go
+++ b/internal/service/kendra/thesaurus_data_source_test.go
@@ -1,0 +1,87 @@
+package kendra_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/backup"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccKendraThesaurusDataSource_basic(t *testing.T) {
+	datasourceName := "data.aws_kendra_thesaurus.test"
+	resourceName := "aws_kendra_thesaurus.test"
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, backup.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccThesaurusDataSourceConfig_nonExistent,
+				ExpectError: regexp.MustCompile(`getting Kendra Thesaurus`),
+			},
+			{
+				Config: testAccThesaurusDataSourceConfig_basic(rName, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(datasourceName, "created_at"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrSet(datasourceName, "file_size_bytes"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "index_id", resourceName, "index_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "role_arn", resourceName, "role_arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "source_s3_path.#", resourceName, "source_s3_path.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "source_s3_path.0.bucket", resourceName, "source_s3_path.0.bucket"),
+					resource.TestCheckResourceAttrPair(datasourceName, "source_s3_path.0.key", resourceName, "source_s3_path.0.key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "status", resourceName, "status"),
+					resource.TestCheckResourceAttrSet(datasourceName, "synonym_rule_count"),
+					resource.TestCheckResourceAttrSet(datasourceName, "term_count"),
+					resource.TestCheckResourceAttrPair(datasourceName, "thesaurus_id", resourceName, "thesaurus_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "updated_at"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Key1", resourceName, "tags.Key1")),
+			},
+		},
+	})
+}
+
+const testAccThesaurusDataSourceConfig_nonExistent = `
+data "aws_kendra_thesaurus" "test" {
+  index_id     = "tf-acc-test-does-not-exist-kendra-id"
+  thesaurus_id = "tf-acc-test-does-not-exist-kendra-thesaurus-id"
+}
+`
+
+func testAccThesaurusDataSourceConfig_basic(rName, rName2 string) string {
+	return acctest.ConfigCompose(
+		testAccThesaurusBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_kendra_thesaurus" "test" {
+  index_id    = aws_kendra_index.test.id
+  name        = %[1]q
+  description = "example description thesaurus"
+  role_arn    = aws_iam_role.test.arn
+
+  source_s3_path {
+    bucket = aws_s3_bucket.test.id
+    key    = aws_s3_object.test.key
+  }
+
+  tags = {
+    "Key1" = "Value1"
+  }
+}
+
+data "aws_kendra_thesaurus" "test" {
+  index_id     = aws_kendra_index.test.id
+  thesaurus_id = aws_kendra_thesaurus.test.thesaurus_id
+}
+`, rName2))
+}

--- a/website/docs/d/kendra_thesaurus.html.markdown
+++ b/website/docs/d/kendra_thesaurus.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Kendra"
+layout: "aws"
+page_title: "AWS: aws_kendra_thesaurus"
+description: |-
+  Provides details about a specific Amazon Kendra Thesaurus.
+---
+
+# Data Source: aws_kendra_thesaurus
+
+Provides details about a specific Amazon Kendra Thesaurus.
+
+## Example Usage
+
+```hcl
+data "aws_kendra_thesaurus" "example" {
+  index_id     = "12345678-1234-1234-1234-123456789123"
+  thesaurus_id = "87654321-1234-4321-4321-321987654321"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `index_id` - (Required) The identifier of the index that contains the Thesaurus.
+* `thesaurus_id` - (Required) The identifier of the Thesaurus.
+
+## Attributes Reference
+
+In addition to all of the arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the Thesaurus.
+* `created_at` - The Unix datetime that the Thesaurus was created.
+* `description` - The description of the Thesaurus.
+* `error_message` - When the `status` field value is `FAILED`, this contains a message that explains why.
+* `file_size_bytes` - The size of the Thesaurus file in bytes.
+* `id` - The unique identifiers of the Thesaurus and index separated by a slash (`/`).
+* `name` - Specifies the name of the Thesaurus.
+* `role_arn` - The Amazon Resource Name (ARN) of a role with permission to access the S3 bucket that contains the Thesaurus. For more information, see [IAM Roles for Amazon Kendra](https://docs.aws.amazon.com/kendra/latest/dg/iam-roles.html).
+* `source_s3_path` - The S3 location of the Thesaurus input data. Detailed below.
+* `status` - The status of the Thesaurus. It is ready to use when the status is `ACTIVE`.
+* `synonym_rule_count` - The number of synonym rules in the Thesaurus file.
+* `term_count` - The number of unique terms in the Thesaurus file. For example, the synonyms `a,b,c` and `a=>d`, the term count would be 4.
+* `updated_at` - The date and time that the Thesaurus was last updated.
+* `tags` - Metadata that helps organize the Thesaurus you create.
+
+The `source_s3_path` configuration block supports the following attributes:
+
+* `bucket` - The name of the S3 bucket that contains the file.
+* `key` - The name of the file.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13367

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKendraThesaurusDataSource_basic' PKG=kendra
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kendra/... -v -count 1 -parallel 20  -run=TestAccKendraThesaurusDataSource_basic -timeout 180m
=== RUN   TestAccKendraThesaurusDataSource_basic
=== PAUSE TestAccKendraThesaurusDataSource_basic
=== CONT  TestAccKendraThesaurusDataSource_basic
--- PASS: TestAccKendraThesaurusDataSource_basic (760.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kendra     760.755s

...
```
