### PR TITLE
r/aws_api_gateway_model: remove schema length validation

### DIFF
--- a/.changelog/25623.txt
+++ b/.changelog/25623.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_model: Remove length validation from schema
+```

--- a/internal/service/apigateway/model.go
+++ b/internal/service/apigateway/model.go
@@ -68,12 +68,9 @@ func ResourceModel() *schema.Resource {
 			},
 
 			"schema": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 32768),
-					validation.StringIsJSON,
-				),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Fixes an issue with [25623](https://github.com/hashicorp/terraform-provider-aws/pull/25623) where the length constraint from `apigatewayv2` was incorrectly copied across to `apigateway`. This change removes the `StringLenBetween` validation entirely.