### PR TITLE
Add AppRunner Observability Configuration argument configuration block

### DIFF
--- a/.changelog/25697.txt
+++ b/.changelog/25697.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_apprunner_service: Add `observability_configuration` argument configuration block
+```

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -182,6 +182,25 @@ func ResourceService() *schema.Resource {
 				},
 			},
 
+			"observability_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			"service_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -413,6 +432,10 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("observability_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(v.([]interface{}))
+	}
+
 	var output *apprunner.CreateServiceOutput
 
 	err := resource.RetryContext(ctx, propagationTimeout, func() *resource.RetryError {
@@ -515,6 +538,10 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(fmt.Errorf("error setting network_configuration: %w", err))
 	}
 
+	if err := d.Set("observability_configuration", flattenServiceObservabilityConfiguration(service.ObservabilityConfiguration)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting observability_configuration: %w", err))
+	}
+
 	if err := d.Set("source_configuration", flattenServiceSourceConfiguration(service.SourceConfiguration)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting source_configuration: %w", err))
 	}
@@ -546,6 +573,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		"auto_scaling_configuration_arn",
 		"instance_configuration",
 		"network_configuration",
+		"observability_configuration",
 		"source_configuration",
 	) {
 		input := &apprunner.UpdateServiceInput{
@@ -562,6 +590,10 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if d.HasChange("network_configuration") {
 			input.NetworkConfiguration = expandNetworkConfiguration(d.Get("network_configuration").([]interface{}))
+		}
+
+		if d.HasChange("observability_configuration") {
+			input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(d.Get("observability_configuration").([]interface{}))
 		}
 
 		if d.HasChange("source_configuration") {
@@ -721,6 +753,30 @@ func expandNetworkConfiguration(l []interface{}) *apprunner.NetworkConfiguration
 
 	if v, ok := tfMap["egress_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		result.EgressConfiguration = expandNetworkEgressConfiguration(v)
+	}
+
+	return result
+}
+
+func expandServiceObservabilityConfiguration(l []interface{}) *apprunner.ServiceObservabilityConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	result := &apprunner.ServiceObservabilityConfiguration{}
+
+	if v, ok := tfMap["arn"].(string); ok {
+		result.ObservabilityConfigurationArn = aws.String(v)
+	}
+
+	if v, ok := tfMap["enabled"].(bool); ok {
+		result.ObservabilityEnabled = aws.Bool(v)
 	}
 
 	return result
@@ -1037,6 +1093,19 @@ func flattenNetworkEgressConfiguration(config *apprunner.EgressConfiguration) []
 	m := map[string]interface{}{
 		"egress_type":       aws.StringValue(config.EgressType),
 		"vpc_connector_arn": aws.StringValue(config.VpcConnectorArn),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenServiceObservabilityConfiguration(config *apprunner.ServiceObservabilityConfiguration) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"arn":     aws.StringValue(config.ObservabilityConfigurationArn),
+		"enabled": aws.BoolValue(config.ObservabilityEnabled),
 	}
 
 	return []interface{}{m}

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -188,12 +188,12 @@ func ResourceService() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"arn": {
+						"observability_configuration_arn": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: verify.ValidARN,
 						},
-						"enabled": {
+						"observability_enabled": {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
@@ -771,11 +771,11 @@ func expandServiceObservabilityConfiguration(l []interface{}) *apprunner.Service
 
 	result := &apprunner.ServiceObservabilityConfiguration{}
 
-	if v, ok := tfMap["arn"].(string); ok {
+	if v, ok := tfMap["observability_configuration_arn"].(string); ok {
 		result.ObservabilityConfigurationArn = aws.String(v)
 	}
 
-	if v, ok := tfMap["enabled"].(bool); ok {
+	if v, ok := tfMap["observability_enabled"].(bool); ok {
 		result.ObservabilityEnabled = aws.Bool(v)
 	}
 
@@ -1104,8 +1104,8 @@ func flattenServiceObservabilityConfiguration(config *apprunner.ServiceObservabi
 	}
 
 	m := map[string]interface{}{
-		"arn":     aws.StringValue(config.ObservabilityConfigurationArn),
-		"enabled": aws.BoolValue(config.ObservabilityEnabled),
+		"observability_configuration_arn": aws.StringValue(config.ObservabilityConfigurationArn),
+		"observability_enabled":           aws.BoolValue(config.ObservabilityEnabled),
 	}
 
 	return []interface{}{m}

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -190,7 +190,7 @@ func ResourceService() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"observability_configuration_arn": {
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"observability_enabled": {

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -720,7 +720,7 @@ resource "aws_apprunner_service" "test" {
 
   observability_configuration {
     observability_configuration_arn = aws_apprunner_observability_configuration.test.arn
-    observability_enabled 			= true
+    observability_enabled           = true
   }
 
   source_configuration {

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -720,7 +720,7 @@ resource "aws_apprunner_service" "test" {
 
   observability_configuration {
     observability_configuration_arn = aws_apprunner_observability_configuration.test.arn
-    observability_enabled = true
+    observability_enabled 			= true
   }
 
   source_configuration {

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -587,10 +587,6 @@ resource "aws_apprunner_service" "test" {
     kms_key = aws_kms_key.test.arn
   }
 
-  observability_configuration {
-    enabled = true
-  }
-
   source_configuration {
     auto_deployments_enabled = false
     image_repository {

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -305,6 +305,35 @@ func TestAccAppRunnerService_ImageRepository_networkConfiguration(t *testing.T) 
 	})
 }
 
+func TestAccAppRunnerService_ImageRepository_observabilityConfiguration(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_apprunner_service.test"
+	observabilityConfigurationResourceName := "aws_apprunner_observability_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, apprunner.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_ImageRepository_observabilityConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "observability_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "observability_configuration.0.observability_configuration_arn", observabilityConfigurationResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "observability_configuration.0.observability_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19469
 func TestAccAppRunnerService_ImageRepository_runtimeEnvironmentVars(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -558,6 +587,10 @@ resource "aws_apprunner_service" "test" {
     kms_key = aws_kms_key.test.arn
   }
 
+  observability_configuration {
+    enabled = true
+  }
+
   source_configuration {
     auto_deployments_enabled = false
     image_repository {
@@ -674,6 +707,43 @@ resource "aws_apprunner_service" "test" {
       image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
+  }
+}
+`, rName)
+}
+
+func testAccServiceConfig_ImageRepository_observabilityConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apprunner_service" "test" {
+  service_name = %[1]q
+
+  health_check_configuration {
+    healthy_threshold = 2
+    timeout           = 5
+  }
+
+  observability_configuration {
+    observability_configuration_arn = aws_apprunner_observability_configuration.test.arn
+    observability_enabled = true
+  }
+
+  source_configuration {
+    auto_deployments_enabled = false
+    image_repository {
+      image_configuration {
+        port = "80"
+      }
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
+      image_repository_type = "ECR_PUBLIC"
+    }
+  }
+}
+
+resource "aws_apprunner_observability_configuration" "test" {
+  observability_configuration_name = %[1]q
+
+  trace_configuration {
+    vendor = "AWSXRAY"
   }
 }
 `, rName)

--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -76,6 +76,42 @@ resource "aws_apprunner_service" "example" {
 }
 ```
 
