### PR TITLE
r/aws_acmpca_certificate_authority: Add support for OCSP

### DIFF
--- a/.changelog/25720.txt
+++ b/.changelog/25720.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_acmpca_certificate_authority: Add `revocation_configuration.ocsp_configuration` argument
+```

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -255,6 +255,31 @@ func ResourceCertificateAuthority() *schema.Resource {
 								},
 							},
 						},
+						// https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_OcspConfiguration.html
+						"ocsp_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if old == "1" && new == "0" {
+									return true
+								}
+								return false
+							},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"ocsp_custom_cname": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(0, 253),
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -630,6 +655,24 @@ func expandCrlConfiguration(l []interface{}) *acmpca.CrlConfiguration {
 	return config
 }
 
+func expandOcspConfiguration(l []interface{}) *acmpca.OcspConfiguration {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &acmpca.OcspConfiguration{
+		Enabled: aws.Bool(m["enabled"].(bool)),
+	}
+
+	if v, ok := m["ocsp_custom_cname"]; ok && v.(string) != "" {
+		config.OcspCustomCname = aws.String(v.(string))
+	}
+
+	return config
+}
+
 func expandRevocationConfiguration(l []interface{}) *acmpca.RevocationConfiguration {
 	if len(l) == 0 {
 		return nil
@@ -638,7 +681,8 @@ func expandRevocationConfiguration(l []interface{}) *acmpca.RevocationConfigurat
 	m := l[0].(map[string]interface{})
 
 	config := &acmpca.RevocationConfiguration{
-		CrlConfiguration: expandCrlConfiguration(m["crl_configuration"].([]interface{})),
+		CrlConfiguration:  expandCrlConfiguration(m["crl_configuration"].([]interface{})),
+		OcspConfiguration: expandOcspConfiguration(m["ocsp_configuration"].([]interface{})),
 	}
 
 	return config
@@ -698,13 +742,27 @@ func flattenCrlConfiguration(config *acmpca.CrlConfiguration) []interface{} {
 	return []interface{}{m}
 }
 
+func flattenOcspConfiguration(config *acmpca.OcspConfiguration) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enabled":           aws.BoolValue(config.Enabled),
+		"ocsp_custom_cname": aws.StringValue(config.OcspCustomCname),
+	}
+
+	return []interface{}{m}
+}
+
 func flattenRevocationConfiguration(config *acmpca.RevocationConfiguration) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"crl_configuration": flattenCrlConfiguration(config.CrlConfiguration),
+		"crl_configuration":  flattenCrlConfiguration(config.CrlConfiguration),
+		"ocsp_configuration": flattenOcspConfiguration(config.OcspConfiguration),
 	}
 
 	return []interface{}{m}

--- a/internal/service/acmpca/certificate_authority_data_source.go
+++ b/internal/service/acmpca/certificate_authority_data_source.go
@@ -79,6 +79,24 @@ func DataSourceCertificateAuthority() *schema.Resource {
 								},
 							},
 						},
+						// https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_OcspConfiguration.html
+						"ocsp_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"ocsp_custom_cname": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -881,8 +881,8 @@ resource "aws_acmpca_certificate_authority" "test" {
 
   revocation_configuration {
     ocsp_configuration {
-	  enabled            = true
-      ocsp_custom_cname  = %[2]q
+      enabled           = true
+      ocsp_custom_cname = %[2]q
     }
   }
 }
@@ -905,7 +905,7 @@ resource "aws_acmpca_certificate_authority" "test" {
 
   revocation_configuration {
     ocsp_configuration {
-      enabled            = %[2]t
+      enabled = %[2]t
     }
   }
 }

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -48,7 +48,6 @@ func TestAccACMPCACertificateAuthority_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "serial", ""),
 					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_CERTIFICATE"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -442,6 +442,155 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL(t *testing.T) {
 	})
 }
 
+func TestAccACMPCACertificateAuthority_RevocationOcsp_enabled(t *testing.T) {
+	var certificateAuthority acmpca.CertificateAuthority
+	resourceName := "aws_acmpca_certificate_authority.test"
+
+	commonName := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, acmpca.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCertificateAuthorityDestroy,
+		Steps: []resource.TestStep{
+			// Test creating OCSP revocation configuration on resource creation
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, true),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname", ""),
+				),
+			},
+			// Test importing OCSP revocation configuration
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
+			},
+			// Test disabling OCSP revocation configuration
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, false),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "false"),
+				),
+			},
+			// Test enabling OCSP revocation configuration
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, true),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname", ""),
+				),
+			},
+			// Test removing revocation configuration on resource update
+			{
+				Config: testAccCertificateAuthorityConfig_required(commonName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) {
+	var certificateAuthority acmpca.CertificateAuthority
+	resourceName := "aws_acmpca_certificate_authority.test"
+
+	domain := acctest.RandomDomain()
+	commonName := domain.String()
+	customCName := domain.Subdomain("ocspl").String()
+	customCName2 := domain.Subdomain("ocsp2").String()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, acmpca.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCertificateAuthorityDestroy,
+		Steps: []resource.TestStep{
+			// Test creating revocation configuration on resource creation
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname", customCName),
+				),
+			},
+			// Test importing OCSP revocation configuration
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
+			},
+			// Test updating OCSP revocation configuration
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCName2),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname", customCName2),
+				),
+			},
+			// Test removing OCSP custom cname on resource update
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, true),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname", ""),
+				),
+			},
+			// Test adding OCSP custom cname on resource update
+			{
+				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname", customCName),
+				),
+			},
+			// Test removing revocation configuration on resource update
+			{
+				Config: testAccCertificateAuthorityConfig_required(commonName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckACMPCACertificateAuthorityExists(resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccACMPCACertificateAuthority_tags(t *testing.T) {
 	var certificateAuthority acmpca.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
@@ -714,6 +863,53 @@ resource "aws_acmpca_certificate_authority" "test" {
   depends_on = [aws_s3_bucket_policy.test]
 }
 `, commonName, s3ObjectAcl))
