### PR TITLE
b/aws_route53_resolver_endpoint

### DIFF
--- a/.changelog/25708.txt
+++ b/.changelog/25708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_resolver_endpoint: Fix deduplication with multiple IPs on the same subnet
+```

--- a/internal/service/route53resolver/endpoint.go
+++ b/internal/service/route53resolver/endpoint.go
@@ -411,7 +411,7 @@ func waitEndpointDeleted(ctx context.Context, conn *route53resolver.Route53Resol
 func endpointHashIPAddress(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-%s-", m["subnet_id"].(string), m["ip"].(string)))
 	return create.StringHashcode(buf.String())
 }
 


### PR DESCRIPTION
Adding the IP address to the hash to avoid deduplication when using multiple IPs in the same subnet.

The following code:
```hcl
resource "aws_route53_resolver_endpoint" "test" {
  name      = "r53-resolver-inbound"
  direction = "INBOUND"

  security_group_ids = ["sg-12345"]

  ip_address {
    subnet_id = "subnet-12345"
    ip        = "172.31.64.13"
  }

  ip_address {
    subnet_id = "subnet-12345"
    ip        = "172.31.64.14"
  }

  tags = {
    Name = "route53resolver"
  }
}
```

Without the fix:
```terraform
  # aws_route53_resolver_endpoint.test will be created
  + resource "aws_route53_resolver_endpoint" "test" {
      + arn                = (known after apply)
      + direction          = "INBOUND"
      + host_vpc_id        = (known after apply)
      + id                 = (known after apply)
      + name               = "r53-resolver-inbound"
      + security_group_ids = [
          + "sg-12345",
        ]
      + tags               = {
          + "Name" = "route53resolver"
        }
      + tags_all           = {
          + "Name" = "route53resolver"
        }

      + ip_address {
          + ip        = "172.31.64.14"
          + ip_id     = (known after apply)
          + subnet_id = "subnet-12345"
        }
    }
```

With the fix:
```terraform
  # aws_route53_resolver_endpoint.test will be created
  + resource "aws_route53_resolver_endpoint" "test" {
      + arn                = (known after apply)
      + direction          = "INBOUND"
      + host_vpc_id        = (known after apply)
      + id                 = (known after apply)
      + name               = "r53-resolver-inbound"
      + security_group_ids = [
          + "sg-12345",
        ]
      + tags               = {
          + "Name" = "route53resolver"
        }
      + tags_all           = {
          + "Name" = "route53resolver"
        }

      + ip_address {
          + ip        = "172.31.64.13"
          + ip_id     = (known after apply)
          + subnet_id = "subnet-12345"
        }
      + ip_address {
          + ip        = "172.31.64.14"
          + ip_id     = (known after apply)
          + subnet_id = "subnet-12345"
        }
    }
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9626

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRoute53ResolverEndpoint PKG=route53

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53ResolverEndpoint'  -timeout 180m
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	2.916s [no tests to run]
```