### PR TITLE
Correct required arguments for `aws_cloudtrail_event_data_store`

### DIFF
--- a/website/docs/r/cloudtrail_event_data_store.html.markdown
+++ b/website/docs/r/cloudtrail_event_data_store.html.markdown
@@ -18,12 +18,11 @@ More information about event data stores can be found in the [Event Data Store U
 
 ### Basic
 
-The most simple event data store configuration requires us to only set the `name` and `retention_period` attributes. The event data store will automatically capture all management events. To capture management events from all the regions, `multi_region_enabled` must be `true`.
+The most simple event data store configuration requires us to only set the `name` attribute. The event data store will automatically capture all management events. To capture management events from all the regions, `multi_region_enabled` must be `true`.
 
 ```terraform
 resource "aws_cloudtrail_event_data_store" "example" {
   name             = "example-event-data-store"
-  retention_period = 7
 }
 ```
 
@@ -80,7 +79,7 @@ resource "aws_cloudtrail_event_data_store" "example" {
 The following arguments are supported:
 
 - `name` - (Required) The name of the event data store.
-- `advanced_event_selector` - (Required) The advanced event selectors to use to select the events for the data store. For more information about how to use advanced event selectors, see [Log events by using advanced event selectors](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html#creating-data-event-selectors-advanced) in the CloudTrail User Guide.
+- `advanced_event_selector` - (Optional) The advanced event selectors to use to select the events for the data store. For more information about how to use advanced event selectors, see [Log events by using advanced event selectors](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html#creating-data-event-selectors-advanced) in the CloudTrail User Guide.
 - `multi_region_enabled` - (Optional) Specifies whether the event data store includes events from all regions, or only from the region in which the event data store is created. Default: `true`.
 - `organization_enabled` - (Optional) Specifies whether an event data store collects events logged for an organization in AWS Organizations. Default: `false`.
 - `retention_period` - (Optional) The retention period of the event data store, in days. You can set a retention period of up to 2555 days, the equivalent of seven years. Default: `2555`.

--- a/website/docs/r/cloudtrail_event_data_store.html.markdown
+++ b/website/docs/r/cloudtrail_event_data_store.html.markdown
@@ -22,7 +22,7 @@ The most simple event data store configuration requires us to only set the `name
 
 ```terraform
 resource "aws_cloudtrail_event_data_store" "example" {
-  name             = "example-event-data-store"
+  name = "example-event-data-store"
 }
 ```
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25730

Output from acceptance testing: N/a, docs

### Information

The documentation incorrectly stated that `advanced_event_selector` was required, and that `retention_period` was optional (though elsewhere in the document, it stated that `retention_period` was required). This PR aims to correct these indicators.

### References
- [`advanced_event_selector`](https://github.com/hashicorp/terraform-provider-aws/blob/32b04631f3f7cbe01df599fd8457a563da0aa30a/internal/service/cloudtrail/event_data_store.go#L40-L43)
- [`retention_period`](https://github.com/hashicorp/terraform-provider-aws/blob/32b04631f3f7cbe01df599fd8457a563da0aa30a/internal/service/cloudtrail/event_data_store.go#L151-L157)