### PR TITLE
r/aws_location_geofence_collection: new resource

### DIFF
--- a/.changelog/25762.txt
+++ b/.changelog/25762.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_location_geofence_collection
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1677,10 +1677,11 @@ func Provider() *schema.Provider {
 			"aws_lightsail_static_ip":                            lightsail.ResourceStaticIP(),
 			"aws_lightsail_static_ip_attachment":                 lightsail.ResourceStaticIPAttachment(),
 
-			"aws_location_map":              location.ResourceMap(),
-			"aws_location_place_index":      location.ResourcePlaceIndex(),
-			"aws_location_route_calculator": location.ResourceRouteCalculator(),
-			"aws_location_tracker":          location.ResourceTracker(),
+			"aws_location_geofence_collection": location.ResourceGeofenceCollection(),
+			"aws_location_map":                 location.ResourceMap(),
+			"aws_location_place_index":         location.ResourcePlaceIndex(),
+			"aws_location_route_calculator":    location.ResourceRouteCalculator(),
+			"aws_location_tracker":             location.ResourceTracker(),
 
 			"aws_macie_member_account_association": macie.ResourceMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":      macie.ResourceS3BucketAssociation(),

--- a/internal/service/location/geofence_collection.go
+++ b/internal/service/location/geofence_collection.go
@@ -1,0 +1,237 @@
+package location
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceGeofenceCollection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGeofenceCollectionCreate,
+		ReadContext:   resourceGeofenceCollectionRead,
+		UpdateContext: resourceGeofenceCollectionUpdate,
+		DeleteContext: resourceGeofenceCollectionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"collection_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"collection_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1000),
+			},
+			"kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 2048),
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameGeofenceCollection = "Geofence Collection"
+)
+
+func resourceGeofenceCollectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	in := &locationservice.CreateGeofenceCollectionInput{
+		CollectionName: aws.String(d.Get("collection_name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok && v != "" {
+		in.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok && v != "" {
+		in.KmsKeyId = aws.String(v.(string))
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateGeofenceCollectionWithContext(ctx, in)
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionCreating, ResNameGeofenceCollection, d.Get("collection_name").(string), err)
+	}
+
+	if out == nil {
+		return names.DiagError(names.Location, names.ErrActionCreating, ResNameGeofenceCollection, d.Get("collection_name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.StringValue(out.CollectionName))
+
+	return resourceGeofenceCollectionRead(ctx, d, meta)
+}
+
+func resourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	out, err := findGeofenceCollectionByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Location GeofenceCollection (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionReading, ResNameGeofenceCollection, d.Id(), err)
+	}
+
+	d.Set("collection_arn", out.CollectionArn)
+	d.Set("collection_name", out.CollectionName)
+	d.Set("create_time", aws.TimeValue(out.CreateTime).Format(time.RFC3339))
+	d.Set("description", out.Description)
+	d.Set("kms_key_id", out.KmsKeyId)
+	d.Set("update_time", aws.TimeValue(out.UpdateTime).Format(time.RFC3339))
+
+	tags, err := ListTagsWithContext(ctx, conn, d.Get("collection_arn").(string))
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionReading, ResNameGeofenceCollection, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return names.DiagError(names.Location, names.ErrActionSetting, ResNameGeofenceCollection, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return names.DiagError(names.Location, names.ErrActionSetting, ResNameGeofenceCollection, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceGeofenceCollectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	update := false
+
+	in := &locationservice.UpdateGeofenceCollectionInput{
+		CollectionName: aws.String(d.Id()),
+	}
+
+	if d.HasChange("description") {
+		in.Description = aws.String(d.Get("description").(string))
+		update = true
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("collection_arn").(string), o, n); err != nil {
+			return names.DiagError(names.Location, names.ErrActionUpdating, ResNameGeofenceCollection, d.Id(), err)
+		}
+	}
+
+	if !update {
+		return nil
+	}
+
+	log.Printf("[DEBUG] Updating Location GeofenceCollection (%s): %#v", d.Id(), in)
+	_, err := conn.UpdateGeofenceCollectionWithContext(ctx, in)
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionUpdating, ResNameGeofenceCollection, d.Id(), err)
+	}
+
+	return resourceGeofenceCollectionRead(ctx, d, meta)
+}
+
+func resourceGeofenceCollectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	log.Printf("[INFO] Deleting Location GeofenceCollection %s", d.Id())
+
+	_, err := conn.DeleteGeofenceCollectionWithContext(ctx, &locationservice.DeleteGeofenceCollectionInput{
+		CollectionName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionDeleting, ResNameGeofenceCollection, d.Id(), err)
+	}
+
+	return nil
+}
+
+func findGeofenceCollectionByName(ctx context.Context, conn *locationservice.LocationService, name string) (*locationservice.DescribeGeofenceCollectionOutput, error) {
+	in := &locationservice.DescribeGeofenceCollectionInput{
+		CollectionName: aws.String(name),
+	}
+
+	out, err := conn.DescribeGeofenceCollectionWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}

