### PR TITLE
Fix breaking changes with Terraform Plugin Framework v0.10.0

### DIFF
--- a/internal/provider/fwprovider/duration.go
+++ b/internal/provider/fwprovider/duration.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
@@ -17,7 +19,7 @@ const (
 )
 
 var (
-	_ attr.TypeWithValidate = DurationType
+	_ xattr.TypeWithValidate = DurationType
 )
 
 func (d durationType) TerraformType(_ context.Context) tftypes.Type {
@@ -61,7 +63,7 @@ func (d durationType) String() string {
 }
 
 // Validate implements type validation.
-func (d durationType) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
+func (d durationType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if !in.Type().Is(tftypes.String) {

--- a/internal/provider/fwprovider/duration_test.go
+++ b/internal/provider/fwprovider/duration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/fwprovider"
 )
@@ -89,8 +90,7 @@ func TestDurationTypeValidate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.TODO()
 
-			attributePath := tftypes.NewAttributePath().WithAttributeName("test")
-			diags := fwprovider.DurationType.Validate(ctx, test.val, attributePath)
+			diags := fwprovider.DurationType.Validate(ctx, test.val, path.Root("test"))
 
 			if !diags.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #25871.
Relates https://github.com/hashicorp/terraform-plugin-framework/pull/390.

```console
% make
==> Checking that code complies with gofmt requirements...
go install
go: downloading github.com/hashicorp/terraform-plugin-go v0.12.0
go: downloading github.com/hashicorp/terraform-plugin-framework v0.10.0
go: downloading github.com/hashicorp/terraform-plugin-mux v0.7.0
go: downloading github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
go: downloading github.com/aws/aws-sdk-go v1.44.57
go: downloading github.com/hashicorp/terraform-plugin-log v0.6.0
go: downloading google.golang.org/grpc v1.48.0
# github.com/hashicorp/terraform-provider-aws/internal/provider/fwprovider
internal/provider/fwprovider/duration.go:20:4: undefined: attr.TypeWithValidate
internal/provider/fwprovider/duration.go:68:26: cannot use path (type *tftypes.AttributePath) as type path.Path in argument to diags.AddAttributeError
internal/provider/fwprovider/duration.go:84:26: cannot use path (type *tftypes.AttributePath) as type path.Path in argument to diags.AddAttributeError
internal/provider/fwprovider/duration.go:95:26: cannot use path (type *tftypes.AttributePath) as type path.Path in argument to diags.AddAttributeError
make: *** [build] Error 2
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -v ./internal/provider/fwprovider
=== RUN   TestDurationTypeValueFromTerraform
=== PAUSE TestDurationTypeValueFromTerraform
=== RUN   TestDurationTypeValidate
=== PAUSE TestDurationTypeValidate
=== CONT  TestDurationTypeValueFromTerraform
=== CONT  TestDurationTypeValidate
=== RUN   TestDurationTypeValueFromTerraform/null_value
=== RUN   TestDurationTypeValidate/not_a_string
=== RUN   TestDurationTypeValueFromTerraform/unknown_value
=== RUN   TestDurationTypeValidate/unknown_string
=== RUN   TestDurationTypeValueFromTerraform/valid_duration
=== RUN   TestDurationTypeValidate/null_string
=== RUN   TestDurationTypeValidate/valid_string
=== RUN   TestDurationTypeValueFromTerraform/invalid_duration
=== RUN   TestDurationTypeValidate/invalid_string
--- PASS: TestDurationTypeValueFromTerraform (0.00s)
    --- PASS: TestDurationTypeValueFromTerraform/null_value (0.00s)
    --- PASS: TestDurationTypeValueFromTerraform/unknown_value (0.00s)
    --- PASS: TestDurationTypeValueFromTerraform/valid_duration (0.00s)
    --- PASS: TestDurationTypeValueFromTerraform/invalid_duration (0.00s)
--- PASS: TestDurationTypeValidate (0.00s)
    --- PASS: TestDurationTypeValidate/not_a_string (0.00s)
    --- PASS: TestDurationTypeValidate/unknown_string (0.00s)
    --- PASS: TestDurationTypeValidate/null_string (0.00s)
    --- PASS: TestDurationTypeValidate/valid_string (0.00s)
    --- PASS: TestDurationTypeValidate/invalid_string (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/fwprovider	1.015s
```