### PR TITLE
dynamodb/table: Add replica PITR

### DIFF
--- a/.changelog/25659.txt
+++ b/.changelog/25659.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `replica.*.point_in_time_recovery` argument
+```
+
+```release-note:bug
+resource/aws_dynamodb_table: Prevent `restore_source_name` from forcing replacement when removed to enable restoring from a PITR backup
+```
+
+```release-note:bug
+resource/aws_dynamodb_table: Respect custom timeouts including when working with replicas
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -890,6 +890,12 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if d.HasChange("ttl") {
+		if err := updateTimeToLive(conn, d.Id(), d.Get("ttl").([]interface{}), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error updating DynamoDB Table (%s) time to live: %w", d.Id(), err)
+		}
+	}
+
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
@@ -897,21 +903,15 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("replica") {
-		if err := updateReplica(d, conn, meta.(*conns.AWSClient).TerraformVersion); err != nil {
-			return fmt.Errorf("error updating DynamoDB Table (%s) replica: %w", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("ttl") {
-		if err := updateTimeToLive(conn, d.Id(), d.Get("ttl").([]interface{}), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("error updating DynamoDB Table (%s) time to live: %w", d.Id(), err)
-		}
-	}
-
 	if d.HasChange("point_in_time_recovery") {
 		if err := updatePITR(conn, d.Id(), d.Get("point_in_time_recovery.0.enabled").(bool), aws.StringValue(conn.Config.Region), meta.(*conns.AWSClient).TerraformVersion, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("error updating DynamoDB Table (%s) point in time recovery: %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("replica") {
+		if err := updateReplica(d, conn, meta.(*conns.AWSClient).TerraformVersion); err != nil {
+			return fmt.Errorf("error updating DynamoDB Table (%s) replica: %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -24,6 +24,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const provisionedThroughputMinValue = 1
@@ -249,6 +250,11 @@ func ResourceTable() *schema.Resource {
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: verify.ValidARN,
+						},
+						"point_in_time_recovery": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"region_name": {
 							Type:     schema.TypeString,
@@ -558,21 +564,21 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error waiting for creation of DynamoDB table (%s): %w", d.Id(), err)
 	}
 
+	if v := d.Get("replica").(*schema.Set); v.Len() > 0 {
+		if err := createReplicas(conn, d.Id(), v.List(), meta.(*conns.AWSClient).TerraformVersion, true); err != nil {
+			return fmt.Errorf("error initially creating DynamoDB Table (%s) replicas: %w", d.Id(), err)
+		}
+	}
+
 	if d.Get("ttl.0.enabled").(bool) {
-		if err := updateTimeToLive(d.Id(), d.Get("ttl").([]interface{}), conn); err != nil {
+		if err := updateTimeToLive(conn, d.Id(), d.Get("ttl").([]interface{})); err != nil {
 			return fmt.Errorf("error enabling DynamoDB Table (%s) Time to Live: %w", d.Id(), err)
 		}
 	}
 
 	if d.Get("point_in_time_recovery.0.enabled").(bool) {
-		if err := updatePITR(d, conn); err != nil {
+		if err := updatePITR(conn, d.Id(), true, aws.StringValue(conn.Config.Region), meta.(*conns.AWSClient).TerraformVersion); err != nil {
 			return fmt.Errorf("error enabling DynamoDB Table (%s) point in time recovery: %w", d.Id(), err)
-		}
-	}
-
-	if v := d.Get("replica").(*schema.Set); v.Len() > 0 {
-		if err := createReplicas(d.Id(), v.List(), conn); err != nil {
-			return fmt.Errorf("error initially creating DynamoDB Table (%s) replicas: %w", d.Id(), err)
 		}
 	}
 
@@ -660,7 +666,13 @@ func resourceTableRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting server_side_encryption: %w", err)
 	}
 
-	if err := d.Set("replica", flattenReplicaDescriptions(table.Replicas)); err != nil {
+	replicas := flattenReplicaDescriptions(table.Replicas)
+
+	if replicas, err = addReplicaPITRs(conn, d.Id(), meta.(*conns.AWSClient).TerraformVersion, replicas); err != nil {
+		return names.Error(names.DynamoDB, names.ErrActionReading, "Table", d.Id(), err)
+	}
+
+	if err := d.Set("replica", replicas); err != nil {
 		return fmt.Errorf("error setting replica: %w", err)
 	}
 
@@ -874,12 +886,6 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("ttl") {
-		if err := updateTimeToLive(d.Id(), d.Get("ttl").([]interface{}), conn); err != nil {
-			return fmt.Errorf("error updating DynamoDB Table (%s) time to live: %w", d.Id(), err)
-		}
-	}
-
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
@@ -887,15 +893,21 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("point_in_time_recovery") {
-		if err := updatePITR(d, conn); err != nil {
-			return fmt.Errorf("error updating DynamoDB Table (%s) point in time recovery: %w", d.Id(), err)
+	if d.HasChange("replica") {
+		if err := updateReplica(d, conn, meta.(*conns.AWSClient).TerraformVersion); err != nil {
+			return fmt.Errorf("error updating DynamoDB Table (%s) replica: %w", d.Id(), err)
 		}
 	}
 
-	if d.HasChange("replica") {
-		if err := updateReplica(d, conn); err != nil {
-			return fmt.Errorf("error updating DynamoDB Table (%s) replica: %w", d.Id(), err)
+	if d.HasChange("ttl") {
+		if err := updateTimeToLive(conn, d.Id(), d.Get("ttl").([]interface{})); err != nil {
+			return fmt.Errorf("error updating DynamoDB Table (%s) time to live: %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("point_in_time_recovery") {
+		if err := updatePITR(conn, d.Id(), d.Get("point_in_time_recovery.0.enabled").(bool), aws.StringValue(conn.Config.Region), meta.(*conns.AWSClient).TerraformVersion); err != nil {
+			return fmt.Errorf("error updating DynamoDB Table (%s) point in time recovery: %w", d.Id(), err)
 		}
 	}
 
@@ -908,12 +920,12 @@ func resourceTableDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] DynamoDB delete table: %s", d.Id())
 
 	if replicas := d.Get("replica").(*schema.Set).List(); len(replicas) > 0 {
-		if err := deleteReplicas(d.Id(), replicas, conn); err != nil {
+		if err := deleteReplicas(conn, d.Id(), replicas); err != nil {
 			return fmt.Errorf("error deleting DynamoDB Table (%s) replicas: %w", d.Id(), err)
 		}
 	}
 
-	err := deleteTable(d.Id(), conn)
+	err := deleteTable(conn, d.Id())
 	if err != nil {
 		if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeResourceNotFoundException, "Requested resource not found: Table: ") {
 			return nil
@@ -941,7 +953,7 @@ func isTableOptionDisabled(v interface{}) bool {
 
 // CRUD helpers
 
-func createReplicas(tableName string, tfList []interface{}, conn *dynamodb.DynamoDB) error {
+func createReplicas(conn *dynamodb.DynamoDB, tableName string, tfList []interface{}, tfVersion string, create bool) error {
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
 
@@ -968,6 +980,27 @@ func createReplicas(tableName string, tfList []interface{}, conn *dynamodb.Dynam
 			},
 		}
 
+		if !create {
+			var replicaInput = &dynamodb.UpdateReplicationGroupMemberAction{}
+
+			if v, ok := tfMap["region_name"].(string); ok && v != "" {
+				replicaInput.RegionName = aws.String(v)
+			}
+
+			if v, ok := tfMap["kms_key_arn"].(string); ok && v != "" {
+				replicaInput.KMSMasterKeyId = aws.String(v)
+			}
+
+			input = &dynamodb.UpdateTableInput{
+				TableName: aws.String(tableName),
+				ReplicaUpdates: []*dynamodb.ReplicationGroupUpdate{
+					{
+						Update: replicaInput,
+					},
+				},
+			}
+		}
+
 		err := resource.Retry(replicaUpdateTimeout, func() *resource.RetryError {
 			_, err := conn.UpdateTable(input)
 			if err != nil {
@@ -990,19 +1023,29 @@ func createReplicas(tableName string, tfList []interface{}, conn *dynamodb.Dynam
 			_, err = conn.UpdateTable(input)
 		}
 
-		if err != nil {
+		if create && tfawserr.ErrMessageContains(err, "ValidationException", "already exist") {
+			return createReplicas(conn, tableName, tfList, tfVersion, false)
+		}
+
+		if err != nil && !tfawserr.ErrMessageContains(err, "ValidationException", "no actions specified") {
 			return fmt.Errorf("error creating DynamoDB Table (%s) replica (%s): %w", tableName, tfMap["region_name"].(string), err)
 		}
 
 		if _, err := waitReplicaActive(conn, tableName, tfMap["region_name"].(string)); err != nil {
 			return fmt.Errorf("error waiting for DynamoDB Table (%s) replica (%s) creation: %w", tableName, tfMap["region_name"].(string), err)
 		}
+
+		// pitr
+		if err = updatePITR(conn, tableName, tfMap["point_in_time_recovery"].(bool), tfMap["region_name"].(string), tfVersion); err != nil {
+			return names.Error(names.DynamoDB, names.ErrActionUpdating, "Table", tableName, err)
+		}
+
 	}
 
 	return nil
 }
 
-func updateTimeToLive(tableName string, ttlList []interface{}, conn *dynamodb.DynamoDB) error {
+func updateTimeToLive(conn *dynamodb.DynamoDB, tableName string, ttlList []interface{}) error {
 	ttlMap := ttlList[0].(map[string]interface{})
 
 	input := &dynamodb.UpdateTimeToLiveInput{
@@ -1027,17 +1070,24 @@ func updateTimeToLive(tableName string, ttlList []interface{}, conn *dynamodb.Dy
 	return nil
 }
 
-func updatePITR(d *schema.ResourceData, conn *dynamodb.DynamoDB) error {
-	toEnable := d.Get("point_in_time_recovery.0.enabled").(bool)
-
+func updatePITR(conn *dynamodb.DynamoDB, tableName string, enabled bool, region string, tfVersion string) error {
+	// pitr must be modified from region where the main/replica resides
+	log.Printf("[DEBUG] Updating DynamoDB point in time recovery status to %v (%s)", enabled, region)
 	input := &dynamodb.UpdateContinuousBackupsInput{
-		TableName: aws.String(d.Id()),
+		TableName: aws.String(tableName),
 		PointInTimeRecoverySpecification: &dynamodb.PointInTimeRecoverySpecification{
-			PointInTimeRecoveryEnabled: aws.Bool(toEnable),
+			PointInTimeRecoveryEnabled: aws.Bool(enabled),
 		},
 	}
 
-	log.Printf("[DEBUG] Updating DynamoDB point in time recovery status to %v", toEnable)
+	if aws.StringValue(conn.Config.Region) != region {
+		session, err := conns.NewSessionForRegion(&conn.Config, region, tfVersion)
+		if err != nil {
+			return names.Error(names.DynamoDB, names.ErrActionUpdating, "Table", tableName, err)
+		}
+
+		conn = dynamodb.New(session)
+	}
 
 	err := resource.Retry(updateTableContinuousBackupsTimeout, func() *resource.RetryError {
 		_, err := conn.UpdateContinuousBackups(input)
@@ -1050,21 +1100,23 @@ func updatePITR(d *schema.ResourceData, conn *dynamodb.DynamoDB) error {
 		}
 		return nil
 	})
+
 	if tfresource.TimedOut(err) {
 		_, err = conn.UpdateContinuousBackups(input)
 	}
+
 	if err != nil {
-		return fmt.Errorf("error updating DynamoDB PITR status: %w", err)
+		return names.Error(names.DynamoDB, "updating PITR", "Table", tableName, err)
 	}
 
-	if _, err := waitPITRUpdated(conn, d.Id(), toEnable); err != nil {
-		return fmt.Errorf("error waiting for DynamoDB PITR update: %w", err)
+	if _, err := waitPITRUpdated(conn, tableName, enabled); err != nil {
+		return names.Error(names.DynamoDB, "waiting for PITR update", "Table", tableName, err)
 	}
 
 	return nil
 }
 
-func updateReplica(d *schema.ResourceData, conn *dynamodb.DynamoDB) error {
+func updateReplica(d *schema.ResourceData, conn *dynamodb.DynamoDB, tfVersion string) error {
 	oRaw, nRaw := d.GetChange("replica")
 	o := oRaw.(*schema.Set)
 	n := nRaw.(*schema.Set)
@@ -1072,14 +1124,27 @@ func updateReplica(d *schema.ResourceData, conn *dynamodb.DynamoDB) error {
 	removed := o.Difference(n).List()
 	added := n.Difference(o).List()
 
+	// For true updates, don't remove and add, just update (i.e., keep in added
+	// but remove from removed)
+	for _, a := range added {
+		for j, r := range removed {
+			ma := a.(map[string]interface{})
+			mr := r.(map[string]interface{})
+			if ma["region_name"].(string) == mr["region_name"].(string) {
+				removed = append(removed[:j], removed[j+1:]...)
+				continue
+			}
+		}
+	}
+
 	if len(added) > 0 {
-		if err := createReplicas(d.Id(), added, conn); err != nil {
+		if err := createReplicas(conn, d.Id(), added, tfVersion, true); err != nil {
 			return fmt.Errorf("error updating DynamoDB replicas for table (%s), while creating: %w", d.Id(), err)
 		}
 	}
 
 	if len(removed) > 0 {
-		if err := deleteReplicas(d.Id(), removed, conn); err != nil {
+		if err := deleteReplicas(conn, d.Id(), removed); err != nil {
 			return fmt.Errorf("error updating DynamoDB replicas for table (%s), while deleting: %w", d.Id(), err)
 		}
 	}
@@ -1195,7 +1260,7 @@ func UpdateDiffGSI(oldGsi, newGsi []interface{}, billingMode string) (ops []*dyn
 	return ops, nil
 }
 
-func deleteTable(tableName string, conn *dynamodb.DynamoDB) error {
+func deleteTable(conn *dynamodb.DynamoDB, tableName string) error {
 	input := &dynamodb.DeleteTableInput{
 		TableName: aws.String(tableName),
 	}
@@ -1230,7 +1295,7 @@ func deleteTable(tableName string, conn *dynamodb.DynamoDB) error {
 	return err
 }
 
-func deleteReplicas(tableName string, tfList []interface{}, conn *dynamodb.DynamoDB) error {
+func deleteReplicas(conn *dynamodb.DynamoDB, tableName string, tfList []interface{}) error {
 	var g multierror.Group
 
 	for _, tfMapRaw := range tfList {
@@ -1297,6 +1362,62 @@ func deleteReplicas(tableName string, tfList []interface{}, conn *dynamodb.Dynam
 	}
 
 	return g.Wait().ErrorOrNil()
+}
+
+func replicaPITR(conn *dynamodb.DynamoDB, tableName string, region string, tfVersion string) (bool, error) {
+	// At a future time, replicas should probably have a separate resource because,
+	// to manage them, you need connections from the different regions. However, they
+	// have to be created from the starting/main region...
+	session, err := conns.NewSessionForRegion(&conn.Config, region, tfVersion)
+	if err != nil {
+		return false, names.Error(names.DynamoDB, names.ErrActionUpdating, "Table", tableName, err)
+	}
+
+	conn = dynamodb.New(session)
+
+	pitrOut, err := conn.DescribeContinuousBackups(&dynamodb.DescribeContinuousBackupsInput{
+		TableName: aws.String(tableName),
+	})
+
+	if err != nil && !tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
+		return false, fmt.Errorf("error describing DynamoDB Table (%s) Continuous Backups: %w", tableName, err)
+	}
+
+	if pitrOut == nil {
+		return false, nil
+	}
+
+	enabled := false
+
+	if pitrOut.ContinuousBackupsDescription != nil {
+		pitr := pitrOut.ContinuousBackupsDescription.PointInTimeRecoveryDescription
+		if pitr != nil {
+			enabled = (aws.StringValue(pitr.PointInTimeRecoveryStatus) == dynamodb.PointInTimeRecoveryStatusEnabled)
+		}
+	}
+
+	return enabled, nil
+}
+
+func addReplicaPITRs(conn *dynamodb.DynamoDB, tableName string, tfVersion string, replicas []interface{}) ([]interface{}, error) {
+	// This non-standard approach is needed because PITR info for a replica
+	// must come from a region-specific connection. A future table_replica
+	// resource may improve this.
+
+	// addReplicaPITRs(conn, d.Id(), meta.(*conns.AWSClient).TerraformVersion, replicas)
+	for i, replicaRaw := range replicas {
+		replica := replicaRaw.(map[string]interface{})
+
+		var enabled bool
+		var err error
+		if enabled, err = replicaPITR(conn, tableName, replica["region_name"].(string), tfVersion); err != nil {
+			return nil, err
+		}
+		replica["point_in_time_recovery"] = enabled
+		replicas[i] = replica
+	}
+
+	return replicas, nil
 }
 
 // flatteners, expanders
@@ -1446,7 +1567,6 @@ func flattenReplicaDescription(apiObject *dynamodb.ReplicaDescription) map[strin
 	}
 
 	return tfMap
-
 }
 
 func flattenReplicaDescriptions(apiObjects []*dynamodb.ReplicaDescription) []interface{} {

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -21,6 +21,14 @@ const (
 	ttlUpdateTimeout                           = 30 * time.Second
 )
 
+func maxDuration(a, b time.Duration) time.Duration {
+	if a >= b {
+		return a
+	}
+
+	return b
+}
+
 func waitKinesisStreamingDestinationActive(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{dynamodb.DestinationStatusDisabled, dynamodb.DestinationStatusEnabling},
@@ -47,7 +55,7 @@ func waitKinesisStreamingDestinationDisabled(ctx context.Context, conn *dynamodb
 	return err
 }
 
-func waitTableActive(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.TableDescription, error) { //nolint:unparam
+func waitTableActive(conn *dynamodb.DynamoDB, tableName string, timeout time.Duration) (*dynamodb.TableDescription, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.TableStatusCreating,
@@ -56,7 +64,7 @@ func waitTableActive(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.Table
 		Target: []string{
 			dynamodb.TableStatusActive,
 		},
-		Timeout: createTableTimeout,
+		Timeout: maxDuration(createTableTimeout, timeout),
 		Refresh: statusTable(conn, tableName),
 	}
 
@@ -69,14 +77,14 @@ func waitTableActive(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.Table
 	return nil, err
 }
 
-func waitTableDeleted(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.TableDescription, error) {
+func waitTableDeleted(conn *dynamodb.DynamoDB, tableName string, timeout time.Duration) (*dynamodb.TableDescription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.TableStatusActive,
 			dynamodb.TableStatusDeleting,
 		},
 		Target:  []string{},
-		Timeout: deleteTableTimeout,
+		Timeout: maxDuration(deleteTableTimeout, timeout),
 		Refresh: statusTable(conn, tableName),
 	}
 
@@ -89,7 +97,7 @@ func waitTableDeleted(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.Tabl
 	return nil, err
 }
 
-func waitReplicaActive(conn *dynamodb.DynamoDB, tableName, region string) (*dynamodb.DescribeTableOutput, error) {
+func waitReplicaActive(conn *dynamodb.DynamoDB, tableName, region string, timeout time.Duration) (*dynamodb.DescribeTableOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.ReplicaStatusCreating,
@@ -99,7 +107,7 @@ func waitReplicaActive(conn *dynamodb.DynamoDB, tableName, region string) (*dyna
 		Target: []string{
 			dynamodb.ReplicaStatusActive,
 		},
-		Timeout: replicaUpdateTimeout,
+		Timeout: maxDuration(replicaUpdateTimeout, timeout),
 		Refresh: statusReplicaUpdate(conn, tableName, region),
 	}
 
@@ -112,7 +120,7 @@ func waitReplicaActive(conn *dynamodb.DynamoDB, tableName, region string) (*dyna
 	return nil, err
 }
 
-func waitReplicaDeleted(conn *dynamodb.DynamoDB, tableName, region string) (*dynamodb.DescribeTableOutput, error) {
+func waitReplicaDeleted(conn *dynamodb.DynamoDB, tableName, region string, timeout time.Duration) (*dynamodb.DescribeTableOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.ReplicaStatusCreating,
@@ -121,7 +129,7 @@ func waitReplicaDeleted(conn *dynamodb.DynamoDB, tableName, region string) (*dyn
 			dynamodb.ReplicaStatusActive,
 		},
 		Target:  []string{""},
-		Timeout: replicaUpdateTimeout,
+		Timeout: maxDuration(replicaUpdateTimeout, timeout),
 		Refresh: statusReplicaDelete(conn, tableName, region),
 	}
 
@@ -134,7 +142,7 @@ func waitReplicaDeleted(conn *dynamodb.DynamoDB, tableName, region string) (*dyn
 	return nil, err
 }
 
-func waitGSIActive(conn *dynamodb.DynamoDB, tableName, indexName string) (*dynamodb.GlobalSecondaryIndexDescription, error) { //nolint:unparam
+func waitGSIActive(conn *dynamodb.DynamoDB, tableName, indexName string, timeout time.Duration) (*dynamodb.GlobalSecondaryIndexDescription, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.IndexStatusCreating,
@@ -143,7 +151,7 @@ func waitGSIActive(conn *dynamodb.DynamoDB, tableName, indexName string) (*dynam
 		Target: []string{
 			dynamodb.IndexStatusActive,
 		},
-		Timeout: updateTableTimeout,
+		Timeout: maxDuration(updateTableTimeout, timeout),
 		Refresh: statusGSI(conn, tableName, indexName),
 	}
 
@@ -156,7 +164,7 @@ func waitGSIActive(conn *dynamodb.DynamoDB, tableName, indexName string) (*dynam
 	return nil, err
 }
 
-func waitGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string) (*dynamodb.GlobalSecondaryIndexDescription, error) {
+func waitGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string, timeout time.Duration) (*dynamodb.GlobalSecondaryIndexDescription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.IndexStatusActive,
@@ -164,7 +172,7 @@ func waitGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string) (*dyna
 			dynamodb.IndexStatusUpdating,
 		},
 		Target:  []string{},
-		Timeout: updateTableTimeout,
+		Timeout: maxDuration(updateTableTimeout, timeout),
 		Refresh: statusGSI(conn, tableName, indexName),
 	}
 
@@ -177,7 +185,7 @@ func waitGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string) (*dyna
 	return nil, err
 }
 
-func waitPITRUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (*dynamodb.PointInTimeRecoveryDescription, error) {
+func waitPITRUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool, timeout time.Duration) (*dynamodb.PointInTimeRecoveryDescription, error) {
 	var pending []string
 	target := []string{dynamodb.TimeToLiveStatusDisabled}
 
@@ -191,7 +199,7 @@ func waitPITRUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (
 	stateConf := &resource.StateChangeConf{
 		Pending: pending,
 		Target:  target,
-		Timeout: pitrUpdateTimeout,
+		Timeout: maxDuration(pitrUpdateTimeout, timeout),
 		Refresh: statusPITR(conn, tableName),
 	}
 
@@ -204,7 +212,7 @@ func waitPITRUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (
 	return nil, err
 }
 
-func waitTTLUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (*dynamodb.TimeToLiveDescription, error) {
+func waitTTLUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool, timeout time.Duration) (*dynamodb.TimeToLiveDescription, error) {
 	pending := []string{
 		dynamodb.TimeToLiveStatusEnabled,
 		dynamodb.TimeToLiveStatusDisabling,
@@ -222,7 +230,7 @@ func waitTTLUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (*
 	stateConf := &resource.StateChangeConf{
 		Pending: pending,
 		Target:  target,
-		Timeout: ttlUpdateTimeout,
+		Timeout: maxDuration(ttlUpdateTimeout, timeout),
 		Refresh: statusTTL(conn, tableName),
 	}
 
@@ -235,7 +243,7 @@ func waitTTLUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (*
 	return nil, err
 }
 
-func waitSSEUpdated(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.TableDescription, error) {
+func waitSSEUpdated(conn *dynamodb.DynamoDB, tableName string, timeout time.Duration) (*dynamodb.TableDescription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.SSEStatusDisabling,
@@ -246,7 +254,7 @@ func waitSSEUpdated(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.TableD
 			dynamodb.SSEStatusDisabled,
 			dynamodb.SSEStatusEnabled,
 		},
-		Timeout: updateTableTimeout,
+		Timeout: maxDuration(updateTableTimeout, timeout),
 		Refresh: statusTableSES(conn, tableName),
 	}
 

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -12,10 +12,18 @@ Provides a DynamoDB table resource
 
 ~> **Note:** It is recommended to use `lifecycle` [`ignore_changes`](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) for `read_capacity` and/or `write_capacity` if there's [autoscaling policy](/docs/providers/aws/r/appautoscaling_policy.html) attached to the table.
 
+## DynamoDB Table attributes
+
+Only define attributes on the table object that are going to be used as:
+
+* Table hash key or range key
+* LSI or GSI hash key or range key
+
+The DynamoDB API expects attribute structure (name and type) to be passed along when creating or updating GSI/LSIs or creating the initial table. In these cases it expects the Hash / Range keys to be provided. Because these get re-used in numerous places (i.e the table's range key could be a part of one or more GSIs), they are stored on the table object to prevent duplication and increase consistency. If you add attributes here that are not used in these scenarios it can cause an infinite loop in planning.
+
 ## Example Usage
 
-The following dynamodb table description models the table and GSI shown
-in the [AWS SDK example documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html)
+The following dynamodb table description models the table and GSI shown in the [AWS SDK example documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html)
 
 ```terraform
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
@@ -92,128 +100,93 @@ resource "aws_dynamodb_table" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+Required arguments:
 
-* `name` - (Required) The name of the table, this needs to be unique
-  within a region.
+* `attribute` - (Required) Set of nested attribute definitions. Only required for `hash_key` and `range_key` attributes. See below.
+* `hash_key` - (Required, Forces new resource) Attribute to use as the hash (partition) key. Must also be defined as an `attribute`. See below.
+* `name` - (Required) Unique within a region name of the table.
+
+Optional arguments:
+
 * `billing_mode` - (Optional) Controls how you are charged for read and write throughput and how you manage capacity. The valid values are `PROVISIONED` and `PAY_PER_REQUEST`. Defaults to `PROVISIONED`.
-* `hash_key` - (Required, Forces new resource) The attribute to use as the hash (partition) key. Must also be defined as an `attribute`, see below.
-* `range_key` - (Optional, Forces new resource) The attribute to use as the range (sort) key. Must also be defined as an `attribute`, see below.
-* `write_capacity` - (Optional) The number of write units for this table. If the `billing_mode` is `PROVISIONED`, this field is required.
-* `read_capacity` - (Optional) The number of read units for this table. If the `billing_mode` is `PROVISIONED`, this field is required.
-* `attribute` - (Required) List of nested attribute definitions. Only required for `hash_key` and `range_key` attributes. Each attribute has two properties:
-    * `name` - (Required) The name of the attribute
-    * `type` - (Required) Attribute type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data
-* `ttl` - (Optional) Defines ttl, has two properties, and can only be specified once:
-    * `enabled` - (Required) Indicates whether ttl is enabled (true) or disabled (false).
-    * `attribute_name` - (Required) The name of the table attribute to store the TTL timestamp in.
-* `local_secondary_index` - (Optional, Forces new resource) Describe an LSI on the table;
-  these can only be allocated *at creation* so you cannot change this
-definition after you have created the resource.
-* `global_secondary_index` - (Optional) Describe a GSI for the table;
-  subject to the normal limits on the number of GSIs, projected
-attributes, etc.
-* `point_in_time_recovery` - (Optional) Enable point-in-time recovery options.
-* `replica` - (Optional) Configuration block(s) with [DynamoDB Global Tables V2 (version 2019.11.21)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html) replication configurations. Detailed below.
-* `restore_source_name` - (Optional) The name of the table to restore. Must match the name of an existing table.
+* `global_secondary_index` - (Optional) Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. See below.
+* `local_secondary_index` - (Optional, Forces new resource) Describe an LSI on the table; these can only be allocated *at creation* so you cannot change this definition after you have created the resource. See below.
+* `point_in_time_recovery` - (Optional) Enable point-in-time recovery options. See below.
+* `range_key` - (Optional, Forces new resource) Attribute to use as the range (sort) key. Must also be defined as an `attribute`, see below.
+* `read_capacity` - (Optional) Number of read units for this table. If the `billing_mode` is `PROVISIONED`, this field is required.
+* `replica` - (Optional) Configuration block(s) with [DynamoDB Global Tables V2 (version 2019.11.21)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html) replication configurations. See below.
+* `restore_date_time` - (Optional) Time of the point-in-time recovery point to restore.
+* `restore_source_name` - (Optional) Name of the table to restore. Must match the name of an existing table.
 * `restore_to_latest_time` - (Optional) If set, restores table to the most recent point-in-time recovery point.
-* `restore_date_time` - (Optional) The time of the point-in-time recovery point to restore.
-* `stream_enabled` - (Optional) Indicates whether Streams are to be enabled (true) or disabled (false).
+* `server_side_encryption` - (Optional) Encryption at rest options. AWS DynamoDB tables are automatically encrypted at rest with an AWS-owned Customer Master Key if this argument isn't specified. See below.
+* `stream_enabled` - (Optional) Whether Streams are enabled.
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`.
-* `server_side_encryption` - (Optional) Encryption at rest options. AWS DynamoDB tables are automatically encrypted at rest with an AWS owned Customer Master Key if this argument isn't specified.
-* `table_class` - (Optional) The storage class of the table. Valid values are `STANDARD` and `STANDARD_INFREQUENT_ACCESS`.
+* `table_class` - (Optional) Storage class of the table. Valid values are `STANDARD` and `STANDARD_INFREQUENT_ACCESS`.
 * `tags` - (Optional) A map of tags to populate on the created table. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `ttl` - (Optional) Configuration block for TTL. See below.
+* `write_capacity` - (Optional) Number of write units for this table. If the `billing_mode` is `PROVISIONED`, this field is required.
 
-### Timeouts
+### `attribute`
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) for certain actions:
-
-* `create` - (Defaults to 10 mins) Used when creating the table
-* `update` - (Defaults to 60 mins) Used when updating the table configuration and reset for each individual Global Secondary Index and Replica update
-* `delete` - (Defaults to 10 mins) Used when deleting the table
-
-### Nested fields
-
-#### `local_secondary_index`
-
-* `name` - (Required) The name of the index
-* `range_key` - (Required) The name of the range key; must be defined
-* `projection_type` - (Required) One of `ALL`, `INCLUDE` or `KEYS_ONLY`
-   where `ALL` projects every attribute into the index, `KEYS_ONLY`
-    projects just the hash and range key into the index, and `INCLUDE`
-    projects only the keys specified in the _non_key_attributes_
-    parameter.
-* `non_key_attributes` - (Optional) Only required with `INCLUDE` as a
-  projection type; a list of attributes to project into the index. These
-  do not need to be defined as attributes on the table.
+* `name` - (Required) Name of the attribute
+* `type` - (Required) Attribute type. Valid values are `S` (string), `N` (number), `B` (binary).
 
 #### `global_secondary_index`
 
-* `name` - (Required) The name of the index
-* `write_capacity` - (Optional) The number of write units for this index. Must be set if billing_mode is set to PROVISIONED.
-* `read_capacity` - (Optional) The number of read units for this index. Must be set if billing_mode is set to PROVISIONED.
-* `hash_key` - (Required) The name of the hash key in the index; must be
-  defined as an attribute in the resource.
-* `range_key` - (Optional) The name of the range key; must be defined
-* `projection_type` - (Required) One of `ALL`, `INCLUDE` or `KEYS_ONLY`
-   where `ALL` projects every attribute into the index, `KEYS_ONLY`
-    projects just the hash and range key into the index, and `INCLUDE`
-    projects only the keys specified in the _non_key_attributes_
-    parameter.
-* `non_key_attributes` - (Optional) Only required with `INCLUDE` as a
-  projection type; a list of attributes to project into the index. These
-  do not need to be defined as attributes on the table.
+* `hash_key` - (Required) Name of the hash key in the index; must be defined as an attribute in the resource.
+* `name` - (Required) Name of the index.
+* `non_key_attributes` - (Optional) Only required with `INCLUDE` as a projection type; a list of attributes to project into the index. These do not need to be defined as attributes on the table.
+* `projection_type` - (Required) One of `ALL`, `INCLUDE` or `KEYS_ONLY` where `ALL` projects every attribute into the index, `KEYS_ONLY` projects just the hash and range key into the index, and `INCLUDE` projects only the keys specified in the `non_key_attributes` parameter.
+* `range_key` - (Optional) Name of the range key; must be defined
+* `read_capacity` - (Optional) Number of read units for this index. Must be set if billing_mode is set to PROVISIONED.
+* `write_capacity` - (Optional) Number of write units for this index. Must be set if billing_mode is set to PROVISIONED.
 
-#### `replica`
+### `local_secondary_index`
 
-The `replica` configuration block supports the following arguments:
+* `name` - (Required) Name of the index
+* `non_key_attributes` - (Optional) Only required with `INCLUDE` as a projection type; a list of attributes to project into the index. These do not need to be defined as attributes on the table.
+* `projection_type` - (Required) One of `ALL`, `INCLUDE` or `KEYS_ONLY` where `ALL` projects every attribute into the index, `KEYS_ONLY` projects just the hash and range key into the index, and `INCLUDE` projects only the keys specified in the `non_key_attributes` parameter.
+* `range_key` - (Required) Name of the range key.
 
+### `point_in_time_recovery`
+
+* `enabled` - (Required) Whether to enable point-in-time recovery. It can take 10 minutes to enable for new tables. If the `point_in_time_recovery` block is not provided, this defaults to `false`.
+
+### `replica`
+
+* `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption.
+* `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica.
 * `region_name` - (Required) Region name of the replica.
-* `kms_key_arn` - (Optional) The ARN of the CMK that should be used for the AWS KMS encryption.
 
-#### `server_side_encryption`
+### `server_side_encryption`
 
-* `enabled` - (Required) Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK).
-* `kms_key_arn` - (Optional) The ARN of the CMK that should be used for the AWS KMS encryption.
-This attribute should only be specified if the key is different from the default DynamoDB CMK, `alias/aws/dynamodb`.
+* `enabled` - (Required) Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK). If `enabled` is `false` then server-side encryption is set to AWS owned CMK (shown as `DEFAULT` in the AWS console). If `enabled` is `true` and no `kms_key_arn` is specified then server-side encryption is set to AWS managed CMK (shown as `KMS` in the AWS console). The [AWS KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html) explains the difference between AWS owned and AWS managed CMKs.
+* `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, `alias/aws/dynamodb`.
 
-If `enabled` is `false` then server-side encryption is set to AWS owned CMK (shown as `DEFAULT` in the AWS console).
-If `enabled` is `true` and no `kms_key_arn` is specified then server-side encryption is set to AWS managed CMK (shown as `KMS` in the AWS console).
-The [AWS KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html) explains the difference between AWS owned and AWS managed CMKs.
+### `ttl`
 
-#### `point_in_time_recovery`
-
-* `enabled` - (Required) Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. If the `point_in_time_recovery` block is not provided then this defaults to `false`.
-
-### A note about attributes
-
-Only define attributes on the table object that are going to be used as:
-
-* Table hash key or range key
-* LSI or GSI hash key or range key
-
-The DynamoDB API expects attribute structure (name and type) to be
-passed along when creating or updating GSI/LSIs or creating the initial
-table. In these cases it expects the Hash / Range keys to be provided;
-because these get re-used in numerous places (i.e the table's range key
-could be a part of one or more GSIs), they are stored on the table
-object to prevent duplication and increase consistency. If you add
-attributes here that are not used in these scenarios it can cause an
-infinite loop in planning.
-
+* `enabled` - (Required) Whether TTL is enabled.
+* `attribute_name` - (Required) Name of the table attribute to store the TTL timestamp in.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The arn of the table
-* `id` - The name of the table
-* `stream_arn` - The ARN of the Table Stream. Only available when `stream_enabled = true`
-* `stream_label` - A timestamp, in ISO 8601 format, for this stream. Note that this timestamp is not
-  a unique identifier for the stream on its own. However, the combination of AWS customer ID,
-  table name and this field is guaranteed to be unique.
-  It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of the table
+* `id` - Name of the table
+* `stream_arn` - ARN of the Table Stream. Only available when `stream_enabled = true`
+* `stream_label` - Timestamp, in ISO 8601 format, for this stream. Note that this timestamp is not a unique identifier for the stream on its own. However, the combination of AWS customer ID, table name and this field is guaranteed to be unique. It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Timeouts
+
+~> **Note:** There are a variety of default timeouts set internally. If you set a shorter custom timeout than one of the defaults, the custom timeout will not be respected as the longer of the custom or internal default will be used.
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 mins) Used when creating the table
+* `update` - (Defaults to 60 mins) Used when updating the table configuration and reset for each individual Global Secondary Index and Replica update
+* `delete` - (Defaults to 10 mins) Used when deleting the table
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21323
Closes #25214
Closes #24473

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccDynamoDBTable_ PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_'  -timeout 180m
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (17.66s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (26.50s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_disappears (83.11s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (102.54s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_basic (109.98s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_tags (120.50s)
=== CONT  TestAccDynamoDBTable_Replica_single
=== CONT  TestAccDynamoDBTable_Replica_singleWithCMK
--- PASS: TestAccDynamoDBTable_TTL_disabled (161.67s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (168.65s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (169.50s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (172.54s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (173.08s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_streamSpecification (177.19s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (184.59s)
--- PASS: TestAccDynamoDBTable_enablePITR (204.80s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (120.47s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (62.65s)
--- PASS: TestAccDynamoDBTable_encryption (252.70s)
--- PASS: TestAccDynamoDBTable_extended (255.19s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (86.65s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (105.23s)
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (257.97s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (439.55s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (395.73s)
--- PASS: TestAccDynamoDBTable_backupEncryption (372.33s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (545.54s)
--- PASS: TestAccDynamoDBTable_Replica_single (537.85s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (707.77s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (537.08s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (722.98s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (937.50s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1029.86s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (1144.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	1146.723s
```
