### PR TITLE
Match IPv6 CIDRs as lower-case

### DIFF
--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -452,11 +452,15 @@ func findRuleMatch(p *ec2.IpPermission, rules []*ec2.IpPermission, isVPC bool) *
 
 		remaining = len(p.Ipv6Ranges)
 		for _, ipv6 := range p.Ipv6Ranges {
+			if ipv6.CidrIpv6 == nil {
+				continue
+			}
+			expectedCidrIpv6 := strings.ToLower(aws.StringValue(ipv6.CidrIpv6))
 			for _, ipv6ip := range r.Ipv6Ranges {
-				if ipv6.CidrIpv6 == nil || ipv6ip.CidrIpv6 == nil {
+				if ipv6ip.CidrIpv6 == nil {
 					continue
 				}
-				if aws.StringValue(ipv6.CidrIpv6) == aws.StringValue(ipv6ip.CidrIpv6) {
+				if expectedCidrIpv6 == aws.StringValue(ipv6ip.CidrIpv6) {
 					remaining--
 				}
 			}

--- a/internal/service/ec2/vpc_security_group_rules_matching_test.go
+++ b/internal/service/ec2/vpc_security_group_rules_matching_test.go
@@ -585,6 +585,66 @@ func TestRulesMixedMatching(t *testing.T) {
 				},
 			},
 		},
+		// ipv6
+		{
+			local: []interface{}{
+				map[string]interface{}{
+					"from_port":        80,
+					"to_port":          8000,
+					"protocol":         "tcp",
+					"cidr_ipv6_blocks": []interface{}{"2001:0db8:85a3:0000::/64"},
+					"security_groups":  schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+				},
+			},
+			remote: []map[string]interface{}{
+				{
+					"from_port":        int64(80),
+					"to_port":          int64(8000),
+					"protocol":         "tcp",
+					"cidr_ipv6_blocks": []interface{}{"2001:0db8:85a3:0000::/64"},
+					"security_groups":  schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+				},
+			},
+			saves: []map[string]interface{}{
+				{
+					"from_port":        80,
+					"to_port":          8000,
+					"protocol":         "tcp",
+					"cidr_ipv6_blocks": []interface{}{"2001:0db8:85a3:0000::/64"},
+					"security_groups":  schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+				},
+			},
+		},
+		// ipv6: local/remote differ in capitalization
+		{
+			local: []interface{}{
+				map[string]interface{}{
+					"from_port":        80,
+					"to_port":          8000,
+					"protocol":         "tcp",
+					"cidr_ipv6_blocks": []interface{}{"2001:0DB8:85A3:0000::/64"},
+					"security_groups":  schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+				},
+			},
+			remote: []map[string]interface{}{
+				{
+					"from_port":        int64(80),
+					"to_port":          int64(8000),
+					"protocol":         "tcp",
+					"cidr_ipv6_blocks": []interface{}{"2001:0db8:85a3:0000::/64"},
+					"security_groups":  schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+				},
+			},
+			saves: []map[string]interface{}{
+				{
+					"from_port":        80,
+					"to_port":          8000,
+					"protocol":         "tcp",
+					"cidr_ipv6_blocks": []interface{}{"2001:0db8:85a3:0000::/64"},
+					"security_groups":  schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+				},
+			},
+		},
 	}
 	for i, c := range cases {
 		saves := tfec2.MatchRules("ingress", c.local, c.remote)


### PR DESCRIPTION
AWS reports IPv6 CIDRs in security groups using lower-case hexadecimal (matching the SHOULD recommendation
in RFC5952), but it is possible that the rule we're trying to match uses upper-case hexadecimal, leading to
a non-match.

Fix this problem by lower-casing the CIDR in the permission before matching.

See https://www.rfc-editor.org/rfc/rfc5952#section-4.3

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCSecurityGroupRule* PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroupRule*'  -timeout 180m
=== RUN   TestAccVPCSecurityGroupRule_Ingress_vpc
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_vpc
=== RUN   TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id
=== PAUSE TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id
=== RUN   TestAccVPCSecurityGroupRule_Ingress_protocol
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_protocol
=== RUN   TestAccVPCSecurityGroupRule_Ingress_icmpv6
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_icmpv6
=== RUN   TestAccVPCSecurityGroupRule_Ingress_ipv6
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_ipv6
=== RUN   TestAccVPCSecurityGroupRule_Ingress_classic
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_classic
=== RUN   TestAccVPCSecurityGroupRule_multiIngress
=== PAUSE TestAccVPCSecurityGroupRule_multiIngress
=== RUN   TestAccVPCSecurityGroupRule_egress
=== PAUSE TestAccVPCSecurityGroupRule_egress
=== RUN   TestAccVPCSecurityGroupRule_selfReference
=== PAUSE TestAccVPCSecurityGroupRule_selfReference
=== RUN   TestAccVPCSecurityGroupRule_expectInvalidTypeError
=== PAUSE TestAccVPCSecurityGroupRule_expectInvalidTypeError
=== RUN   TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== PAUSE TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== RUN   TestAccVPCSecurityGroupRule_PartialMatching_basic
=== PAUSE TestAccVPCSecurityGroupRule_PartialMatching_basic
=== RUN   TestAccVPCSecurityGroupRule_PartialMatching_source
=== PAUSE TestAccVPCSecurityGroupRule_PartialMatching_source
=== RUN   TestAccVPCSecurityGroupRule_issue5310
=== PAUSE TestAccVPCSecurityGroupRule_issue5310
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_selfSource
=== PAUSE TestAccVPCSecurityGroupRule_selfSource
=== RUN   TestAccVPCSecurityGroupRule_prefixListEgress
=== PAUSE TestAccVPCSecurityGroupRule_prefixListEgress
=== RUN   TestAccVPCSecurityGroupRule_ingressDescription
=== PAUSE TestAccVPCSecurityGroupRule_ingressDescription
=== RUN   TestAccVPCSecurityGroupRule_egressDescription
=== PAUSE TestAccVPCSecurityGroupRule_egressDescription
=== RUN   TestAccVPCSecurityGroupRule_IngressDescription_updates
=== PAUSE TestAccVPCSecurityGroupRule_IngressDescription_updates
=== RUN   TestAccVPCSecurityGroupRule_EgressDescription_updates
=== PAUSE TestAccVPCSecurityGroupRule_EgressDescription_updates
=== RUN   TestAccVPCSecurityGroupRule_Description_allPorts
=== PAUSE TestAccVPCSecurityGroupRule_Description_allPorts
=== RUN   TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== PAUSE TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== RUN   TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== PAUSE TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== RUN   TestAccVPCSecurityGroupRule_multiDescription
=== PAUSE TestAccVPCSecurityGroupRule_multiDescription
=== CONT  TestAccVPCSecurityGroupRule_Ingress_vpc
=== CONT  TestAccVPCSecurityGroupRule_issue5310
=== CONT  TestAccVPCSecurityGroupRule_EgressDescription_updates
=== CONT  TestAccVPCSecurityGroupRule_ingressDescription
=== CONT  TestAccVPCSecurityGroupRule_egress
=== CONT  TestAccVPCSecurityGroupRule_selfSource
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_multiDescription
=== CONT  TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== CONT  TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== CONT  TestAccVPCSecurityGroupRule_Description_allPorts
=== CONT  TestAccVPCSecurityGroupRule_prefixListEgress
=== CONT  TestAccVPCSecurityGroupRule_egressDescription
=== CONT  TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== CONT  TestAccVPCSecurityGroupRule_PartialMatching_source
=== CONT  TestAccVPCSecurityGroupRule_PartialMatching_basic
=== CONT  TestAccVPCSecurityGroupRule_Ingress_protocol
=== CONT  TestAccVPCSecurityGroupRule_multiIngress
=== CONT  TestAccVPCSecurityGroupRule_Ingress_ipv6
=== CONT  TestAccVPCSecurityGroupRule_IngressDescription_updates
=== CONT  TestAccVPCSecurityGroupRule_Ingress_icmpv6
--- PASS: TestAccVPCSecurityGroupRule_expectInvalidCIDR (5.53s)
=== CONT  TestAccVPCSecurityGroupRule_multiDescription
    vpc_security_group_rule_test.go:1121: Step 1/9 error: Error running apply: exit status 1
        
        Error: error creating EC2 VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: 43badc0d-ab79-4af7-a26a-96add27b4a37
        
          with aws_vpc.tf_sgrule_description_test,
          on terraform_plugin_test.tf line 2, in resource "aws_vpc" "tf_sgrule_description_test":
           2: resource "aws_vpc" "tf_sgrule_description_test" {
        
--- FAIL: TestAccVPCSecurityGroupRule_multiDescription (19.40s)
=== CONT  TestAccVPCSecurityGroupRule_Ingress_classic
--- PASS: TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash (47.93s)
=== CONT  TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id
--- PASS: TestAccVPCSecurityGroupRule_egressDescription (48.34s)
=== CONT  TestAccVPCSecurityGroupRule_selfReference
--- PASS: TestAccVPCSecurityGroupRule_Ingress_vpc (48.57s)
=== CONT  TestAccVPCSecurityGroupRule_expectInvalidTypeError
--- PASS: TestAccVPCSecurityGroupRule_expectInvalidTypeError (2.50s)
--- PASS: TestAccVPCSecurityGroupRule_issue5310 (53.04s)
--- PASS: TestAccVPCSecurityGroupRule_ingressDescription (55.46s)
--- PASS: TestAccVPCSecurityGroupRule_egress (55.65s)
--- PASS: TestAccVPCSecurityGroupRule_selfSource (56.56s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_protocol (56.56s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_ipv6 (56.70s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_icmpv6 (51.17s)
--- PASS: TestAccVPCSecurityGroupRule_multiIngress (57.05s)
--- PASS: TestAccVPCSecurityGroupRule_PartialMatching_source (59.84s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_classic (40.51s)
=== CONT  TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id
    vpc_security_group_rule_test.go:168: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating EC2 VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: 3a2d26a0-6dab-4e93-9fc0-02ab6ee8c071
        
          with aws_vpc.foo,
          on terraform_plugin_test.tf line 4, in resource "aws_vpc" "foo":
           4: resource "aws_vpc" "foo" {
        
--- FAIL: TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id (13.08s)
--- PASS: TestAccVPCSecurityGroupRule_prefixListEgress (66.47s)
--- PASS: TestAccVPCSecurityGroupRule_PartialMatching_basic (66.80s)
--- PASS: TestAccVPCSecurityGroupRule_Description_allPorts (71.08s)
--- PASS: TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts (71.68s)
--- PASS: TestAccVPCSecurityGroupRule_IngressDescription_updates (73.52s)
--- PASS: TestAccVPCSecurityGroupRule_EgressDescription_updates (74.03s)
--- PASS: TestAccVPCSecurityGroupRule_selfReference (37.06s)
--- PASS: TestAccVPCSecurityGroupRule_race (390.61s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	392.914s
FAIL
make: *** [testacc] Error 1
```
