### PR TITLE
resource/aws_ecs_service: Add customizable timeouts for Create and Update

### DIFF
--- a/.changelog/25641.txt
+++ b/.changelog/25641.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_ecs_service: Fix error where tags are sometimes not retrieved.
+```
+
+```release-note:bug
+resource/aws_ecs_service: Fix "unexpected new value" errors on creation.
+```
+
+```release-note:enhancement
+resource/aws_ecs_service: Add configurable timeouts for Create and Delete.
+```

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -135,6 +135,7 @@ func (e *expectActiveError) Error() string {
 
 func FindServiceByIDWaitForActive(ctx context.Context, conn *ecs.ECS, id, cluster string) (*ecs.Service, error) {
 	var service *ecs.Service
+	// Use the resource.Retry function instead of WaitForState() because we don't want the timeout error, if any
 	err := resource.Retry(serviceDescribeTimeout, func() *resource.RetryError {
 		var err error
 		service, err = FindServiceByID(ctx, conn, id, cluster)

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -97,4 +98,104 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	}
 
 	return output.Clusters[0], nil
+}
+
+func FindServiceByID(ctx context.Context, conn *ecs.ECS, id, cluster string) (*ecs.Service, error) {
+	input := &ecs.DescribeServicesInput{
+		Cluster:  aws.String(cluster),
+		Include:  aws.StringSlice([]string{ecs.ServiceFieldTags}),
+		Services: aws.StringSlice([]string{id}),
+	}
+
+	return FindService(ctx, conn, input)
+}
+
+func FindServiceNoTagsByID(ctx context.Context, conn *ecs.ECS, id, cluster string) (*ecs.Service, error) {
+	input := &ecs.DescribeServicesInput{
+		Cluster:  aws.String(cluster),
+		Services: aws.StringSlice([]string{id}),
+	}
+
+	return FindService(ctx, conn, input)
+}
+
+type expectActiveError struct {
+	status string
+}
+
+func newExpectActiveError(status string) *expectActiveError {
+	return &expectActiveError{
+		status: status,
+	}
+}
+
+func (e *expectActiveError) Error() string {
+	return fmt.Sprintf("expected status %[1]q, was %[2]q", serviceStatusActive, e.status)
+}
+
+func FindServiceByIDWaitForActive(ctx context.Context, conn *ecs.ECS, id, cluster string) (*ecs.Service, error) {
+	var service *ecs.Service
+	err := resource.Retry(serviceDescribeTimeout, func() *resource.RetryError {
+		var err error
+		service, err = FindServiceByID(ctx, conn, id, cluster)
+		if tfresource.NotFound(err) {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if status := aws.StringValue(service.Status); status != serviceStatusActive {
+			return resource.RetryableError(newExpectActiveError(status))
+		}
+
+		return nil
+	})
+	if tfresource.TimedOut(err) {
+		service, err = FindServiceByID(ctx, conn, id, cluster)
+	}
+
+	return service, err
+}
+
+func FindService(ctx context.Context, conn *ecs.ECS, input *ecs.DescribeServicesInput) (*ecs.Service, error) {
+	output, err := conn.DescribeServices(input)
+
+	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) && input.Include != nil {
+		id := aws.StringValueSlice(input.Services)[0]
+		log.Printf("[WARN] failed describing ECS Service (%s) with tags: %s; retrying without tags", id, err)
+
+		input.Include = nil
+		output, err = conn.DescribeServices(input)
+	}
+
+	// As of AWS SDK for Go v1.44.42, DescribeServices does not return the error code ecs.ErrCodeServiceNotFoundException
+	// Keep this here in case it ever does
+	if tfawserr.ErrCodeEquals(err, ecs.ErrCodeServiceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// When an ECS Service is not found by DescribeServices(), it will return a Failure struct with Reason = "MISSING"
+	for _, v := range output.Failures {
+		if aws.StringValue(v.Reason) == "MISSING" {
+			return nil, &resource.NotFoundError{
+				LastRequest: input,
+			}
+		}
+	}
+
+	if len(output.Services) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+	if n := len(output.Services); n > 1 {
+		return nil, tfresource.NewTooManyResultsError(n, input)
+	}
+
+	return output.Services[0], nil
 }

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -532,14 +532,14 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
-		log.Printf("[WARN] ECS tagging failed creating Service (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
+		log.Printf("[WARN] failed creating ECS Service (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
 		output, err = retryServiceCreate(conn, input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed creating ECS service (%s): %w", d.Get("name").(string), err)
+		return fmt.Errorf("error creating ECS service (%s): %w", d.Get("name").(string), err)
 	}
 
 	if output == nil || output.Service == nil {
@@ -567,7 +567,7 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
-			log.Printf("[WARN] ECS tagging failed adding tags after create for Service (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for ECS Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}
 
@@ -595,14 +595,14 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
-		log.Printf("[WARN] ECS tagging failed describing Service (%s) with tags: %s; retrying without tags", d.Id(), err)
+		log.Printf("[WARN] failed describing ECS Service (%s) with tags: %s; retrying without tags", d.Id(), err)
 
 		input.Include = nil
 		output, err = conn.DescribeServices(&input)
 	}
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ecs.ErrCodeServiceNotFoundException) {
-		log.Printf("[WARN] ECS service (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] ECS Service (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -626,7 +626,7 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 		if d.IsNewResource() {
 			return fmt.Errorf("ECS service not created: %q", d.Id())
 		}
-		log.Printf("[WARN] Removing ECS service %s (%s) because it's gone", d.Get("name").(string), d.Id())
+		log.Printf("[WARN] ECS Service (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -1130,12 +1130,12 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
-			log.Printf("[WARN] ECS tagging failed updating tags for Service (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed updating tags for ECS Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failed updating tags for Service (%s): %w", d.Id(), err)
+			return fmt.Errorf("failed updating tags for ECS Service (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -37,6 +37,8 @@ func ResourceService() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
@@ -553,11 +555,11 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	cluster := d.Get("cluster").(string)
 
 	if d.Get("wait_for_steady_state").(bool) {
-		if err := waitServiceStable(conn, d.Id(), cluster); err != nil {
+		if _, err := waitServiceStable(conn, d.Id(), cluster, d.Timeout(schema.TimeoutCreate)); err != nil {
 			return fmt.Errorf("error waiting for ECS service (%s) to reach steady state after creation: %w", d.Id(), err)
 		}
 	} else {
-		if _, err := waitServiceActive(conn, d.Id(), cluster); err != nil {
+		if _, err := waitServiceActive(conn, d.Id(), cluster, d.Timeout(schema.TimeoutCreate)); err != nil {
 			return fmt.Errorf("error waiting for ECS service (%s) to become active after creation: %w", d.Id(), err)
 		}
 	}
@@ -1083,11 +1085,11 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		cluster := d.Get("cluster").(string)
 		if d.Get("wait_for_steady_state").(bool) {
-			if err := waitServiceStable(conn, d.Id(), cluster); err != nil {
+			if _, err := waitServiceStable(conn, d.Id(), cluster, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return fmt.Errorf("error waiting for ECS service (%s) to reach steady state after update: %w", d.Id(), err)
 			}
 		} else {
-			if _, err := waitServiceActive(conn, d.Id(), cluster); err != nil {
+			if _, err := waitServiceActive(conn, d.Id(), cluster, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return fmt.Errorf("error waiting for ECS service (%s) to become active after update: %w", d.Id(), err)
 			}
 		}

--- a/internal/service/ecs/status.go
+++ b/internal/service/ecs/status.go
@@ -2,11 +2,9 @@ package ecs
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -16,9 +14,6 @@ const (
 	serviceStatusInactive = "INACTIVE"
 	serviceStatusActive   = "ACTIVE"
 	serviceStatusDraining = "DRAINING"
-
-	serviceStatusError = "ERROR"
-	serviceStatusNone  = "NONE"
 
 	clusterStatusError = "ERROR"
 	clusterStatusNone  = "NONE"
@@ -60,29 +55,15 @@ func statusCapacityProviderUpdate(conn *ecs.ECS, arn string) resource.StateRefre
 	}
 }
 
-func statusService(conn *ecs.ECS, id, cluster string) resource.StateRefreshFunc {
+func statusServiceNoTags(conn *ecs.ECS, id, cluster string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &ecs.DescribeServicesInput{
-			Services: aws.StringSlice([]string{id}),
-			Cluster:  aws.String(cluster),
+
+		service, err := FindServiceNoTagsByID(context.TODO(), conn, id, cluster)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
-		output, err := conn.DescribeServices(input)
-
-		if tfawserr.ErrCodeEquals(err, ecs.ErrCodeServiceNotFoundException) {
-			return nil, serviceStatusNone, nil
-		}
-
-		if err != nil {
-			return nil, serviceStatusError, err
-		}
-
-		if len(output.Services) == 0 {
-			return nil, serviceStatusNone, nil
-		}
-
-		log.Printf("[DEBUG] ECS service (%s) is currently %q", id, *output.Services[0].Status)
-		return output, aws.StringValue(output.Services[0].Status), err
+		return service, aws.StringValue(service.Status), err
 	}
 }
 

--- a/internal/service/ecs/wait.go
+++ b/internal/service/ecs/wait.go
@@ -112,8 +112,8 @@ func waitServiceInactive(conn *ecs.ECS, id, cluster string) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{serviceStatusActive, serviceStatusDraining},
-		Target:     []string{serviceStatusInactive, serviceStatusNone},
-		Refresh:    statusService(conn, id, cluster),
+		Target:     []string{serviceStatusInactive},
+		Refresh:    statusServiceNoTags(conn, id, cluster),
 		Timeout:    serviceInactiveTimeout,
 		MinTimeout: serviceInactiveTimeoutMin,
 	}
@@ -127,17 +127,17 @@ func waitServiceInactive(conn *ecs.ECS, id, cluster string) error {
 	return nil
 }
 
-func waitServiceDescribeReady(conn *ecs.ECS, id, cluster string) (*ecs.DescribeServicesOutput, error) {
+func waitServiceActive(conn *ecs.ECS, id, cluster string) (*ecs.Service, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{serviceStatusInactive, serviceStatusDraining, serviceStatusNone},
+		Pending: []string{serviceStatusInactive, serviceStatusDraining},
 		Target:  []string{serviceStatusActive},
-		Refresh: statusService(conn, id, cluster),
+		Refresh: statusServiceNoTags(conn, id, cluster),
 		Timeout: serviceDescribeTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*ecs.DescribeServicesOutput); ok {
+	if v, ok := outputRaw.(*ecs.Service); ok {
 		return v, err
 	}
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -203,6 +203,8 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_ecs_service` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
 