+}
+
+func testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCname string) string {
+	return fmt.Sprintf(`
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = %[1]q
+    }
+  }
+
+  revocation_configuration {
+    ocsp_configuration {
+	  enabled            = true
+      ocsp_custom_cname  = %[2]q
+    }
+  }
+}
+`, commonName, customCname)
+}
+
+func testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = %[1]q
+    }
+  }
+
+  revocation_configuration {
+    ocsp_configuration {
+      enabled            = %[2]t
+    }
+  }
+}
+`, commonName, enabled)
 }
 
 func testAccCertificateAuthorityConfig_S3Bucket(rName string) string {

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -48,6 +48,7 @@ func TestAccACMPCACertificateAuthority_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "serial", ""),
 					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_CERTIFICATE"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/website/docs/d/acmpca_certificate_authority.html.markdown
+++ b/website/docs/d/acmpca_certificate_authority.html.markdown
@@ -41,6 +41,8 @@ In addition to all arguments above, the following attributes are exported:
         * `revocation_configuration.0.crl_configuration.0.expiration_in_days` - Number of days until a certificate expires.
         * `revocation_configuration.0.crl_configuration.0.s3_bucket_name` - Name of the S3 bucket that contains the CRL.
         * `revocation_configuration.0.crl_configuration.0.s3_object_acl` - Whether the CRL is publicly readable or privately held in the CRL Amazon S3 bucket.
+        * `revocation_configuration.0.ocsp_configuration.0.enabled` - Boolean value that specifies whether a custom OCSP responder is enabled.
+        * `revocation_configuration.0.ocsp_configuration.0.ocsp_custom_cname` - A CNAME specifying a customized OCSP domain.
 * `serial` - Serial number of the certificate authority. Only available after the certificate authority certificate has been imported.
 * `status` - Status of the certificate authority.
 * `tags` - Specifies a key-value map of user-defined tags that are attached to the certificate authority.

--- a/website/docs/r/acmpca_certificate_authority.html.markdown
+++ b/website/docs/r/acmpca_certificate_authority.html.markdown
@@ -125,6 +125,8 @@ Contains information about the certificate subject. Identifies the entity that o
 ### revocation_configuration
 
 * `crl_configuration` - (Optional) Nested argument containing configuration of the certificate revocation list (CRL), if any, maintained by the certificate authority. Defined below.
+* `ocsp_configuration` - (Optional) Nested argument containing configuration of
+the custom OCSP responder endpoint. Defined below.
 
 #### crl_configuration
 
@@ -133,6 +135,11 @@ Contains information about the certificate subject. Identifies the entity that o
 * `expiration_in_days` - (Required) Number of days until a certificate expires. Must be between 1 and 5000.
 * `s3_bucket_name` - (Optional) Name of the S3 bucket that contains the CRL. If you do not provide a value for the `custom_cname` argument, the name of your S3 bucket is placed into the CRL Distribution Points extension of the issued certificate. You must specify a bucket policy that allows ACM PCA to write the CRL to your bucket. Must be less than or equal to 255 characters in length.
 * `s3_object_acl` - (Optional) Determines whether the CRL will be publicly readable or privately held in the CRL Amazon S3 bucket. Defaults to `PUBLIC_READ`.
+
+#### ocsp_configuration
+
+* `enabled` - (Required) Boolean value that specifies whether a custom OCSP responder is enabled.
+* `ocsp_custom_cname` - (Optional) A CNAME specifying a customized OCSP domain. Note: The value of the CNAME must not include a protocol prefix such as "http://" or "https://".
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20946

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccACMPCACertificateAuthority PKG=acmpca
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acmpca/... -v -count 1 -parallel 20 -run='TestAccACMPCACertificateAuthority'  -timeout 180m
=== RUN   TestAccACMPCACertificateAuthorityCertificate_rootCA
=== PAUSE TestAccACMPCACertificateAuthorityCertificate_rootCA
=== RUN   TestAccACMPCACertificateAuthorityCertificate_updateRootCA
=== PAUSE TestAccACMPCACertificateAuthorityCertificate_updateRootCA
=== RUN   TestAccACMPCACertificateAuthorityCertificate_subordinateCA
=== PAUSE TestAccACMPCACertificateAuthorityCertificate_subordinateCA
=== RUN   TestAccACMPCACertificateAuthorityDataSource_basic
=== PAUSE TestAccACMPCACertificateAuthorityDataSource_basic
=== RUN   TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL
=== PAUSE TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL
=== RUN   TestAccACMPCACertificateAuthority_basic
=== PAUSE TestAccACMPCACertificateAuthority_basic
=== RUN   TestAccACMPCACertificateAuthority_disappears
=== PAUSE TestAccACMPCACertificateAuthority_disappears
=== RUN   TestAccACMPCACertificateAuthority_enabledDeprecated
=== PAUSE TestAccACMPCACertificateAuthority_enabledDeprecated
=== RUN   TestAccACMPCACertificateAuthority_deleteFromActiveState
=== PAUSE TestAccACMPCACertificateAuthority_deleteFromActiveState
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== RUN   TestAccACMPCACertificateAuthority_RevocationOcsp_enabled
=== PAUSE TestAccACMPCACertificateAuthority_RevocationOcsp_enabled
=== RUN   TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME
=== PAUSE TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME
=== RUN   TestAccACMPCACertificateAuthority_tags
=== PAUSE TestAccACMPCACertificateAuthority_tags
=== CONT  TestAccACMPCACertificateAuthorityCertificate_rootCA
=== CONT  TestAccACMPCACertificateAuthority_deleteFromActiveState
=== CONT  TestAccACMPCACertificateAuthority_tags
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== CONT  TestAccACMPCACertificateAuthorityCertificate_subordinateCA
=== CONT  TestAccACMPCACertificateAuthorityCertificate_updateRootCA
=== CONT  TestAccACMPCACertificateAuthorityDataSource_basic
=== CONT  TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME
=== CONT  TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL
=== CONT  TestAccACMPCACertificateAuthority_disappears
=== CONT  TestAccACMPCACertificateAuthority_enabledDeprecated
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== CONT  TestAccACMPCACertificateAuthority_basic
=== CONT  TestAccACMPCACertificateAuthority_RevocationOcsp_enabled
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
--- PASS: TestAccACMPCACertificateAuthority_disappears (48.09s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL (62.70s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_basic (62.78s)
--- PASS: TestAccACMPCACertificateAuthority_deleteFromActiveState (66.92s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_subordinateCA (81.33s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_rootCA (81.50s)
--- PASS: TestAccACMPCACertificateAuthority_basic (82.43s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_updateRootCA (97.74s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL (101.29s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays (119.18s)
--- PASS: TestAccACMPCACertificateAuthority_enabledDeprecated (119.43s)
--- PASS: TestAccACMPCACertificateAuthority_tags (130.81s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationOcsp_enabled (134.15s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME (146.56s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_enabled (147.91s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME (162.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	162.165s
```
