### PR TITLE
d/aws_location_geofence_collection: new data source

### DIFF
--- a/.changelog/25844.txt
+++ b/.changelog/25844.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_location_geofence_collection
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -730,10 +730,11 @@ func Provider() *schema.Provider {
 			"aws_lex_intent":    lexmodels.DataSourceIntent(),
 			"aws_lex_slot_type": lexmodels.DataSourceSlotType(),
 
-			"aws_location_map":              location.DataSourceMap(),
-			"aws_location_place_index":      location.DataSourcePlaceIndex(),
-			"aws_location_route_calculator": location.DataSourceRouteCalculator(),
-			"aws_location_tracker":          location.DataSourceTracker(),
+			"aws_location_geofence_collection": location.DataSourceGeofenceCollection(),
+			"aws_location_map":                 location.DataSourceMap(),
+			"aws_location_place_index":         location.DataSourcePlaceIndex(),
+			"aws_location_route_calculator":    location.DataSourceRouteCalculator(),
+			"aws_location_tracker":             location.DataSourceTracker(),
 
 			"aws_arn":                     meta.DataSourceARN(),
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),

--- a/internal/service/location/geofence_collection_data_source.go
+++ b/internal/service/location/geofence_collection_data_source.go
@@ -1,0 +1,80 @@
+package location
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceGeofenceCollection() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeofenceCollectionRead,
+
+		Schema: map[string]*schema.Schema{
+			"collection_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"collection_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameGeofenceCollection = "Geofence Collection Data Source"
+)
+
+func dataSourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	name := d.Get("collection_name").(string)
+
+	out, err := findGeofenceCollectionByName(ctx, conn, name)
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionReading, DSNameGeofenceCollection, name, err)
+	}
+
+	d.SetId(aws.StringValue(out.CollectionName))
+	d.Set("collection_arn", out.CollectionArn)
+	d.Set("create_time", aws.TimeValue(out.CreateTime).Format(time.RFC3339))
+	d.Set("description", out.Description)
+	d.Set("kms_key_id", out.KmsKeyId)
+	d.Set("update_time", aws.TimeValue(out.UpdateTime).Format(time.RFC3339))
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	if err := d.Set("tags", KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return names.DiagError(names.Location, names.ErrActionSetting, DSNameGeofenceCollection, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/location/geofence_collection_data_source_test.go
+++ b/internal/service/location/geofence_collection_data_source_test.go
@@ -1,0 +1,51 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationGeofenceCollectionDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_geofence_collection.test"
+	resourceName := "aws_location_geofence_collection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckGeofenceCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeofenceCollectionDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeofenceCollectionExists(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "collection_arn", resourceName, "collection_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "collection_name", resourceName, "collection_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_time", resourceName, "create_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "update_time", resourceName, "update_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGeofenceCollectionDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+  collection_name = %[1]q
+}
+
+data "aws_location_geofence_collection" "test" {
+  collection_name = aws_location_geofence_collection.test.collection_name
+}
+`, rName)
+}

--- a/website/docs/d/location_geofence_collection.html.markdown
+++ b/website/docs/d/location_geofence_collection.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_geofence_collection"
+description: |-
+    Retrieve information about a Location Service Geofence Collection.
+---
+
+# Data Source: aws_location_geofencecollection
+
+Retrieve information about a Location Service Geofence Collection.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_location_geofence_collection" "example" {
+  collection_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `collection_name` - (Required) The name of the geofence collection.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `collection_arn` - The Amazon Resource Name (ARN) for the geofence collection resource. Used when you need to specify a resource across all AWS.
+* `create_time` - The timestamp for when the geofence collection resource was created in ISO 8601 format.
+* `description` - The optional description of the geofence collection resource.
+* `kms_key_id` - A key identifier for an AWS KMS customer managed key assigned to the Amazon Location resource.
+* `tags` - Key-value map of resource tags for the geofence collection.
+* `update_time` - The timestamp for when the geofence collection resource was last updated in ISO 8601 format.

--- a/website/docs/d/location_geofence_collection.html.markdown
+++ b/website/docs/d/location_geofence_collection.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Retrieve information about a Location Service Geofence Collection.
 ---
 
-# Data Source: aws_location_geofencecollection
+# Data Source: aws_location_geofence_collection
 
 Retrieve information about a Location Service Geofence Collection.
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #19629.

Output from acceptance testing:

```
$ make testacc PKG=location TESTS="TestAccLocationGeofenceCollectionDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationGeofenceCollectionDataSource_basic'  -timeout 180m
=== RUN   TestAccLocationGeofenceCollectionDataSource_basic
=== PAUSE TestAccLocationGeofenceCollectionDataSource_basic
=== CONT  TestAccLocationGeofenceCollectionDataSource_basic
--- PASS: TestAccLocationGeofenceCollectionDataSource_basic (25.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   27.927s
```
