### PR TITLE
Fix Error: error reading EMR Studio Session Mapping

### DIFF
--- a/internal/service/emr/find.go
+++ b/internal/service/emr/find.go
@@ -83,7 +83,7 @@ func FindStudioByID(conn *emr.EMR, id string) (*emr.Studio, error) {
 }
 
 func FindStudioSessionMappingByID(conn *emr.EMR, id string) (*emr.SessionMappingDetail, error) {
-	studioId, identityType, identityId, err := readStudioSessionMapping(id)
+	studioId, identityType, identityId, identityName, err := readStudioSessionMapping(id)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,14 @@ func FindStudioSessionMappingByID(conn *emr.EMR, id string) (*emr.SessionMapping
 	input := &emr.GetStudioSessionMappingInput{
 		StudioId:     aws.String(studioId),
 		IdentityType: aws.String(identityType),
-		IdentityId:   aws.String(identityId),
+	}
+
+	if identityId != "" {
+		input.IdentityId = aws.String(identityId)
+	}
+
+	if identityName != "" {
+		input.IdentityName = aws.String(identityName)
 	}
 
 	output, err := conn.GetStudioSessionMapping(input)

--- a/internal/service/emr/id.go
+++ b/internal/service/emr/id.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-func readStudioSessionMapping(id string) (studioId, identityType, identityId string, err error) {
+func readStudioSessionMapping(id string) (studioId, identityType, identityId, identityName string, err error) {
 	idParts := strings.Split(id, ":")
-	if len(idParts) != 3 {
-		return "", "", "", fmt.Errorf("expected ID in format studio-id:identity-type:identity-id, received: %s", id)
+	if len(idParts) != 4 {
+		return "", "", "", "", fmt.Errorf("expected ID in format studio-id:identity-type:identity-id:identity-name, received: %s", id)
 	}
-	return idParts[0], idParts[1], idParts[2], nil
+	return idParts[0], idParts[1], idParts[2], idParts[3], nil
 }


### PR DESCRIPTION
Error: error reading EMR Studio Session Mapping (es-xxxxxxxxx:USER:pecastro@xxxx.onmicrosoft.com): InvalidRequestException: IdentityId is invalid (Service: AWSEditors; Status Code: 400; Error Code: InvalidRequestException; Request ID: xxxxx-xxxx-xxxx-xxxx-xxxxxxxx; Proxy: null)

When a session mapping resource is created with only the IdentityName, the IdentityId won't be known until creation.
In this case the previous code was storing a Name in the state ID and then trying to use it as an Id to query the API.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_IDENTITY_STORE_USER_ID=xxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx make testacc TESTS=TestAccEMRStudioSessionMapping_ PKG=emr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 20 -run='TestAccEMRStudioSessionMapping_'  -timeout 180m
=== RUN   TestAccEMRStudioSessionMapping_basic
=== PAUSE TestAccEMRStudioSessionMapping_basic
=== RUN   TestAccEMRStudioSessionMapping_disappears
=== PAUSE TestAccEMRStudioSessionMapping_disappears
=== CONT  TestAccEMRStudioSessionMapping_basic
=== CONT  TestAccEMRStudioSessionMapping_disappears
--- PASS: TestAccEMRStudioSessionMapping_disappears (20.43s)
--- PASS: TestAccEMRStudioSessionMapping_basic (28.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        28.039s
```

@ewbankkit @YakDriver @DrFaust92 Please review.