+- `create` - (Default `20 minutes`)
+- `update` - (Default `20 minutes`)
 - `delete` - (Default `20 minutes`)
 
 ## Import


### PR DESCRIPTION
Adds customizable timeouts for Create and Update operations on `aws_ecs_service`. In some cases, when `wait_for_steady_state` is set, deployment takes longer than the default timeout. Allow practitioners to adjust the timeout and extend the default to 20 minutes.

Also fixes various error handling problems that cause "unexpected new value" errors. 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16012
Closes #24565
Closes #24018
Closes #16184
Closes #17118
Closes #18329

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ecs TESTS=TestAccECSService_

--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (98.31s)
--- PASS: TestAccECSService_DeploymentValues_basic (108.75s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (125.64s)
--- PASS: TestAccECSService_iamRole (130.64s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (130.70s)
--- PASS: TestAccECSService_DeploymentControllerType_external (132.98s)
--- PASS: TestAccECSService_clusterName (133.57s)
--- PASS: TestAccECSService_Tags_managed (141.17s)
--- PASS: TestAccECSService_PlacementStrategy_missing (13.86s)
--- PASS: TestAccECSService_executeCommand (173.84s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (73.36s)
--- PASS: TestAccECSService_basic (183.62s)
--- PASS: TestAccECSService_ServiceRegistries_container (215.13s)
--- PASS: TestAccECSService_ServiceRegistries_basic (216.72s)
--- PASS: TestAccECSService_Tags_propagate (229.28s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (133.26s)
--- PASS: TestAccECSService_Tags_basic (265.50s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (137.36s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (203.04s)
--- PASS: TestAccECSService_multipleTargetGroups (339.13s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (228.26s)
--- PASS: TestAccECSService_alb (361.70s)
--- PASS: TestAccECSService_ServiceRegistries_changes (364.16s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (372.84s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (148.74s)
--- PASS: TestAccECSService_PlacementConstraints_basic (217.29s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (188.42s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (293.72s)
--- PASS: TestAccECSService_renamedCluster (208.23s)
--- PASS: TestAccECSService_familyAndRevision (217.71s)
--- PASS: TestAccECSService_loadBalancerChanges (434.49s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (308.12s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (320.23s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (237.30s)
--- PASS: TestAccECSService_forceNewDeployment (148.89s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (542.11s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (359.93s)
--- PASS: TestAccECSService_PlacementStrategy_basic (186.44s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (272.52s)
--- PASS: TestAccECSService_disappears (228.96s)
--- PASS: TestAccECSService_basicImport (269.20s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (437.10s)
```
