### PR TITLE
add 'rack_elevation' attribute to aws_outposts_asset data source

### DIFF
--- a/.changelog/25822.txt
+++ b/.changelog/25822.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data/aws_outposts_asset: Add `rack_elevation` attribute
+```

--- a/internal/service/outposts/outpost_asset_data_source.go
+++ b/internal/service/outposts/outpost_asset_data_source.go
@@ -32,6 +32,10 @@ func DataSourceOutpostAsset() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"rack_elevation": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"rack_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -78,6 +82,7 @@ func DataSourceOutpostAssetRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("asset_id", asset.AssetId)
 	d.Set("asset_type", asset.AssetType)
 	d.Set("host_id", asset.ComputeAttributes.HostId)
+	d.Set("rack_elevation", asset.AssetLocation.RackElevation)
 	d.Set("rack_id", asset.RackId)
 	return nil
 }

--- a/internal/service/outposts/outpost_asset_data_source_test.go
+++ b/internal/service/outposts/outpost_asset_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccOutpostsAssetDataSource_id(t *testing.T) {
+func TestAccOutpostsAssetDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_outposts_asset.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
@@ -17,11 +17,12 @@ func TestAccOutpostsAssetDataSource_id(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOutpostAssetDataSourceConfig_id(),
+				Config: testAccOutpostAssetDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "outposts", regexp.MustCompile(`outpost/.+`)),
 					resource.TestMatchResourceAttr(dataSourceName, "asset_id", regexp.MustCompile(`^(\w+)$`)),
 					resource.TestCheckResourceAttrSet(dataSourceName, "asset_type"),
+					resource.TestMatchResourceAttr(dataSourceName, "rack_elevation", regexp.MustCompile(`^[\S \n]+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "rack_id", regexp.MustCompile(`^[\S \n]+$`)),
 				),
 			},
@@ -29,7 +30,7 @@ func TestAccOutpostsAssetDataSource_id(t *testing.T) {
 	})
 }
 
-func testAccOutpostAssetDataSourceConfig_id() string {
+func testAccOutpostAssetDataSourceConfig_basic() string {
 	return `
 data "aws_outposts_outposts" "test" {}
 

--- a/website/docs/d/outposts_asset.html.markdown
+++ b/website/docs/d/outposts_asset.html.markdown
@@ -38,4 +38,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `asset_type` - The type of the asset.
 * `host_id` - The host ID of the Dedicated Hosts on the asset, if a Dedicated Host is provisioned.
+* `rack_elevation` - The position of an asset in a rack measured in rack units.
 * `rack_id` - The rack ID of the asset.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25814

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS='TestAccOutpostsAssetDataSource_basic' PKG=outposts TESTARGS=-short                                        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/outposts/... -v -count 1 -parallel 20 -run='TestAccOutpostsAssetDataSource_basic' -short -timeout 180m
=== RUN   TestAccOutpostsAssetDataSource_basic
=== PAUSE TestAccOutpostsAssetDataSource_basic
=== CONT  TestAccOutpostsAssetDataSource_basic
--- PASS: TestAccOutpostsAssetDataSource_basic (14.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts   14.172s

...
```
