### PR TITLE
WIP adding image import

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1303,7 +1303,7 @@ func Provider() *schema.Provider {
 			"aws_ec2_client_vpn_route":                             ec2.ResourceClientVPNRoute(),
 			"aws_ec2_fleet":                                        ec2.ResourceFleet(),
 			"aws_ec2_host":                                         ec2.ResourceHost(),
-			"aws_ec2_image_import":                                 ec2.ResourceEC2ImageImport(),
+			"aws_ec2_image_import":                                 ec2.ResourceImageImport(),
 			"aws_ec2_local_gateway_route":                          ec2.ResourceLocalGatewayRoute(),
 			"aws_ec2_local_gateway_route_table_vpc_association":    ec2.ResourceLocalGatewayRouteTableVPCAssociation(),
 			"aws_ec2_managed_prefix_list":                          ec2.ResourceManagedPrefixList(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1303,6 +1303,7 @@ func Provider() *schema.Provider {
 			"aws_ec2_client_vpn_route":                             ec2.ResourceClientVPNRoute(),
 			"aws_ec2_fleet":                                        ec2.ResourceFleet(),
 			"aws_ec2_host":                                         ec2.ResourceHost(),
+			"aws_ec2_image_import":                                 ec2.ResourceEC2ImageImport(),
 			"aws_ec2_local_gateway_route":                          ec2.ResourceLocalGatewayRoute(),
 			"aws_ec2_local_gateway_route_table_vpc_association":    ec2.ResourceLocalGatewayRouteTableVPCAssociation(),
 			"aws_ec2_managed_prefix_list":                          ec2.ResourceManagedPrefixList(),

--- a/internal/service/ec2/consts.go
+++ b/internal/service/ec2/consts.go
@@ -56,6 +56,7 @@ const (
 )
 
 // See https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#check-import-task-status
+// TODO: Note: These may be mistakenly used for Snapshot image import. The only documented states are active and completed.
 const (
 	EBSSnapshotImportStateActive     = "active"
 	EBSSnapshotImportStateDeleting   = "deleting"
@@ -65,6 +66,18 @@ const (
 	EBSSnapshotImportStateValidated  = "validated"
 	EBSSnapshotImportStateConverting = "converting"
 	EBSSnapshotImportStateCompleted  = "completed"
+)
+
+// See https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#check-import-task-status
+const (
+	EC2ImageImportStateActive     = "active"
+	EC2ImageImportStateDeleting   = "deleting"
+	EC2ImageImportStateDeleted    = "deleted"
+	EC2ImageImportStateUpdating   = "updating"
+	EC2ImageImportStateValidating = "validating"
+	EC2ImageImportStateValidated  = "validated"
+	EC2ImageImportStateConverting = "converting"
+	EC2ImageImportStateCompleted  = "completed"
 )
 
 // See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html#API_CreateNetworkInterface_Example_2_Response.

--- a/internal/service/ec2/consts.go
+++ b/internal/service/ec2/consts.go
@@ -70,14 +70,14 @@ const (
 
 // See https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#check-import-task-status
 const (
-	EC2ImageImportStateActive     = "active"
-	EC2ImageImportStateDeleting   = "deleting"
-	EC2ImageImportStateDeleted    = "deleted"
-	EC2ImageImportStateUpdating   = "updating"
-	EC2ImageImportStateValidating = "validating"
-	EC2ImageImportStateValidated  = "validated"
-	EC2ImageImportStateConverting = "converting"
-	EC2ImageImportStateCompleted  = "completed"
+	ImageImportStateActive     = "active"
+	ImageImportStateDeleting   = "deleting"
+	ImageImportStateDeleted    = "deleted"
+	ImageImportStateUpdating   = "updating"
+	ImageImportStateValidating = "validating"
+	ImageImportStateValidated  = "validated"
+	ImageImportStateConverting = "converting"
+	ImageImportStateCompleted  = "completed"
 )
 
 // See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html#API_CreateNetworkInterface_Example_2_Response.

--- a/internal/service/ec2/ec2_image_import.go
+++ b/internal/service/ec2/ec2_image_import.go
@@ -17,10 +17,10 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-func ResourceEC2ImageImport() *schema.Resource {
+func ResourceImageImport() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceEC2ImageImportCreate,
-		Read:   resourceEC2ImageImportRead,
+		Create: resourceImageImportCreate,
+		Read:   resourceImageImportRead,
 		Update: resourceAMIUpdate,
 		Delete: resourceAMIDelete,
 
@@ -170,7 +170,7 @@ func ResourceEC2ImageImport() *schema.Resource {
 	}
 }
 
-func resourceEC2ImageImportCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceImageImportCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -227,7 +227,7 @@ func resourceEC2ImageImportCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	taskID := aws.StringValue(outputRaw.(*ec2.ImportImageOutput).ImportTaskId)
-	output, err := WaitEC2ImageImportComplete(conn, taskID, d.Timeout(schema.TimeoutCreate))
+	output, err := WaitImageImportComplete(conn, taskID, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return fmt.Errorf("waiting for EC2 Image Import (%s) create: %w", taskID, err)
@@ -241,10 +241,10 @@ func resourceEC2ImageImportCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	return resourceEC2ImageImportRead(d, meta)
+	return resourceImageImportRead(d, meta)
 }
 
-func resourceEC2ImageImportRead(d *schema.ResourceData, meta interface{}) error {
+func resourceImageImportRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig

--- a/internal/service/ec2/ec2_image_import_test.go
+++ b/internal/service/ec2/ec2_image_import_test.go
@@ -1,0 +1,440 @@
+package ec2_test
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+// Cannot run acceptance tests without a "real" image. Smallest image I could find was 385Mb
+// Instead run tests and catch the failed state
+func TestAccEC2ImageImport_badFileFormat(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ec2_image_import.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckAMIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageImportConfig_basic(t, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+				ExpectError: regexp.MustCompile(`create: unexpected state 'deleted', wanted target 'completed'. last error: ClientError: No valid partitions. Not a valid volume`),
+			},
+		},
+	})
+}
+
+func TestAccEC2ImageImport_disk_container_conflict(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ec2_image_import.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckAMIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageImportConfig_disk_container_conflict(t, rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+				ExpectError: regexp.MustCompile(`url and user_bucket cannot be set on the same disk container`),
+			},
+		},
+	})
+}
+
+func TestAccEC2ImageImport_boot_mode_bad_string(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ec2_image_import.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckAMIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageImportConfig_boot_mode_bad_string(t, rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+				ExpectError: regexp.MustCompile(`expected boot_mode to be one o`),
+			},
+		},
+	})
+}
+
+func TestAccEC2ImageImport_no_os(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ec2_image_import.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckAMIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageImportConfig_no_os(t, rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+				ExpectError: regexp.MustCompile(`create: unexpected state 'deleted', wanted target 'completed'. last error: ClientError: Unknown OS / Missing OS files`),
+			},
+		},
+	})
+}
+
+func TestAccEC2ImageImport_tags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ec2_image_import.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckAMIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageImportConfig_tags1(t, rName, "key1", "value1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+				ExpectError: regexp.MustCompile(`create: unexpected state 'deleted', wanted target 'completed'. last error: ClientError: No valid partitions. Not a valid volume`),
+			},
+			{
+				Config: testAccImageImportConfig_tags2(t, rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+				ExpectError: regexp.MustCompile(`create: unexpected state 'deleted', wanted target 'completed'. last error: ClientError: No valid partitions. Not a valid volume`),
+			},
+			{
+				Config: testAccImageImportConfig_tags1(t, rName, "key2", "value2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value3"),
+				),
+				ExpectError: regexp.MustCompile(`create: unexpected state 'deleted', wanted target 'completed'. last error: ClientError: No valid partitions. Not a valid volume`),
+			},
+		},
+	})
+}
+
+func testAccImageImportNonBucketConfig(t *testing.T) string {
+	return `
+
+# The following resources are for the *vmimport service user*
+# See: https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role
+resource "aws_iam_role" "test" {
+  assume_role_policy = data.aws_iam_policy_document.vmimport-trust.json
+}
+
+resource "aws_iam_role_policy" "test" {
+  role   = aws_iam_role.test.id
+  policy = data.aws_iam_policy_document.vmimport-access.json
+}
+
+data "aws_iam_policy_document" "vmimport-access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.test.arn,
+      "${aws_s3_bucket.test.arn}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:ModifySnapshotAttribute",
+      "ec2:CopySnapshot",
+      "ec2:RegisterImage",
+      "ec2:Describe*"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "vmimport-trust" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["vmie.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = ["vmimport"]
+    }
+  }
+}
+`
+}
+
+func testAccImageImportBaseConfig(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccImageImportNonBucketConfig(t), fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_object" "test" {
+  bucket         = aws_s3_bucket.test.id
+  key            = "diskimage.vhd"
+  content_base64 = %[2]q
+}
+`, rName, testAccImageDisk(t)))
+}
+
+func testAccImageImportBaseConfigNoOs(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccImageImportNonBucketConfig(t), fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_object" "test" {
+  bucket         = aws_s3_bucket.test.id
+  key            = "diskimage.vhd"
+  content_base64 = %[2]q
+}
+`, rName, testAccImageDiskNoOS(t)))
+}
+
+func testAccImageImportConfig_basic(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccImageImportBaseConfig(t, rName), `
+resource "aws_ec2_image_import" "test" {
+  disk_container {
+    description = "test"
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.test.id
+      s3_key    = aws_s3_object.test.key
+    }
+  }
+
+  role_name = aws_iam_role.test.name
+}
+`)
+}
+
+func testAccImageImportConfig_no_os(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccImageImportBaseConfigNoOs(t, rName), `
+resource "aws_ec2_image_import" "test" {
+  disk_container {
+    description = "test"
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.test.id
+      s3_key    = aws_s3_object.test.key
+    }
+  }
+
+  role_name = aws_iam_role.test.name
+}
+`)
+}
+
+func testAccImageImportConfig_disk_container_conflict(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccImageImportBaseConfig(t, rName), fmt.Sprintf(`
+resource "aws_ec2_image_import" "test" {
+  disk_container {
+    description = "test"
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.test.id
+      s3_key    = aws_s3_object.test.key
+    }
+	url = "url"
+  }
+
+  role_name    = aws_iam_role.test.name
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccImageImportConfig_boot_mode_bad_string(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccImageImportBaseConfig(t, rName), fmt.Sprintf(`
+resource "aws_ec2_image_import" "test" {
+  disk_container {
+    description = "test"
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.test.id
+      s3_key    = aws_s3_object.test.key
+    }
+  }
+
+  boot_mode = "not-uefi"
+
+  role_name    = aws_iam_role.test.name
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccImageImportConfig_tags1(t *testing.T, rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccImageImportBaseConfig(t, rName), fmt.Sprintf(`
+resource "aws_ec2_image_import" "test" {
+  disk_container {
+    description = "test"
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.test.id
+      s3_key    = aws_s3_object.test.key
+    }
+  }
+
+  role_name = aws_iam_role.test.name
+
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1))
+}
+
+func testAccImageImportConfig_tags2(t *testing.T, rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccImageImportBaseConfig(t, rName), fmt.Sprintf(`
+resource "aws_ec2_image_import" "test" {
+  disk_container {
+    description = "test"
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.test.id
+      s3_key    = aws_s3_object.test.key
+    }
+  }
+
+  role_name = aws_iam_role.test.name
+
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccImageDisk(t *testing.T) string {
+	// Take a compressed then base64'd disk image,
+	// base64 decode, then decompress, then re-base64
+	// the image, so it can be uploaded to s3.
+
+	// little vmdk built by:
+	// $ VBoxManage createmedium disk --filename ./image.vhd --sizebytes 512 --format vhd
+	// $ cat image.vhd | gzip --best | base64
+	b64_compressed := "H4sIAAAAAAACA0vOz0tNLsmsYGBgYGJgZIACJgZ1789hZUn5FQxsDIzhmUbZMHEEzSIIJJj///+QlV1rMXFVnLzHwteXYmWDDfYxjIIhA5IrigsSi4pT/0MBRJSNAZoWGBkUGBj+//9SNhpSo2AUDD+AyPOjYESW/6P1/4gGAAvDpVcACgAA"
+
+	// TODO: They only support certain linux flavors. And it checks for a full operating system.
+	// How can we import this? Pull from public bucket?
+	// Expect fail?
+	// little filesystem built by:
+	// $ sudo dd if=/dev/zero of=vhd.img bs=4k count=55
+	// $ sudo mkfs -t ext3 vhd.img
+	// $ qemu-img convert -f raw -O vpc vhd.img image.vhd
+	// $ cat image.vhd | gzip --best | base64
+	// b64_compressed := "H4sIAAAAAAACA+3cz0tUQRwA8Nm3u265gnrw0smzhQch6pQKXQJR1INea9toMTVTQwLBDkbXzp1Cow5hQoeELp78Q4LQi9TBwIu89u2uS4qnyNL184GZNzO8/fGGYZgvzLzC9FSxMFdaCCFEIRVqotA1OLI6U5ycD9mQHiv1TFSa0xuhfs1l2pNSHO8erG9vLWaHh5ZX9tdGDwbGewPnRmFh9vHdJ7PFuKba2hRqYyEVOkOI472negoaUiYGLiTTH1xc5eV9uFGJ+EK4Vk4d9QiwmsJSNXXW2t+/+nIviQhGv6cqIUK1HmrBQlW+9rGbte9Il9PDZ19f73we+vCxeS2//PPKy//xrLe/rb7L99/59PbWjxfX299sJv+35chz/X0pQwwAgDPkcH2eqaz/O8r1jE4BAACABhPnknzJRggAAABoZLlkNy8AAADQyA73ASTnXw/Tv9x/sNtfztpO+v10uPTbfVlbNTgFS8/L2WbfCeMvdWT8/YnmY3Vnwc+ezWT+6Ttp/onq7zxINJVTslUqGROXdRsAAOdUcv6/JaSi7no5irq7q+/w2mltjh5Nz85dfTA9P3VfXwEAAMB5lT8W/++1VuN/AAAAoMG06QIAAAAQ/wMAAADifwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOS2F6qliYKy2Ui1FIHbZGoWtwZHWmODkfsiE9VuqZqDSnN0L9msu0J6U43j1Y395azA4PLa/sr40eDIz36tXz4xf/D/tgAAwgAA=="
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64_compressed))
+	zr, err := gzip.NewReader(decoder)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	encoder := base64.NewEncoder(base64.StdEncoding, &out)
+
+	_, err = io.Copy(encoder, zr)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoder.Close()
+
+	return out.String()
+}
+
+func testAccImageDiskNoOS(t *testing.T) string {
+	// Take a compressed then base64'd disk image,
+	// base64 decode, then decompress, then re-base64
+	// the image, so it can be uploaded to s3.
+
+	// little vmdk built by:
+	// $ VBoxManage createmedium disk --filename ./image.vhd --sizebytes 512 --format vhd
+	// $ cat image.vhd | gzip --best | base64
+	// b64_compressed := "H4sIAAAAAAACA0vOz0tNLsmsYGBgYGJgZIACJgZ1789hZUn5FQxsDIzhmUbZMHEEzSIIJJj///+QlV1rMXFVnLzHwteXYmWDDfYxjIIhA5IrigsSi4pT/0MBRJSNAZoWGBkUGBj+//9SNhpSo2AUDD+AyPOjYESW/6P1/4gGAAvDpVcACgAA"
+
+	// TODO: They only support certain linux flavors. And it checks for a full operating system.
+	// How can we import this? Pull from public bucket?
+	// Expect fail?
+	// little filesystem built by:
+	// $ sudo dd if=/dev/zero of=vhd.img bs=4k count=55
+	// $ sudo mkfs -t ext3 vhd.img
+	// $ qemu-img convert -f raw -O vpc vhd.img image.vhd
+	// $ cat image.vhd | gzip --best | base64
+	b64_compressed := "H4sIAAAAAAACA+3cz0tUQRwA8Nm3u265gnrw0smzhQch6pQKXQJR1INea9toMTVTQwLBDkbXzp1Cow5hQoeELp78Q4LQi9TBwIu89u2uS4qnyNL184GZNzO8/fGGYZgvzLzC9FSxMFdaCCFEIRVqotA1OLI6U5ycD9mQHiv1TFSa0xuhfs1l2pNSHO8erG9vLWaHh5ZX9tdGDwbGewPnRmFh9vHdJ7PFuKba2hRqYyEVOkOI472negoaUiYGLiTTH1xc5eV9uFGJ+EK4Vk4d9QiwmsJSNXXW2t+/+nIviQhGv6cqIUK1HmrBQlW+9rGbte9Il9PDZ19f73we+vCxeS2//PPKy//xrLe/rb7L99/59PbWjxfX299sJv+35chz/X0pQwwAgDPkcH2eqaz/O8r1jE4BAACABhPnknzJRggAAABoZLlkNy8AAADQyA73ASTnXw/Tv9x/sNtfztpO+v10uPTbfVlbNTgFS8/L2WbfCeMvdWT8/YnmY3Vnwc+ezWT+6Ttp/onq7zxINJVTslUqGROXdRsAAOdUcv6/JaSi7no5irq7q+/w2mltjh5Nz85dfTA9P3VfXwEAAMB5lT8W/++1VuN/AAAAoMG06QIAAAAQ/wMAAADifwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOS2F6qliYKy2Ui1FIHbZGoWtwZHWmODkfsiE9VuqZqDSnN0L9msu0J6U43j1Y395azA4PLa/sr40eDIz36tXz4xf/D/tgAAwgAA=="
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64_compressed))
+	zr, err := gzip.NewReader(decoder)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	encoder := base64.NewEncoder(base64.StdEncoding, &out)
+
+	_, err = io.Copy(encoder, zr)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoder.Close()
+
+	return out.String()
+}

