### PR TITLE
d/aws_s3_account_public_access_block - new data source

### DIFF
--- a/.changelog/25781.txt
+++ b/.changelog/25781.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_s3_account_public_access_block
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * **New Resource:** `aws_ce_anomaly_monitor` ([#25177](https://github.com/hashicorp/terraform-provider-aws/issues/25177))
+* **New Data Source:** `aws_s3_account_public_access_block` ([#23783](https://github.com/hashicorp/terraform-provider-aws/issues/23783))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 FEATURES:
 
 * **New Resource:** `aws_ce_anomaly_monitor` ([#25177](https://github.com/hashicorp/terraform-provider-aws/issues/25177))
-* **New Data Source:** `aws_s3_account_public_access_block` ([#23783](https://github.com/hashicorp/terraform-provider-aws/issues/23783))
 
 BUG FIXES:
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -832,6 +832,8 @@ func Provider() *schema.Provider {
 			"aws_s3_bucket_objects": s3.DataSourceBucketObjects(), // DEPRECATED: use aws_s3_objects instead
 			"aws_s3_bucket_policy":  s3.DataSourceBucketPolicy(),
 
+			"aws_s3_account_public_access_block": s3control.DataSourceAccountPublicAccessBlock(),
+
 			"aws_sagemaker_prebuilt_ecr_image": sagemaker.DataSourcePrebuiltECRImage(),
 
 			"aws_secretsmanager_secret":          secretsmanager.DataSourceSecret(),

--- a/internal/service/s3control/account_public_access_block_data_source.go
+++ b/internal/service/s3control/account_public_access_block_data_source.go
@@ -66,7 +66,6 @@ func dataSourceAccountPublicAccessBlockRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error reading S3 Account Public Access Block (%s): missing public access block configuration", accountID)
 	}
 
-	// d.Set("account_id", accountID)
 	d.SetId(accountID)
 	d.Set("block_public_acls", output.PublicAccessBlockConfiguration.BlockPublicAcls)
 	d.Set("block_public_policy", output.PublicAccessBlockConfiguration.BlockPublicPolicy)

--- a/internal/service/s3control/account_public_access_block_data_source.go
+++ b/internal/service/s3control/account_public_access_block_data_source.go
@@ -1,0 +1,77 @@
+package s3control
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func DataSourceAccountPublicAccessBlock() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceAccountPublicAccessBlockRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"block_public_acls": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"block_public_policy": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ignore_public_acls": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"restrict_public_buckets": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAccountPublicAccessBlockRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3ControlConn
+
+	accountID := meta.(*conns.AWSClient).AccountID
+	if v, ok := d.GetOk("account_id"); ok {
+		accountID = v.(string)
+	}
+
+	input := &s3control.GetPublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+	}
+
+	log.Printf("[DEBUG] Reading Account access block: %s", input)
+
+	output, err := conn.GetPublicAccessBlock(input)
+
+	if err != nil {
+		return diag.Errorf("error reading S3 Account Public Access Block: %s", err)
+	}
+
+	if output == nil || output.PublicAccessBlockConfiguration == nil {
+		return diag.Errorf("error reading S3 Account Public Access Block (%s): missing public access block configuration", accountID)
+	}
+
+	// d.Set("account_id", accountID)
+	d.SetId(accountID)
+	d.Set("block_public_acls", output.PublicAccessBlockConfiguration.BlockPublicAcls)
+	d.Set("block_public_policy", output.PublicAccessBlockConfiguration.BlockPublicPolicy)
+	d.Set("ignore_public_acls", output.PublicAccessBlockConfiguration.IgnorePublicAcls)
+	d.Set("restrict_public_buckets", output.PublicAccessBlockConfiguration.RestrictPublicBuckets)
+
+	return nil
+}

--- a/internal/service/s3control/account_public_access_block_data_source_test.go
+++ b/internal/service/s3control/account_public_access_block_data_source_test.go
@@ -1,0 +1,119 @@
+package s3control_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
+	var conf s3control.PublicAccessBlockConfiguration
+	resourceName := "aws_s3_account_public_access_block.test"
+	dataSourceName := "data.aws_s3_account_public_access_block.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3control.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3ControlAccountPublicAccessBlockDataSource_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountPublicAccessBlockExistsDataSource(resourceName, &conf),
+					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "block_public_acls", resourceName),
+					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "block_public_policy", resourceName),
+					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "ignore_public_acls", resourceName),
+					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "restrict_public_buckets", resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAccountPublicAccessBlockMatch(datasource, attribute, resource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[datasource]
+		if !ok {
+			return fmt.Errorf("not found: %s", datasource)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+		attrDataSourceValue, ok := rs.Primary.Attributes[attribute]
+		if !ok {
+			return fmt.Errorf("attribute %q not found for %q", attribute, datasource)
+		}
+
+		rs, ok = s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("not found: %s", resource)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("mo ID is set")
+		}
+		attrResourceValue, ok := rs.Primary.Attributes[attribute]
+		if !ok {
+			return fmt.Errorf("attribute %q not found for %q", attribute, resource)
+		}
+		if attrDataSourceValue != attrResourceValue {
+			return fmt.Errorf("Account public access block policies differ for %s attribute.\aDataSourceValue: %s\aResourceValue: %s", attribute, attrDataSourceValue, attrResourceValue)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAccountPublicAccessBlockExistsDataSource(n string, configuration *s3control.PublicAccessBlockConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no account public access block is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3ControlConn
+
+		input := &s3control.GetPublicAccessBlockInput{
+			AccountId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetPublicAccessBlock(input)
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.PublicAccessBlockConfiguration == nil {
+			return fmt.Errorf("S3 Account Public Access Block not found")
+		}
+
+		*configuration = *output.PublicAccessBlockConfiguration
+
+		return nil
+	}
+}
+
+func testAccDataSourceAccountPublicAccessBlockBaseConfig() string {
+	return fmt.Sprintf(`
+resource "aws_s3_account_public_access_block" "test" {
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+`)
+}
+
+func testAccS3ControlAccountPublicAccessBlockDataSource_basic() string {
+	return acctest.ConfigCompose(testAccDataSourceAccountPublicAccessBlockBaseConfig(), `
+data "aws_s3_account_public_access_block" "test" {
+  depends_on = [aws_s3_account_public_access_block.test]
+}
+`)
+}

--- a/internal/service/s3control/account_public_access_block_data_source_test.go
+++ b/internal/service/s3control/account_public_access_block_data_source_test.go
@@ -1,7 +1,6 @@
 package s3control_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3control"
@@ -31,14 +30,14 @@ func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
 }
 
 func testAccAccountPublicAccessBlockDataSourceConfig_base() string {
-	return fmt.Sprintf(`
+	return `
 resource "aws_s3_account_public_access_block" "test" {
   block_public_acls       = false
   block_public_policy     = false
   ignore_public_acls      = false
   restrict_public_buckets = false
 }
-`)
+`
 }
 
 func testAccAccountPublicAccessBlockDataSourceConfig_basic() string {

--- a/internal/service/s3control/account_public_access_block_data_source_test.go
+++ b/internal/service/s3control/account_public_access_block_data_source_test.go
@@ -4,16 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3control"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
-	var conf s3control.PublicAccessBlockConfiguration
 	resourceName := "aws_s3_account_public_access_block.test"
 	dataSourceName := "data.aws_s3_account_public_access_block.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,88 +20,23 @@ func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
 			{
 				Config: testAccS3ControlAccountPublicAccessBlockDataSource_basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAccountPublicAccessBlockExistsDataSource(resourceName, &conf),
-					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "block_public_acls", resourceName),
-					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "block_public_policy", resourceName),
-					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "ignore_public_acls", resourceName),
-					testAccCheckAccountPublicAccessBlockMatch(dataSourceName, "restrict_public_buckets", resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "block_public_acls", dataSourceName, "block_public_acls"),
+					resource.TestCheckResourceAttrPair(resourceName, "block_public_policy", dataSourceName, "block_public_policy"),
+					resource.TestCheckResourceAttrPair(resourceName, "ignore_public_acls", dataSourceName, "ignore_public_acls"),
+					resource.TestCheckResourceAttrPair(resourceName, "restrict_public_buckets", dataSourceName, "restrict_public_buckets"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckAccountPublicAccessBlockMatch(datasource, attribute, resource string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[datasource]
-		if !ok {
-			return fmt.Errorf("not found: %s", datasource)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-		attrDataSourceValue, ok := rs.Primary.Attributes[attribute]
-		if !ok {
-			return fmt.Errorf("attribute %q not found for %q", attribute, datasource)
-		}
-
-		rs, ok = s.RootModule().Resources[resource]
-		if !ok {
-			return fmt.Errorf("not found: %s", resource)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("mo ID is set")
-		}
-		attrResourceValue, ok := rs.Primary.Attributes[attribute]
-		if !ok {
-			return fmt.Errorf("attribute %q not found for %q", attribute, resource)
-		}
-		if attrDataSourceValue != attrResourceValue {
-			return fmt.Errorf("Account public access block policies differ for %s attribute.\aDataSourceValue: %s\aResourceValue: %s", attribute, attrDataSourceValue, attrResourceValue)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAccountPublicAccessBlockExistsDataSource(n string, configuration *s3control.PublicAccessBlockConfiguration) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no account public access block is set")
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3ControlConn
-
-		input := &s3control.GetPublicAccessBlockInput{
-			AccountId: aws.String(rs.Primary.ID),
-		}
-		output, err := conn.GetPublicAccessBlock(input)
-		if err != nil {
-			return err
-		}
-
-		if output == nil || output.PublicAccessBlockConfiguration == nil {
-			return fmt.Errorf("S3 Account Public Access Block not found")
-		}
-
-		*configuration = *output.PublicAccessBlockConfiguration
-
-		return nil
-	}
-}
-
 func testAccDataSourceAccountPublicAccessBlockBaseConfig() string {
 	return fmt.Sprintf(`
 resource "aws_s3_account_public_access_block" "test" {
-  block_public_acls = true
-  block_public_policy = true
-  ignore_public_acls = true
-  restrict_public_buckets = true
+	block_public_acls       = false
+	block_public_policy     = false
+	ignore_public_acls      = false
+	restrict_public_buckets = false
 }
 `)
 }
@@ -113,7 +44,7 @@ resource "aws_s3_account_public_access_block" "test" {
 func testAccS3ControlAccountPublicAccessBlockDataSource_basic() string {
 	return acctest.ConfigCompose(testAccDataSourceAccountPublicAccessBlockBaseConfig(), `
 data "aws_s3_account_public_access_block" "test" {
-  depends_on = [aws_s3_account_public_access_block.test]
+	depends_on = [aws_s3_account_public_access_block.test]
 }
 `)
 }

--- a/internal/service/s3control/account_public_access_block_data_source_test.go
+++ b/internal/service/s3control/account_public_access_block_data_source_test.go
@@ -33,10 +33,10 @@ func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
 func testAccDataSourceAccountPublicAccessBlockBaseConfig() string {
 	return fmt.Sprintf(`
 resource "aws_s3_account_public_access_block" "test" {
-	block_public_acls       = false
-	block_public_policy     = false
-	ignore_public_acls      = false
-	restrict_public_buckets = false
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 `)
 }
@@ -44,7 +44,7 @@ resource "aws_s3_account_public_access_block" "test" {
 func testAccS3ControlAccountPublicAccessBlockDataSource_basic() string {
 	return acctest.ConfigCompose(testAccDataSourceAccountPublicAccessBlockBaseConfig(), `
 data "aws_s3_account_public_access_block" "test" {
-	depends_on = [aws_s3_account_public_access_block.test]
+  depends_on = [aws_s3_account_public_access_block.test]
 }
 `)
 }

--- a/internal/service/s3control/account_public_access_block_data_source_test.go
+++ b/internal/service/s3control/account_public_access_block_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccS3ControlAccountPublicAccessBlockDataSource_basic(),
+				Config: testAccAccountPublicAccessBlockDataSourceConfig_basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "block_public_acls", dataSourceName, "block_public_acls"),
 					resource.TestCheckResourceAttrPair(resourceName, "block_public_policy", dataSourceName, "block_public_policy"),
@@ -30,7 +30,7 @@ func TestAccS3ControlAccountPublicAccessBlockDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAccountPublicAccessBlockBaseConfig() string {
+func testAccAccountPublicAccessBlockDataSourceConfig_base() string {
 	return fmt.Sprintf(`
 resource "aws_s3_account_public_access_block" "test" {
   block_public_acls       = false
@@ -41,8 +41,8 @@ resource "aws_s3_account_public_access_block" "test" {
 `)
 }
 
-func testAccS3ControlAccountPublicAccessBlockDataSource_basic() string {
-	return acctest.ConfigCompose(testAccDataSourceAccountPublicAccessBlockBaseConfig(), `
+func testAccAccountPublicAccessBlockDataSourceConfig_basic() string {
+	return acctest.ConfigCompose(testAccAccountPublicAccessBlockDataSourceConfig_base(), `
 data "aws_s3_account_public_access_block" "test" {
   depends_on = [aws_s3_account_public_access_block.test]
 }

--- a/website/docs/d/s3_account_public_access_block.html.markdown
+++ b/website/docs/d/s3_account_public_access_block.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "S3 Control"
+layout: "aws"
+page_title: "AWS: aws_s3_account_public_access_block"
+description: |-
+  Provides S3 account-level Public Access Block Configuration
+---
+
+# Data Source: aws_s3_account_public_access_block
+
+The S3 account public access block data source returns account-level public access block configuration.
+
+## Example Usage
+
+```terraform
+data "aws_s3_account_public_access_block" "example" {
+}
+
+output "foo" {
+  block_public_acls_value = data.aws_s3_bucket_policy.example.block_public_acls
+  block_public_policy_value = data.aws_s3_bucket_policy.example.block_public_policy
+  ignore_public_acls_value = data.aws_s3_bucket_policy.example.ignore_public_acls
+  restrict_public_buckets_value = data.aws_s3_bucket_policy.example.restrict_public_buckets
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Optional) AWS account ID to configure. Defaults to automatically determined account ID of the Terraform AWS provider.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - AWS account ID
+* `block_public_acls` - Whether or not Amazon S3 should block public ACLs for buckets in this account is enabled. Returns as `true` or `false`.
+* `block_public_policy` - Whether or not Amazon S3 should block public bucket policies for buckets in this account is enabled. Returns as `true` or `false`.
+* `ignore_public_acls` - Whether or not Amazon S3 should ignore public ACLs for buckets in this account is enabled. Returns as `true` or `false`.
+* `restrict_public_buckets` - Whether or not Amazon S3 should restrict public bucket policies for buckets in this account is enabled. Returns as `true` or `false`.

--- a/website/docs/d/s3_account_public_access_block.html.markdown
+++ b/website/docs/d/s3_account_public_access_block.html.markdown
@@ -16,12 +16,6 @@ The S3 account public access block data source returns account-level public acce
 data "aws_s3_account_public_access_block" "example" {
 }
 
-output "foo" {
-  block_public_acls_value = data.aws_s3_bucket_policy.example.block_public_acls
-  block_public_policy_value = data.aws_s3_bucket_policy.example.block_public_policy
-  ignore_public_acls_value = data.aws_s3_bucket_policy.example.ignore_public_acls
-  restrict_public_buckets_value = data.aws_s3_bucket_policy.example.restrict_public_buckets
-}
 ```
 
 ## Argument Reference

--- a/website/docs/d/s3_account_public_access_block.html.markdown
+++ b/website/docs/d/s3_account_public_access_block.html.markdown
@@ -15,7 +15,6 @@ The S3 account public access block data source returns account-level public acce
 ```terraform
 data "aws_s3_account_public_access_block" "example" {
 }
-
 ```
 
 ## Argument Reference


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #23783

Output from acceptance testing:

```
make testacc TESTS=TestAccS3ControlAccountPublicAccessBlockDataSource PKG=s3control
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3control/... -v -count 1 -parallel 20 -run='TestAccS3ControlAccountPublicAccessBlockDataSource'  -timeout 180m
=== RUN   TestAccS3ControlAccountPublicAccessBlockDataSource_basic
=== PAUSE TestAccS3ControlAccountPublicAccessBlockDataSource_basic
=== CONT  TestAccS3ControlAccountPublicAccessBlockDataSource_basic
--- PASS: TestAccS3ControlAccountPublicAccessBlockDataSource_basic (34.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	38.429s
```
