### PR TITLE
Fix secret_binary in secret_version datasource

### DIFF
--- a/.changelog/25758.txt
+++ b/.changelog/25758.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_secretsmanager_secret_version: Fix data corruption in `secret_binary` attribute
+```

--- a/internal/service/secretsmanager/secret_version_data_source.go
+++ b/internal/service/secretsmanager/secret_version_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceSecretVersion() *schema.Resource {
@@ -89,7 +90,7 @@ func dataSourceSecretVersionRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("secret_id", secretID)
 	d.Set("secret_string", output.SecretString)
 	d.Set("version_id", output.VersionId)
-	d.Set("secret_binary", string(output.SecretBinary))
+	d.Set("secret_binary", verify.Base64Encode(output.SecretBinary))
 	d.Set("arn", output.ARN)
 
 	if err := d.Set("version_stages", flex.FlattenStringList(output.VersionStages)); err != nil {

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -52,5 +52,5 @@ output "example" {
 * `arn` - The ARN of the secret.
 * `id` - The unique identifier of this version of the secret.
 * `secret_string` - The decrypted part of the protected secret information that was originally provided as a string.
-* `secret_binary` - The decrypted part of the protected secret information that was originally provided as a binary.
+* `secret_binary` - The decrypted and base64 encoded part of the protected secret information that was originally provided as a binary.
 * `version_id` - The unique identifier of this version of the secret.


### PR DESCRIPTION
Base64 encode the returned binary secret. This is consistant with how the
binary secret is supplied to the resource and with how the resource itself
represents the binary data. Simply casting the binary data to a string doesn't
appear to result in anything usable.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25603

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ gmake testacc TESTS='TestAccSecretsManagerSecretVersionDataSource*' PKG=secretsmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersionDataSource*'  -timeout 180m
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== RUN   TestAccSecretsManagerSecretVersionDataSource_binary
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_binary
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionID
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionID
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionStage
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionStage
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionID
=== CONT  TestAccSecretsManagerSecretVersionDataSource_binary
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionStage
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionStage (14.90s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_binary (14.91s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionID (14.93s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (15.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	15.246s
```
