### PR TITLE
service/Network Manager: Use `UpdateTagsWithContext`

### DIFF
--- a/internal/service/networkmanager/connection.go
+++ b/internal/service/networkmanager/connection.go
@@ -210,7 +210,7 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return diag.Errorf("error updating Network Manager Connection (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/networkmanager/device.go
+++ b/internal/service/networkmanager/device.go
@@ -304,7 +304,7 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return diag.Errorf("error updating Network Manager Device (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/networkmanager/generate.go
+++ b/internal/service/networkmanager/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOutTagsElem=TagList -ServiceTagsSlice -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package networkmanager

--- a/internal/service/networkmanager/global_network.go
+++ b/internal/service/networkmanager/global_network.go
@@ -142,7 +142,7 @@ func resourceGlobalNetworkUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return diag.Errorf("error updating Network Manager Global Network (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/networkmanager/link.go
+++ b/internal/service/networkmanager/link.go
@@ -236,7 +236,7 @@ func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return diag.Errorf("error updating Network Manager Link (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/networkmanager/site.go
+++ b/internal/service/networkmanager/site.go
@@ -214,7 +214,7 @@ func resourceSiteUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return diag.Errorf("error updating Network Manager Site (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/networkmanager/tags_gen.go
+++ b/internal/service/networkmanager/tags_gen.go
@@ -11,27 +11,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-// ListTags lists networkmanager service tags.
-// The identifier is typically the Amazon Resource Name (ARN), although
-// it may also be a different identifier depending on the service.
-func ListTags(conn networkmanageriface.NetworkManagerAPI, identifier string) (tftags.KeyValueTags, error) {
-	return ListTagsWithContext(context.Background(), conn, identifier)
-}
-
-func ListTagsWithContext(ctx context.Context, conn networkmanageriface.NetworkManagerAPI, identifier string) (tftags.KeyValueTags, error) {
-	input := &networkmanager.ListTagsForResourceInput{
-		ResourceArn: aws.String(identifier),
-	}
-
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
-
-	if err != nil {
-		return tftags.New(nil), err
-	}
-
-	return KeyValueTags(output.TagList), nil
-}
-
 // []*SERVICE.Tag handling
 
 // Tags returns networkmanager service tags.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #25238.

```console
% make testacc TESTARGS='-run=TestAccNetworkManagerGlobalNetwork_tags' PKG=networkmanager ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 2  -run=TestAccNetworkManagerGlobalNetwork_tags -timeout 180m
=== RUN   TestAccNetworkManagerGlobalNetwork_tags
=== PAUSE TestAccNetworkManagerGlobalNetwork_tags
=== CONT  TestAccNetworkManagerGlobalNetwork_tags
--- PASS: TestAccNetworkManagerGlobalNetwork_tags (54.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	63.537s
```