### PR TITLE
Correcting misspelt auto_deployments attribute (Docs)

### DIFF
--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -67,7 +67,7 @@ resource "aws_apprunner_service" "example" {
       image_identifier      = "public.ecr.aws/aws-containers/hello-app-runner:latest"
       image_repository_type = "ECR_PUBLIC"
     }
-    auto_deployment_enabled = false
+    auto_deployments_enabled = false
   }
 
   tags = {
@@ -95,7 +95,7 @@ resource "aws_apprunner_service" "example" {
       image_identifier      = "public.ecr.aws/aws-containers/hello-app-runner:latest"
       image_repository_type = "ECR_PUBLIC"
     }
-    auto_deployment_enabled = false
+    auto_deployments_enabled = false
   }
 
   tags = {


### PR DESCRIPTION
# What
- Fixing misspelling in docs: `auto_deployment_enabled` should be `auto_deployments_enabled` (plural)