### PR TITLE
Fix crash in ACMPCA with empty revocation_configuration

### DIFF
--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -631,7 +631,7 @@ func expandCrlConfiguration(l []interface{}) *acmpca.CrlConfiguration {
 }
 
 func expandRevocationConfiguration(l []interface{}) *acmpca.RevocationConfiguration {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #25674

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccACMPCACertificateAuthority PKG=acmpca
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acmpca/... -v -count 1 -parallel 20 -run='TestAccACMPCACertificateAuthority'  -timeout 180m
=== RUN   TestAccACMPCACertificateAuthorityCertificate_rootCA
=== PAUSE TestAccACMPCACertificateAuthorityCertificate_rootCA
=== RUN   TestAccACMPCACertificateAuthorityCertificate_updateRootCA
=== PAUSE TestAccACMPCACertificateAuthorityCertificate_updateRootCA
=== RUN   TestAccACMPCACertificateAuthorityCertificate_subordinateCA
=== PAUSE TestAccACMPCACertificateAuthorityCertificate_subordinateCA
=== RUN   TestAccACMPCACertificateAuthorityDataSource_basic
=== PAUSE TestAccACMPCACertificateAuthorityDataSource_basic
=== RUN   TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL
=== PAUSE TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL
=== RUN   TestAccACMPCACertificateAuthority_basic
=== PAUSE TestAccACMPCACertificateAuthority_basic
=== RUN   TestAccACMPCACertificateAuthority_disappears
=== PAUSE TestAccACMPCACertificateAuthority_disappears
=== RUN   TestAccACMPCACertificateAuthority_enabledDeprecated
=== PAUSE TestAccACMPCACertificateAuthority_enabledDeprecated
=== RUN   TestAccACMPCACertificateAuthority_deleteFromActiveState
=== PAUSE TestAccACMPCACertificateAuthority_deleteFromActiveState
=== RUN   TestAccACMPCACertificateAuthority_RevocationConfiguration_empty
=== PAUSE TestAccACMPCACertificateAuthority_RevocationConfiguration_empty
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== RUN   TestAccACMPCACertificateAuthority_tags
=== PAUSE TestAccACMPCACertificateAuthority_tags
=== CONT  TestAccACMPCACertificateAuthorityCertificate_rootCA
=== CONT  TestAccACMPCACertificateAuthority_deleteFromActiveState
=== CONT  TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL
=== CONT  TestAccACMPCACertificateAuthority_enabledDeprecated
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== CONT  TestAccACMPCACertificateAuthority_RevocationConfiguration_empty
=== CONT  TestAccACMPCACertificateAuthority_basic
=== CONT  TestAccACMPCACertificateAuthority_disappears
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== CONT  TestAccACMPCACertificateAuthority_tags
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== CONT  TestAccACMPCACertificateAuthorityCertificate_subordinateCA
=== CONT  TestAccACMPCACertificateAuthorityDataSource_basic
=== CONT  TestAccACMPCACertificateAuthorityCertificate_updateRootCA
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
--- PASS: TestAccACMPCACertificateAuthority_disappears (30.45s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL (47.11s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_basic (48.43s)
--- PASS: TestAccACMPCACertificateAuthority_deleteFromActiveState (49.81s)
--- PASS: TestAccACMPCACertificateAuthority_basic (51.24s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationConfiguration_empty (54.19s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_rootCA (59.23s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_subordinateCA (60.33s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_updateRootCA (73.27s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL (79.01s)
--- PASS: TestAccACMPCACertificateAuthority_enabledDeprecated (89.04s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays (92.65s)
--- PASS: TestAccACMPCACertificateAuthority_tags (100.69s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_enabled (106.54s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME (117.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	117.080s
```
