### PR TITLE
Switch `bucket` to `id` in `aws_s3_bucket_cors_configuration` example

### DIFF
--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_cors_configuration" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   cors_rule {
     allowed_headers = ["*"]


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25604

Output from acceptance testing: N/a, docs

### Information

While `bucket` is valid in this case, the other examples (for other `aws_s3_bucket_*` resources) use `id`, and that's probably a better method to suggest.