### PR TITLE
r/aws_location_route_calculator - new resource

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1669,9 +1669,10 @@ func Provider() *schema.Provider {
 			"aws_lightsail_static_ip":                            lightsail.ResourceStaticIP(),
 			"aws_lightsail_static_ip_attachment":                 lightsail.ResourceStaticIPAttachment(),
 
-			"aws_location_map":         location.ResourceMap(),
-			"aws_location_place_index": location.ResourcePlaceIndex(),
-			"aws_location_tracker":     location.ResourceTracker(),
+			"aws_location_map":              location.ResourceMap(),
+			"aws_location_place_index":      location.ResourcePlaceIndex(),
+			"aws_location_route_calculator": location.ResourceRouteCalculator(),
+			"aws_location_tracker":          location.ResourceTracker(),
 
 			"aws_macie_member_account_association": macie.ResourceMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":      macie.ResourceS3BucketAssociation(),

--- a/internal/service/location/generate.go
+++ b/internal/service/location/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags -ListTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package location

--- a/internal/service/location/route_calculator.go
+++ b/internal/service/location/route_calculator.go
@@ -1,0 +1,227 @@
+package location
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceRouteCalculator() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRouteCalculatorCreate,
+		ReadContext:   resourceRouteCalculatorRead,
+		UpdateContext: resourceRouteCalculatorUpdate,
+		DeleteContext: resourceRouteCalculatorDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"calculator_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"calculator_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1000),
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceRouteCalculatorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	in := &locationservice.CreateRouteCalculatorInput{
+		CalculatorName: aws.String(d.Get("calculator_name").(string)),
+		DataSource:     aws.String(d.Get("data_source").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		in.Description = aws.String(v.(string))
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateRouteCalculatorWithContext(ctx, in)
+	if err != nil {
+		return diag.Errorf("creating Location Service Route Calculator (%s): %s", d.Get("calculator_name").(string), err)
+	}
+
+	if out == nil {
+		return diag.Errorf("creating Location Service Route Calculator (%s): empty output", d.Get("calculator_name").(string))
+	}
+
+	d.SetId(aws.StringValue(out.CalculatorName))
+
+	return resourceRouteCalculatorRead(ctx, d, meta)
+}
+
+func resourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	out, err := findRouteCalculatorByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Location Service Route Calculator (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("reading Location Service Route Calculator (%s): %s", d.Id(), err)
+	}
+
+	d.Set("calculator_arn", out.CalculatorArn)
+	d.Set("calculator_name", out.CalculatorName)
+	d.Set("create_time", aws.TimeValue(out.CreateTime).Format(time.RFC3339))
+	d.Set("data_source", out.DataSource)
+	d.Set("description", out.Description)
+	d.Set("update_time", aws.TimeValue(out.UpdateTime).Format(time.RFC3339))
+
+	tags, err := ListTagsWithContext(ctx, conn, d.Get("calculator_arn").(string))
+	if err != nil {
+		return diag.Errorf("listing tags for Location Service Route Calculator (%s): %s", d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.Errorf("setting tags: %s", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.Errorf("setting tags_all: %s", err)
+	}
+
+	return nil
+}
+
+func resourceRouteCalculatorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	update := false
+
+	in := &locationservice.UpdateRouteCalculatorInput{
+		CalculatorName: aws.String(d.Get("calculator_name").(string)),
+	}
+
+	if d.HasChange("description") {
+		in.Description = aws.String(d.Get("description").(string))
+		update = true
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("calculator_arn").(string), o, n); err != nil {
+			return diag.Errorf("updating tags for Location Service Route Calculator (%s): %s", d.Id(), err)
+		}
+	}
+
+	if !update {
+		return nil
+	}
+
+	log.Printf("[DEBUG] Updating Location Service Route Calculator (%s): %#v", d.Id(), in)
+	_, err := conn.UpdateRouteCalculatorWithContext(ctx, in)
+	if err != nil {
+		return diag.Errorf("updating Location Service Route Calculator (%s): %s", d.Id(), err)
+	}
+
+	return resourceRouteCalculatorRead(ctx, d, meta)
+}
+
+func resourceRouteCalculatorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	log.Printf("[INFO] Deleting Location Service Route Calculator %s", d.Id())
+
+	_, err := conn.DeleteRouteCalculatorWithContext(ctx, &locationservice.DeleteRouteCalculatorInput{
+		CalculatorName: aws.String(d.Get("calculator_name").(string)),
+	})
+
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("deleting Location Service Route Calculator (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func findRouteCalculatorByName(ctx context.Context, conn *locationservice.LocationService, name string) (*locationservice.DescribeRouteCalculatorOutput, error) {
+	in := &locationservice.DescribeRouteCalculatorInput{
+		CalculatorName: aws.String(name),
+	}
+
+	out, err := conn.DescribeRouteCalculatorWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}

