### PR TITLE
skaff: Use ListTagsWithContext instead of ListTags

### DIFF
--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -342,7 +342,7 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	// below. Many resources do include tags so this a reminder to include them
 	// where possible.
 	{{- end }}
-	tags, err := ListTags(ctx, conn, d.Id())
+	tags, err := ListTagsWithContext(ctx, conn, d.Id())
 	if err != nil {
 		return diag.Errorf("listing tags for {{ .Service }} {{ .Resource }} (%s): %s", d.Id(), err)
 	}

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -342,7 +342,11 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	// below. Many resources do include tags so this a reminder to include them
 	// where possible.
 	{{- end }}
+	{{ if .AWSGoSDKV2 }}
+	tags, err := ListTags(ctx, conn, d.Id())
+	{{- else }}
 	tags, err := ListTagsWithContext(ctx, conn, d.Id())
+	{{- end }}
 	if err != nil {
 		return diag.Errorf("listing tags for {{ .Service }} {{ .Resource }} (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

`ListTagsWithContext` should be used instead of `ListTags` as we pass the context to the function. Example:
https://github.com/hashicorp/terraform-provider-aws/blob/28ce9c2ce384c9b871364d1ebbc330d66590796e/internal/service/ce/tags_gen.go#L17-L33