### PR TITLE
resource/aws_cloudtrail: Skips CloudTrail tests on `AccessDeniedException` instead of failing

### DIFF
--- a/internal/service/cloudtrail/cloudtrail_test.go
+++ b/internal/service/cloudtrail/cloudtrail_test.go
@@ -16,6 +16,18 @@ import (
 	tfcloudtrail "github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(cloudtrail.EndpointsID, testAccErrorCheckSkip)
+
+}
+
+// testAccErrorCheckSkip skips CloudTrail tests that have error messages indicating unsupported features
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"AccessDeniedException:",
+	)
+}
+
 func TestAccCloudTrail_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Trail": {


### PR DESCRIPTION
Now skips acceptance tests which return `AccessDeniedException` instead of failing.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25563

Output from acceptance testing:

Previously

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc PKG=cloudtrail TESTS=TestAccCloudTrail_serial/Trail/enableLogging

        Error: Error stopping logging on CloudTrail (tf-acc-test-3771676142374103965): AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider5_test-admin/gdavison@hashicorp.com is not authorized to perform: cloudtrail:StopLogging on resource: arn:aws:cloudtrail:us-west-2:123456789012:trail/tf-acc-test-3771676142374103965 with an explicit deny in a service control policy
        	status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
        
          with aws_cloudtrail.test,
          on terraform_plugin_test.tf line 37, in resource "aws_cloudtrail" "test":
          37: resource "aws_cloudtrail" "test" {
        
--- FAIL: TestAccCloudTrail_serial (38.11s)
    --- FAIL: TestAccCloudTrail_serial/Trail (38.11s)
        --- FAIL: TestAccCloudTrail_serial/Trail/enableLogging (38.11s)
```

Now

```console
$ make testacc PKG=cloudtrail TESTS=TestAccCloudTrail_serial/Trail/enableLogging

        Error: Error stopping logging on CloudTrail (tf-acc-test-2671520323514520425): AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider5_test-admin/gdavison@hashicorp.com is not authorized to perform: cloudtrail:StopLogging on resource: arn:aws:cloudtrail:us-west-2:123456789012:trail/tf-acc-test-2671520323514520425 with an explicit deny in a service control policy
        	status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
        
          with aws_cloudtrail.test,
          on terraform_plugin_test.tf line 37, in resource "aws_cloudtrail" "test":
          37: resource "aws_cloudtrail" "test" {
        
--- PASS: TestAccCloudTrail_serial (37.73s)
    --- PASS: TestAccCloudTrail_serial/Trail (37.73s)
        --- SKIP: TestAccCloudTrail_serial/Trail/enableLogging (37.73s)
```