### PR TITLE
Fix typo in `aws_ce_anomaly_monitor` example

### DIFF
--- a/website/docs/r/ce_anomaly_monitor.html.markdown
+++ b/website/docs/r/ce_anomaly_monitor.html.markdown
@@ -31,7 +31,7 @@ resource "aws_ce_anomaly_monitor" "test" {
   name         = "AWSCustomAnomalyMonitor"
   monitor_type = "CUSTOM"
 
-  specification = <<JSON
+  monitor_specification = <<JSON
 {
 	"And": null,
 	"CostCategories": null,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing: n/a, docs

### Information

The example use specification argument instead of monitor_specification. The argument reference use the good typo.