+### Service with Observability Configuration
+
+```terraform
+resource "aws_apprunner_service" "example" {
+  service_name = "example"
+
+  observability_configuration {
+    observability_configuration_arn = aws_apprunner_observability_configuration.example.arn
+    observability_enabled           = true
+  }
+
+  source_configuration {
+    image_repository {
+      image_configuration {
+        port = "8000"
+      }
+      image_identifier      = "public.ecr.aws/aws-containers/hello-app-runner:latest"
+      image_repository_type = "ECR_PUBLIC"
+    }
+    auto_deployment_enabled = false
+  }
+
+  tags = {
+    Name = "example-apprunner-service"
+  }
+}
+
+resource "aws_apprunner_observability_configuration" "example" {
+  observability_configuration_name = "example"
+
+  trace_configuration {
+    vendor = "AWSXRAY"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -89,8 +125,9 @@ The following arguments are optional:
 * `encryption_configuration` - (Forces new resource) An optional custom encryption key that App Runner uses to encrypt the copy of your source repository that it maintains and your service logs. By default, App Runner uses an AWS managed CMK. See [Encryption Configuration](#encryption-configuration) below for more details.
 * `health_check_configuration` - (Forces new resource) Settings of the health check that AWS App Runner performs to monitor the health of your service. See [Health Check Configuration](#health-check-configuration) below for more details.
 * `instance_configuration` - The runtime configuration of instances (scaling units) of the App Runner service. See [Instance Configuration](#instance-configuration) below for more details.
+* `network_configuration` - Configuration settings related to network traffic of the web application that the App Runner service runs. See [Network Configuration](#network-configuration) below for more details.
+* `observability_configuration` - The observability configuration of your service. See [Observability Configuration](#observability-configuration) below for more details.
 * `tags` - Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `network_configuration` - Configuration settings related to network traffic of the web application that the App Runner service runs.
 
 ### Encryption Configuration
 
@@ -142,6 +179,13 @@ The `network_configuration` block supports the following arguments:
 * `egress_configuration` - (Optional) Network configuration settings for outbound message traffic.
 * `egress_type` - (Optional) The type of egress configuration.Set to DEFAULT for access to resources hosted on public networks.Set to VPC to associate your service to a custom VPC specified by VpcConnectorArn.
 * `vpc_connector_arn` - The Amazon Resource Name (ARN) of the App Runner VPC connector that you want to associate with your App Runner service. Only valid when EgressType = VPC.
+
+### Observability Configuration
+
+The `observability_configuration` block supports the following arguments:
+
+* `observability_configuration_arn` - (Required) The Amazon Resource Name (ARN) of the observability configuration that is associated with the service.
+* `observability_enabled` - (Required) When `true`, an observability configuration resource is associated with the service.
 
 ### Code Repository
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25677

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
bruno@pop-os ~/G/terraform-provider-aws (e/add-apprunner-observability-configuration-attribute-block)> make testacc TESTS=TestAccAppRunnerService_ImageRepository_observabilityConfiguration PKG=apprunner   (base) 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apprunner/... -v -count 1 -parallel 20 -run='TestAccAppRunnerService_ImageRepository_observabilityConfiguration'  -timeout 180m
=== RUN   TestAccAppRunnerService_ImageRepository_observabilityConfiguration
=== PAUSE TestAccAppRunnerService_ImageRepository_observabilityConfiguration
=== CONT  TestAccAppRunnerService_ImageRepository_observabilityConfiguration
--- PASS: TestAccAppRunnerService_ImageRepository_observabilityConfiguration (326.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  326.054s
```
