### PR TITLE
sweeper/aws_location_route_calculator - new sweeper

### DIFF
--- a/internal/service/location/route_calculator.go
+++ b/internal/service/location/route_calculator.go
@@ -188,7 +188,7 @@ func resourceRouteCalculatorDelete(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[INFO] Deleting Location Service Route Calculator %s", d.Id())
 
 	_, err := conn.DeleteRouteCalculatorWithContext(ctx, &locationservice.DeleteRouteCalculatorInput{
-		CalculatorName: aws.String(d.Get("calculator_name").(string)),
+		CalculatorName: aws.String(d.Id()),
 	})
 
 	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {

--- a/internal/service/location/sweep.go
+++ b/internal/service/location/sweep.go
@@ -30,6 +30,10 @@ func init() {
 		Name: "aws_location_tracker",
 		F:    sweepTrackers,
 	})
+	resource.AddTestSweepers("aws_location_route_calculator", &resource.Sweeper{
+		Name: "aws_location_route_calculator",
+		F:    sweepRouteCalculators,
+	})
 }
 
 func sweepMaps(region string) error {
@@ -167,6 +171,53 @@ func sweepTrackers(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping Location Service Tracker sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepRouteCalculators(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).LocationConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+
+	input := &locationservice.ListRouteCalculatorsInput{}
+
+	err = conn.ListRouteCalculatorsPages(input, func(page *locationservice.ListRouteCalculatorsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, entry := range page.Entries {
+			r := ResourceRouteCalculator()
+			d := r.Data(nil)
+
+			id := aws.StringValue(entry.CalculatorName)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Location Service Route Calculator for %s: %w", region, err))
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Location Service Route Calculator for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Location Service Route Calculator sweep for %s: %s", region, errs)
 		return nil
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ SWEEPARGS=-sweep-run=aws_location_route_calculator SWEEP=us-west-2 make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_location_route_calculator -timeout 60m
2022/07/05 21:08:06 Completed Sweepers for region (us-west-2) in 3.174622334s
2022/07/05 21:08:06 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_location_route_calculator
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      4.676s
...
```
```
$ make testacc PKG=location TESTS="TestAccLocationRouteCalculator_"               

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationRouteCalculator_'  -timeout 180m
        === RUN   TestAccLocationRouteCalculator_basic
=== PAUSE TestAccLocationRouteCalculator_basic
=== RUN   TestAccLocationRouteCalculator_disappears
=== PAUSE TestAccLocationRouteCalculator_disappears
=== RUN   TestAccLocationRouteCalculator_description
=== PAUSE TestAccLocationRouteCalculator_description
=== RUN   TestAccLocationRouteCalculator_tags
=== PAUSE TestAccLocationRouteCalculator_tags
=== CONT  TestAccLocationRouteCalculator_basic
=== CONT  TestAccLocationRouteCalculator_description
=== CONT  TestAccLocationRouteCalculator_tags
=== CONT  TestAccLocationRouteCalculator_disappears
--- PASS: TestAccLocationRouteCalculator_disappears (20.61s)
--- PASS: TestAccLocationRouteCalculator_basic (29.44s)
--- PASS: TestAccLocationRouteCalculator_description (48.79s)
--- PASS: TestAccLocationRouteCalculator_tags (66.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   67.770s
```