--- a/internal/service/location/route_calculator_test.go
+++ b/internal/service/location/route_calculator_test.go
@@ -1,0 +1,244 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+
+	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
+)
+
+func TestAccLocationRouteCalculator_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_route_calculator.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRouteCalculatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteCalculatorConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "calculator_arn", "geo", fmt.Sprintf("route-calculator/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "calculator_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "create_time"),
+					resource.TestCheckResourceAttr(resourceName, "data_source", "Here"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					acctest.CheckResourceAttrRFC3339(resourceName, "update_time"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationRouteCalculator_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_route_calculator.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRouteCalculatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteCalculatorConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourceRouteCalculator(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationRouteCalculator_description(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_route_calculator.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRouteCalculatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteCalculatorConfig_description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRouteCalculatorConfig_description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLocationRouteCalculator_tags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_route_calculator.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRouteCalculatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteCalculatorConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRouteCalculatorConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccRouteCalculatorConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRouteCalculatorDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_location_route_calculator" {
+			continue
+		}
+
+		input := &locationservice.DescribeRouteCalculatorInput{
+			CalculatorName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeRouteCalculator(input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Expected Location Service Route Calculator to be destroyed, %s found", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckRouteCalculatorExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Location Service Route Calculator is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+		_, err := conn.DescribeRouteCalculator(&locationservice.DescribeRouteCalculatorInput{
+			CalculatorName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error describing Location Service Route Calculator: %s", err.Error())
+		}
+
+		return nil
+	}
+}
+
+func testAccRouteCalculatorConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_route_calculator" "test" {
+  calculator_name = %[1]q
+  data_source     = "Here"
+}
+`, rName)
+}
+
+func testAccRouteCalculatorConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_location_route_calculator" "test" {
+  calculator_name = %[1]q
+  data_source	  = "Here"
+  description  	  = %[2]q
+}
+`, rName, description)
+}
+
+func testAccRouteCalculatorConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_route_calculator" "test" {
+  calculator_name = %[1]q
+  data_source     = "Here"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccRouteCalculatorConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_route_calculator" "test" {
+  calculator_name = %[1]q
+  data_source     = "Here"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/location/tags_gen.go
+++ b/internal/service/location/tags_gen.go
@@ -11,6 +11,27 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
+// ListTags lists location service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func ListTags(conn locationserviceiface.LocationServiceAPI, identifier string) (tftags.KeyValueTags, error) {
+	return ListTagsWithContext(context.Background(), conn, identifier)
+}
+
+func ListTagsWithContext(ctx context.Context, conn locationserviceiface.LocationServiceAPI, identifier string) (tftags.KeyValueTags, error) {
+	input := &locationservice.ListTagsForResourceInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+
+	if err != nil {
+		return tftags.New(nil), err
+	}
+
+	return KeyValueTags(output.Tags), nil
+}
+
 // map[string]*string handling
 
 // Tags returns location service tags.

--- a/website/docs/r/location_route_calculator.html.markdown
+++ b/website/docs/r/location_route_calculator.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_route_calculator"
+description: |-
+    Provides a Location Service Route Calculator.
+---
+
+# Resource: aws_location_route_calculator
+
+Provides a Location Service Route Calculator.
+
+## Example Usage
+
+```terraform
+resource "aws_location_route_calculator" "example" {
+  calculator_name = "example"
+  data_source     = "Here"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `calculator_name` - (Required) The name of the route calculator resource.
+* `data_source` - (Required) Specifies the data provider of traffic and road network data.
+
+The following arguments are optional:
+
+* `description` - (Optional) The optional description for the route calculator resource.
+* `tags` - (Optional) Key-value tags for the route calculator. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `calculator_arn` - The Amazon Resource Name (ARN) for the Route calculator resource. Use the ARN when you specify a resource across AWS.
+* `create_time` - The timestamp for when the route calculator resource was created in ISO 8601 format.
+* `update_time` - The timestamp for when the route calculator resource was last update in ISO 8601.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Timeouts
+
+`aws_location_route_calculator` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Optional, Default: `30m`)
+* `update` - (Optional, Default: `30m`)
+* `delete` - (Optional, Default: `30m`)
+
+## Import
+
+`aws_location_route_calculator` can be imported using the route calculator name, e.g.,
+
+```
+$ terraform import aws_location_route_calculator.example example
+```

--- a/website/docs/r/location_tracker.html.markdown
+++ b/website/docs/r/location_tracker.html.markdown
@@ -29,7 +29,7 @@ The following arguments are optional:
 * `description` - (Optional) The optional description for the tracker resource.
 * `kms_key_id` - (Optional) A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
 * `position_filtering` - (Optional) The position filtering method of the tracker resource. Valid values: `TimeBased`, `DistanceBased`, `AccuracyBased`. Default: `TimeBased`.
-* `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Key-value tags for the tracker. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationRouteCalculator_"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationRouteCalculator_'  -timeout 180m
=== RUN   TestAccLocationRouteCalculator_basic
=== PAUSE TestAccLocationRouteCalculator_basic
=== RUN   TestAccLocationRouteCalculator_disappears
=== PAUSE TestAccLocationRouteCalculator_disappears
=== RUN   TestAccLocationRouteCalculator_description
=== PAUSE TestAccLocationRouteCalculator_description
=== RUN   TestAccLocationRouteCalculator_tags
=== PAUSE TestAccLocationRouteCalculator_tags
=== CONT  TestAccLocationRouteCalculator_basic
=== CONT  TestAccLocationRouteCalculator_description
=== CONT  TestAccLocationRouteCalculator_disappears
=== CONT  TestAccLocationRouteCalculator_tags
--- PASS: TestAccLocationRouteCalculator_disappears (20.51s)
--- PASS: TestAccLocationRouteCalculator_basic (29.22s)
--- PASS: TestAccLocationRouteCalculator_description (48.51s)
--- PASS: TestAccLocationRouteCalculator_tags (76.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   77.819s
```
