### PR TITLE
Make aws_rds_cluster_instance resource support monthly performance insights retention period

### DIFF
--- a/.changelog/25729.txt
+++ b/.changelog/25729.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_cluster_instance: Add support to monthly performance insights retention period
+```

--- a/.changelog/25729.txt
+++ b/.changelog/25729.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_rds_cluster_instance: Add support to monthly performance insights retention period
+resource/aws_rds_cluster_instance: Allow `performance_insights_retention_period` values that are multiples of `31`
 ```

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -210,10 +210,17 @@ func ResourceClusterInstance() *schema.Resource {
 			},
 
 			"performance_insights_retention_period": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntInSlice([]int{7, 731}),
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.Any(
+					validation.IntInSlice([]int{7, 731}),
+					validation.All(
+						validation.IntAtLeast(7),
+						validation.IntAtMost(731),
+						validation.IntDivisibleBy(31),
+					),
+				),
 			},
 
 			"copy_tags_to_snapshot": {

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -854,6 +854,14 @@ func TestAccRDSClusterInstance_performanceInsightsRetentionPeriod(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "7"),
 				),
 			},
+			{
+				Config: testAccClusterInstanceConfig_performanceInsightsRetentionPeriod(rName, 155),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "155"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -81,7 +81,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
 * `performance_insights_enabled` - (Optional) Specifies whether Performance Insights is enabled or not.
 * `performance_insights_kms_key_id` - (Optional) ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true.
-* `performance_insights_retention_period` - (Optional) Amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). When specifying `performance_insights_retention_period`, `performance_insights_enabled` needs to be set to true. Defaults to '7'.
+* `performance_insights_retention_period` - (Optional) Amount of time in days to retain Performance Insights data. The value must be at least 7 (7 days) and at most 731 (2 years) and multiple from 31. When specifying `performance_insights_retention_period`, `performance_insights_enabled` needs to be set to true. Defaults to '7'.
 * `copy_tags_to_snapshot` – (Optional, boolean) Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. Default `false`.
 * `ca_cert_identifier` - (Optional) The identifier of the CA certificate for the DB instance.
 * `tags` - (Optional) A map of tags to assign to the instance. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -81,7 +81,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
 * `performance_insights_enabled` - (Optional) Specifies whether Performance Insights is enabled or not.
 * `performance_insights_kms_key_id` - (Optional) ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true.
-* `performance_insights_retention_period` - (Optional) Amount of time in days to retain Performance Insights data. The value must be at least 7 (7 days) and at most 731 (2 years) and multiple from 31. When specifying `performance_insights_retention_period`, `performance_insights_enabled` needs to be set to true. Defaults to '7'.
+* `performance_insights_retention_period` - (Optional) Amount of time in days to retain Performance Insights data. Valida values are `7`, `731` (2 years) or a multiple of `31`. When specifying `performance_insights_retention_period`, `performance_insights_enabled` needs to be set to true. Defaults to '7'.
 * `copy_tags_to_snapshot` – (Optional, boolean) Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. Default `false`.
 * `ca_cert_identifier` - (Optional) The identifier of the CA certificate for the DB instance.
 * `tags` - (Optional) A map of tags to assign to the instance. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25666

Output from acceptance testing:

```
$ make testacc TESTS=TestAccRDSClusterInstance_performanceInsightsRetentionPeriod PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterInstance_performanceInsightsRetentionPeriod'  -timeout 180m
=== RUN   TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== CONT  TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
--- PASS: TestAccRDSClusterInstance_performanceInsightsRetentionPeriod (1262.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1262.085s
...
```