### PR TITLE
d/aws_location_route_calculator - new data source

### DIFF
--- a/.changelog/25689.txt
+++ b/.changelog/25689.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_location_tracker
+```

--- a/.changelog/25689.txt
+++ b/.changelog/25689.txt
@@ -1,3 +1,3 @@
 ```release-note:new-data-source
-aws_location_tracker
+aws_location_route_calculator
 ```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -743,9 +743,10 @@ func Provider() *schema.Provider {
 			"aws_lex_intent":    lexmodels.DataSourceIntent(),
 			"aws_lex_slot_type": lexmodels.DataSourceSlotType(),
 
-			"aws_location_map":         location.DataSourceMap(),
-			"aws_location_place_index": location.DataSourcePlaceIndex(),
-			"aws_location_tracker":     location.DataSourceTracker(),
+			"aws_location_map":              location.DataSourceMap(),
+			"aws_location_place_index":      location.DataSourcePlaceIndex(),
+			"aws_location_route_calculator": location.DataSourceRouteCalculator(),
+			"aws_location_tracker":          location.DataSourceTracker(),
 
 			"aws_arn":                     meta.DataSourceARN(),
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),

--- a/internal/service/location/route_calculator_data_source.go
+++ b/internal/service/location/route_calculator_data_source.go
@@ -1,0 +1,77 @@
+package location
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceRouteCalculator() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRouteCalculatorRead,
+
+		Schema: map[string]*schema.Schema{
+			"calculator_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"calculator_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	out, err := findRouteCalculatorByName(ctx, conn, d.Get("calculator_name").(string))
+	if err != nil {
+		return diag.Errorf("reading Location Service Route Calculator (%s): %s", d.Get("calculator_name").(string), err)
+	}
+
+	if out == nil {
+		return diag.Errorf("reading Location Service Route Calculator (%s): empty response", d.Get("calculator_name").(string))
+	}
+
+	d.SetId(aws.StringValue(out.CalculatorName))
+	d.Set("calculator_arn", out.CalculatorArn)
+	d.Set("calculator_name", out.CalculatorName)
+	d.Set("create_time", aws.TimeValue(out.CreateTime).Format(time.RFC3339))
+	d.Set("data_source", out.DataSource)
+	d.Set("description", out.Description)
+	d.Set("update_time", aws.TimeValue(out.UpdateTime).Format(time.RFC3339))
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	if err := d.Set("tags", KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("listing tags for Location Service Route Calculator (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/location/route_calculator_data_source_test.go
+++ b/internal/service/location/route_calculator_data_source_test.go
@@ -1,0 +1,52 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationRouteCalculatorDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_route_calculator.test"
+	resourceName := "aws_location_route_calculator.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckRouteCalculatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteCalculatorDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteCalculatorExists(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "calculator_arn", resourceName, "calculator_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "calculator_name", resourceName, "calculator_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_time", resourceName, "create_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "data_source", resourceName, "data_source"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "update_time", resourceName, "update_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRouteCalculatorDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_route_calculator" "test" {
+  calculator_name = %[1]q
+  data_source     = "Here"
+}
+
+data "aws_location_route_calculator" "test" {
+  calculator_name = aws_location_route_calculator.test.calculator_name
+}
+`, rName)
+}

--- a/website/docs/d/location_route_calculator.html.markdown
+++ b/website/docs/d/location_route_calculator.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_route_calculator"
+description: |-
+    Retrieve information about a Location Service Route Calculator.
+---
+
+# Data Source: aws_location_route_calculator
+
+Retrieve information about a Location Service Route Calculator.
+
+## Example Usage
+
+```terraform
+data "aws_location_route_calculator" "example" {
+  calculator_name = "example"
+}
+```
+
+## Argument Reference
+
+* `calculator_name` - (Required) The name of the route calculator resource.
+
+## Attributes Reference
+
+* `calculator_arn` - The Amazon Resource Name (ARN) for the Route calculator resource. Use the ARN when you specify a resource across AWS.
+* `create_time` - The timestamp for when the route calculator resource was created in ISO 8601 format.
+* `data_source` - The data provider of traffic and road network data.
+* `description` - The optional description of the route calculator resource.
+* `tags` - Key-value map of resource tags for the route calculator.
+* `update_time` - The timestamp for when the route calculator resource was last updated in ISO 8601 format.

--- a/website/docs/d/location_tracker.html.markdown
+++ b/website/docs/d/location_tracker.html.markdown
@@ -28,6 +28,6 @@ data "aws_location_tracker" "example" {
 * `description` - The optional description for the tracker resource.
 * `kms_key_id` - A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
 * `position_filtering` - The position filtering method of the tracker resource.
-* `tags` - Key-value map of resource tags for the map.
+* `tags` - Key-value map of resource tags for the tracker.
 * `tracker_arn` - The Amazon Resource Name (ARN) for the tracker resource. Used when you need to specify a resource across all AWS.
 * `update_time` - The timestamp for when the tracker resource was last updated in ISO 8601 format.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationRouteCalculatorDataSource_basic"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationRouteCalculatorDataSource_basic'  -timeout 180m
=== RUN   TestAccLocationRouteCalculatorDataSource_basic
=== PAUSE TestAccLocationRouteCalculatorDataSource_basic
=== CONT  TestAccLocationRouteCalculatorDataSource_basic
--- PASS: TestAccLocationRouteCalculatorDataSource_basic (26.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   27.964s
```
