### PR TITLE
d/aws_networkmanager_core_network_policy_document allow `segments` block bools to set specified values

### DIFF
--- a/.changelog/25789.txt
+++ b/.changelog/25789.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_networkmanager_core_network_policy_document: Fix bug where bool values in `segments` blocks weren't being included in json payloads
+```

--- a/internal/service/networkmanager/core_network_policy_document_data_source_test.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source_test.go
@@ -249,7 +249,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     action {
       association_method = "constant"
       segment            = "GoodSegmentSpecification"
-      require_acceptance = true
+      require_acceptance = false
     }
   }
 
@@ -360,7 +360,8 @@ func testAccPolicyDocumentExpectedJSON() string {
       "rule-number": 1,
       "action": {
         "association-method": "tag",
-        "tag-value-of-key": "segment"
+        "tag-value-of-key": "segment",
+        "require-acceptance": false
       },
       "conditions": [
         {
@@ -442,7 +443,7 @@ func testAccPolicyDocumentExpectedJSON() string {
       "action": {
         "association-method": "constant",
         "segment": "GoodSegmentSpecification",
-        "require-acceptance": true
+        "require-acceptance": false
       },
       "conditions": [
         {

--- a/internal/service/networkmanager/core_network_policy_document_data_source_test.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source_test.go
@@ -76,7 +76,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
   segments {
     name                          = "AnotherGoodSegmentSpecification"
     description                   = "A good segment."
-    require_attachment_acceptance = true
+    require_attachment_acceptance = false
     isolate_attachments           = false
     allow_filter                  = ["AllowThisSegment"]
   }
@@ -99,12 +99,12 @@ data "aws_networkmanager_core_network_policy_document" "test" {
   segments {
     name                          = "b"
     require_attachment_acceptance = true
-    isolate_attachments           = false
+    isolate_attachments           = true
   }
   segments {
     name                          = "c"
-    require_attachment_acceptance = true
     isolate_attachments           = false
+    require_attachment_acceptance = true
   }
 
   segment_actions {
@@ -314,6 +314,7 @@ func testAccPolicyDocumentExpectedJSON() string {
         "us-east-1",
         "eu-west-1"
       ],
+      "isolate-attachments": false,
       "require-attachment-acceptance": true
     },
     {
@@ -322,29 +323,35 @@ func testAccPolicyDocumentExpectedJSON() string {
       "allow-filter": [
         "AllowThisSegment"
       ],
-      "require-attachment-acceptance": true
+      "isolate-attachments": false,
+      "require-attachment-acceptance": false
     },
     {
       "name": "AllowThisSegment",
       "deny-filter": [
         "DenyThisSegment"
       ],
+      "isolate-attachments": false,
       "require-attachment-acceptance": true
     },
     {
       "name": "DenyThisSegment",
+      "isolate-attachments": false,
       "require-attachment-acceptance": true
     },
     {
       "name": "a",
+      "isolate-attachments": false,
       "require-attachment-acceptance": true
     },
     {
       "name": "b",
+      "isolate-attachments": true,
       "require-attachment-acceptance": true
     },
     {
       "name": "c",
+      "isolate-attachments": false,
       "require-attachment-acceptance": true
     }
   ],

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -51,8 +51,8 @@ type CoreNetworkPolicySegment struct {
 	AllowFilter                 interface{} `json:"allow-filter,omitempty"`
 	DenyFilter                  interface{} `json:"deny-filter,omitempty"`
 	EdgeLocations               interface{} `json:"edge-locations,omitempty"`
-	IsolateAttachments          bool        `json:"isolate-attachments,omitempty"`
-	RequireAttachmentAcceptance bool        `json:"require-attachment-acceptance,omitempty"`
+	IsolateAttachments          bool        `json:"isolate-attachments"`
+	RequireAttachmentAcceptance bool        `json:"require-attachment-acceptance"`
 }
 
 type CoreNetworkPolicyCoreNetworkConfiguration struct {

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -35,7 +35,7 @@ type CoreNetworkAttachmentPolicyAction struct {
 	AssociationMethod string `json:"association-method,omitempty"`
 	Segment           string `json:"segment,omitempty"`
 	TagValueOfKey     string `json:"tag-value-of-key,omitempty"`
-	RequireAcceptance bool   `json:"require-acceptance,omitempty"`
+	RequireAcceptance bool   `json:"require-acceptance"`
 }
 
 type CoreNetworkAttachmentPolicyCondition struct {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25787

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=networkmanager TESTS="TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic'  -timeout 180m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (21.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     25.812s
```
