### PR TITLE
docs(sqs): Correct usage of redrive_allow_policy

### DIFF
--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -21,10 +21,6 @@ resource "aws_sqs_queue" "terraform_queue" {
     deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
     maxReceiveCount     = 4
   })
-  redrive_allow_policy = jsonencode({
-    redrivePermission = "byQueue",
-    sourceQueueArns   = [aws_sqs_queue.terraform_queue_deadletter.arn]
-  })
 
   tags = {
     Environment = "production"
@@ -50,6 +46,18 @@ resource "aws_sqs_queue" "terraform_queue" {
   fifo_queue            = true
   deduplication_scope   = "messageGroup"
   fifo_throughput_limit = "perMessageGroupId"
+}
+```
+
+## Dead-letter queue
+
+```terraform
+resource "aws_sqs_queue" "terraform_queue_deadletter" {
+  name                  = "terraform-example-deadletter-queue"
+  redrive_allow_policy  = jsonencode({
+    redrivePermission   = "byQueue",
+    sourceQueueArns     = [aws_sqs_queue.terraform_queue.arn]
+  })
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
---
Relates #22577

As mentioned in the linked issue, the provider documentation is incorrect and can be confusing, [example for `aws_sqs_queue`](https://registry.terraform.io/providers/hashicorp/aws/4.21.0/docs/resources/sqs_queue#example-usage) states:

```hcl
resource "aws_sqs_queue" "terraform_queue" {
  name                      = "terraform-example-queue"
  delay_seconds             = 90
  max_message_size          = 2048
  message_retention_seconds = 86400
  receive_wait_time_seconds = 10
  redrive_policy = jsonencode({
    deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
    maxReceiveCount     = 4
  })
  redrive_allow_policy = jsonencode({                                    #  <- Intended for DLQ
    redrivePermission = "byQueue",                                       #
    sourceQueueArns   = [aws_sqs_queue.terraform_queue_deadletter.arn]   #  <- Should be source queue arn
  })                                                                     #

  tags = {
    Environment = "production"
  }
}
```

Relevant [AWS API Documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters).
