### PR TITLE
r/aws_budgets_budget: Add PlannedBudgetLimits support

### DIFF
--- a/.changelog/25766.txt
+++ b/.changelog/25766.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_budgets_budget: Add `planned_limit.*` attribute for planned budget limits
+```

--- a/internal/service/budgets/budget.go
+++ b/internal/service/budgets/budget.go
@@ -2,9 +2,6 @@ package budgets
 
 import (
 	"fmt"
-	"log"
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/budgets"
@@ -17,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/shopspring/decimal"
+	"log"
+	"strings"
 )
 
 func ResourceBudget() *schema.Resource {
@@ -143,12 +142,39 @@ func ResourceBudget() *schema.Resource {
 			},
 			"limit_amount": {
 				Type:             schema.TypeString,
-				Required:         true,
+				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
+				ConflictsWith:    []string{"planned_limit"},
 			},
 			"limit_unit": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"planned_limit"},
+			},
+			"planned_limit": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_time": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: ValidTimePeriodTimestamp,
+						},
+						"amount": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
+						},
+						"unit": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				ConflictsWith: []string{"limit_amount", "limit_unit"},
 			},
 			"name": {
 				Type:          schema.TypeString,
@@ -312,6 +338,7 @@ func resourceBudgetRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("limit_unit", budget.BudgetLimit.Unit)
 	}
 
+	d.Set("planned_limit", convertPlannedBudgetLimitsToSet(budget.PlannedBudgetLimits))
 	d.Set("name", budget.BudgetName)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(budget.BudgetName)))
 
@@ -556,13 +583,58 @@ func convertCostFiltersToStringMap(costFilters map[string][]*string) map[string]
 	return convertedCostFilters
 }
 
+func convertPlannedBudgetLimitsToSet(plannedBudgetLimits map[string]*budgets.Spend) []interface{} {
+	if plannedBudgetLimits == nil {
+		return nil
+	}
+
+	convertedPlannedBudgetLimits := make([]interface{}, len(plannedBudgetLimits))
+	i := 0
+
+	for k, v := range plannedBudgetLimits {
+		if v == nil {
+			return nil
+		}
+
+		startTime, err := TimePeriodSecondsToString(k)
+		if err != nil {
+			return nil
+		}
+
+		convertedPlannedBudgetLimit := make(map[string]string)
+		convertedPlannedBudgetLimit["start_time"] = startTime
+		convertedPlannedBudgetLimit["amount"] = *v.Amount
+		convertedPlannedBudgetLimit["unit"] = *v.Unit
+
+		convertedPlannedBudgetLimits[i] = convertedPlannedBudgetLimit
+		i++
+	}
+
+	return convertedPlannedBudgetLimits
+}
+
 func expandBudgetUnmarshal(d *schema.ResourceData) (*budgets.Budget, error) {
 	budgetName := d.Get("name").(string)
 	budgetType := d.Get("budget_type").(string)
-	budgetLimitAmount := d.Get("limit_amount").(string)
-	budgetLimitUnit := d.Get("limit_unit").(string)
 	budgetTimeUnit := d.Get("time_unit").(string)
 	budgetCostFilters := make(map[string][]*string)
+	var budgetLimit *budgets.Spend
+	var plannedBudgetLimits map[string]*budgets.Spend
+
+	if plannedBudgetLimitsRaw, ok := d.GetOk("planned_limit"); ok {
+		plannedBudgetLimitsRaw := plannedBudgetLimitsRaw.(*schema.Set).List()
+
+		var err error
+		plannedBudgetLimits, err = expandPlannedBudgetLimitsUnmarshal(plannedBudgetLimitsRaw)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		budgetLimit = &budgets.Spend{
+			Amount: aws.String(d.Get("limit_amount").(string)),
+			Unit:   aws.String(d.Get("limit_unit").(string)),
+		}
+	}
 
 	if costFilter, ok := d.GetOk("cost_filter"); ok {
 		for _, v := range costFilter.(*schema.Set).List() {
@@ -592,16 +664,14 @@ func expandBudgetUnmarshal(d *schema.ResourceData) (*budgets.Budget, error) {
 	}
 
 	budget := &budgets.Budget{
-		BudgetName: aws.String(budgetName),
-		BudgetType: aws.String(budgetType),
-		BudgetLimit: &budgets.Spend{
-			Amount: aws.String(budgetLimitAmount),
-			Unit:   aws.String(budgetLimitUnit),
-		},
+		BudgetName:          aws.String(budgetName),
+		BudgetType:          aws.String(budgetType),
+		PlannedBudgetLimits: plannedBudgetLimits,
 		TimePeriod: &budgets.TimePeriod{
 			End:   budgetTimePeriodEnd,
 			Start: budgetTimePeriodStart,
 		},
+		BudgetLimit: budgetLimit,
 		TimeUnit:    aws.String(budgetTimeUnit),
 		CostFilters: budgetCostFilters,
 	}
@@ -655,6 +725,29 @@ func expandCostTypes(tfMap map[string]interface{}) *budgets.CostTypes {
 	}
 
 	return apiObject
+}
+
+func expandPlannedBudgetLimitsUnmarshal(plannedBudgetLimitsRaw []interface{}) (map[string]*budgets.Spend, error) {
+	plannedBudgetLimits := make(map[string]*budgets.Spend, len(plannedBudgetLimitsRaw))
+
+	for _, plannedBudgetLimit := range plannedBudgetLimitsRaw {
+		plannedBudgetLimit := plannedBudgetLimit.(map[string]interface{})
+
+		key, err := TimePeriodSecondsFromString(plannedBudgetLimit["start_time"].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		amount := plannedBudgetLimit["amount"].(string)
+		unit := plannedBudgetLimit["unit"].(string)
+
+		plannedBudgetLimits[key] = &budgets.Spend{
+			Amount: aws.String(amount),
+			Unit:   aws.String(unit),
+		}
+	}
+
+	return plannedBudgetLimits, nil
 }
 
 func expandBudgetNotificationsUnmarshal(notificationsRaw []interface{}) ([]*budgets.Notification, [][]*budgets.Subscriber) {

--- a/internal/service/budgets/budget_test.go
+++ b/internal/service/budgets/budget_test.go
@@ -343,6 +343,55 @@ func TestAccBudgetsBudget_notifications(t *testing.T) {
 	})
 }
 
+func TestAccBudgetsBudget_plannedLimits(t *testing.T) {
+	var budget budgets.Budget
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_budgets_budget.test"
+	now := time.Now()
+	config1, testCheckFuncs1 := generateStartTimes(resourceName, "100.0", now)
+	config2, testCheckFuncs2 := generateStartTimes(resourceName, "200.0", now)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(budgets.EndpointsID, t) },
+		ErrorCheck:        acctest.ErrorCheck(t, budgets.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccBudgetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetConfig_plannedLimits(rName, config1),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						testCheckFuncs1,
+						testAccBudgetExists(resourceName, &budget),
+						resource.TestCheckResourceAttr(resourceName, "name", rName),
+						resource.TestCheckResourceAttr(resourceName, "budget_type", "COST"),
+						resource.TestCheckResourceAttr(resourceName, "time_unit", "MONTHLY"),
+						resource.TestCheckResourceAttr(resourceName, "planned_limit.#", "12"),
+					)...,
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBudgetConfig_plannedLimitsUpdated(rName, config2),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						testCheckFuncs2,
+						testAccBudgetExists(resourceName, &budget),
+						resource.TestCheckResourceAttr(resourceName, "name", rName),
+						resource.TestCheckResourceAttr(resourceName, "budget_type", "COST"),
+						resource.TestCheckResourceAttr(resourceName, "time_unit", "MONTHLY"),
+						resource.TestCheckResourceAttr(resourceName, "planned_limit.#", "12"),
+					)...,
+				),
+			},
+		},
+	})
+}
+
 func testAccBudgetExists(resourceName string, v *budgets.Budget) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -554,4 +603,59 @@ resource "aws_budgets_budget" "test" {
   }
 }
 `, rName, emailAddress1)
