### PR TITLE
Add Oversize_Handling to AWS WAF v2 Web ACL

### DIFF
--- a/.changelog/25589.txt
+++ b/.changelog/25589.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `oversize_handling` attribute as part of `byte_match_statement`.
+```

--- a/.changelog/25589.txt
+++ b/.changelog/25589.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_wafv2_web_acl: Add `oversize_handling` attribute as part of `byte_match_statement`.
+resource/aws_wafv2_web_acl: Add `oversize_handling` attribute as part of `field_to_match` its `body` attribute.
 ```

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -142,11 +142,6 @@ func byteMatchStatementSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"field_to_match": fieldToMatchSchema(),
-				"oversize_handling": {
-					Type:         schema.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
-				},
 				"positional_constraint": {
 					Type:     schema.TypeString,
 					Required: true,
@@ -338,9 +333,22 @@ func fieldToMatchBaseSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"all_query_arguments": emptySchema(),
-			"body":                emptySchema(),
-			"method":              emptySchema(),
-			"query_string":        emptySchema(),
+			"body": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"oversize_handling": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
+						},
+					},
+				},
+			},
+			"method":       emptySchema(),
+			"query_string": emptySchema(),
 			"single_header": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -156,7 +156,7 @@ func byteMatchStatementSchema() *schema.Schema {
 				"oversize_handling": {
 					Type:         schema.TypeString,
 					Required:     true,
-					ValidateFunc: validation.StringInSlice(wafv2.OversizeConstraintAction_Values(), false),
+					ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
 				},
 				"search_string": {
 					Type:         schema.TypeString,

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -142,6 +142,11 @@ func byteMatchStatementSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"field_to_match": fieldToMatchSchema(),
+				"oversize_handling": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
+				},
 				"positional_constraint": {
 					Type:     schema.TypeString,
 					Required: true,
@@ -152,11 +157,6 @@ func byteMatchStatementSchema() *schema.Schema {
 						wafv2.PositionalConstraintExactly,
 						wafv2.PositionalConstraintStartsWith,
 					}, false),
-				},
-				"oversize_handling": {
-					Type:         schema.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
 				},
 				"search_string": {
 					Type:         schema.TypeString,

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -153,6 +153,11 @@ func byteMatchStatementSchema() *schema.Schema {
 						wafv2.PositionalConstraintStartsWith,
 					}, false),
 				},
+				"oversize_handling": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.OversizeConstraintAction_Values(), false),
+				},
 				"search_string": {
 					Type:         schema.TypeString,
 					Required:     true,

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -404,6 +404,7 @@ The byte match statement provides the bytes to search for, the location in reque
 The `byte_match_statement` block supports the following arguments:
 
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
+* `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
 * `positional_constraint` - (Required) Area within the portion of a web request that you want AWS WAF to search for `search_string`. Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchStatement.html) for more information.
 * `search_string` - (Required) String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in `field_to_match`. The maximum length of the value is 50 bytes.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. See [Text Transformation](#text-transformation) below for details.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -404,7 +404,6 @@ The byte match statement provides the bytes to search for, the location in reque
 The `byte_match_statement` block supports the following arguments:
 
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
-* `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
 * `positional_constraint` - (Required) Area within the portion of a web request that you want AWS WAF to search for `search_string`. Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchStatement.html) for more information.
 * `search_string` - (Required) String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in `field_to_match`. The maximum length of the value is 50 bytes.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. See [Text Transformation](#text-transformation) below for details.
@@ -543,7 +542,7 @@ The `field_to_match` block supports the following arguments:
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
-* `body` - (Optional) Inspect the request body, which immediately follows the request headers.
+* `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [Body](#body) below for details.
 * `method` - (Optional) Inspect the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Inspect a single header. See [Single Header](#single-header) below for details.
@@ -570,6 +569,15 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 * `fallback_behavior` - (Required) - Match status to assign to the web request if the request doesn't have a valid IP address in the specified position. Valid values include: `MATCH` or `NO_MATCH`.
 * `header_name` - (Required) - Name of the HTTP header to use for the IP address.
 * `position` - (Required) - Position in the header to search for the IP address. Valid values include: `FIRST`, `LAST`, or `ANY`. If `ANY` is specified and the header contains more than 10 IP addresses, AWS WAFv2 inspects the last 10.
+
+
+### Body
+
+Inspect the body of the web request. The body immediately follows the request headers.
+
+The `body` block supports the following arguments:
+
+* `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
 
 ### Single Header
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25545

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
bruno@pop-os ~/G/terraform-provider-aws (enhancement/#25545-add-oversize-handling-to-wafv2-web-acl)> make testacc TESTS=TestAccWAFV2WebACL_ PKG=wafv2                                                                                        (base) 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_'  -timeout 180m
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
=== CONT  TestAccWAFV2WebACL_RuleLabels
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_RateBased_basic
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_basic (32.87s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (40.49s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_minimal (44.94s)
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (51.33s)
--- PASS: TestAccWAFV2WebACL_disappears (21.80s)
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (56.39s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (58.23s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (61.44s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (61.66s)
--- PASS: TestAccWAFV2WebACL_RuleLabels (63.78s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (63.99s)
--- PASS: TestAccWAFV2WebACL_RateBased_basic (66.80s)
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (69.81s)
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (74.75s)
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (81.59s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (86.50s)
--- PASS: TestAccWAFV2WebACL_tags (89.92s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (90.36s)
--- PASS: TestAccWAFV2WebACL_Update_rule (51.43s)
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (107.49s)
--- PASS: TestAccWAFV2WebACL_Custom_response (108.44s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (112.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      112.679s
```
