### PR TITLE
ssm/parameter: Add insecure_value argument

### DIFF
--- a/.changelog/25721.txt
+++ b/.changelog/25721.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ssm_parameter: Add `insecure_value` argument to enable dynamic use of SSM parameter values
+```

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -274,7 +274,7 @@ func TestAccSSMParameter_disappears(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_overwrite(t *testing.T) {
+func TestAccSSMParameter_Overwrite_basic(t *testing.T) {
 	var param ssm.Parameter
 	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 	resourceName := "aws_ssm_parameter.test"
@@ -311,7 +311,7 @@ func TestAccSSMParameter_overwrite(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12213
-func TestAccSSMParameter_overwriteCascade(t *testing.T) {
+func TestAccSSMParameter_Overwrite_cascade(t *testing.T) {
 	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -336,7 +336,7 @@ func TestAccSSMParameter_overwriteCascade(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18550
-func TestAccSSMParameter_overwriteWithTags(t *testing.T) {
+func TestAccSSMParameter_Overwrite_tags(t *testing.T) {
 	var param ssm.Parameter
 	rName := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 	resourceName := "aws_ssm_parameter.test"
@@ -366,7 +366,7 @@ func TestAccSSMParameter_overwriteWithTags(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18550
-func TestAccSSMParameter_noOverwriteWithTags(t *testing.T) {
+func TestAccSSMParameter_Overwrite_noOverwriteTags(t *testing.T) {
 	var param ssm.Parameter
 	rName := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 	resourceName := "aws_ssm_parameter.test"
@@ -396,7 +396,7 @@ func TestAccSSMParameter_noOverwriteWithTags(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18550
-func TestAccSSMParameter_updateToOverwriteWithTags(t *testing.T) {
+func TestAccSSMParameter_Overwrite_updateToTags(t *testing.T) {
 	var param ssm.Parameter
 	rName := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 	resourceName := "aws_ssm_parameter.test"
@@ -509,7 +509,7 @@ func TestAccSSMParameter_updateType(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_updateDescription(t *testing.T) {
+func TestAccSSMParameter_Overwrite_updateDescription(t *testing.T) {
 	var param ssm.Parameter
 	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 	resourceName := "aws_ssm_parameter.test"
@@ -605,7 +605,7 @@ func TestAccSSMParameter_fullPath(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_secure(t *testing.T) {
+func TestAccSSMParameter_Secure_basic(t *testing.T) {
 	var param ssm.Parameter
 	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
 	resourceName := "aws_ssm_parameter.test"
@@ -635,7 +635,7 @@ func TestAccSSMParameter_secure(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_insecure(t *testing.T) {
+func TestAccSSMParameter_Secure_insecure(t *testing.T) {
 	var param ssm.Parameter
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_parameter.test"
@@ -675,6 +675,45 @@ func TestAccSSMParameter_insecure(t *testing.T) {
 	})
 }
 
+func TestAccSSMParameter_Secure_insecureChangeSecure(t *testing.T) {
+	var param ssm.Parameter
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ssm.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterConfig_insecure(rName, "String", "notsecret"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "insecure_value", "notsecret"),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+				),
+			},
+			{
+				Config: testAccParameterConfig_secure(rName, "newvalue"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "value", "newvalue"),
+					resource.TestCheckResourceAttr(resourceName, "type", "SecureString"),
+				),
+			},
+			{
+				Config: testAccParameterConfig_insecure(rName, "String", "atlantis"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "insecure_value", "atlantis"),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSSMParameter_DataType_ec2Image(t *testing.T) {
 	var param ssm.Parameter
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -703,11 +742,11 @@ func TestAccSSMParameter_DataType_ec2Image(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_secureWithKey(t *testing.T) {
+func TestAccSSMParameter_Secure_key(t *testing.T) {
 	var param ssm.Parameter
 	randString := sdkacctest.RandString(10)
 	name := fmt.Sprintf("%s_%s", t.Name(), randString)
-	resourceName := "aws_ssm_parameter.secret_test"
+	resourceName := "aws_ssm_parameter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -738,7 +777,7 @@ func TestAccSSMParameter_Secure_keyUpdate(t *testing.T) {
 	var param ssm.Parameter
 	randString := sdkacctest.RandString(10)
 	name := fmt.Sprintf("%s_%s", t.Name(), randString)
-	resourceName := "aws_ssm_parameter.secret_test"
+	resourceName := "aws_ssm_parameter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -994,7 +1033,7 @@ resource "aws_ssm_parameter" "test_downstream" {
 
 func testAccParameterConfig_secure(rName string, value string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_parameter" "secret_test" {
+resource "aws_ssm_parameter" "test" {
   name        = "test_secure_parameter-%[1]s"
   description = "description for parameter %[1]s"
   type        = "SecureString"
@@ -1005,7 +1044,7 @@ resource "aws_ssm_parameter" "secret_test" {
 
 func testAccParameterConfig_secureKey(rName string, value string, keyAlias string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_parameter" "secret_test" {
+resource "aws_ssm_parameter" "test" {
   name        = "test_secure_parameter-%[1]s"
   description = "description for parameter %[1]s"
   type        = "SecureString"

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -12,7 +12,7 @@ Provides an SSM Parameter resource.
 
 ## Example Usage
 
-To store a basic string parameter:
+### Basic example
 
 ```terraform
 resource "aws_ssm_parameter" "foo" {
@@ -22,7 +22,7 @@ resource "aws_ssm_parameter" "foo" {
 }
 ```
 
-To store an encrypted string using the default SSM KMS key:
+### Encrypted string using default SSM KMS key
 
 ```terraform
 resource "aws_db_instance" "default" {
@@ -55,35 +55,30 @@ resource "aws_ssm_parameter" "secret" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `name` - (Required) The name of the parameter. If the name contains a path (e.g., any forward slashes (`/`)), it must be fully qualified with a leading forward slash (`/`). For additional requirements and constraints, see the [AWS SSM User Guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html).
-* `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
-* `value` - (Required) The value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of `type`. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the [Terraform v0.15 Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values).
-* `description` - (Optional) The description of the parameter.
-* `tier` - (Optional) The parameter tier to assign to the parameter.
-  If not specified, will use the default parameter tier for the region.
-  Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`.
-  Downgrading an `Advanced` tier parameter to `Standard` will recreate the resource.
-  For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
-* `key_id` - (Optional) The KMS key id or arn for encrypting a SecureString.
+* `name` - (Required) Name of the parameter. If the name contains a path (e.g., any forward slashes (`/`)), it must be fully qualified with a leading forward slash (`/`). For additional requirements and constraints, see the [AWS SSM User Guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html).
+* `type` - (Required) Type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
+
+The following arguments are optional:
+
+* `allowed_pattern` - (Optional) Regular expression used to validate the parameter value.
+* `data_type` - (Optional) Data type of the parameter. Valid values: `text` and `aws:ec2:image` for AMI format, see the [Native parameter support for Amazon Machine Image IDs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html).
+* `description` - (Optional) Description of the parameter.
+* `insecure_value` - (Optional, exactly one of `value` or `insecure_value` is required) Value of the parameter. **Use caution:** This value is _never_ marked as sensitive in the Terraform plan output. This argument is not valid with a `type` of `SecureString`.
+* `key_id` - (Optional) KMS key ID or ARN for encrypting a SecureString.
 * `overwrite` - (Optional) Overwrite an existing parameter. If not specified, will default to `false` if the resource has not been created by terraform to avoid overwrite of existing resource and will default to `true` otherwise (terraform lifecycle rules should then be used to manage the update behavior).
-* `allowed_pattern` - (Optional) A regular expression used to validate the parameter value.
-* `data_type` - (Optional) The data_type of the parameter. Valid values: text and aws:ec2:image for AMI format, see the [Native parameter support for Amazon Machine Image IDs
-](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html)
-* `tags` - (Optional) A map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tier` - (Optional) Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`. Downgrading an `Advanced` tier parameter to `Standard` will recreate the resource. For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
+* `value` - (Optional, exactly one of `value` or `insecure_value` is required) Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of `type`. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the [Terraform v0.15 Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values).
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the parameter.
-* `name` - (Required) The name of the parameter.
-* `description` - (Required) The description of the parameter.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
-* `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
-* `value` - (Required) The value of the parameter.
-* `version` - The version of the parameter.
+* `arn` - ARN of the parameter.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `version` - Version of the parameter.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9090

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TESTS=TestAccSSMParameter PKG=ssm                            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameter'  -timeout 180m
--- PASS: TestAccSSMParameter_disappears (85.04s)
--- PASS: TestAccSSMParametersByPathDataSource_withRecursion (100.87s)
--- PASS: TestAccSSMParametersByPathDataSource_basic (101.10s)
--- PASS: TestAccSSMParameter_Overwrite_tags (101.64s)
--- PASS: TestAccSSMParameter_Overwrite_noOverwriteTags (102.34s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnCreation (102.75s)
--- PASS: TestAccSSMParameter_basic (115.85s)
--- PASS: TestAccSSMParameter_DataType_ec2Image (117.20s)
--- PASS: TestAccSSMParameter_Secure_key (117.55s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnUpdate (157.26s)
--- PASS: TestAccSSMParameterDataSource_basic (169.01s)
--- PASS: TestAccSSMParameterDataSource_fullPath (84.10s)
--- PASS: TestAccSSMParameter_Overwrite_basic (173.72s)
--- PASS: TestAccSSMParameter_Overwrite_updateToTags (178.85s)
--- PASS: TestAccSSMParameter_Secure_keyUpdate (181.05s)
--- PASS: TestAccSSMParameter_fullPath (89.29s)
--- PASS: TestAccSSMParameter_Secure_basic (94.79s)
--- PASS: TestAccSSMParameter_Overwrite_cascade (204.42s)
--- PASS: TestAccSSMParameter_Secure_insecureChangeSecure (217.89s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (218.18s)
--- PASS: TestAccSSMParameter_tags (221.95s)
--- PASS: TestAccSSMParameter_tier (223.69s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (224.31s)
--- PASS: TestAccSSMParameter_Overwrite_updateDescription (127.35s)
--- PASS: TestAccSSMParameter_updateType (129.49s)
--- PASS: TestAccSSMParameter_changeNameForcesNew (122.50s)
--- PASS: TestAccSSMParameter_Secure_insecure (153.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	256.932s
```
