### PR TITLE
tools: Update `skaff` for AWS SDK for Go v2

### DIFF
--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -54,8 +54,8 @@ import (
 {{- else }}
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/{{ .ServicePackage }}"
-{{- end }}
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+{{- end }}
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -351,7 +351,7 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	// below. Many resources do include tags so this a reminder to include them
 	// where possible.
 	{{- end }}
-	{{ if .AWSGoSDKV2 }}
+	{{- if .AWSGoSDKV2 }}
 	tags, err := ListTags(ctx, conn, d.Id())
 	{{- else }}
 	tags, err := ListTagsWithContext(ctx, conn, d.Id())
@@ -488,6 +488,16 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	// TIP: On rare occassions, the API returns a not found error after deleting a
 	// resource. If that happens, we don't want it to show up as an error.
 	{{- end }}
+	{{- if .AWSGoSDKV2 }}
+	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+
+		return names.DiagError(names.Comprehend, names.ErrActionDeleting, ResNameEndpoint, d.Id(), err)
+	}
+	{{- else }}
 	if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
 		return nil
 	}
@@ -495,6 +505,7 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return names.DiagError(names.{{ .Service }}, names.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)
 	}
+	{{- end }}
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Use a waiter to wait for delete to complete
 	{{- end }}
@@ -628,6 +639,19 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .
 	}
 
 	out, err := conn.Get{{ .Resource }}WithContext(ctx, in)
+	{{- if .AWSGoSDKV2 }}
+	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+	{{- else }}
 	if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
@@ -638,6 +662,7 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .
 	if err != nil {
 		return nil, err
 	}
