### PR TITLE
Fix: unexpected state 'rebooting' when creating Multi A-Z rds cluster

### DIFF
--- a/.changelog/25718.txt
+++ b/.changelog/25718.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Prevent failure of AWS RDS Cluster creation when it is in `rebooting` state.
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1501,6 +1501,7 @@ var resourceClusterCreatePendingStates = []string{
 	"preparing-data-migration",
 	"migrating",
 	"resetting-master-credentials",
+	"rebooting",
 }
 
 var resourceClusterDeletePendingStates = []string{


### PR DESCRIPTION
This PR adds the `rebooting` state to the list of allowable pending states when creating a Multi A-Z RDS cluster.

Affected resource: `aws_rds_cluster`

Closes https://github.com/hashicorp/terraform-provider-aws/issues/24721

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Output from acceptance testing:
[ Need help with running test `make testacc TESTS=TestAccRDSCluster_basic PKG=rds` ]:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
