### PR TITLE
rd/aws_imagebuilder_image_recipe: add support for EBS throughput

### DIFF
--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -90,6 +90,12 @@ func ResourceImageRecipe() *schema.Resource {
 										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 1024),
 									},
+									"throughput": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.IntBetween(125, 1000),
+									},
 									"volume_size": {
 										Type:         schema.TypeInt,
 										Optional:     true,
@@ -520,6 +526,10 @@ func expandEBSInstanceBlockDeviceSpecification(tfMap map[string]interface{}) *im
 		apiObject.SnapshotId = aws.String(v)
 	}
 
+	if v, ok := tfMap["throughput"].(int); ok && v != 0 {
+		apiObject.Throughput = aws.Int64(int64(v))
+	}
+
 	if v, ok := tfMap["volume_size"].(int); ok && v != 0 {
 		apiObject.VolumeSize = aws.Int64(int64(v))
 	}
@@ -696,6 +706,10 @@ func flattenEBSInstanceBlockDeviceSpecification(apiObject *imagebuilder.EbsInsta
 
 	if v := apiObject.SnapshotId; v != nil {
 		tfMap["snapshot_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Throughput; v != nil {
+		tfMap["throughput"] = aws.Int64Value(v)
 	}
 
 	if v := apiObject.VolumeSize; v != nil {

--- a/internal/service/imagebuilder/image_recipe_data_source.go
+++ b/internal/service/imagebuilder/image_recipe_data_source.go
@@ -55,6 +55,10 @@ func DataSourceImageRecipe() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"throughput": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
 									"volume_size": {
 										Type:     schema.TypeInt,
 										Computed: true,

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -247,6 +247,35 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID(t *testing.
 	})
 }
 
+func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageRecipeConfig_blockDeviceMappingEBSThroughput(rName, 200),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageRecipeExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mapping.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "block_device_mapping.*", map[string]string{
+						"ebs.0.throughput": "200",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
@@ -905,6 +934,29 @@ resource "aws_imagebuilder_image_recipe" "test" {
   version      = "1.0.0"
 }
 `, rName))
+}
+
+func testAccImageRecipeConfig_blockDeviceMappingEBSThroughput(rName string, throughput int) string {
+	return acctest.ConfigCompose(
+		testAccImageRecipeBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_image_recipe" "test" {
+  block_device_mapping {
+    ebs {
+      throughput  = %[2]d
+	  volume_type = "gp3"
+    }
+  }
+
+  component {
+    component_arn = aws_imagebuilder_component.test.arn
+  }
+
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
+}
+`, rName, throughput))
 }
 
 func testAccImageRecipeConfig_blockDeviceMappingEBSVolumeSize(rName string, volumeSize int) string {

--- a/website/docs/d/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/d/imagebuilder_image_recipe.html.markdown
@@ -36,6 +36,7 @@ In addition to all arguments above, the following attributes are exported:
         * `iops` - Number of Input/Output (I/O) operations per second to provision for an `io1` or `io2` volume.
         * `kms_key_id` - Amazon Resource Name (ARN) of the Key Management Service (KMS) Key for encryption.
         * `snapshot_id` - Identifier of the EC2 Volume Snapshot.
+        * `throughput` - For GP3 volumes only. The throughput in MiB/s that the volume supports.
         * `volume_size` - Size of the volume, in GiB.
         * `volume_type` - Type of the volume. For example, `gp2` or `io2`.
     * `no_device` - Whether to remove a mapping from the parent image.

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -80,6 +80,7 @@ The following arguments are optional:
 * `iops` - (Optional) Number of Input/Output (I/O) operations per second to provision for an `io1` or `io2` volume.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the Key Management Service (KMS) Key for encryption.
 * `snapshot_id` - (Optional) Identifier of the EC2 Volume Snapshot.
+* `throughput` - (Optional) For GP3 volumes only. The throughput in MiB/s that the volume supports.
 * `volume_size` - (Optional) Size of the volume, in GiB.
 * `volume_type` - (Optional) Type of the volume. For example, `gp2` or `io2`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25786.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=imagebuilder ACCTEST_PARALLELISM=2 TESTS="TestAccImageBuilderImageRecipe_"          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 2 -run='TestAccImageBuilderImageRecipe_'  -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_disappears
=== PAUSE TestAccImageBuilderImageRecipe_disappears
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderImageRecipe_component
=== PAUSE TestAccImageBuilderImageRecipe_component
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== RUN   TestAccImageBuilderImageRecipe_description
=== PAUSE TestAccImageBuilderImageRecipe_description
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImageRecipe_workingDirectory
=== PAUSE TestAccImageBuilderImageRecipe_workingDirectory
=== RUN   TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageBuilderImageRecipe_systemsManagerAgent
=== PAUSE TestAccImageBuilderImageRecipe_systemsManagerAgent
=== RUN   TestAccImageBuilderImageRecipe_updateDependency
=== PAUSE TestAccImageBuilderImageRecipe_updateDependency
=== RUN   TestAccImageBuilderImageRecipe_userDataBase64
=== PAUSE TestAccImageBuilderImageRecipe_userDataBase64
=== RUN   TestAccImageBuilderImageRecipe_windowsBaseImage
=== PAUSE TestAccImageBuilderImageRecipe_windowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_basic
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
--- PASS: TestAccImageBuilderImageRecipe_basic (31.57s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (31.76s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (28.48s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (28.29s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (28.57s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (29.39s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput (27.89s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (28.36s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (64.46s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (28.42s)
=== CONT  TestAccImageBuilderImageRecipe_disappears
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (28.65s)
=== CONT  TestAccImageBuilderImageRecipe_workingDirectory
--- PASS: TestAccImageBuilderImageRecipe_disappears (24.56s)
=== CONT  TestAccImageBuilderImageRecipe_windowsBaseImage
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (28.92s)
=== CONT  TestAccImageBuilderImageRecipe_userDataBase64
--- PASS: TestAccImageBuilderImageRecipe_windowsBaseImage (28.88s)
=== CONT  TestAccImageBuilderImageRecipe_updateDependency
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (27.99s)
=== CONT  TestAccImageBuilderImageRecipe_systemsManagerAgent
--- PASS: TestAccImageBuilderImageRecipe_systemsManagerAgent (27.61s)
=== CONT  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
--- PASS: TestAccImageBuilderImageRecipe_updateDependency (50.01s)
=== CONT  TestAccImageBuilderImageRecipe_component
--- PASS: TestAccImageBuilderImageRecipe_component (47.66s)
=== CONT  TestAccImageBuilderImageRecipe_tags
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (70.45s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (29.15s)
=== CONT  TestAccImageBuilderImageRecipe_description
--- PASS: TestAccImageBuilderImageRecipe_description (28.36s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
--- PASS: TestAccImageBuilderImageRecipe_tags (88.91s)
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (28.15s)
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (25.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       440.657s
```
