### PR TITLE
rd/aws_imagebuilder_distribution_configuration - support fastLaunchConfigurations

### DIFF
--- a/.changelog/25671.txt
+++ b/.changelog/25671.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_imagebuilder_distribution_configuration: Add `fast_launch_configuration` argument to the `distribution` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_imagebuilder_distribution_configuration: Add `fast_launch_configuration` attribute to the `distribution` configuration block
+```

--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -168,6 +168,68 @@ func ResourceDistributionConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"fast_launch_configuration": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 1000,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"account_id": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: verify.ValidAccountID,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"launch_template": {
+										Type:     schema.TypeList,
+										MaxItems: 1,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"launch_template_id": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidLaunchTemplateID,
+												},
+												"launch_template_name": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidLaunchTemplateName,
+												},
+												"launch_template_version": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
+												},
+											},
+										},
+									},
+									"max_parallel_launches": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntBetween(1, 10000),
+									},
+									"snapshot_configuration": {
+										Type:     schema.TypeList,
+										MaxItems: 1,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"target_resource_count": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(1, 10000),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"launch_template_configuration": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -461,6 +523,10 @@ func expandDistribution(tfMap map[string]interface{}) *imagebuilder.Distribution
 		apiObject.ContainerDistributionConfiguration = expandContainerDistributionConfiguration(v[0].(map[string]interface{}))
 	}
 
+	if v, ok := tfMap["fast_launch_configuration"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.FastLaunchConfigurations = expandFastLaunchConfigurations(v.List())
+	}
+
 	if v, ok := tfMap["launch_template_configuration"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.LaunchTemplateConfigurations = expandLaunchTemplateConfigurations(v.List())
 	}
@@ -548,6 +614,98 @@ func expandTargetContainerRepository(tfMap map[string]interface{}) *imagebuilder
 
 	if v, ok := tfMap["service"].(string); ok && v != "" {
 		apiObject.Service = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandFastLaunchConfigurations(tfList []interface{}) []*imagebuilder.FastLaunchConfiguration {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*imagebuilder.FastLaunchConfiguration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandFastLaunchConfiguration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandFastLaunchConfiguration(tfMap map[string]interface{}) *imagebuilder.FastLaunchConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.FastLaunchConfiguration{}
+
+	if v, ok := tfMap["account_id"].(string); ok && v != "" {
+		apiObject.AccountId = aws.String(v)
+	}
+
+	if v, ok := tfMap["enabled"].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		apiObject.LaunchTemplate = expandFastLaunchLaunchTemplateSpecification(v[0].(map[string]interface{}))
+	}
+
+	if v, ok := tfMap["max_parallel_launches"].(int); ok && v != 0 {
+		apiObject.MaxParallelLaunches = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["snapshot_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		apiObject.SnapshotConfiguration = expandFastLaunchSnapshotConfiguration(v[0].(map[string]interface{}))
+	}
+
+	return apiObject
+}
+
+func expandFastLaunchLaunchTemplateSpecification(tfMap map[string]interface{}) *imagebuilder.FastLaunchLaunchTemplateSpecification {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.FastLaunchLaunchTemplateSpecification{}
+
+	if v, ok := tfMap["launch_template_id"].(string); ok && v != "" {
+		apiObject.LaunchTemplateId = aws.String(v)
+	}
+
+	if v, ok := tfMap["launch_template_name"].(string); ok && v != "" {
+		apiObject.LaunchTemplateName = aws.String(v)
+	}
+
+	if v, ok := tfMap["launch_template_version"].(string); ok && v != "" {
+		apiObject.LaunchTemplateVersion = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandFastLaunchSnapshotConfiguration(tfMap map[string]interface{}) *imagebuilder.FastLaunchSnapshotConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.FastLaunchSnapshotConfiguration{}
+
+	if v, ok := tfMap["target_resource_count"].(int); ok && v != 0 {
+		apiObject.TargetResourceCount = aws.Int64(int64(v))
 	}
 
 	return apiObject
@@ -664,6 +822,10 @@ func flattenDistribution(apiObject *imagebuilder.Distribution) map[string]interf
 		tfMap["container_distribution_configuration"] = []interface{}{flattenContainerDistributionConfiguration(v)}
 	}
 
+	if v := apiObject.FastLaunchConfigurations; v != nil {
+		tfMap["fast_launch_configuration"] = flattenFastLaunchConfigurations(v)
+	}
+
 	if v := apiObject.LaunchTemplateConfigurations; v != nil {
 		tfMap["launch_template_configuration"] = flattenLaunchTemplateConfigurations(v)
 	}
@@ -758,6 +920,90 @@ func flattenLaunchTemplateConfiguration(apiObject *imagebuilder.LaunchTemplateCo
 
 	if v := apiObject.AccountId; v != nil {
 		tfMap["account_id"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenFastLaunchConfigurations(apiObjects []*imagebuilder.FastLaunchConfiguration) []interface{} {
+	if apiObjects == nil {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenFastLaunchConfiguration(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenFastLaunchConfiguration(apiObject *imagebuilder.FastLaunchConfiguration) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.AccountId; v != nil {
+		tfMap["account_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Enabled; v != nil {
+		tfMap["enabled"] = aws.BoolValue(v)
+	}
+
+	if v := apiObject.LaunchTemplate; v != nil {
+		tfMap["launch_template"] = []interface{}{flattenFastLaunchLaunchTemplateSpecification(v)}
+	}
+
+	if v := apiObject.MaxParallelLaunches; v != nil {
+		tfMap["max_parallel_launches"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.SnapshotConfiguration; v != nil {
+		tfMap["snapshot_configuration"] = []interface{}{flattenFastLaunchSnapshotConfiguration(v)}
+	}
+
+	return tfMap
+}
+
+func flattenFastLaunchLaunchTemplateSpecification(apiObject *imagebuilder.FastLaunchLaunchTemplateSpecification) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.LaunchTemplateId; v != nil {
+		tfMap["launch_template_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.LaunchTemplateName; v != nil {
+		tfMap["launch_template_name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.LaunchTemplateVersion; v != nil {
+		tfMap["launch_template_version"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenFastLaunchSnapshotConfiguration(apiObject *imagebuilder.FastLaunchSnapshotConfiguration) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.TargetResourceCount; v != nil {
+		tfMap["target_resource_count"] = aws.Int64Value(v)
 	}
 
 	return tfMap

--- a/internal/service/imagebuilder/distribution_configuration_data_source.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source.go
@@ -137,6 +137,58 @@ func DataSourceDistributionConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"fast_launch_configuration": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"account_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"launch_template": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"launch_template_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"launch_template_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"launch_template_version": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"max_parallel_launches": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"snapshot_configuration": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"target_resource_count": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"launch_template_configuration": {
 							Type:     schema.TypeSet,
 							Computed: true,

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -35,6 +35,16 @@ func TestAccImageBuilderDistributionConfigurationDataSource_arn(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.#", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.#", resourceName, "distribution.0.fast_launch_configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.account_id", resourceName, "distribution.0.fast_launch_configuration.0.account_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.enabled", resourceName, "distribution.0.fast_launch_configuration.0.enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.launch_template.#", resourceName, "distribution.0.fast_launch_configuration.0.launch_template.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_id", resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_name", resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_version", resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.max_parallel_launches", resourceName, "distribution.0.fast_launch_configuration.0.max_parallel_launches"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.#", resourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.0.target_resource_count", resourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.0.target_resource_count"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.#", resourceName, "distribution.0.launch_template_configuration.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.default", resourceName, "distribution.0.launch_template_configuration.0.default"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.launch_template_id", resourceName, "distribution.0.launch_template_configuration.0.launch_template_id"),
@@ -77,6 +87,22 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       account_id         = data.aws_caller_identity.current.account_id
       default            = false
       launch_template_id = aws_launch_template.test.id
+    }
+
+    fast_launch_configuration {
+      account_id = data.aws_caller_identity.current.account_id
+      enabled    = true
+
+      launch_template {
+        launch_template_id      = aws_launch_template.test.id
+        launch_template_version = "1"
+      }
+
+      max_parallel_launches = 1
+
+      snapshot_configuration {
+        target_resource_count = 1
+      }
     }
 
     region = data.aws_region.current.name

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -587,6 +587,164 @@ func TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribut
 	})
 }
 
+func TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchEnabled(rName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchEnabled(rName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+	launchTemplateResourceName1 := "aws_launch_template.test"
+	launchTemplateResourceName2 := "aws_launch_template.test2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchLaunchTemplate1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_id", launchTemplateResourceName1, "id"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_version", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchLaunchTemplate2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_name", launchTemplateResourceName2, "name"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.launch_template.0.launch_template_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchMaxParallelLaunches(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.max_parallel_launches", "5"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchMaxParallelLaunches(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.max_parallel_launches", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchSnapshotConfiguration(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.0.target_resource_count", "5"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationConfig_fastLaunchSnapshotConfiguration(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.fast_launch_configuration.0.snapshot_configuration.0.target_resource_count", "10"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	launchTemplateResourceName := "aws_launch_template.test"
@@ -1099,6 +1257,136 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   }
 }
 `, rName, containerTag)
