### PR TITLE
Adjust tgw transit_gateway_cidr_blocks validation

### DIFF
--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -113,15 +113,15 @@ func ResourceTransitGateway() *schema.Resource {
 			"transit_gateway_cidr_blocks": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				MaxItems: 2,
+				MaxItems: 5,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: verify.IsIPv4CIDRBlockOrIPv6CIDRBlock(
 						validation.All(
-							validation.IsCIDRNetwork(16, 24),
+							validation.IsCIDRNetwork(0, 24),
 							validation.StringDoesNotMatch(regexp.MustCompile(`^169\.254\.`), "must not be from range 169.254.0.0/16"),
 						),
-						validation.IsCIDRNetwork(40, 64),
+						validation.IsCIDRNetwork(0, 64),
 					),
 				},
 			},


### PR DESCRIPTION
Transit gateway service quotas list 5 as the maximum CIDR blocks per transit gateway and it is not adjustable. https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-quotas.html

API docs specify a minimum CIDR block of /24 or /64 for IPv4 and IPv6, respectively. It does not specify a maximum size. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayRequestOptions.html

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25316

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Tests not run because it seems that all of the little tests are tied together into one huge test. 
