### PR TITLE
sweeper/aws_location - fix Place Index & Tracker sweepers

### DIFF
--- a/internal/service/location/sweep.go
+++ b/internal/service/location/sweep.go
@@ -103,7 +103,7 @@ func sweepPlaceIndexes(region string) error {
 		}
 
 		for _, entry := range page.Entries {
-			r := ResourceMap()
+			r := ResourcePlaceIndex()
 			d := r.Data(nil)
 
 			id := aws.StringValue(entry.IndexName)
@@ -197,7 +197,7 @@ func sweepTrackers(region string) error {
 		}
 
 		for _, entry := range page.Entries {
-			r := ResourceMap()
+			r := ResourceTracker()
 			d := r.Data(nil)
 
 			id := aws.StringValue(entry.TrackerName)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #19629.

Output from acceptance testing:
```
$ SWEEPARGS=-sweep-run=aws_location_place_index SWEEP=us-west-2 make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_location_place_index -timeout 60m
2022/07/07 21:02:43 Completed Sweepers for region (us-west-2) in 3.355488333s
2022/07/07 21:02:43 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_location_place_index
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      5.041s
```
```
$ SWEEPARGS=-sweep-run=aws_location_tracker SWEEP=us-west-2 make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_location_tracker -timeout 60m
2022/07/07 21:03:41 Completed Sweepers for region (us-west-2) in 2.875736208s
2022/07/07 21:03:41 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_location_tracker
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      4.556s
```