--- a/internal/service/location/geofence_collection_test.go
+++ b/internal/service/location/geofence_collection_test.go
@@ -227,7 +227,7 @@ func testAccCheckGeofenceCollectionExists(name string) resource.TestCheckFunc {
 func testAccGeofenceCollectionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_location_geofence_collection" "test" {
-    collection_name = %[1]q
+  collection_name = %[1]q
 }
 `, rName)
 }
@@ -235,8 +235,8 @@ resource "aws_location_geofence_collection" "test" {
 func testAccGeofenceCollectionConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_location_geofence_collection" "test" {
-    collection_name = %[1]q
-	description     = %[2]q
+  collection_name = %[1]q
+  description     = %[2]q
 }
 `, rName, description)
 }
@@ -244,12 +244,12 @@ resource "aws_location_geofence_collection" "test" {
 func testAccGeofenceCollectionConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-    deletion_window_in_days = 7
+  deletion_window_in_days = 7
 }
 
 resource "aws_location_geofence_collection" "test" {
-    collection_name = %[1]q
-    kms_key_id      = aws_kms_key.test.arn
+  collection_name = %[1]q
+  kms_key_id      = aws_kms_key.test.arn
 }
 `, rName)
 }

--- a/internal/service/location/geofence_collection_test.go
+++ b/internal/service/location/geofence_collection_test.go
@@ -1,0 +1,280 @@
+package location_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLocationGeofenceCollection_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_geofence_collection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGeofenceCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeofenceCollectionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "collection_arn", "geo", fmt.Sprintf("geofence-collection/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "collection_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "create_time"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+					acctest.CheckResourceAttrRFC3339(resourceName, "update_time"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationGeofenceCollection_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_geofence_collection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGeofenceCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeofenceCollectionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourceGeofenceCollection(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationGeofenceCollection_description(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_geofence_collection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGeofenceCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeofenceCollectionConfig_description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGeofenceCollectionConfig_description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLocationGeofenceCollection_kmsKeyID(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_geofence_collection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGeofenceCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeofenceCollectionConfig_kmsKeyID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationGeofenceCollection_tags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_geofence_collection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGeofenceCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeofenceCollectionConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGeofenceCollectionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccGeofenceCollectionConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGeofenceCollectionDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_location_geofence_collection" {
+			continue
+		}
+
+		input := &locationservice.DescribeGeofenceCollectionInput{
+			CollectionName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeGeofenceCollection(input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+				return nil
+			}
+			return err
+		}
+
+		return names.Error(names.Location, names.ErrActionCheckingDestroyed, tflocation.ResNameGeofenceCollection, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckGeofenceCollectionExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameGeofenceCollection, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameGeofenceCollection, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+		_, err := conn.DescribeGeofenceCollection(&locationservice.DescribeGeofenceCollectionInput{
+			CollectionName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameGeofenceCollection, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccGeofenceCollectionConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+    collection_name = %[1]q
+}
+`, rName)
+}
+
+func testAccGeofenceCollectionConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+    collection_name = %[1]q
+	description     = %[2]q
+}
+`, rName, description)
+}
+
+func testAccGeofenceCollectionConfig_kmsKeyID(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+    deletion_window_in_days = 7
+}
+
+resource "aws_location_geofence_collection" "test" {
+    collection_name = %[1]q
+    kms_key_id      = aws_kms_key.test.arn
+}
+`, rName)
+}
+
+func testAccGeofenceCollectionConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+  collection_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccGeofenceCollectionConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+  collection_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/website/docs/r/location_geofence_collection.html.markdown
+++ b/website/docs/r/location_geofence_collection.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_geofence_collection"
+description: |-
+  Terraform resource for managing an AWS Location Geofence Collection.
+---
+
+# Resource: aws_location_geofence_collection
+
+Terraform resource for managing an AWS Location Geofence Collection.
+
+## Example Usage
+
+```terraform
+resource "aws_location_geofence_collection" "example" {
+  collection_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `collection_name` - (Required) The name of the geofence collection.
+
+The following arguments are optional:
+
+* `description` - (Optional) The optional description for the geofence collection.
+* `kms_key_id` - (Optional) A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
+* `tags` - (Optional) Key-value tags for the geofence collection. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `collection_arn` - The Amazon Resource Name (ARN) for the geofence collection resource. Used when you need to specify a resource across all AWS.
+* `create_time` - The timestamp for when the geofence collection resource was created in ISO 8601 format.
+* `update_time` - The timestamp for when the geofence collection resource was last updated in ISO 8601 format.
+
+## Timeouts
+
+`aws_location_geofence_collection` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Optional, Default: `30m`)
+* `update` - (Optional, Default: `30m`)
+* `delete` - (Optional, Default: `30m`)
+
+## Import
+
+Location Geofence Collection can be imported using the `collection_name`, e.g.,
+
+```
+$ terraform import aws_location_geofence_collection.example example
+```

--- a/website/docs/r/location_geofence_collection.html.markdown
+++ b/website/docs/r/location_geofence_collection.html.markdown
@@ -30,7 +30,6 @@ The following arguments are optional:
 * `kms_key_id` - (Optional) A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
 * `tags` - (Optional) Key-value tags for the geofence collection. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/location_tracker.html.markdown
+++ b/website/docs/r/location_tracker.html.markdown
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 * `create_time` - The timestamp for when the tracker resource was created in ISO 8601 format.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 * `tracker_arn` - The Amazon Resource Name (ARN) for the tracker resource. Used when you need to specify a resource across all AWS.
-* `update_time` - The timestamp for when the tracker resource was last update in ISO 8601 format.
+* `update_time` - The timestamp for when the tracker resource was last updated in ISO 8601 format.
 
 ## Import
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #19629.

Output from acceptance testing:
```
$ make testacc PKG=location TESTS="TestAccLocationGeofenceCollection_"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationGeofenceCollection_'  -timeout 180m
=== RUN   TestAccLocationGeofenceCollection_basic
=== PAUSE TestAccLocationGeofenceCollection_basic
=== RUN   TestAccLocationGeofenceCollection_disappears
=== PAUSE TestAccLocationGeofenceCollection_disappears
=== RUN   TestAccLocationGeofenceCollection_description
=== PAUSE TestAccLocationGeofenceCollection_description
=== RUN   TestAccLocationGeofenceCollection_kmsKeyID
=== PAUSE TestAccLocationGeofenceCollection_kmsKeyID
=== RUN   TestAccLocationGeofenceCollection_tags
=== PAUSE TestAccLocationGeofenceCollection_tags
=== CONT  TestAccLocationGeofenceCollection_basic
=== CONT  TestAccLocationGeofenceCollection_description
=== CONT  TestAccLocationGeofenceCollection_kmsKeyID
=== CONT  TestAccLocationGeofenceCollection_tags
=== CONT  TestAccLocationGeofenceCollection_disappears
--- PASS: TestAccLocationGeofenceCollection_disappears (22.44s)
--- PASS: TestAccLocationGeofenceCollection_basic (31.93s)
--- PASS: TestAccLocationGeofenceCollection_kmsKeyID (33.71s)
--- PASS: TestAccLocationGeofenceCollection_description (51.57s)
--- PASS: TestAccLocationGeofenceCollection_tags (79.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   81.536s
```
