### PR TITLE
d/aws_location_tracker - new data source

### DIFF
--- a/.changelog/25639.txt
+++ b/.changelog/25639.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_location_tracker
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -745,6 +745,7 @@ func Provider() *schema.Provider {
 
 			"aws_location_map":         location.DataSourceMap(),
 			"aws_location_place_index": location.DataSourcePlaceIndex(),
+			"aws_location_tracker":     location.DataSourceTracker(),
 
 			"aws_arn":                     meta.DataSourceARN(),
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),

--- a/internal/service/location/tracker_data_source.go
+++ b/internal/service/location/tracker_data_source.go
@@ -14,6 +14,7 @@ import (
 
 func DataSourceTracker() *schema.Resource {
 	return &schema.Resource{
+		Read: dataSourceTrackerRead,
 		Schema: map[string]*schema.Schema{
 			"create_time": {
 				Type:     schema.TypeString,

--- a/internal/service/location/tracker_data_source.go
+++ b/internal/service/location/tracker_data_source.go
@@ -1,0 +1,80 @@
+package location
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceTracker() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"position_filtering": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"tracker_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tracker_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTrackerRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	input := &locationservice.DescribeTrackerInput{
+		TrackerName: aws.String(d.Get("tracker_name").(string)),
+	}
+
+	output, err := conn.DescribeTracker(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Location Service Tracker: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Location Service Tracker: empty response")
+	}
+
+	d.SetId(aws.StringValue(output.TrackerName))
+	d.Set("create_time", aws.TimeValue(output.CreateTime).Format(time.RFC3339))
+	d.Set("description", output.Description)
+	d.Set("kms_key_id", output.KmsKeyId)
+	d.Set("position_filtering", output.PositionFiltering)
+	d.Set("tags", KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(meta.(*conns.AWSClient).IgnoreTagsConfig).Map())
+	d.Set("tracker_arn", output.TrackerArn)
+	d.Set("tracker_name", output.TrackerName)
+	d.Set("update_time", aws.TimeValue(output.UpdateTime).Format(time.RFC3339))
+
+	return nil
+}

--- a/internal/service/location/tracker_data_source_test.go
+++ b/internal/service/location/tracker_data_source_test.go
@@ -1,0 +1,51 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationTrackerDataSource_indexName(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_tracker.test"
+	resourceName := "aws_location_tracker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrackerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerDataSourceConfig_indexName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_time", resourceName, "create_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "position_filtering", resourceName, "position_filtering"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tracker_arn", resourceName, "tracker_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tracker_name", resourceName, "tracker_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "update_time", resourceName, "update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTrackerDataSourceConfig_indexName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_tracker" "test" {
+  tracker_name = %[1]q
+}
+
+data "aws_location_tracker" "test" {
+  tracker_name = aws_location_tracker.test.tracker_name
+}
+`, rName)
+}

--- a/website/docs/d/location_map.html.markdown
+++ b/website/docs/d/location_map.html.markdown
@@ -30,4 +30,4 @@ data "aws_location_map" "example" {
 * `description` - The optional description for the map resource.
 * `map_arn` - The Amazon Resource Name (ARN) for the map resource.
 * `tags` - Key-value map of resource tags for the map.
-* `update_time` - The timestamp for when the map resource was last updated in ISO 8601.
+* `update_time` - The timestamp for when the map resource was last updated in ISO 8601 format.

--- a/website/docs/d/location_place_index.html.markdown
+++ b/website/docs/d/location_place_index.html.markdown
@@ -30,4 +30,4 @@ data "aws_location_place_index" "example" {
 * `description` - The optional description for the place index resource.
 * `index_arn` - The Amazon Resource Name (ARN) for the place index resource.
 * `tags` - Key-value map of resource tags for the map.
-* `update_time` - The timestamp for when the place index resource was last update in ISO 8601.
+* `update_time` - The timestamp for when the place index resource was last updated in ISO 8601 format.

--- a/website/docs/d/location_place_index.html.markdown
+++ b/website/docs/d/location_place_index.html.markdown
@@ -29,5 +29,5 @@ data "aws_location_place_index" "example" {
 * `data_source_configuration` - List of configurations that specify data storage option for requesting Places.
 * `description` - The optional description for the place index resource.
 * `index_arn` - The Amazon Resource Name (ARN) for the place index resource.
-* `tags` - Key-value map of resource tags for the map.
+* `tags` - Key-value map of resource tags for the place index.
 * `update_time` - The timestamp for when the place index resource was last updated in ISO 8601 format.

--- a/website/docs/d/location_tracker.html.markdown
+++ b/website/docs/d/location_tracker.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_tracker"
+description: |-
+    Retrieve information about a Location Service Tracker.
+---
+
+# Data Source: aws_location_tracker
+
+Retrieve information about a Location Service Tracker.
+
+## Example Usage
+
+```terraform
+data "aws_location_tracker" "example" {
+  tracker_name = "example"
+}
+```
+
+## Argument Reference
+
+* `tracker_name` - (Required) The name of the tracker resource.
+
+## Attribute Reference
+
+* `create_time` - The timestamp for when the tracker resource was created in ISO 8601 format.
+* `description` - The optional description for the tracker resource.
+* `kms_key_id` - A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
+* `position_filtering` - The position filtering method of the tracker resource.
+* `tags` - Key-value map of resource tags for the map.
+* `tracker_arn` - The Amazon Resource Name (ARN) for the tracker resource. Used when you need to specify a resource across all AWS.
+* `update_time` - The timestamp for when the tracker resource was last updated in ISO 8601 format.

--- a/website/docs/r/location_map.html.markdown
+++ b/website/docs/r/location_map.html.markdown
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 * `create_time` - The timestamp for when the map resource was created in ISO 8601 format.
 * `map_arn` - The Amazon Resource Name (ARN) for the map resource. Used to specify a resource across all AWS.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
-* `update_time` - The timestamp for when the map resource was last updated in ISO 8601.
+* `update_time` - The timestamp for when the map resource was last updated in ISO 8601 format.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationTrackerDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationTrackerDataSource_'  -timeout 180m
=== RUN   TestAccLocationTrackerDataSource_indexName
=== PAUSE TestAccLocationTrackerDataSource_indexName
=== CONT  TestAccLocationTrackerDataSource_indexName
--- PASS: TestAccLocationTrackerDataSource_indexName (35.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   37.347s
```
