### PR TITLE
aws_codestarconnections_connection: update docs

### DIFF
--- a/website/docs/d/codestarconnections_connection.html.markdown
+++ b/website/docs/d/codestarconnections_connection.html.markdown
@@ -45,5 +45,5 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The CodeStar Connection ARN.
 * `host_arn` - The Amazon Resource Name (ARN) of the host associated with the connection.
 * `name` - The name of the CodeStar Connection. The name is unique in the calling AWS account.
-* `provider_type` - The name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket`, `GitHub`, or `GitHubEnterpriseServer`.
+* `provider_type` - The name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket` and `GitHub`. For connections to a GitHub Enterprise Server instance, you must create an [aws_codestarconnections_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_host) resource and use `host_arn` instead.
 * `tags` - Map of key-value resource tags to associate with the resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Small documentation update to clarify the correct use of aws_codestarconnection_connection resources when used  with GitHub Enterprise instances.

It's unclear from the current documentation that this does not work:

```hcl
resource "aws_codestarconnections_connection" "example" {
	name                = "example-connection"
	provider_type  = "GitHubEnterpriseServer"
}
```

This results in:
```
│ Error: creating CodeStar Connections Connection (example-connection): ValidationException: To use a hosted provider specify HostArn instead of ProviderType
│ 	status code: 400, request id: 25360ff3-d168-49c1-a825-a771ef3b76f8
│
│   with aws_codestarconnections_connection.example,
│   on main.tf line 1, in resource "aws_codestarconnections_connection" "example":
│    1: resource "aws_codestarconnections_connection" "example" {
│
```
Which matches AWS CLI output:
```
aws codestar-connections create-connection --provider-
type "GitHubEnterpriseServer" --connection-name "test"

An error occurred (ValidationException) when calling the CreateConnection operation: To use a hosted provider specify HostArn instead of ProviderType
```

A valid configuration would be:

```hcl
resource "aws_codestarconnections_host" "example" {
	name                       = "example-host"
	provider_endpoint  = "https://github.example.com"
	provider_type         = "GitHubEnterpriseServer"
}

resource "aws_codestarconnections_connection" "example" {
	name          = "wv-github-auth-test-connection"
	host_arn	   = aws_codestarconnections_host.example.arn
}
```

