### PR TITLE
aws_vpc_route_table: retry read on new resource

### DIFF
--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -217,7 +217,9 @@ func resourceRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	routeTable, err := FindRouteTableByID(conn, d.Id())
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(propagationTimeout, func() (interface{}, error) {
+		return FindRouteTableByID(conn, d.Id())
+	}, d.IsNewResource())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route Table (%s) not found, removing from state", d.Id())
@@ -228,6 +230,8 @@ func resourceRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error reading Route Table (%s): %w", d.Id(), err)
 	}
+
+	routeTable := outputRaw.(*ec2.RouteTable)
 
 	d.Set("vpc_id", routeTable.VpcId)
 


### PR DESCRIPTION
We are seeing failures to read a newly created Route Table:

```
time="2022-07-12T14:52:59Z" level=error
time="2022-07-12T14:52:59Z" level=error msg="Error: error reading Route Table (rtb-0f35a4184bea5e3dd): couldn't find resource"
time="2022-07-12T14:52:59Z" level=error
time="2022-07-12T14:52:59Z" level=error msg="  with module.vpc.aws_route_table.private_routes[0],"
time="2022-07-12T14:52:59Z" level=error msg="  on vpc/vpc-private.tf line 1, in resource \"aws_route_table\" \"private_routes\":"
time="2022-07-12T14:52:59Z" level=error msg="   1: resource \"aws_route_table\" \"private_routes\" {"
time="2022-07-12T14:52:59Z" level=error
```

#22927 instituted retry logic for route table associations. I'm just applying that same logic here.
We should retry reads in those cases to alow for eventual consistency.


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25791 

Output from acceptance testing:

