### PR TITLE
Fix broken `Location.CreateMap` link

### DIFF
--- a/website/docs/r/location_map.html.markdown
+++ b/website/docs/r/location_map.html.markdown
@@ -38,7 +38,7 @@ The following arguments are optional:
 
 The following arguments are required:
 
-* `style` - (Required) Specifies the map style selected from an available data provider. Valid values can be found in the [Location Service CreateMap API Reference](https://docs.aws.amazon.com/location-maps/latest/APIReference/API_CreateMap.html).
+* `style` - (Required) Specifies the map style selected from an available data provider. Valid values can be found in the [Location Service CreateMap API Reference](https://docs.aws.amazon.com/location/latest/APIReference/API_CreateMap.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Fixes

```
FILE: website/docs/r/location_map.html.markdown
  [✖] https://docs.aws.amazon.com/location-maps/latest/APIReference/API_CreateMap.html → Status: 404
  2 links checked.
  ERROR: 1 dead links found!
  [✖] https://docs.aws.amazon.com/location-maps/latest/APIReference/API_CreateMap.html → Status: 404
```