### PR TITLE
Increase SageMaker `ProjectCreatedTimeout` and `ProjectDeletedTimeout` to 15 minutes

### DIFF
--- a/.changelog/25638.txt
+++ b/.changelog/25638.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_project: Increase SageMaker Project create and delete timeout to 15 minutes
+```

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -30,8 +30,8 @@ const (
 	AppDeletedTimeout                 = 10 * time.Minute
 	FlowDefinitionActiveTimeout       = 2 * time.Minute
 	FlowDefinitionDeletedTimeout      = 2 * time.Minute
-	ProjectCreatedTimeout             = 2 * time.Minute
-	ProjectDeletedTimeout             = 5 * time.Minute
+	ProjectCreatedTimeout             = 15 * time.Minute
+	ProjectDeletedTimeout             = 15 * time.Minute
 )
 
 // WaitNotebookInstanceInService waits for a NotebookInstance to return InService


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25637

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
bruno@pop-os ~/G/terraform-provider-aws (e/#25637-increase-sagemaker-project-timeouts)> make testacc TESTS=TestAccSageMakerProject_ PKG=sagemaker                                                                                            (base) 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerProject_'  -timeout 180m
=== RUN   TestAccSageMakerProject_basic
=== PAUSE TestAccSageMakerProject_basic
=== RUN   TestAccSageMakerProject_description
=== PAUSE TestAccSageMakerProject_description
=== RUN   TestAccSageMakerProject_tags
=== PAUSE TestAccSageMakerProject_tags
=== RUN   TestAccSageMakerProject_disappears
=== PAUSE TestAccSageMakerProject_disappears
=== CONT  TestAccSageMakerProject_basic
=== CONT  TestAccSageMakerProject_disappears
=== CONT  TestAccSageMakerProject_description
=== CONT  TestAccSageMakerProject_tags
--- PASS: TestAccSageMakerProject_disappears (155.77s)
--- PASS: TestAccSageMakerProject_basic (196.02s)
--- PASS: TestAccSageMakerProject_tags (288.13s)
--- PASS: TestAccSageMakerProject_description (291.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  291.577s
```