--- a/internal/service/ec2/ec2_image_import_test.go
+++ b/internal/service/ec2/ec2_image_import_test.go
@@ -17,7 +17,7 @@ import (
 
 // Cannot run acceptance tests without a "real" image. Smallest image I could find was 385Mb
 // Instead run tests and catch the failed state
-func TestAccEC2ImageImport_badFileFormat(t *testing.T) {
+func TestAccImageImport_badFileFormat(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -39,7 +39,7 @@ func TestAccEC2ImageImport_badFileFormat(t *testing.T) {
 	})
 }
 
-func TestAccEC2ImageImport_disk_container_conflict(t *testing.T) {
+func TestAccImageImport_disk_container_conflict(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -61,7 +61,7 @@ func TestAccEC2ImageImport_disk_container_conflict(t *testing.T) {
 	})
 }
 
-func TestAccEC2ImageImport_boot_mode_bad_string(t *testing.T) {
+func TestAccImageImport_boot_mode_bad_string(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -83,7 +83,7 @@ func TestAccEC2ImageImport_boot_mode_bad_string(t *testing.T) {
 	})
 }
 
-func TestAccEC2ImageImport_no_os(t *testing.T) {
+func TestAccImageImport_no_os(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -105,7 +105,7 @@ func TestAccEC2ImageImport_no_os(t *testing.T) {
 	})
 }
 
-func TestAccEC2ImageImport_tags(t *testing.T) {
+func TestAccImageImport_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 

--- a/internal/service/ec2/ec2_image_import_test.go
+++ b/internal/service/ec2/ec2_image_import_test.go
@@ -17,7 +17,7 @@ import (
 
 // Cannot run acceptance tests without a "real" image. Smallest image I could find was 385Mb
 // Instead run tests and catch the failed state
-func TestAccImageImport_badFileFormat(t *testing.T) {
+func TestAccEC2ImageImport_badFileFormat(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -39,7 +39,7 @@ func TestAccImageImport_badFileFormat(t *testing.T) {
 	})
 }
 
-func TestAccImageImport_disk_container_conflict(t *testing.T) {
+func TestAccEC2ImageImport_disk_container_conflict(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -61,7 +61,7 @@ func TestAccImageImport_disk_container_conflict(t *testing.T) {
 	})
 }
 
-func TestAccImageImport_boot_mode_bad_string(t *testing.T) {
+func TestAccEC2ImageImport_boot_mode_bad_string(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -83,7 +83,7 @@ func TestAccImageImport_boot_mode_bad_string(t *testing.T) {
 	})
 }
 
-func TestAccImageImport_no_os(t *testing.T) {
+func TestAccEC2ImageImport_no_os(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -105,7 +105,7 @@ func TestAccImageImport_no_os(t *testing.T) {
 	})
 }
 
-func TestAccImageImport_tags(t *testing.T) {
+func TestAccEC2ImageImport_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_image_import.test"
 
@@ -281,10 +281,10 @@ resource "aws_ec2_image_import" "test" {
       s3_bucket = aws_s3_bucket.test.id
       s3_key    = aws_s3_object.test.key
     }
-	url = "url"
+    url = "url"
   }
 
-  role_name    = aws_iam_role.test.name
+  role_name = aws_iam_role.test.name
 
   tags = {
     Name = %[1]q
@@ -307,7 +307,7 @@ resource "aws_ec2_image_import" "test" {
 
   boot_mode = "not-uefi"
 
-  role_name    = aws_iam_role.test.name
+  role_name = aws_iam_role.test.name
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/flex.go
+++ b/internal/service/ec2/flex.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -179,4 +180,54 @@ func FlattenSecurityGroups(list []*ec2.UserIdGroupPair, ownerId *string) []*Grou
 		}
 	}
 	return result
+}
+
+// Expands a user bucket map used by image and snapshot import
+func ExpandUserBucket(tfMap map[string]interface{}) *ec2.UserBucket {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &ec2.UserBucket{}
+
+	if v, ok := tfMap["s3_bucket"].(string); ok && v != "" {
+		apiObject.S3Bucket = aws.String(v)
+	}
+
+	if v, ok := tfMap["s3_key"].(string); ok && v != "" {
+		apiObject.S3Key = aws.String(v)
+	}
+
+	return apiObject
+}
+
+// Expands Client data map used by image and snapshot import
+func ExpandClientData(tfMap map[string]interface{}) *ec2.ClientData {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &ec2.ClientData{}
+
+	if v, ok := tfMap["comment"].(string); ok && v != "" {
+		apiObject.Comment = aws.String(v)
+	}
+
+	if v, ok := tfMap["upload_end"].(string); ok && v != "" {
+		v, _ := time.Parse(time.RFC3339, v)
+
+		apiObject.UploadEnd = aws.Time(v)
+	}
+
+	if v, ok := tfMap["upload_size"].(float64); ok && v != 0.0 {
+		apiObject.UploadSize = aws.Float64(v)
+	}
+
+	if v, ok := tfMap["upload_start"].(string); ok {
+		v, _ := time.Parse(time.RFC3339, v)
+
+		apiObject.UploadStart = aws.Time(v)
+	}
+
+	return apiObject
 }

--- a/internal/service/ec2/flex_test.go
+++ b/internal/service/ec2/flex_test.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -432,4 +433,81 @@ func TestFlattenSecurityGroups(t *testing.T) {
 			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
 		}
 	}
+}
+
+func TestExpandUserBucket(t *testing.T) {
+	expanded := map[string]interface{}{
+		"s3_bucket": "bucket",
+		"s3_key":    "key",
+	}
+
+	bucket := ExpandUserBucket(expanded)
+
+	expected := &ec2.UserBucket{
+		S3Bucket: aws.String("bucket"),
+		S3Key:    aws.String("key"),
+	}
+
+	if aws.StringValue(expected.S3Bucket) != aws.StringValue(bucket.S3Bucket) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			aws.StringValue(bucket.S3Bucket),
+			aws.StringValue(expected.S3Bucket))
+	}
+
+	if aws.StringValue(expected.S3Key) != aws.StringValue(bucket.S3Key) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			aws.StringValue(bucket.S3Key),
+			aws.StringValue(expected.S3Key))
+	}
+}
+
+func TestExpandClientData(t *testing.T) {
+	expanded := map[string]interface{}{
+		"comment":      "bucket",
+		"upload_end":   "2018-05-13T07:44:12Z",
+		"upload_start": "2018-05-13T07:44:12Z",
+		"upload_size":  123,
+	}
+
+	data := ExpandClientData(expanded)
+
+	ti, _ := time.Parse(time.RFC3339, "2018-05-13T07:44:12Z")
+
+	expected := &ec2.ClientData{
+		Comment:     aws.String("bucket"),
+		UploadEnd:   aws.Time(ti),
+		UploadSize:  aws.Float64(123),
+		UploadStart: aws.Time(ti),
+	}
+
+	if aws.StringValue(expected.Comment) != aws.StringValue(data.Comment) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			aws.StringValue(data.Comment),
+			aws.StringValue(expected.Comment))
+	}
+
+	if aws.TimeValue(expected.UploadEnd) != aws.TimeValue(data.UploadEnd) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			aws.TimeValue(data.UploadEnd),
+			aws.TimeValue(expected.UploadEnd))
+	}
+
+	if aws.Float64Value(expected.UploadSize) != aws.Float64Value(data.UploadSize) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			aws.Float64Value(data.UploadSize),
+			aws.Float64Value(expected.UploadSize))
+	}
+
+	if aws.TimeValue(expected.UploadStart) != aws.TimeValue(data.UploadStart) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			aws.TimeValue(data.UploadStart),
+			aws.TimeValue(expected.UploadStart))
+	}
+
 }