+	{{- end }}
 
 	if out == nil || out.{{ .Resource }} == nil {
 		return nil, tfresource.NewEmptyResultError(in)

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -558,7 +558,11 @@ const (
 //
 // You will need to adjust the parameters and names to fit the service.
 {{- end }}
+{{ if .AWSGoSDKV2 }}
+func wait{{ .Resource }}Created(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
 func wait{{ .Resource }}Created(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{},
 		Target:                    []string{statusNormal},
@@ -581,7 +585,11 @@ func wait{{ .Resource }}Created(ctx context.Context, conn *{{ .ServiceLower }}.{
 // the update has been fully realized. Other times, you can check to see if a
 // key resource argument is updated to a new value or not.
 {{- end }}
+{{ if .AWSGoSDKV2 }}
+func wait{{ .Resource }}Updated(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
 func wait{{ .Resource }}Updated(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{statusChangePending},
 		Target:                    []string{statusUpdated},
@@ -602,7 +610,11 @@ func wait{{ .Resource }}Updated(ctx context.Context, conn *{{ .ServiceLower }}.{
 // TIP: A deleted waiter is almost like a backwards created waiter. There may
 // be additional pending states, however.
 {{- end }}
+{{ if .AWSGoSDKV2 }}
+func wait{{ .Resource }}Deleted(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
 func wait{{ .Resource }}Deleted(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{statusDeleting, statusNormal},
 		Target:                    []string{},
@@ -626,7 +638,11 @@ func wait{{ .Resource }}Deleted(ctx context.Context, conn *{{ .ServiceLower }}.{
 // Waiters consume the values returned by status functions. Design status so
 // that it can be reused by a create, update, and delete waiter, if possible.
 {{- end }}
+{{ if .AWSGoSDKV2 }}
+func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string) resource.StateRefreshFunc {
+{{- else }}
 func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string) resource.StateRefreshFunc {
+{{- end }}
 	return func() (interface{}, string, error) {
 		out, err := find{{ .Resource }}ByID(ctx, conn, id)
 		if tfresource.NotFound(err) {
@@ -647,7 +663,11 @@ func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Se
 // comes in handy in other places besides the status function. As a result, it
 // is good practice to define it separately.
 {{- end }}
+{{ if .AWSGoSDKV2 }}
+func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
 func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
 	in := &{{ .ServiceLower }}.Get{{ .Resource }}Input{
 		Id: aws.String(id),
 	}

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -238,7 +238,11 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 	{{ if .IncludeComments }}
 	// TIP: -- 3. Call the AWS create function
 	{{- end }}
+	{{- if .AWSGoSDKV2 }}
+	out, err := conn.Create{{ .Resource }}(ctx, in)
+	{{- else }}
 	out, err := conn.Create{{ .Resource }}WithContext(ctx, in)
+	{{- end }}
 	if err != nil {
 		{{- if .IncludeComments }}
 		// TIP: Since d.SetId() has not been called yet, you cannot use d.Id()
@@ -435,7 +439,11 @@ func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, 
 	// TIP: -- 3. Call the AWS modify/update function
 	{{- end }}
 	log.Printf("[DEBUG] Updating {{ .Service }} {{ .Resource }} (%s): %#v", d.Id(), in)
+	{{- if .AWSGoSDKV2 }}
+	out, err := conn.Update{{ .Resource }}(ctx, in)
+	{{- else }}
 	out, err := conn.Update{{ .Resource }}WithContext(ctx, in)
+	{{- end }}
 	if err != nil {
 		return names.DiagError(names.{{ .Service }}, names.ErrActionUpdating, ResName{{ .Resource }}, d.Id(), err)
 	}
@@ -481,9 +489,15 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	{{ if .IncludeComments }}
 	// TIP: -- 3. Call the AWS delete function
 	{{- end }}
+	{{- if .AWSGoSDKV2 }}
+	_, err := conn.Delete{{ .Resource }}(ctx, &{{ .ServiceLower }}.Delete{{ .Resource }}Input{
+		Id: aws.String(d.Id()),
+	})
+	{{- else }}
 	_, err := conn.Delete{{ .Resource }}WithContext(ctx, &{{ .ServiceLower }}.Delete{{ .Resource }}Input{
 		Id: aws.String(d.Id()),
 	})
+	{{- end }}
 	{{ if .IncludeComments }}
 	// TIP: On rare occassions, the API returns a not found error after deleting a
 	// resource. If that happens, we don't want it to show up as an error.
@@ -638,8 +652,8 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .
 		Id: aws.String(id),
 	}
 
-	out, err := conn.Get{{ .Resource }}WithContext(ctx, in)
 	{{- if .AWSGoSDKV2 }}
+	out, err := conn.Get{{ .Resource }}(ctx, in)
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
@@ -652,6 +666,7 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .
 		return nil, err
 	}
 	{{- else }}
+	out, err := conn.Get{{ .Resource }}WithContext(ctx, in)
 	if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -39,6 +39,7 @@ import (
 	// need to import types and reference the nested types, e.g., as
 	// types.<Type Name>.
 {{- end }}
+	"context"
 	"fmt"
 	"regexp"
 	"strings"

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -65,6 +65,9 @@ import (
     // any normal context constants, variables, or functions.
 {{- end }}
 	tf{{ .ServicePackage }} "github.com/hashicorp/terraform-provider-aws/internal/service/{{ .ServicePackage }}"
+{{- if .AWSGoSDKV2 }}
+	"github.com/hashicorp/terraform-provider-aws/names"
+{{- end }}
 )
 {{ if .IncludeComments }}
 // TIP: File Structure. The basic outline for all test files should be as
@@ -168,10 +171,18 @@ func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			{{- if .AWSGoSDKV2 }}
+			acctest.PreCheckPartitionHasService(names.{{ .Service }}EndpointID, t)
+			{{- else }}
 			acctest.PreCheckPartitionHasService({{ .ServicePackage }}.EndpointsID, t)
+			{{- end }}
 			testAccPreCheck(t)
 		},
+		{{- if .AWSGoSDKV2 }}
+		ErrorCheck:        acctest.ErrorCheck(t, names.{{ .Service }}EndpointID),
+		{{- else }}
 		ErrorCheck:        acctest.ErrorCheck(t, {{ .ServicePackage }}.EndpointsID),
+		{{- end }}
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheck{{ .Resource }}Destroy,
 		Steps: []resource.TestStep{
@@ -212,10 +223,18 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			{{- if .AWSGoSDKV2 }}
+			acctest.PreCheckPartitionHasService(names.{{ .Service }}EndpointID, t)
+			{{- else }}
 			acctest.PreCheckPartitionHasService({{ .ServicePackage }}.EndpointsID, t)
+			{{- end }}
 			testAccPreCheck(t)
 		},
+		{{- if .AWSGoSDKV2 }}
+		ErrorCheck:        acctest.ErrorCheck(t, names.{{ .Service }}EndpointID),
+		{{- else }}
 		ErrorCheck:        acctest.ErrorCheck(t, {{ .ServicePackage }}.EndpointsID),
+		{{- end }}
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheck{{ .Resource }}Destroy,
 		Steps: []resource.TestStep{

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -276,9 +276,17 @@ func testAccCheck{{ .Resource }}Exists(name string, {{ .ResourceLower }} *{{ .Se
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).{{ .Service }}Conn
-		resp, err := conn.Describe{{ .Resource }}(&{{ .ServicePackage }}.Describe{{ .Resource }}Input{
+		ctx := context.Background()
+
+		{{- if .AWSGoSDKV2 }}
+		resp, err := conn.Describe{{ .Resource }}(ctx, &{{ .ServicePackage }}.Describe{{ .Resource }}Input{
 			{{ .Resource }}Id: aws.String(rs.Primary.ID),
 		})
+		{{- else }}
+		resp, err := conn.Describe{{ .Resource }}WithContext(ctx, &{{ .ServicePackage }}.Describe{{ .Resource }}Input{
+			{{ .Resource }}Id: aws.String(rs.Primary.ID),
+		})
+		{{- end }}
 
 		if err != nil {
 			return names.Error(names.{{ .Service }}, names.ErrActionCheckingExistence, tf{{ .ServicePackage }}.ResName{{ .Resource }}, rs.Primary.ID, err)
@@ -292,10 +300,15 @@ func testAccCheck{{ .Resource }}Exists(name string, {{ .ResourceLower }} *{{ .Se
 
 func testAccPreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).{{ .Service }}Conn
+	ctx := context.Background()
 
 	input := &{{ .ServicePackage }}.List{{ .Resource }}sInput{}
 
-	_, err := conn.List{{ .Resource }}s(input)
+	{{- if .AWSGoSDKV2 }}
+	_, err := conn.List{{ .Resource }}s(ctx, input)
+	{{- else }}
+	_, err := conn.List{{ .Resource }}sWithContext(ctx, input)
+	{{- end }}
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -50,8 +50,8 @@ import (
 {{- else }}
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/{{ .ServicePackage }}"
-{{- end }}
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+{{- end }}
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -245,9 +245,16 @@ func testAccCheck{{ .Resource }}Destroy(s *terraform.State) error {
 
 		_, err := conn.Describe{{ .Resource }}(input)
 		if err != nil {
+			{{- if .AWSGoSDKV2 }}
+			var nfe *types.ResourceNotFoundException
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			{{- else }}
 			if tfawserr.ErrCodeEquals(err, {{ .ServicePackage }}.ErrCodeNotFoundException) {
 				return nil
 			}
+			{{- end }}
 			return err
 		}
 


### PR DESCRIPTION
Makes a number of updates to `skaff` generated code for AWS SDK for Go v2, including

* Uses updated error type checking using `errors.As`
* The AWS SDK for Go v2 always uses context and doesn't include `WithContext` in function names
* API Clients are named `<service>.Client`