### PR TITLE
Update argument/attribute descriptions for `aws_vpc_ipam_pool` data source

### DIFF
--- a/website/docs/d/vpc_ipam_pool.html.markdown
+++ b/website/docs/d/vpc_ipam_pool.html.markdown
@@ -45,7 +45,7 @@ The arguments of this data source act as filters for querying the available
 VPCs in the current region. The given filters must match exactly one
 VPC whose data will be exported as attributes.
 
-* `id` -
+* `ipam_pool_id` - The ID of the IPAM pool you would like information on.
 * `filter` - Custom filter block as described below.
 
 ## Attributes Reference
@@ -68,6 +68,7 @@ The following attribute is additionally exported:
 * `auto_import` - If enabled, IPAM will continuously look for resources within the CIDR range of this pool and automatically import them as allocations into your IPAM.
 * `aws_service` - Limits which service in AWS that the pool can be used in. "ec2", for example, allows users to use space for Elastic IP addresses and VPCs.
 * `description` - A description for the IPAM pool.
+* `id` - The ID of the IPAM pool.
 * `ipam_scope_id` - The ID of the scope the pool belongs to.
 * `locale` - Locale is the Region where your pool is available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region.
 * `source_ipam_pool_id` - The ID of the source IPAM pool.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25465

Output from acceptance testing: N/a, docs

### Information

Previously, the `aws_vpc_ipam_pool` data source listed `id` as an argument (notably, it had no description), where the correct argument is `ipam_pool_id`. This PR corrects the argument name, adds a description, and then adds `id` to the list of attributes.

### Information

- [Relevant bit of data source schema](https://github.com/hashicorp/terraform-provider-aws/blob/b52677b3dbe3b13df35435ee913bba952694292f/internal/service/ec2/ipam_pool_data_source.go#L21-L24)
- [Relevant bit of data source code](https://github.com/hashicorp/terraform-provider-aws/blob/b52677b3dbe3b13df35435ee913bba952694292f/internal/service/ec2/ipam_pool_data_source.go#L102-L105)
- [AWS documentation for description](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeIpamPools.html)