+}
+
+func testAccBudgetConfig_plannedLimits(rName, config string) string {
+	return fmt.Sprintf(`
+resource "aws_budgets_budget" "test" {
+  name         = %[1]q
+  budget_type  = "COST"
+  time_unit    = "MONTHLY"
+  %[2]s
+}
+`, rName, config)
+}
+
+func testAccBudgetConfig_plannedLimitsUpdated(rName, config string) string {
+	return fmt.Sprintf(`
+resource "aws_budgets_budget" "test" {
+  name         = %[1]q
+  budget_type  = "COST"
+  time_unit    = "MONTHLY"
+  %[2]s
+}
+`, rName, config)
+}
+
+func generateStartTimes(resourceName, amount string, now time.Time) (string, []resource.TestCheckFunc) {
+	startTimes := make([]time.Time, 12)
+
+	year, month, _ := now.Date()
+	startTimes[0] = time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := 1; i < len(startTimes); i++ {
+		startTimes[i] = startTimes[i-1].AddDate(0, 1, 0)
+	}
+
+	configBuilder := strings.Builder{}
+	for i := 0; i < len(startTimes); i++ {
+		configBuilder.WriteString(fmt.Sprintf(`
+planned_limit {
+  start_time = %[1]q
+  amount     = %[2]q
+  unit       = "USD"
+}
+`, tfbudgets.TimePeriodTimestampToString(&startTimes[i]), amount))
+	}
+
+	testCheckFuncs := make([]resource.TestCheckFunc, len(startTimes))
+	for i := 0; i < len(startTimes); i++ {
+		testCheckFuncs[i] = resource.TestCheckTypeSetElemNestedAttrs(resourceName, "planned_limit.*", map[string]string{
+			"start_time": tfbudgets.TimePeriodTimestampToString(&startTimes[i]),
+			"amount":     amount,
+			"unit":       "USD",
+		})
+	}
+
+	return configBuilder.String(), testCheckFuncs
 }

