### PR TITLE
Ignore IPv6 Metadata Options and Metadata Tags on aws-iso Partition

### DIFF
--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1907,7 +1907,7 @@ func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]interfa
 				apiObject.HttpPutResponseHopLimit = aws.Int64(int64(v))
 			}
 
-			if v, ok := tfMap["instance_metadata_tags"].(string); ok && v != "" {
+			if v, ok := tfMap["instance_metadata_tags"].(string); ok && v != "" && partition != endpoints.AwsIsoPartitionID {
 				apiObject.InstanceMetadataTags = aws.String(v)
 			}
 		}

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -1268,7 +1269,7 @@ func expandRequestLaunchTemplateData(conn *ec2.EC2, d *schema.ResourceData) (*ec
 	}
 
 	if v, ok := d.GetOk("metadata_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.MetadataOptions = expandLaunchTemplateInstanceMetadataOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+		apiObject.MetadataOptions = expandLaunchTemplateInstanceMetadataOptionsRequest(v.([]interface{})[0].(map[string]interface{}), conn.PartitionID)
 	}
 
 	if v, ok := d.GetOk("monitoring"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -1886,7 +1887,7 @@ func expandLaunchTemplateLicenseConfigurationRequests(tfList []interface{}) []*e
 	return apiObjects
 }
 
-func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]interface{}) *ec2.LaunchTemplateInstanceMetadataOptionsRequest {
+func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]interface{}, partition string) *ec2.LaunchTemplateInstanceMetadataOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1912,7 +1913,7 @@ func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]interfa
 		}
 	}
 
-	if v, ok := tfMap["http_protocol_ipv6"].(string); ok && v != "" {
+	if v, ok := tfMap["http_protocol_ipv6"].(string); ok && v != "" && partition != endpoints.AwsIsoPartitionID {
 		apiObject.HttpProtocolIpv6 = aws.String(v)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25227

Checks `conn.Partition` for the current partition, compares with "aws-iso", ignores value for `http_protocol_ipv6` if match.

Not positive that `conn.Partition` is the right thing to do

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
