### PR TITLE
s/sagemaker Add support repository_auth_config in image_config

### DIFF
--- a/.changelog/25557.txt
+++ b/.changelog/25557.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/sagemaker: Add `repository_auth_config` arguments in support of [Private Docker Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-containers-inference-private.html)
+```

--- a/internal/service/sagemaker/model.go
+++ b/internal/service/sagemaker/model.go
@@ -69,6 +69,21 @@ func ResourceModel() *schema.Resource {
 										ForceNew:     true,
 										ValidateFunc: validation.StringInSlice(sagemaker.RepositoryAccessMode_Values(), false),
 									},
+									"repository_auth_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_credentials_provider_arn": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -158,6 +173,21 @@ func ResourceModel() *schema.Resource {
 										Required:     true,
 										ForceNew:     true,
 										ValidateFunc: validation.StringInSlice(sagemaker.RepositoryAccessMode_Values(), false),
+									},
+									"repository_auth_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_credentials_provider_arn": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -430,7 +460,23 @@ func expandModelImageConfig(l []interface{}) *sagemaker.ImageConfig {
 		RepositoryAccessMode: aws.String(m["repository_access_mode"].(string)),
 	}
 
+	if v, ok := m["repository_auth_config"]; ok {
+		imageConfig.RepositoryAuthConfig = expandRepositoryAuthConfig(v.([]interface{}))
+	}
+
 	return imageConfig
+}
+
+func expandRepositoryAuthConfig(l []interface{}) *sagemaker.RepositoryAuthConfig {
+	if len(l) == 0 {
+		return nil
+	}
+	m := l[0].(map[string]interface{})
+	repositoryAuthConfig := &sagemaker.RepositoryAuthConfig{
+		RepositoryCredentialsProviderArn: aws.String(m["repository_credentials_provider_arn"].(string)),
+	}
+
+	return repositoryAuthConfig
 }
 
 func expandContainers(a []interface{}) []*sagemaker.ContainerDefinition {
@@ -481,6 +527,19 @@ func flattenImageConfig(imageConfig *sagemaker.ImageConfig) []interface{} {
 	cfg := make(map[string]interface{})
 
 	cfg["repository_access_mode"] = aws.StringValue(imageConfig.RepositoryAccessMode)
+	cfg["repository_auth_config"] = flattenRepositoryAuthConfig(imageConfig.RepositoryAuthConfig)
+
+	return []interface{}{cfg}
+}
+
+func flattenRepositoryAuthConfig(repositoryAuthConfig *sagemaker.RepositoryAuthConfig) []interface{} {
+	if repositoryAuthConfig == nil {
+		return []interface{}{}
+	}
+
+	cfg := make(map[string]interface{})
+
+	cfg["repository_credentials_provider_arn"] = aws.StringValue(repositoryAuthConfig.RepositoryCredentialsProviderArn)
 
 	return []interface{}{cfg}
 }

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -325,7 +325,7 @@ func TestAccSageMakerModel_primaryContainerPrivateDockerRegistry(t *testing.T) {
 					testAccCheckModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image_config.0.repository_access_mode", "Vpc"),
-					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image_config.0.repository_auth_config.0.repository_credentials_provider_arn", "arn:aws:lambda:us-east-2:123456789012:function:my-function:1"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image_config.0.repository_auth_config.0.repository_credentials_provider_arn", "arn:aws:lambda:us-east-2:123456789012:function:my-function:1"), //lintignore:AWSAT003,AWSAT005
 				),
 			},
 			{
@@ -767,6 +767,7 @@ resource "aws_security_group" "bar" {
 `, rName))
 }
 
