### PR TITLE
Add custom timeout block to `aws_db_instance_automated_backups_replication`

### DIFF
--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -3,6 +3,7 @@ package rds
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -18,6 +19,12 @@ func ResourceInstanceAutomatedBackupsReplication() *schema.Resource {
 		Create: resourceInstanceAutomatedBackupsReplicationCreate,
 		Read:   resourceInstanceAutomatedBackupsReplicationRead,
 		Delete: resourceInstanceAutomatedBackupsReplicationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(75 * time.Minute),
+			Update: schema.DefaultTimeout(75 * time.Minute),
+			Delete: schema.DefaultTimeout(75 * time.Minute),
+		},
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/website/docs/r/db_instance_automated_backups_replication.markdown
+++ b/website/docs/r/db_instance_automated_backups_replication.markdown
@@ -87,6 +87,15 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Amazon Resource Name (ARN) of the replicated automated backups.
 
+## Timeouts
+
+`aws_db_instance_automated_backups_replication` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
+configuration options:
+
+- `create` - (Default `75m`) How long to wait before RDS initiates the automated backup replication.
+- `update` - (Default `75m`) How long to wait before RDS updates the automated backup replication.
+- `delete` - (Default `75m`) How long to wait before RDS deletes the automated backup replication.
+
 ## Import
 
 RDS instance automated backups replication can be imported using the `arn`, e.g.,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25776

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
```
