### PR TITLE
Changing Lambda Integration Type to AWS_PROXY

### DIFF
--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "example" {
 
 resource "aws_apigatewayv2_integration" "example" {
   api_id           = aws_apigatewayv2_api.example.id
-  integration_type = "AWS"
+  integration_type = "AWS_MOCK"
 
   connection_type           = "INTERNET"
   content_handling_strategy = "CONVERT_TO_TEXT"

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "example" {
 
 resource "aws_apigatewayv2_integration" "example" {
   api_id           = aws_apigatewayv2_api.example.id
-  integration_type = "AWS_MOCK"
+  integration_type = "AWS_PROXY"
 
   connection_type           = "INTERNET"
   content_handling_strategy = "CONVERT_TO_TEXT"


### PR DESCRIPTION
According to the [AWS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-integration-types.html) integration type should be `AWS_PROXY` for Lambda functions. This really tripped me up for a while since it seems like the example is just wrong here.

Previously was getting the following error when trying to use `AWS` like the example shows:

> Error: error creating API Gateway v2 integration: BadRequestException: Currently, an API with a protocol type of HTTP may only be associated with proxy integrations (AWS_PROXY, HTTP_PROXY)