+//lintignore:AWSAT003,AWSAT005
 func testAccModelConfig_primaryContainerPrivateDockerRegistry(rName string) string {
 	return acctest.ConfigCompose(testAccModelConfigBase(rName), acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -774,8 +774,8 @@ func testAccModelConfig_primaryContainerPrivateDockerRegistry(rName string) stri
 		acctest.ConfigAvailableAZsNoOptIn() +
 		fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
-  name               = %[1]q
-  execution_role_arn = aws_iam_role.test.arn
+  name                     = %[1]q
+  execution_role_arn       = aws_iam_role.test.arn
   enable_network_isolation = true
 
   primary_container {
@@ -783,9 +783,10 @@ resource "aws_sagemaker_model" "test" {
 
     image_config {
       repository_access_mode = "Vpc"
-	    repository_auth_config {
-		    repository_credentials_provider_arn = "arn:aws:lambda:us-east-2:123456789012:function:my-function:1"
-	    }
+
+      repository_auth_config {
+        repository_credentials_provider_arn = "arn:aws:lambda:us-east-2:123456789012:function:my-function:1"
+      }
     }
   }
 

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -466,7 +466,7 @@ data "aws_sagemaker_prebuilt_ecr_image" "test" {
 }
 
 func testAccModelConfig_basic(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -475,11 +475,11 @@ resource "aws_sagemaker_model" "test" {
     image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_inferenceExecution(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -496,11 +496,11 @@ resource "aws_sagemaker_model" "test" {
     image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -513,11 +513,11 @@ resource "aws_sagemaker_model" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccModelConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -531,11 +531,11 @@ resource "aws_sagemaker_model" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccModelConfig_primaryContainerDataURL(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -606,11 +606,11 @@ resource "aws_s3_object" "test" {
   key     = "model.tar.gz"
   content = "some-data"
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_primaryContainerHostname(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -620,11 +620,11 @@ resource "aws_sagemaker_model" "test" {
     container_hostname = "test"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_primaryContainerImage(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -637,11 +637,11 @@ resource "aws_sagemaker_model" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_primaryContainerEnvironment(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -654,11 +654,11 @@ resource "aws_sagemaker_model" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_primaryContainerModeSingle(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -668,11 +668,11 @@ resource "aws_sagemaker_model" "test" {
     mode  = "SingleModel"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_containers(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
@@ -685,11 +685,11 @@ resource "aws_sagemaker_model" "test" {
     image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_networkIsolation(rName string) string {
-	return testAccModelConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name                     = %[1]q
   execution_role_arn       = aws_iam_role.test.arn
@@ -699,13 +699,11 @@ resource "aws_sagemaker_model" "test" {
     image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_vpcBasic(rName string) string {
-	return testAccModelConfigBase(rName) +
-		acctest.ConfigAvailableAZsNoOptIn() +
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name                     = %[1]q
   execution_role_arn       = aws_iam_role.test.arn
@@ -766,13 +764,11 @@ resource "aws_security_group" "bar" {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccModelConfig_primaryContainerPrivateDockerRegistry(rName string) string {
-	return testAccModelConfigBase(rName) +
-		acctest.ConfigAvailableAZsNoOptIn() +
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccModelConfigBase(rName), acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name                     = %[1]q
   execution_role_arn       = aws_iam_role.test.arn
@@ -822,5 +818,5 @@ resource "aws_security_group" "test" {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName))
 }

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -70,6 +70,11 @@ The `primary_container` and `container` block both support:
 ### Image Config
 
 * `repository_access_mode` - (Required) Specifies whether the model container is in Amazon ECR or a private Docker registry accessible from your Amazon Virtual Private Cloud (VPC). Allowed values are: `Platform` and `Vpc`.
+* `repository_auth_config` - (Optional) Specifies an authentication configuration for the private docker registry where your model image is hosted. Specify a value for this property only if you specified Vpc as the value for the RepositoryAccessMode field, and the private Docker registry where the model image is hosted requires authentication. see [Repository Auth Config](#repository-auth-config).
+
+#### Repository Auth Config
+
+* `repository_credentials_provider_arn` - (Required) The Amazon Resource Name (ARN) of an AWS Lambda function that provides credentials to authenticate to the private Docker registry where your model image is hosted. For information about how to create an AWS Lambda function, see [Create a Lambda function with the console](https://docs.aws.amazon.com/lambda/latest/dg/getting-started-create-function.html) in the _AWS Lambda Developer Guide_.
 
 ## Inference Execution Config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSageMakerModel_primaryContainerPrivateDockerRegistry PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerModel_primaryContainerPrivateDockerRegistry'  -timeout 180m
=== RUN   TestAccSageMakerModel_primaryContainerPrivateDockerRegistry
=== PAUSE TestAccSageMakerModel_primaryContainerPrivateDockerRegistry
=== CONT  TestAccSageMakerModel_primaryContainerPrivateDockerRegistry
--- PASS: TestAccSageMakerModel_primaryContainerPrivateDockerRegistry (50.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  53.342s

...
```