+}
+
+func testAccDistributionConfigurationConfig_fastLaunchEnabled(rName, enabled string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    fast_launch_configuration {
+      account_id = data.aws_caller_identity.current.account_id
+      enabled    = %[2]s
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName, enabled)
+}
+
+func testAccDistributionConfigurationConfig_fastLaunchLaunchTemplate1(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_launch_template" "test" {
+  instance_type = "t2.micro"
+  name          = %[1]q
+}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    fast_launch_configuration {
+      account_id = data.aws_caller_identity.current.account_id
+      enabled    = true
+
+      launch_template {
+        launch_template_id      = aws_launch_template.test.id
+        launch_template_version = "1"
+      }
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName)
+}
+
+func testAccDistributionConfigurationConfig_fastLaunchLaunchTemplate2(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_launch_template" "test2" {
+  instance_type = "t2.micro"
+  name          = %[1]q
+}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    fast_launch_configuration {
+      account_id = data.aws_caller_identity.current.account_id
+      enabled    = true
+
+      launch_template {
+        launch_template_name    = aws_launch_template.test2.name
+        launch_template_version = "2"
+      }
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName)
+}
+
+func testAccDistributionConfigurationConfig_fastLaunchMaxParallelLaunches(rName string, maxParallelLaunches int) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    fast_launch_configuration {
+      account_id            = data.aws_caller_identity.current.account_id
+      enabled               = true
+      max_parallel_launches = %[2]d
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName, maxParallelLaunches)
+}
+
+func testAccDistributionConfigurationConfig_fastLaunchSnapshotConfiguration(rName string, targetResourceCount int) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    fast_launch_configuration {
+      account_id = data.aws_caller_identity.current.account_id
+      enabled    = true
+
+      snapshot_configuration {
+        target_resource_count = %[2]d
+      }
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName, targetResourceCount)
 }
 
 func testAccDistributionConfigurationConfig_launchTemplateIDDefault(rName string) string {

--- a/website/docs/d/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/d/imagebuilder_distribution_configuration.html.markdown
@@ -46,6 +46,16 @@ In addition to all arguments above, the following attributes are exported:
         * `target_repository` - Set of destination repositories for the container distribution configuration.
             * `repository_name` - Name of the container repository where the output container image is stored.
             * `service` - Service in which the image is registered.
+    * `fast_launch_configuration` - Nested list of Windows faster-launching configurations to use for AMI distribution.
+        * `account_id` - The owner account ID for the fast-launch enabled Windows AMI.
+        * `enabled` - A Boolean that represents the current state of faster launching for the Windows AMI.
+        * `launch_template` - Nested list of launch templates that the fast-launch enabled Windows AMI uses when it launches Windows instances to create pre-provisioned snapshots.
+            * `launch_template_id` - The ID of the launch template to use for faster launching for a Windows AMI.
+            * `launch_template_name` - The name of the launch template to use for faster launching for a Windows AMI.
+            * `launch_template_version` - The version of the launch template to use for faster launching for a Windows AMI.
+        * `max_parallel_launches` - The maximum number of parallel instances that are launched for creating resources.
+        * `snapshot_configuration` - Nested list of configurations for managing the number of snapshots that are created from pre-provisioned instances for the Windows AMI when faster launching is enabled.
+            * `target_resource_count` - The number of pre-provisioned snapshots to keep on hand for a fast-launch enabled Windows AMI.
     * `launch_template_configuration` - Nested list of launch template configurations.
         * `default` - Indicates whether the specified Amazon EC2 launch template is set as the default launch template.
         * `launch_template_id` - ID of the Amazon EC2 launch template.

--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -61,6 +61,7 @@ The following arguments are optional:
 
 * `ami_distribution_configuration` - (Optional) Configuration block with Amazon Machine Image (AMI) distribution settings. Detailed below.
 * `container_distribution_configuration` - (Optional) Configuration block with container distribution settings. Detailed below.
+* `fast_launch_configuration` - (Optional) Set of Windows faster-launching configurations to use for AMI distribution. Detailed below.
 * `launch_template_configuration` - (Optional) Set of launch template configuration settings that apply to image distribution. Detailed below.
 * `license_configuration_arns` - (Optional) Set of Amazon Resource Names (ARNs) of License Manager License Configurations.
 
@@ -94,6 +95,24 @@ The following arguments are optional:
 
 * `repository_name` - (Required) The name of the container repository where the output container image is stored. This name is prefixed by the repository location.
 * `service` - (Required) The service in which this image is registered. Valid values: `ECR`.
+
+### fast_launch_configuration
+
+* `account_id` - (Required) The owner account ID for the fast-launch enabled Windows AMI.
+* `enabled` - (Required) A Boolean that represents the current state of faster launching for the Windows AMI. Set to `true` to start using Windows faster launching, or `false` to stop using it.
+* `launch_template` - (Optional) Configuration block for the launch template that the fast-launch enabled Windows AMI uses when it launches Windows instances to create pre-provisioned snapshots. Detailed below.
+* `max_parallel_launches` - (Optional) The maximum number of parallel instances that are launched for creating resources.
+* `snapshot_configuration` - (Optional) Configuration block for managing the number of snapshots that are created from pre-provisioned instances for the Windows AMI when faster launching is enabled. Detailed below.
+
+### launch_template
+
+* `launch_template_id` - (Optional) The ID of the launch template to use for faster launching for a Windows AMI.
+* `launch_template_name` - (Optional) The name of the launch template to use for faster launching for a Windows AMI.
+* `launch_template_version` - (Optional) The version of the launch template to use for faster launching for a Windows AMI.
+
+### snapshot_configuration
+
+* `target_resource_count` - (Optional) The number of pre-provisioned snapshots to keep on hand for a fast-launch enabled Windows AMI.
 
 ### launch_template_configuration
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25397.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ ACCTEST_PARALLELISM=2 make testacc PKG=imagebuilder TESTS="TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 2 -run='TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_'  -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches (49.51s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled (50.51s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate (50.20s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration (56.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       108.513s
```
```
$ make testacc PKG=imagebuilder TESTS="TestAccImageBuilderDistributionConfigurationDataSource_arn"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderDistributionConfigurationDataSource_arn'  -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfigurationDataSource_arn
=== PAUSE TestAccImageBuilderDistributionConfigurationDataSource_arn
=== CONT  TestAccImageBuilderDistributionConfigurationDataSource_arn
--- PASS: TestAccImageBuilderDistributionConfigurationDataSource_arn (41.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       43.253s
```