### PR TITLE
d/ec2_ami - make `owners` optional + `include_deprecated` arg

### DIFF
--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -104,6 +104,11 @@ func DataSourceAMI() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"include_deprecated": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"kernel_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -128,7 +133,7 @@ func DataSourceAMI() *schema.Resource {
 			},
 			"owners": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MinItems: 1,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -215,12 +220,17 @@ func dataSourceAMIRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	params := &ec2.DescribeImagesInput{
-		Owners: flex.ExpandStringList(d.Get("owners").([]interface{})),
+		IncludeDeprecated: aws.Bool(d.Get("include_deprecated").(bool)),
+	}
+
+	if v, ok := d.GetOk("owners"); ok && len(v.([]interface{})) > 0 {
+		params.Owners = flex.ExpandStringList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("executable_users"); ok {
 		params.ExecutableUsers = flex.ExpandStringList(v.([]interface{}))
 	}
+
 	if v, ok := d.GetOk("filter"); ok {
 		params.Filters = BuildFiltersDataSource(v.(*schema.Set))
 	}

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -222,7 +222,6 @@ func testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore() string {
 	return `
 data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
   most_recent = true
-  owners      = ["amazon"]
 
   filter {
     name   = "name"

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -39,13 +39,15 @@ data "aws_ami" "example" {
 
 ## Argument Reference
 
-* `owners` - (Required) List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, `self` (the current account), or an AWS owner alias (e.g., `amazon`, `aws-marketplace`, `microsoft`).
+* `owners` - (Optional) List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, `self` (the current account), or an AWS owner alias (e.g., `amazon`, `aws-marketplace`, `microsoft`).
 
 * `most_recent` - (Optional) If more than one result is returned, use the most
 recent AMI.
 
 * `executable_users` - (Optional) Limit search to users with *explicit* launch permission on
  the image. Valid items are the numeric account ID or `self`.
+
+* `include_deprecated` - (Optional) If true, all deprecated AMIs are included in the response. If false, no deprecated AMIs are included in the response. If no value is specified, the default value is false.
 
 * `filter` - (Optional) One or more name/value pairs to filter off of. There are
 several valid keys, for a full reference, check out


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25521

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2AMIDataSource_ PKG=ec2

...
```
