### PR TITLE
New data source: `aws_s3_buckets`

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -830,6 +830,7 @@ func Provider() *schema.Provider {
 
 			"aws_canonical_user_id": s3.DataSourceCanonicalUserID(),
 			"aws_s3_bucket":         s3.DataSourceBucket(),
+			"aws_s3_buckets":        s3.DataSourceBuckets(),
 			"aws_s3_object":         s3.DataSourceObject(),
 			"aws_s3_objects":        s3.DataSourceObjects(),
 			"aws_s3_bucket_object":  s3.DataSourceBucketObject(),  // DEPRECATED: use aws_s3_object instead

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -56,7 +56,7 @@ func dataSourceBucketsRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 
-	var arns, ids []string
+	var ids []string
 
 	for _, r := range results {
 		ids = append(ids, aws.StringValue(r.Name))

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -1,0 +1,70 @@
+package iam
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceBuckets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceBucketsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceBucketsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	input := &s3.ListBucketsInput{}
+
+	var results []*s3.Bucket
+
+	output, err := conn.ListBuckets(input)
+    for _, bucket := range output.Buckets {
+        if bucket == nil {
+            continue
+        }
+
+        if v, ok := d.GetOk("name_regex"); ok && !regexp.MustCompile(v.(string)).MatchString(aws.StringValue(bucket.Name)) {
+            continue
+        }
+
+        results = append(results, bucket)
+    }
+
+	if err != nil {
+		return fmt.Errorf("error reading S3 buckets: %w", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+
+	var arns, ids []string
+
+	for _, r := range results {
+		ids = append(ids, aws.StringValue(r.Name))
+	}
+
+	if err := d.Set("ids", ids); err != nil {
+		return fmt.Errorf("error setting ids: %w", err)
+	}
+
+	return nil
+}

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -38,17 +38,17 @@ func dataSourceBucketsRead(d *schema.ResourceData, meta interface{}) error {
 	var results []*s3.Bucket
 
 	output, err := conn.ListBuckets(input)
-    for _, bucket := range output.Buckets {
-        if bucket == nil {
-            continue
-        }
+	for _, bucket := range output.Buckets {
+		if bucket == nil {
+			continue
+		}
 
-        if v, ok := d.GetOk("name_regex"); ok && !regexp.MustCompile(v.(string)).MatchString(aws.StringValue(bucket.Name)) {
-            continue
-        }
+		if v, ok := d.GetOk("name_regex"); ok && !regexp.MustCompile(v.(string)).MatchString(aws.StringValue(bucket.Name)) {
+			continue
+		}
 
-        results = append(results, bucket)
-    }
+		results = append(results, bucket)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error reading S3 buckets: %w", err)

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -1,4 +1,4 @@
-package iam
+package s3
 
 import (
 	"fmt"

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -1,4 +1,4 @@
-package iam_test
+package s3_test
 
 import (
 	"fmt"

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -1,0 +1,231 @@
+package iam_test
+
+// TODO: WIP
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccIAMRolesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_iam_buckets.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolesDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "names.#", regexp.MustCompile("[^0].*$")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMRolesDataSource_nameRegex(t *testing.T) {
+	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_iam_roles.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolesDataSourceConfig_nameRegex(rCount, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", rCount),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", rCount),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMRolesDataSource_pathPrefix(t *testing.T) {
+	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
+	dataSourceName := "data.aws_iam_roles.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolesDataSourceConfig_pathPrefix(rCount, rName, rPathPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", rCount),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", rCount),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMRolesDataSource_nonExistentPathPrefix(t *testing.T) {
+	dataSourceName := "data.aws_iam_roles.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolesDataSourceConfig_nonExistentPathPrefix,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMRolesDataSource_nameRegexAndPathPrefix(t *testing.T) {
+	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
+	dataSourceName := "data.aws_iam_roles.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolesDataSourceConfig_nameRegexAndPathPrefix(rCount, rName, rPathPrefix, "0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+const testAccRolesDataSourceConfig_basic = `
+data "aws_iam_roles" "test" {}
+`
+
+func testAccRolesDataSourceConfig_nameRegex(rCount, rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  count = %[1]s
+  name  = "%[2]s-${count.index}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+  tags = {
+    Seed = %[2]q
+  }
+}
+
+data "aws_iam_roles" "test" {
+  name_regex = "${aws_iam_role.test[0].tags["Seed"]}-.*-role"
+}
+`, rCount, rName)
+}
+
+func testAccRolesDataSourceConfig_pathPrefix(rCount, rName, rPathPrefix string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  count = %[1]s
+  name  = "%[2]s-${count.index}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+  path = "/%[3]s/"
+}
+
+data "aws_iam_roles" "test" {
+  path_prefix = aws_iam_role.test[0].path
+}
+`, rCount, rName, rPathPrefix)
+}
+
+const testAccRolesDataSourceConfig_nonExistentPathPrefix = `
+data "aws_iam_roles" "test" {
+  path_prefix = "/dne/path"
+}
+`
+
+func testAccRolesDataSourceConfig_nameRegexAndPathPrefix(rCount, rName, rPathPrefix, rIndex string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  count = %[1]s
+  name  = "%[2]s-${count.index}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+  path = "/%[3]s/"
+  tags = {
+    Seed = %[2]q
+  }
+}
+
+data "aws_iam_roles" "test" {
+  name_regex  = "${aws_iam_role.test[0].tags["Seed"]}-%[4]s-role"
+  path_prefix = aws_iam_role.test[0].path
+}
+`, rCount, rName, rPathPrefix, rIndex)
+}

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -1,6 +1,5 @@
 package iam_test
 
-// TODO: WIP
 
 import (
 	"fmt"
@@ -14,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccIAMRolesDataSource_basic(t *testing.T) {
+func TestAccS3BucketsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_iam_buckets.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,19 +22,19 @@ func TestAccIAMRolesDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRolesDataSourceConfig_basic,
+				Config: testAccS3BucketsDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(dataSourceName, "names.#", regexp.MustCompile("[^0].*$")),
+					resource.TestMatchResourceAttr(dataSourceName, "ids.#", regexp.MustCompile("[^0].*$")),
 				),
 			},
 		},
 	})
 }
 
-func TestAccIAMRolesDataSource_nameRegex(t *testing.T) {
+func TestAccS3BucketsDataSource_nameRegex(t *testing.T) {
 	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	dataSourceName := "data.aws_iam_roles.test"
+	dataSourceName := "data.aws_iam_buckets.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -43,189 +42,32 @@ func TestAccIAMRolesDataSource_nameRegex(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRolesDataSourceConfig_nameRegex(rCount, rName),
+				Config: testAccS3BucketsDataSourceConfig_nameRegex(rCount, rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "names.#", rCount),
-					resource.TestCheckResourceAttr(dataSourceName, "arns.#", rCount),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", rCount),
 				),
 			},
 		},
 	})
 }
 
-func TestAccIAMRolesDataSource_pathPrefix(t *testing.T) {
-	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
-	dataSourceName := "data.aws_iam_roles.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRolesDataSourceConfig_pathPrefix(rCount, rName, rPathPrefix),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "names.#", rCount),
-					resource.TestCheckResourceAttr(dataSourceName, "arns.#", rCount),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIAMRolesDataSource_nonExistentPathPrefix(t *testing.T) {
-	dataSourceName := "data.aws_iam_roles.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRolesDataSourceConfig_nonExistentPathPrefix,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
-					resource.TestCheckResourceAttr(dataSourceName, "names.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIAMRolesDataSource_nameRegexAndPathPrefix(t *testing.T) {
-	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
-	dataSourceName := "data.aws_iam_roles.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRolesDataSourceConfig_nameRegexAndPathPrefix(rCount, rName, rPathPrefix, "0"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-const testAccRolesDataSourceConfig_basic = `
-data "aws_iam_roles" "test" {}
+const testAccS3BucketsDataSourceConfig_basic = `
+data "aws_s3_buckets" "test" {}
 `
 
-func testAccRolesDataSourceConfig_nameRegex(rCount, rName string) string {
+func testAccS3BucketsDataSourceConfig_nameRegex(rCount, rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+resource "aws_s3_bucket" "test" {
+  count   = %[1]s
+  bucket  = "%[2]s-${count.index}-bucket"
 
-resource "aws_iam_role" "test" {
-  count = %[1]s
-  name  = "%[2]s-${count.index}-role"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
   tags = {
     Seed = %[2]q
   }
 }
 
-data "aws_iam_roles" "test" {
-  name_regex = "${aws_iam_role.test[0].tags["Seed"]}-.*-role"
+data "aws_s3_buckets" "test" {
+  name_regex = "${aws_s3_bucket.test[0].tags["Seed"]}-.*-bucket"
 }
 `, rCount, rName)
-}
-
-func testAccRolesDataSourceConfig_pathPrefix(rCount, rName, rPathPrefix string) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-
-resource "aws_iam_role" "test" {
-  count = %[1]s
-  name  = "%[2]s-${count.index}-role"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-
-  path = "/%[3]s/"
-}
-
-data "aws_iam_roles" "test" {
-  path_prefix = aws_iam_role.test[0].path
-}
-`, rCount, rName, rPathPrefix)
-}
-
-const testAccRolesDataSourceConfig_nonExistentPathPrefix = `
-data "aws_iam_roles" "test" {
-  path_prefix = "/dne/path"
-}
-`
-
-func testAccRolesDataSourceConfig_nameRegexAndPathPrefix(rCount, rName, rPathPrefix, rIndex string) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-
-resource "aws_iam_role" "test" {
-  count = %[1]s
-  name  = "%[2]s-${count.index}-role"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-
-  path = "/%[3]s/"
-  tags = {
-    Seed = %[2]q
-  }
-}
-
-data "aws_iam_roles" "test" {
-  name_regex  = "${aws_iam_role.test[0].tags["Seed"]}-%[4]s-role"
-  path_prefix = aws_iam_role.test[0].path
-}
-`, rCount, rName, rPathPrefix, rIndex)
 }

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func TestAccS3BucketsDataSource_basic(t *testing.T) {
-	dataSourceName := "data.aws_iam_buckets.test"
+	dataSourceName := "data.aws_s3_buckets.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -33,11 +33,11 @@ func TestAccS3BucketsDataSource_basic(t *testing.T) {
 func TestAccS3BucketsDataSource_nameRegex(t *testing.T) {
 	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	dataSourceName := "data.aws_iam_buckets.test"
+	dataSourceName := "data.aws_s3_buckets.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -1,6 +1,5 @@
 package iam_test
 
-
 import (
 	"fmt"
 	"regexp"

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "S3 (Simple Storage)"
+layout: "aws"
+page_title: "AWS: aws_s3_buckets"
+description: |-
+  Get information about a set of S3 Buckets.
+---
+
+# Data Source: aws_s3_buckets
+
+Use this data source to get the IDs of S3 Buckets.
+
+## Example Usage
+
+### All buckets in an account
+
+```terraform
+data "aws_s3_buckets" "buckets" {}
+```
+
+### Buckets filtered by name regex
+
+Buckets whose role-name contains `project`
+
+```terraform
+data "aws_s3_buckets" "buckets" {
+  name_regex = ".*project.*"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) A regex string to apply to the S3 buckets list returned by AWS. This allows more advanced filtering not supported from the AWS API. This filtering is done locally on what AWS returns, and could have a performance impact if the result is large.
+
+## Attributes Reference
+
+* `ids` - Set of IDs of the matched S3 Buckets.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25891

Output from acceptance testing:

```
$ make testacc TESTS=TestAccS3BucketsDataSource_basic PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketsDataSource_basic'  -timeout 180m
=== RUN   TestAccS3BucketsDataSource_basic
=== PAUSE TestAccS3BucketsDataSource_basic
=== CONT  TestAccS3BucketsDataSource_basic
--- PASS: TestAccS3BucketsDataSource_basic (11.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 11.166s

$ make testacc TESTS=TestAccS3BucketsDataSource_nameRegex PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketsDataSource_nameRegex'  -timeout 180m
=== RUN   TestAccS3BucketsDataSource_nameRegex
=== PAUSE TestAccS3BucketsDataSource_nameRegex
=== CONT  TestAccS3BucketsDataSource_nameRegex
--- PASS: TestAccS3BucketsDataSource_nameRegex (15.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 15.550s

```