--- a/internal/service/ec2/flex_test.go
+++ b/internal/service/ec2/flex_test.go
@@ -489,7 +489,7 @@ func TestExpandClientData(t *testing.T) {
 			aws.StringValue(expected.Comment))
 	}
 
-	if aws.TimeValue(expected.UploadEnd) != aws.TimeValue(data.UploadEnd) {
+	if !aws.TimeValue(expected.UploadEnd).Equal(aws.TimeValue(data.UploadEnd)) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
 			aws.TimeValue(data.UploadEnd),
@@ -503,7 +503,7 @@ func TestExpandClientData(t *testing.T) {
 			aws.Float64Value(expected.UploadSize))
 	}
 
-	if aws.TimeValue(expected.UploadStart) != aws.TimeValue(data.UploadStart) {
+	if !aws.TimeValue(expected.UploadStart).Equal(aws.TimeValue(data.UploadStart)) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
 			aws.TimeValue(data.UploadStart),

--- a/internal/service/ec2/flex_test.go
+++ b/internal/service/ec2/flex_test.go
@@ -468,7 +468,7 @@ func TestExpandClientData(t *testing.T) {
 		"comment":      "bucket",
 		"upload_end":   "2018-05-13T07:44:12Z",
 		"upload_start": "2018-05-13T07:44:12Z",
-		"upload_size":  123,
+		"upload_size":  123.123,
 	}
 
 	data := ExpandClientData(expanded)
@@ -478,7 +478,7 @@ func TestExpandClientData(t *testing.T) {
 	expected := &ec2.ClientData{
 		Comment:     aws.String("bucket"),
 		UploadEnd:   aws.Time(ti),
-		UploadSize:  aws.Float64(123),
+		UploadSize:  aws.Float64(123.123),
 		UploadStart: aws.Time(ti),
 	}
 

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1205,3 +1205,19 @@ func StatusSnapshotStorageTier(conn *ec2.EC2, id string) resource.StateRefreshFu
 		return output, aws.StringValue(output.StorageTier), nil
 	}
 }
