### PR TITLE
aws guardduty organization configuration auto enable eks audit logs #25131

### DIFF
--- a/.changelog/25131.txt
+++ b/.changelog/25131.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_guardduty_organization_configuration: Add `kubernetes` attribute to the `datasources` configuration block
+```

--- a/internal/service/guardduty/guardduty_test.go
+++ b/internal/service/guardduty/guardduty_test.go
@@ -33,8 +33,9 @@ func TestAccGuardDuty_serial(t *testing.T) {
 			"basic": testAccOrganizationAdminAccount_basic,
 		},
 		"OrganizationConfiguration": {
-			"basic":  testAccOrganizationConfiguration_basic,
-			"s3Logs": testAccOrganizationConfiguration_s3logs,
+			"basic":      testAccOrganizationConfiguration_basic,
+			"s3Logs":     testAccOrganizationConfiguration_s3logs,
+			"kubernetes": testAccOrganizationConfiguration_kubernetes,
 		},
 		"ThreatIntelSet": {
 			"basic": testAccThreatintelset_basic,

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -50,6 +50,29 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"kubernetes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"audit_logs": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enable": {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -192,7 +192,9 @@ func flattenOrganizationDataSourceConfigurationsResult(apiObject *guardduty.Orga
 	if v := apiObject.S3Logs; v != nil {
 		tfMap["s3_logs"] = []interface{}{flattenOrganizationS3LogsConfigurationResult(v)}
 	}
-
+	if v := apiObject.Kubernetes; v != nil {
+		tfMap["kubernetes"] = []interface{}{flattenOrganizationKubernetesConfigurationResult(v)}
+	}
 	return tfMap
 }
 

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -182,6 +182,40 @@ func expandOrganizationS3LogsConfiguration(tfMap map[string]interface{}) *guardd
 	return apiObject
 }
 
+func expandOrganizationKubernetesConfiguration(tfMap map[string]interface{}) *guardduty.OrganizationKubernetesConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	l, ok := tfMap["audit_logs"].([]interface{})
+	if !ok || len(l) == 0 {
+		return nil
+	}
+
+	m, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return &guardduty.OrganizationKubernetesConfiguration{
+		AuditLogs: expandOrganizationKubernetesAuditLogsConfiguration(m),
+	}
+}
+
+func expandOrganizationKubernetesAuditLogsConfiguration(tfMap map[string]interface{}) *guardduty.OrganizationKubernetesAuditLogsConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &guardduty.OrganizationKubernetesAuditLogsConfiguration{}
+
+	if v, ok := tfMap["enable"].(bool); ok {
+		apiObject.AutoEnable = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
 func flattenOrganizationDataSourceConfigurationsResult(apiObject *guardduty.OrganizationDataSourceConfigurationsResult) map[string]interface{} {
 	if apiObject == nil {
 		return nil

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -161,6 +161,10 @@ func expandOrganizationDataSourceConfigurations(tfMap map[string]interface{}) *g
 		apiObject.S3Logs = expandOrganizationS3LogsConfiguration(v[0].(map[string]interface{}))
 	}
 
+	if v, ok := tfMap["kubernetes"].([]interface{}); ok && len(v) > 0 {
+		apiObject.Kubernetes = expandOrganizationKubernetesConfiguration(v[0].(map[string]interface{}))
+	}
+
 	return apiObject
 }
 

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -245,3 +245,31 @@ func flattenOrganizationS3LogsConfigurationResult(apiObject *guardduty.Organizat
 
 	return tfMap
 }
+
+func flattenOrganizationKubernetesConfigurationResult(apiObject *guardduty.OrganizationKubernetesConfigurationResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.AuditLogs; v != nil {
+		tfMap["audit_logs"] = []interface{}{flattenOrganizationKubernetesAuditLogsConfiguration(v)}
+	}
+
+	return tfMap
+}
+
+func flattenOrganizationKubernetesAuditLogsConfiguration(apiObject *guardduty.OrganizationKubernetesAuditLogsConfigurationResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.AutoEnable; v != nil {
+		tfMap["enable"] = aws.BoolValue(v)
+	}
+
+	return tfMap
+}

--- a/internal/service/guardduty/organization_configuration_test.go
+++ b/internal/service/guardduty/organization_configuration_test.go
@@ -85,6 +85,44 @@ func testAccOrganizationConfiguration_s3logs(t *testing.T) {
 	})
 }
 
+func testAccOrganizationConfiguration_kubernetes(t *testing.T) {
+	detectorResourceName := "aws_guardduty_detector.test"
+	resourceName := "aws_guardduty_organization_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckOrganizationsAccount(t)
+		},
+		ErrorCheck:        acctest.ErrorCheck(t, guardduty.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDetectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationConfigurationConfig_kubernetes(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOrganizationConfigurationConfig_kubernetes(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccOrganizationConfigurationConfig_autoEnable(autoEnable bool) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
@@ -141,6 +179,42 @@ resource "aws_guardduty_organization_configuration" "test" {
   datasources {
     s3_logs {
       auto_enable = %[1]t
+    }
+  }
+}
+`, autoEnable)
+}
+
+func testAccOrganizationConfigurationConfig_kubernetes(autoEnable bool) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_guardduty_detector" "test" {}
+
+resource "aws_guardduty_organization_admin_account" "test" {
+  depends_on = [aws_organizations_organization.test]
+
+  admin_account_id = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_guardduty_organization_configuration" "test" {
+  depends_on = [aws_guardduty_organization_admin_account.test]
+
+  auto_enable = true
+  detector_id = aws_guardduty_detector.test.id
+
+  datasources {
+    kubernetes {
+      audit_logs {
+        enable = %[1]t
+      }
     }
   }
 }

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -27,6 +27,11 @@ resource "aws_guardduty_organization_configuration" "example" {
     s3_logs {
       auto_enable = true
     }
+    kubernetes {
+      audit_logs {
+        enable = true
+      }
+    }
   }
 }
 ```
@@ -41,12 +46,27 @@ The following arguments are supported:
 
 `datasources` supports the following:
 
-* `s3_logs` - (Optional) Configuration for the builds to store logs to S3.
+* `s3_logs` - (Optional) Enable S3 Protection automatically for new member accounts.
+* `kubernetes` - (Optional) Enable Kubernetes Audit Logs Monitoring automatically for new member accounts.
 
-`s3_logs` supports the following:
+### S3 Logs
+
+`s3_logs` block supports the following:
 
 * `auto_enable` - (Optional) Set to `true` if you want S3 data event logs to be automatically enabled for new members of the organization. Default: `false`
 
+### Kubernetes
+`kubernetes` block supports the following:
+
+ * `audit_logs` - (Required) Enable Kubernetes Audit Logs Monitoring automatically for new member accounts. [Kubernetes protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html).
+   See [Kubernetes Audit Logs](#kubernetes-audit-logs) below for more details.
+
+#### Kubernetes Audit Logs
+
+The `audit_logs` block supports the following:
+
+* `enable` - (Required) If true, enables Kubernetes audit logs as a data source for [Kubernetes protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html).
+  Defaults to `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25131

Enable Kubernetes Audit Logs Monitoring automatically for new member accounts.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
nick@nick1 terraform-provider-aws % TF_ACC=1 go test ./internal/service/guardduty -v -count 1 -parallel 1 -run='TestAccGuardDuty_serial' -timeout=180m
=== RUN   TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/basic
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/kubernetes
--- PASS: TestAccGuardDuty_serial (84.90s)
    --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration (84.90s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/basic (38.75s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/kubernetes (46.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  86.580s

```
