### PR TITLE
skaff: Remove SetTagsDiff from data source template

### DIFF
--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -140,8 +140,6 @@ func DataSource{{ .DataSource }}() *schema.Resource {
 			},
 			"tags":         tftags.TagsSchemaComputed(), {{- if .IncludeComments }} // TIP: Many, but not all, data sources have `tags` attributes.{{- end }}
 		},
-
-		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

(If I'm not mistaken) data sources should not customize diff using `verify.SetTagsDiff`.