```
$ make testacc TESTS=TestAccVPCRouteTable PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCRouteTable'  -timeout 180m
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_changeRouteTable
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_changeRouteTable
=== RUN   TestAccVPCRouteTableAssociation_Gateway_basic
=== PAUSE TestAccVPCRouteTableAssociation_Gateway_basic
=== RUN   TestAccVPCRouteTableAssociation_Gateway_changeRouteTable
=== PAUSE TestAccVPCRouteTableAssociation_Gateway_changeRouteTable
=== RUN   TestAccVPCRouteTableAssociation_disappears
=== PAUSE TestAccVPCRouteTableAssociation_disappears
=== RUN   TestAccVPCRouteTableDataSource_basic
=== PAUSE TestAccVPCRouteTableDataSource_basic
=== RUN   TestAccVPCRouteTableDataSource_main
=== PAUSE TestAccVPCRouteTableDataSource_main
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCRouteTable_disappears
=== PAUSE TestAccVPCRouteTable_disappears
=== RUN   TestAccVPCRouteTable_Disappears_subnetAssociation
=== PAUSE TestAccVPCRouteTable_Disappears_subnetAssociation
=== RUN   TestAccVPCRouteTable_ipv4ToInternetGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToInternetGateway
=== RUN   TestAccVPCRouteTable_ipv4ToInstance
=== PAUSE TestAccVPCRouteTable_ipv4ToInstance
=== RUN   TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway
=== PAUSE TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway
=== RUN   TestAccVPCRouteTable_tags
=== PAUSE TestAccVPCRouteTable_tags
=== RUN   TestAccVPCRouteTable_requireRouteDestination
=== PAUSE TestAccVPCRouteTable_requireRouteDestination
=== RUN   TestAccVPCRouteTable_requireRouteTarget
=== PAUSE TestAccVPCRouteTable_requireRouteTarget
=== RUN   TestAccVPCRouteTable_Route_mode
=== PAUSE TestAccVPCRouteTable_Route_mode
=== RUN   TestAccVPCRouteTable_ipv4ToTransitGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToTransitGateway
=== RUN   TestAccVPCRouteTable_ipv4ToVPCEndpoint
=== PAUSE TestAccVPCRouteTable_ipv4ToVPCEndpoint
=== RUN   TestAccVPCRouteTable_ipv4ToCarrierGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToCarrierGateway
=== RUN   TestAccVPCRouteTable_ipv4ToLocalGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToLocalGateway
=== RUN   TestAccVPCRouteTable_ipv4ToVPCPeeringConnection
=== PAUSE TestAccVPCRouteTable_ipv4ToVPCPeeringConnection
=== RUN   TestAccVPCRouteTable_vgwRoutePropagation
=== PAUSE TestAccVPCRouteTable_vgwRoutePropagation
=== RUN   TestAccVPCRouteTable_conditionalCIDRBlock
=== PAUSE TestAccVPCRouteTable_conditionalCIDRBlock
=== RUN   TestAccVPCRouteTable_ipv4ToNatGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToNatGateway
=== RUN   TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached
=== PAUSE TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached
=== RUN   TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached
=== PAUSE TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached
=== RUN   TestAccVPCRouteTable_vpcMultipleCIDRs
=== PAUSE TestAccVPCRouteTable_vpcMultipleCIDRs
=== RUN   TestAccVPCRouteTable_vpcClassicLink
=== PAUSE TestAccVPCRouteTable_vpcClassicLink
=== RUN   TestAccVPCRouteTable_gatewayVPCEndpoint
=== PAUSE TestAccVPCRouteTable_gatewayVPCEndpoint
=== RUN   TestAccVPCRouteTable_multipleRoutes
=== PAUSE TestAccVPCRouteTable_multipleRoutes
=== RUN   TestAccVPCRouteTable_prefixListToInternetGateway
=== PAUSE TestAccVPCRouteTable_prefixListToInternetGateway
=== RUN   TestAccVPCRouteTablesDataSource_basic
=== PAUSE TestAccVPCRouteTablesDataSource_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCRouteTable_Disappears_subnetAssociation
=== CONT  TestAccVPCRouteTableDataSource_basic
=== CONT  TestAccVPCRouteTableAssociation_Gateway_basic
=== CONT  TestAccVPCRouteTable_ipv4ToTransitGateway
=== CONT  TestAccVPCRouteTablesDataSource_basic
=== CONT  TestAccVPCRouteTable_prefixListToInternetGateway
=== CONT  TestAccVPCRouteTable_multipleRoutes
=== CONT  TestAccVPCRouteTable_gatewayVPCEndpoint
=== CONT  TestAccVPCRouteTable_vpcClassicLink
=== CONT  TestAccVPCRouteTable_vpcMultipleCIDRs
=== CONT  TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached
=== CONT  TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached
=== CONT  TestAccVPCRouteTable_ipv4ToNatGateway
=== CONT  TestAccVPCRouteTable_conditionalCIDRBlock
=== CONT  TestAccVPCRouteTable_vgwRoutePropagation
=== CONT  TestAccVPCRouteTableAssociation_Gateway_changeRouteTable
=== CONT  TestAccVPCRouteTable_ipv4ToVPCPeeringConnection
=== CONT  TestAccVPCRouteTable_ipv4ToLocalGateway
=== CONT  TestAccVPCRouteTableAssociation_disappears
=== CONT  TestAccVPCRouteTable_ipv4ToLocalGateway
    acctest.go:1323: skipping since no Outposts found
--- SKIP: TestAccVPCRouteTable_ipv4ToLocalGateway (1.68s)
=== CONT  TestAccVPCRouteTable_ipv4ToCarrierGateway
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccVPCRouteTable_ipv4ToCarrierGateway (0.13s)
=== CONT  TestAccVPCRouteTable_ipv4ToVPCEndpoint
--- PASS: TestAccVPCRouteTable_vpcClassicLink (28.43s)
=== CONT  TestAccVPCRouteTable_basic
--- PASS: TestAccVPCRouteTablesDataSource_basic (31.31s)
=== CONT  TestAccVPCRouteTable_disappears
--- PASS: TestAccVPCRouteTable_Disappears_subnetAssociation (33.22s)
=== CONT  TestAccVPCRouteTable_tags
--- PASS: TestAccVPCRouteTableDataSource_basic (34.29s)
=== CONT  TestAccVPCRouteTable_Route_mode
--- PASS: TestAccVPCRouteTable_ipv4ToVPCPeeringConnection (37.15s)
=== CONT  TestAccVPCRouteTable_requireRouteTarget
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (38.43s)
=== CONT  TestAccVPCRouteTable_requireRouteDestination
--- PASS: TestAccVPCRouteTableAssociation_Gateway_basic (40.84s)
=== CONT  TestAccVPCRouteTableAssociation_Subnet_changeRouteTable
--- PASS: TestAccVPCRouteTable_prefixListToInternetGateway (41.49s)
=== CONT  TestAccVPCRouteTable_ipv4ToInstance
--- PASS: TestAccVPCRouteTableAssociation_disappears (44.06s)
=== CONT  TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway
--- PASS: TestAccVPCRouteTable_gatewayVPCEndpoint (49.16s)
=== CONT  TestAccVPCRouteTableDataSource_main
--- PASS: TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached (50.28s)
=== CONT  TestAccVPCRouteTable_ipv4ToInternetGateway
--- PASS: TestAccVPCRouteTable_requireRouteTarget (14.41s)
--- PASS: TestAccVPCRouteTable_disappears (23.73s)
--- PASS: TestAccVPCRouteTable_vpcMultipleCIDRs (55.21s)
--- PASS: TestAccVPCRouteTable_basic (28.76s)
--- PASS: TestAccVPCRouteTableAssociation_Gateway_changeRouteTable (60.58s)
--- PASS: TestAccVPCRouteTable_conditionalCIDRBlock (67.48s)
--- PASS: TestAccVPCRouteTableDataSource_main (18.90s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_changeRouteTable (43.05s)
--- PASS: TestAccVPCRouteTable_tags (57.71s)
--- PASS: TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway (47.35s)
--- PASS: TestAccVPCRouteTable_vgwRoutePropagation (91.87s)
--- PASS: TestAccVPCRouteTable_ipv4ToInternetGateway (41.86s)
--- PASS: TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached (93.82s)
--- PASS: TestAccVPCRouteTable_Route_mode (62.47s)
--- PASS: TestAccVPCRouteTable_ipv4ToInstance (119.31s)
--- PASS: TestAccVPCRouteTable_multipleRoutes (217.35s)
--- PASS: TestAccVPCRouteTable_ipv4ToNatGateway (229.68s)
--- PASS: TestAccVPCRouteTable_ipv4ToVPCEndpoint (299.82s)
--- PASS: TestAccVPCRouteTable_ipv4ToTransitGateway (322.49s)
--- PASS: TestAccVPCRouteTable_requireRouteDestination (290.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	329.134s

...
```