+
+func StatusEC2ImageImport(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindImportImageTaskByID(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1206,7 +1206,7 @@ func StatusSnapshotStorageTier(conn *ec2.EC2, id string) resource.StateRefreshFu
 	}
 }
 
-func StatusEC2ImageImport(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+func StatusImageImport(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindImportImageTaskByID(conn, id)
 

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2373,17 +2373,17 @@ func WaitEBSSnapshotImportComplete(conn *ec2.EC2, importTaskID string, timeout t
 	return nil, err
 }
 
-func WaitEC2ImageImportComplete(conn *ec2.EC2, importTaskID string, timeout time.Duration) (*ec2.ImportImageTask, error) {
+func WaitImageImportComplete(conn *ec2.EC2, importTaskID string, timeout time.Duration) (*ec2.ImportImageTask, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
-			EC2ImageImportStateActive,
-			EC2ImageImportStateUpdating,
-			EC2ImageImportStateValidating,
-			EC2ImageImportStateValidated,
-			EC2ImageImportStateConverting,
+			ImageImportStateActive,
+			ImageImportStateUpdating,
+			ImageImportStateValidating,
+			ImageImportStateValidated,
+			ImageImportStateConverting,
 		},
-		Target:  []string{EC2ImageImportStateCompleted},
-		Refresh: StatusEC2ImageImport(conn, importTaskID),
+		Target:  []string{ImageImportStateCompleted},
+		Refresh: StatusImageImport(conn, importTaskID),
 		Timeout: timeout,
 		Delay:   10 * time.Second,
 	}


### PR DESCRIPTION
Signed-off-by: Aidan Jensen <aidan@artificial.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEc2ImageImport PKG=ec2

=== RUN   TestAccEC2ImageImport_badFileFormat
=== PAUSE TestAccEC2ImageImport_badFileFormat
=== RUN   TestAccEC2ImageImport_disk_container_conflict
=== PAUSE TestAccEC2ImageImport_disk_container_conflict
=== RUN   TestAccEC2ImageImport_boot_mode_bad_string
=== PAUSE TestAccEC2ImageImport_boot_mode_bad_string
=== RUN   TestAccEC2ImageImport_no_os
=== PAUSE TestAccEC2ImageImport_no_os
=== RUN   TestAccEC2ImageImport_tags
=== PAUSE TestAccEC2ImageImport_tags
=== CONT  TestAccEC2ImageImport_badFileFormat
=== CONT  TestAccEC2ImageImport_no_os
=== CONT  TestAccEC2ImageImport_boot_mode_bad_string
=== CONT  TestAccEC2ImageImport_tags
=== CONT  TestAccEC2ImageImport_disk_container_conflict
--- PASS: TestAccEC2ImageImport_boot_mode_bad_string (1.87s)
--- PASS: TestAccEC2ImageImport_disk_container_conflict (8.99s)
--- PASS: TestAccEC2ImageImport_no_os (157.57s)
--- PASS: TestAccEC2ImageImport_badFileFormat (162.28s)
--- PASS: TestAccEC2ImageImport_tags (402.64s)
PASS
...
```

Opening this as a draft pull request for some input if possible.

[import-image](https://docs.aws.amazon.com/cli/latest/reference/ec2/import-image.html) is similar to [snapshot-import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_snapshot_import) with some slight differences. I re-implemented a number of functions and tested it the best that I could with 1 big caveat.

Image Import requires a valid OS that can be used as an EC2 instance. The smallest image I could find was ~350Mb, which does not work well for acceptance testing. I wrote acceptance tests that check for errors, and am able to test the process, but I cannot test certain aspects of it (final tags, etc).

Is the current state of testing acceptable to be a non-draft PR? Or does anyone have suggestions for how to test this a different way.