### PR TITLE
CI: Ensures main version of `goenv` being used

### DIFF
--- a/.teamcity/scripts/setup_goenv.sh
+++ b/.teamcity/scripts/setup_goenv.sh
@@ -3,8 +3,13 @@
 set -euo pipefail
 
 pushd "$GOENV_ROOT"
+# Make sure we're using the main `goenv`
+if ! git remote | grep -q syndbg; then
+  printf '\nInstalling syndbg/goenv\n'
+  git remote add -f syndbg https://github.com/syndbg/goenv.git
+fi
 printf '\nUpdating goenv to %s...\n' "${GOENV_TOOL_VERSION}"
-git pull origin "${GOENV_TOOL_VERSION}"
+git reset --hard syndbg/"${GOENV_TOOL_VERSION}"
 popd
 
-goenv install -s "$(goenv local)" && goenv rehash
+goenv install --skip-existing "$(goenv local)" && goenv rehash


### PR DESCRIPTION
Ensure that the main fork of `goenv` is being used. Switch remotes if needed.

Closes #25858