--- a/internal/service/budgets/time.go
+++ b/internal/service/budgets/time.go
@@ -2,6 +2,7 @@ package budgets
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -31,6 +32,31 @@ func TimePeriodTimestampToString(ts *time.Time) string {
 	}
 
 	return aws.TimeValue(ts).Format(timePeriodLayout)
+}
+
+func TimePeriodSecondsFromString(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+
+	ts, err := time.Parse(timePeriodLayout, s)
+
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.FormatInt(aws.Time(ts).Unix(), 10), nil
+}
+
+func TimePeriodSecondsToString(s string) (string, error) {
+	startTime, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return "", err
+	}
+
+	startTime = startTime * 1000
+
+	return aws.SecondsTimeValue(&startTime).UTC().Format(timePeriodLayout), nil
 }
 
 func ValidTimePeriodTimestamp(v interface{}, k string) (ws []string, errors []error) {

--- a/internal/service/budgets/time_test.go
+++ b/internal/service/budgets/time_test.go
@@ -1,0 +1,27 @@
+package budgets
+
+import "testing"
+
+func TestTimePeriodSecondsFromString(t *testing.T) {
+	seconds, err := TimePeriodSecondsFromString("2020-03-01_00:00")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	want := "1583020800"
+	if seconds != want {
+		t.Errorf("got %s, expected %s", seconds, want)
+	}
+}
+
+func TestTimePeriodSecondsToString(t *testing.T) {
+	ts, err := TimePeriodSecondsToString("1583020800")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	want := "2020-03-01_00:00"
+	if ts != want {
+		t.Errorf("got %s, expected %s", ts, want)
+	}
+}

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -50,6 +50,28 @@ resource "aws_budgets_budget" "cost" {
 }
 ```
 
+Create a budget with planned budget limits.
+
+```terraform
+resource "aws_budgets_budget" "cost" {
+  # ...
+  
+  planned_limit {
+    start_time = "2017-07-01_00:00"
+    amount     = "100"
+    unit       = "USD"
+  }
+  
+  planned_limit {
+    start_time = "2017-08-01_00:00"
+    amount     = "200"
+    unit       = "USD"
+  }
+  
+  # ...
+}
+```
+
 Create a budget for s3 with a limit of *3 GB* of storage.
 
 ```terraform
@@ -137,7 +159,8 @@ The following arguments are supported:
 * `time_period_end` - (Optional) The end of the time period covered by the budget. There are no restrictions on the end date. Format: `2017-01-01_12:00`.
 * `time_period_start` - (Optional) The start of the time period covered by the budget. If you don't specify a start date, AWS defaults to the start of your chosen time period. The start date must come before the end date. Format: `2017-01-01_12:00`.
 * `time_unit` - (Required) The length of time until a budget resets the actual and forecasted spend. Valid values: `MONTHLY`, `QUARTERLY`, `ANNUALLY`, and `DAILY`.
-* `notification` - (Optional) Object containing [Budget Notifications](#budget-notification). Can be used multiple times to define more than one budget notification
+* `notification` - (Optional) Object containing [Budget Notifications](#budget-notification). Can be used multiple times to define more than one budget notification.
+* `planned_limit` - (Optional) Object containing [Planned Budget Limits](#planned-budget-limits). Can be used multiple times to plan more than one budget limit. See [PlannedBudgetLimits](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Budget.html#awscostmanagement-Type-budgets_Budget-PlannedBudgetLimits) documentation.
 
 ## Attributes Reference
 
@@ -201,6 +224,14 @@ Valid keys for `notification` parameter.
 * `notification_type` - (Required) What kind of budget value to notify on. Can be `ACTUAL` or `FORECASTED`
 * `subscriber_email_addresses` - (Optional) E-Mail addresses to notify. Either this or `subscriber_sns_topic_arns` is required.
 * `subscriber_sns_topic_arns` - (Optional) SNS topics to notify. Either this or `subscriber_email_addresses` is required.
+
+### Planned Budget Limits
+
+Valid keys for `planned_limit` parameter.
+
+* `start_time` - (Required) The start time of the budget limit. Format: `2017-01-01_12:00`. See [PlannedBudgetLimits](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Budget.html#awscostmanagement-Type-budgets_Budget-PlannedBudgetLimits) documentation.
+* `amount` - (Required) The amount of cost or usage being measured for a budget.
+* `unit` - (Required) The unit of measurement used for the budget forecast, actual spend, or budget threshold, such as dollars or GB. See [Spend](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-spend.html) documentation.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16798

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TESTS=TestAccBudgetsBudget_plannedLimits PKG=budgets
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/budgets/... -v -count 1 -parallel 20 -run='TestAccBudgetsBudget_plannedLimits'  -timeout 180m
=== RUN   TestAccBudgetsBudget_plannedLimits
=== PAUSE TestAccBudgetsBudget_plannedLimits
=== CONT  TestAccBudgetsBudget_plannedLimits
--- PASS: TestAccBudgetsBudget_plannedLimits (47.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/budgets    48.794s
```
