### PR TITLE
Doc: Update data.aws_ecs_task_definition arn attribute

### DIFF
--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the task definition
+* `id` - The ARN of the task definition
 * `family` - The family of this task definition
 * `network_mode` - The Docker networking mode to use for the containers in this task.
 * `revision` - The revision of this task definition

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ARN of the task definition
+* `arn` - The ARN of the task definition
 * `family` - The family of this task definition
 * `network_mode` - The Docker networking mode to use for the containers in this task.
 * `revision` - The revision of this task definition


### PR DESCRIPTION
The `aws_ecs_task_definition` data source exposes the `id` attribute (not the `arn` attribute) which is actually the `ARN` of the Task Definition.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
