### PR TITLE
New resource: aws_ssoadmin_customer_managed_policy_attachment

### DIFF
--- a/.changelog/25915.txt
+++ b/.changelog/25915.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ssoadmin_customer_managed_policy_attachment
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2065,10 +2065,11 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ssm_resource_data_sync":        ssm.ResourceResourceDataSync(),
 			"aws_ssm_service_setting":           ssm.ResourceServiceSetting(),
 
-			"aws_ssoadmin_account_assignment":           ssoadmin.ResourceAccountAssignment(),
-			"aws_ssoadmin_managed_policy_attachment":    ssoadmin.ResourceManagedPolicyAttachment(),
-			"aws_ssoadmin_permission_set":               ssoadmin.ResourcePermissionSet(),
-			"aws_ssoadmin_permission_set_inline_policy": ssoadmin.ResourcePermissionSetInlinePolicy(),
+			"aws_ssoadmin_account_assignment":                 ssoadmin.ResourceAccountAssignment(),
+			"aws_ssoadmin_managed_policy_attachment":          ssoadmin.ResourceManagedPolicyAttachment(),
+			"aws_ssoadmin_customer_managed_policy_attachment": ssoadmin.ResourceCustomerManagedPolicyAttachment(),
+			"aws_ssoadmin_permission_set":                     ssoadmin.ResourcePermissionSet(),
+			"aws_ssoadmin_permission_set_inline_policy":       ssoadmin.ResourcePermissionSetInlinePolicy(),
 
 			"aws_storagegateway_cache":                   storagegateway.ResourceCache(),
 			"aws_storagegateway_cached_iscsi_volume":     storagegateway.ResourceCachediSCSIVolume(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2066,8 +2066,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ssm_service_setting":           ssm.ResourceServiceSetting(),
 
 			"aws_ssoadmin_account_assignment":                 ssoadmin.ResourceAccountAssignment(),
-			"aws_ssoadmin_managed_policy_attachment":          ssoadmin.ResourceManagedPolicyAttachment(),
 			"aws_ssoadmin_customer_managed_policy_attachment": ssoadmin.ResourceCustomerManagedPolicyAttachment(),
+			"aws_ssoadmin_managed_policy_attachment":          ssoadmin.ResourceManagedPolicyAttachment(),
 			"aws_ssoadmin_permission_set":                     ssoadmin.ResourcePermissionSet(),
 			"aws_ssoadmin_permission_set_inline_policy":       ssoadmin.ResourcePermissionSetInlinePolicy(),
 

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -50,15 +51,17 @@ func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(0, 128),
 						},
 						"path": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "/",
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "/",
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(0, 512),
 						},
 					},
 				},

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -157,8 +157,3 @@ func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, 
 	}
 	return idParts[0], idParts[1], idParts[2], idParts[3], nil
 }
-
-// func createCustomerManagedPolicyReference(name string, path string) (map[string]string) { // not string type - check
-// 	//customerManagedPolicyReference := map[string]string{"Name": name, "Path": path}
-// 	return customerManagedPolicyReference
-// }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -153,7 +153,7 @@ func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta 
 func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, string, error) {
 	idParts := strings.Split(id, ",")
 	if len(idParts) != 4 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" || idParts[3] == "" {
-		return "", "", "", "", fmt.Errorf("error parsing ID: expected CUSTOMER_MANAGED_POLICY_NAME, CUSTOMER_MANAGED_POLICY_PATH, PERMISSION_SET_ARN,INSTANCE_ARN")
+		return "", "", "", "", fmt.Errorf("error parsing ID: expected CUSTOMER_MANAGED_POLICY_NAME, CUSTOMER_MANAGED_POLICY_PATH, PERMISSION_SET_ARN, INSTANCE_ARN")
 	}
 	return idParts[0], idParts[1], idParts[2], idParts[3], nil
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -79,7 +79,7 @@ func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta 
 		CustomerManagedPolicyReference: formatPolicyReference(d.Get("customer_managed_policy_reference").([]interface{})),
 		PermissionSetArn:               aws.String(permissionSetArn),
 	}
-	
+
 	err := resource.Retry(customerPolicyAttachmentTimeout, func() *resource.RetryError {
 		var err error
 		_, err = conn.AttachCustomerManagedPolicyReferenceToPermissionSet(input)
@@ -143,6 +143,7 @@ func resourceCustomerManagedPolicyAttachmentRead(d *schema.ResourceData, meta in
 
 	d.Set("instance_arn", instanceArn)
 	d.Set("permission_set_arn", permissionSetArn)
+	d.Set("customer_managed_policy_reference", flattenPolicyReference(policy))
 
 	return nil
 }
@@ -223,4 +224,22 @@ func expandPolicyReference(l []interface{}) (string, string) {
 	policyPath := string(p["path"].(string))
 
 	return policyName, policyPath
+}
+
+func flattenPolicyReference(l *ssoadmin.CustomerManagedPolicyReference) []interface{} {
+	if l == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if v := l.Name; v != nil {
+		m["name"] = aws.StringValue(v)
+	}
+
+	if v := l.Path; v != nil {
+		m["path"] = aws.StringValue(v)
+	}
+
+	return []interface{}{m}
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -25,6 +25,7 @@ func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
 			"customer_managed_policy_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"customer_managed_policy_path": {
 				Type:     schema.TypeString,

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -57,12 +57,12 @@ func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta 
 	policyPath := d.Get("customer_managed_policy_path").(string)
 
 	input := &ssoadmin.AttachCustomerManagedPolicyReferenceToPermissionSetInput{
-		InstanceArn:                    aws.String(instanceArn),
+		InstanceArn: aws.String(instanceArn),
 		CustomerManagedPolicyReference: &ssoadmin.CustomerManagedPolicyReference{
 			Name: aws.String(policyName),
 			Path: aws.String(policyPath),
 		},
-		PermissionSetArn:               aws.String(permissionSetArn),
+		PermissionSetArn: aws.String(permissionSetArn),
 	}
 
 	_, err := conn.AttachCustomerManagedPolicyReferenceToPermissionSet(input)
@@ -71,7 +71,7 @@ func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta 
 		return fmt.Errorf("error attaching Customer Managed Policy to SSO Permission Set (%s): %w", permissionSetArn, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s,%s,%s,%s", policyName, policyPath,permissionSetArn, instanceArn))
+	d.SetId(fmt.Sprintf("%s,%s,%s,%s", policyName, policyPath, permissionSetArn, instanceArn))
 
 	// Provision ALL accounts after attaching the managed policy
 	if err := provisionPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
@@ -149,7 +149,7 @@ func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta 
 	return nil
 }
 
-func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, string, error) { 
+func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, string, error) {
 	idParts := strings.Split(id, ",")
 	if len(idParts) != 4 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" || idParts[3] == "" {
 		return "", "", "", "", fmt.Errorf("error parsing ID: expected CUSTOMER_MANAGED_POLICY_NAME, CUSTOMER_MANAGED_POLICY_PATH, PERMISSION_SET_ARN,INSTANCE_ARN")

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -115,7 +115,7 @@ func resourceCustomerManagedPolicyAttachmentRead(d *schema.ResourceData, meta in
 
 	policy, err := FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetARN, instanceARN)
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SSO Customer Managed Policy Attachment (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -1,0 +1,175 @@
+package ssoadmin
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCustomerManagedPolicyAttachmentCreate,
+		Read:   resourceCustomerManagedPolicyAttachmentRead,
+		Delete: resourceCustomerManagedPolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+
+			"customer_managed_policy_reference": {
+				Type:	schema.TypeList,
+				Required: true,
+				MaxItems: 1
+				Elem: &scheme. Resource{
+					Schema: map[string]*schema.Schema{
+						"customer_managed_policy_name": {
+							Type:	schema.TypeString,
+							Required: true,
+						},
+						"customer_managed_policy_path": {
+							Type: schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"permission_set_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+		},
+	}
+}
+
+func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSOAdminConn
+
+	instanceArn := d.Get("instance_arn").(string)
+	permissionSetArn := d.Get("permission_set_arn").(string)
+
+	input := &ssoadmin.AttachCustomerManagedPolicyReferenceToPermissionSetInput{
+		InstanceArn:      aws.String(instanceArn),
+		CustomerManagedPolicyReference: expandCustomerManagedPolicyReference(d.Get("customer_managed_policy_reference").([]interface{}))
+		PermissionSetArn: aws.String(permissionSetArn),
+	}
+
+	_, err := conn.AttachCustomerManagedPolicyReferenceToPermissionSet(input)
+
+	if err != nil {
+		return fmt.Errorf("error attaching Customer Managed Policy to SSO Permission Set (%s): %w", permissionSetArn, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s,%s,%s", customerManagedPolicyReference, permissionSetArn, instanceArn))
+
+	// Provision ALL accounts after attaching the managed policy
+	if err := provisionPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
+		return err
+	}
+
+	return resourceCustomerManagedPolicyAttachmentRead(d, meta)
+}
+
+func resourceCustomerManagedPolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSOAdminConn
+
+	customerManagedPolicyReference, permissionSetArn, instanceArn, err := ParseManagedPolicyAttachmentID(d.Id())
+	if err != nil {
+		return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID: %w", err)
+	}
+
+	policy, err := FindManagedPolicy(conn, customerManagedPolicyReference, permissionSetArn, instanceArn)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Customer Managed Policy (%s) for SSO Permission Set (%s) not found, removing from state", customerManagedPolicyReference, permissionSetArn)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Customer Managed Policy (%s) for SSO Permission Set (%s): %w", customerManagedPolicyReference, permissionSetArn, err)
+	}
+
+	if policy == nil {
+		log.Printf("[WARN] Customer Managed Policy (%s) for SSO Permission Set (%s) not found, removing from state", customerManagedPolicyReference, permissionSetArn)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("instance_arn", instanceArn)
+	d.Set("customer_managed_policy_arn", policy.Arn) // check
+	d.Set("customer_managed_policy_name", policy.Name) //check
+	d.Set("permission_set_arn", permissionSetArn)
+
+	return nil
+}
+
+func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSOAdminConn
+
+	customerManagedPolicyReference, permissionSetArn, instanceArn, err := ParseManagedPolicyAttachmentID(d.Id())
+	if err != nil {
+		return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID: %w", err)
+	}
+
+	input := &ssoadmin.DetachCustomerManagedPolicyFromPermissionSetInput{
+		InstanceArn:      aws.String(instanceArn),
+		PermissionSetArn: aws.String(permissionSetArn),
+		CustomerManagedPolicyReference: aws.String(customerManagedPolicyReference), // check string type
+	}
+
+	_, err = conn.DetachCustomerManagedPolicyFromPermissionSet(input)
+
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return fmt.Errorf("error detaching Customer Managed Policy (%s) from SSO Permission Set (%s): %w", customerManagedPolicyReference, permissionSetArn, err)
+	}
+
+	// Provision ALL accounts after detaching the customermanaged policy
+	if err := provisionPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, error) { // check this func is renamed similarly where it is used
+	idParts := strings.Split(id, ",")
+	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+		return "", "", "", fmt.Errorf("error parsing ID: expected CUSTOMER_MANAGED_POLICY_REFERENCE,PERMISSION_SET_ARN,INSTANCE_ARN")
+	}
+	return idParts[0], idParts[1], idParts[2], nil
+}
+
+func expandCustomerManagedPolicyReference(customerPolicyRef []interface{}) *ssoadmin.CustomerManagedPolicyReference {
+	customerManagedPolicyReference := &ssoadmin.CustomerManagedPolicyReference{}
+	// only one image_config block is allowed
+	if len(customerPolicyRef) == 1 && customerPolicyRef[0] != nil {
+		policy := customerPolicyRef[0].(map[string]interface{})
+		if len(policy["customer_managed_policy_name"].([]interface{})) > 0 {
+			customerManagedPolicyReference.Name = flex.ExpandStringList(config["customer_managed_policy_name"].([]interface{}))
+		}
+		if len(policy["path"].([]interface{})) > 0 {
+			customerManagedPolicyReference.Path = flex.ExpandStringList(config["customer_managed_policy_path"].([]interface{}))
+		}
+	}
+	return customerManagedPolicyReference
+	// is an error needed in the else situation here?
+}

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -205,23 +205,21 @@ func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, 
 }
 
 func formatPolicyReference(l []interface{}) *ssoadmin.CustomerManagedPolicyReference {
-	n := l[0].(map[string]interface{})
-	p := l[0].(map[string]interface{})
+	m := l[0].(map[string]interface{})
 
 	policyRef := &ssoadmin.CustomerManagedPolicyReference{
-		Name: aws.String(string(n["name"].(string))),
-		Path: aws.String(string(p["path"].(string))),
+		Name: aws.String(string(m["name"].(string))),
+		Path: aws.String(string(m["path"].(string))),
 	}
 
 	return policyRef
 }
 
 func expandPolicyReference(l []interface{}) (string, string) {
-	n := l[0].(map[string]interface{})
-	p := l[0].(map[string]interface{})
+	m := l[0].(map[string]interface{})
 
-	policyName := string(n["name"].(string))
-	policyPath := string(p["path"].(string))
+	policyName := string(m["name"].(string))
+	policyPath := string(m["path"].(string))
 
 	return policyName, policyPath
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -181,6 +181,10 @@ func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta 
 
 	})
 
+	if tfresource.TimedOut(err) {
+		_, err = conn.DetachCustomerManagedPolicyReferenceFromPermissionSet(input)
+	}
+
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
 			return nil
@@ -208,8 +212,8 @@ func formatPolicyReference(l []interface{}) *ssoadmin.CustomerManagedPolicyRefer
 	m := l[0].(map[string]interface{})
 
 	policyRef := &ssoadmin.CustomerManagedPolicyReference{
-		Name: aws.String(string(m["name"].(string))),
-		Path: aws.String(string(m["path"].(string))),
+		Name: aws.String(m["name"].(string)),
+		Path: aws.String(m["path"].(string)),
 	}
 
 	return policyRef
@@ -218,8 +222,8 @@ func formatPolicyReference(l []interface{}) *ssoadmin.CustomerManagedPolicyRefer
 func expandPolicyReference(l []interface{}) (string, string) {
 	m := l[0].(map[string]interface{})
 
-	policyName := string(m["name"].(string))
-	policyPath := string(m["path"].(string))
+	policyName := m["name"].(string)
+	policyPath := m["path"].(string)
 
 	return policyName, policyPath
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -22,31 +22,22 @@ func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"customer_managed_policy_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"customer_managed_policy_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/",
+				ForceNew: true,
+			},
 			"instance_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-
-			"customer_managed_policy_reference": {
-				Type:	schema.TypeList,
-				Required: true,
-				MaxItems: 1
-				Elem: &scheme. Resource{
-					Schema: map[string]*schema.Schema{
-						"customer_managed_policy_name": {
-							Type:	schema.TypeString,
-							Required: true,
-						},
-						"customer_managed_policy_path": {
-							Type: schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-
 			"permission_set_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -62,11 +53,13 @@ func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta 
 
 	instanceArn := d.Get("instance_arn").(string)
 	permissionSetArn := d.Get("permission_set_arn").(string)
+	policyName := d.Get("customer_managed_policy_name").(string)
+	policyPath := d.Get("customer_managed_policy_path").(string)
 
 	input := &ssoadmin.AttachCustomerManagedPolicyReferenceToPermissionSetInput{
-		InstanceArn:      aws.String(instanceArn),
-		CustomerManagedPolicyReference: expandCustomerManagedPolicyReference(d.Get("customer_managed_policy_reference").([]interface{}))
-		PermissionSetArn: aws.String(permissionSetArn),
+		InstanceArn:                    aws.String(instanceArn),
+		CustomerManagedPolicyReference: createCustomerManagedPolicyReference(policyName, policyPath),
+		PermissionSetArn:               aws.String(permissionSetArn),
 	}
 
 	_, err := conn.AttachCustomerManagedPolicyReferenceToPermissionSet(input)
@@ -75,7 +68,7 @@ func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta 
 		return fmt.Errorf("error attaching Customer Managed Policy to SSO Permission Set (%s): %w", permissionSetArn, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s,%s,%s", customerManagedPolicyReference, permissionSetArn, instanceArn))
+	d.SetId(fmt.Sprintf("%s,%s,%s", policyName, permissionSetArn, instanceArn))
 
 	// Provision ALL accounts after attaching the managed policy
 	if err := provisionPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
@@ -88,7 +81,7 @@ func resourceCustomerManagedPolicyAttachmentCreate(d *schema.ResourceData, meta 
 func resourceCustomerManagedPolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SSOAdminConn
 
-	customerManagedPolicyReference, permissionSetArn, instanceArn, err := ParseManagedPolicyAttachmentID(d.Id())
+	customerManagedPolicyReference, permissionSetArn, instanceArn, err := ParseCustomerManagedPolicyAttachmentID(d.Id())
 	if err != nil {
 		return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID: %w", err)
 	}
@@ -112,8 +105,8 @@ func resourceCustomerManagedPolicyAttachmentRead(d *schema.ResourceData, meta in
 	}
 
 	d.Set("instance_arn", instanceArn)
-	d.Set("customer_managed_policy_arn", policy.Arn) // check
-	d.Set("customer_managed_policy_name", policy.Name) //check
+	d.Set("customer_managed_policy_name", policy.Arn)   // check
+	d.Set("customer_managed_policy_path", policy.Name) //check
 	d.Set("permission_set_arn", permissionSetArn)
 
 	return nil
@@ -122,7 +115,7 @@ func resourceCustomerManagedPolicyAttachmentRead(d *schema.ResourceData, meta in
 func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SSOAdminConn
 
-	customerManagedPolicyReference, permissionSetArn, instanceArn, err := ParseManagedPolicyAttachmentID(d.Id())
+	customerManagedPolicyReference, permissionSetArn, instanceArn, err := ParseCustomerManagedPolicyAttachmentID(d.Id())
 	if err != nil {
 		return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID: %w", err)
 	}
@@ -130,7 +123,7 @@ func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta 
 	input := &ssoadmin.DetachCustomerManagedPolicyFromPermissionSetInput{
 		InstanceArn:      aws.String(instanceArn),
 		PermissionSetArn: aws.String(permissionSetArn),
-		CustomerManagedPolicyReference: aws.String(customerManagedPolicyReference), // check string type
+		CustomerManagedPolicyReference: aws.String(customerManagedPolicyReference),
 	}
 
 	_, err = conn.DetachCustomerManagedPolicyFromPermissionSet(input)
@@ -142,7 +135,7 @@ func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta 
 		return fmt.Errorf("error detaching Customer Managed Policy (%s) from SSO Permission Set (%s): %w", customerManagedPolicyReference, permissionSetArn, err)
 	}
 
-	// Provision ALL accounts after detaching the customermanaged policy
+	// Provision ALL accounts after detaching the managed policy
 	if err := provisionPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
 		return err
 	}
@@ -150,7 +143,7 @@ func resourceCustomerManagedPolicyAttachmentDelete(d *schema.ResourceData, meta 
 	return nil
 }
 
-func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, error) { // check this func is renamed similarly where it is used
+func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, error) { 
 	idParts := strings.Split(id, ",")
 	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
 		return "", "", "", fmt.Errorf("error parsing ID: expected CUSTOMER_MANAGED_POLICY_REFERENCE,PERMISSION_SET_ARN,INSTANCE_ARN")
@@ -158,18 +151,7 @@ func ParseCustomerManagedPolicyAttachmentID(id string) (string, string, string, 
 	return idParts[0], idParts[1], idParts[2], nil
 }
 
-func expandCustomerManagedPolicyReference(customerPolicyRef []interface{}) *ssoadmin.CustomerManagedPolicyReference {
-	customerManagedPolicyReference := &ssoadmin.CustomerManagedPolicyReference{}
-	// only one image_config block is allowed
-	if len(customerPolicyRef) == 1 && customerPolicyRef[0] != nil {
-		policy := customerPolicyRef[0].(map[string]interface{})
-		if len(policy["customer_managed_policy_name"].([]interface{})) > 0 {
-			customerManagedPolicyReference.Name = flex.ExpandStringList(config["customer_managed_policy_name"].([]interface{}))
-		}
-		if len(policy["path"].([]interface{})) > 0 {
-			customerManagedPolicyReference.Path = flex.ExpandStringList(config["customer_managed_policy_path"].([]interface{}))
-		}
-	}
+func createCustomerManagedPolicyReference(name string, path string) {
+	customerManagedPolicyReference := map[string]string{"Name": path, "Path": path}
 	return customerManagedPolicyReference
-	// is an error needed in the else situation here?
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -26,23 +26,12 @@ func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
 		Create: resourceCustomerManagedPolicyAttachmentCreate,
 		Read:   resourceCustomerManagedPolicyAttachmentRead,
 		Delete: resourceCustomerManagedPolicyAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: map[string]*schema.Schema{
 
-			"instance_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"permission_set_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		Schema: map[string]*schema.Schema{
 			"customer_managed_policy_reference": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -65,6 +54,18 @@ func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
 						},
 					},
 				},
+			},
+			"instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"permission_set_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 		},
 	}

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -85,89 +85,95 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
 	})
 }
 
-// func TestAccSSOAdminManagedPolicyAttachment_disappears(t *testing.T) {
-// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
-// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+func TestAccSSOAdminCustomerManagedPolicyAttachment_disappears(t *testing.T) {
+	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-// 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
-// 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourceManagedPolicyAttachment(), resourceName),
-// 				),
-// 				ExpectNonEmptyPlan: true,
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourceCustomerManagedPolicyAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
-// func TestAccSSOAdminManagedPolicyAttachment_Disappears_permissionSet(t *testing.T) {
-// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
-// 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
-// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+func TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet(t *testing.T) {
+	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-// 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
-// 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionSet(), permissionSetResourceName),
-// 				),
-// 				ExpectNonEmptyPlan: true,
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionSet(), permissionSetResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
-// func TestAccSSOAdminManagedPolicyAttachment_multipleManagedPolicies(t *testing.T) {
-// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
-// 	otherResourceName := "aws_ssoadmin_managed_policy_attachment.other"
-// 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
-// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+func TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies(t *testing.T) {
+	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
+	otherResourceName := "aws_ssoadmin_customer_managed_policy_attachment.other"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameOther := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-// 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
-// 				),
-// 			},
-// 			{
-// 				Config: testAccCustomerManagedPolicyAttachmentConfig_multiple(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
-// 					testAccCheckManagedPolicyAttachmentExists(otherResourceName),
-// 					//lintignore:AWSAT001
-// 					resource.TestMatchResourceAttr(otherResourceName, "managed_policy_arn", regexp.MustCompile(`policy/AmazonDynamoDBReadOnlyAccess`)),
-// 					resource.TestCheckResourceAttr(otherResourceName, "managed_policy_name", "TestPolicy"),
-// 					resource.TestCheckResourceAttrPair(otherResourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
-// 					resource.TestCheckResourceAttrPair(otherResourceName, "permission_set_arn", permissionSetResourceName, "arn"),
-// 				),
-// 			},
-// 			{
-// 				ResourceName:      otherResourceName,
-// 				ImportState:       true,
-// 				ImportStateVerify: true,
-// 			},
-// 		},
-// 	})
-// }
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+				),
+			},
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_multiple(rName, rNameFoo, rNameBar, rNameOther),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+					testAccCheckCustomerManagedPolicyAttachmentExists(otherResourceName),
+					//lintignore:AWSAT001
+					resource.TestCheckResourceAttr(otherResourceName, "customer_managed_policy_name", rNameOther),
+					resource.TestCheckResourceAttrPair(otherResourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(otherResourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      otherResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
 func testAccCheckCustomerManagedPolicyAttachmentDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
@@ -314,14 +320,34 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
 `)
 }
 
-// func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string) string {
-// 	return acctest.ConfigCompose(
-// 		testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
-// 		`
-// resource "aws_ssoadmin_managed_policy_attachment" "other" {
-//   instance_arn       = tolist(data.aws_ssoadmin_instances.test.arns)[0]
-//   managed_policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
-//   permission_set_arn = aws_ssoadmin_permission_set.test.arn
-// }
-// `)
-// }
+func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string, rNameFoo string, rNameBar string, rNameOther string) string {
+	return acctest.ConfigCompose(
+		testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+		fmt.Sprintf(`
+resource "aws_ssoadmin_customer_managed_policy_attachment" "other" {
+	instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+	permission_set_arn = aws_ssoadmin_permission_set.test.arn
+	customer_managed_policy_name = aws_iam_policy.other.name
+	customer_managed_policy_path = "/"
+}
+
+resource "aws_iam_policy" "other" {
+	name        = %q
+	path        = "/"
+	description = "My test policy"
+	policy = jsonencode({
+	  Version = "2012-10-17"
+	  Statement = [
+		{
+		  Action = [
+			"ec2:Describe*",
+		  ]
+		  Effect   = "Allow"
+		  Resource = "*"
+		},
+	  ]
+	})
+  }
+`, rNameOther),
+	)
+}

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -5,21 +5,21 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
@@ -28,11 +28,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
-					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_reference.0.name", rNameFoo),
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_reference.0.name", rNamePolicy1),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
@@ -50,8 +49,8 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
 	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
@@ -60,17 +59,16 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
 		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 				),
 			},
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName, rNameFoo, rNameBar),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName, rNamePolicy1, rNamePolicy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
-					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_reference.0.name", rNameBar),
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_reference.0.name", rNamePolicy2),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
@@ -87,8 +85,8 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
 func TestAccSSOAdminCustomerManagedPolicyAttachment_disappears(t *testing.T) {
 	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
@@ -97,7 +95,7 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourceCustomerManagedPolicyAttachment(), resourceName),
@@ -112,8 +110,8 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet(t *
 	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
@@ -122,7 +120,7 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet(t *
 		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionSet(), permissionSetResourceName),
@@ -134,13 +132,13 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet(t *
 }
 
 func TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies(t *testing.T) {
-	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
-	otherResourceName := "aws_ssoadmin_customer_managed_policy_attachment.other"
+	resource1Name := "aws_ssoadmin_customer_managed_policy_attachment.test"
+	resource2Name := "aws_ssoadmin_customer_managed_policy_attachment.test2"
 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameOther := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
@@ -149,24 +147,23 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies(t *t
 		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+					testAccCheckCustomerManagedPolicyAttachmentExists(resource1Name),
 				),
 			},
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_multiple(rName, rNameFoo, rNameBar, rNameOther),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_multiple(rName, rNamePolicy1, rNamePolicy2, rNamePolicy3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
-					testAccCheckCustomerManagedPolicyAttachmentExists(otherResourceName),
-					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(otherResourceName, "customer_managed_policy_reference.0.name", rNameOther),
-					resource.TestCheckResourceAttrPair(otherResourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
-					resource.TestCheckResourceAttrPair(otherResourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+					testAccCheckCustomerManagedPolicyAttachmentExists(resource1Name),
+					testAccCheckCustomerManagedPolicyAttachmentExists(resource2Name),
+					resource.TestCheckResourceAttr(resource2Name, "customer_managed_policy_reference.0.name", rNamePolicy3),
+					resource.TestCheckResourceAttrPair(resource2Name, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(resource2Name, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      otherResourceName,
+				ResourceName:      resource2Name,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -182,14 +179,15 @@ func testAccCheckCustomerManagedPolicyAttachmentDestroy(s *terraform.State) erro
 			continue
 		}
 
-		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.CustomerManagedPolicyAttachmentParseResourceID(rs.Primary.ID)
+		policyName, policyPath, permissionSetARN, instanceARN, err := tfssoadmin.CustomerManagedPolicyAttachmentParseResourceID(rs.Primary.ID)
+
 		if err != nil {
-			return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
+			return err
 		}
 
-		policy, err := tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetArn, instanceArn)
+		_, err = tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetARN, instanceARN)
 
-		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+		if tfresource.NotFound(err) {
 			continue
 		}
 
@@ -197,63 +195,54 @@ func testAccCheckCustomerManagedPolicyAttachmentDestroy(s *terraform.State) erro
 			return err
 		}
 
-		if policy == nil {
-			continue
-		}
-
-		return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) still exists", policyName, permissionSetArn)
-
+		return fmt.Errorf("SSO Customer Managed Policy Attachment %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckCustomerManagedPolicyAttachmentExists(resourceName string) resource.TestCheckFunc {
+func testAccCheckCustomerManagedPolicyAttachmentExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+			return fmt.Errorf("No SSO Customer Managed Policy Attachment ID is set")
 		}
 
-		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.CustomerManagedPolicyAttachmentParseResourceID(rs.Primary.ID)
-
-		if err != nil {
-			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
-
-		policy, err := tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetArn, instanceArn)
+		policyName, policyPath, permissionSetARN, instanceARN, err := tfssoadmin.CustomerManagedPolicyAttachmentParseResourceID(rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		if policy == nil {
-			return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) not found", policyName, permissionSetArn)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
+
+		_, err = tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetARN, instanceARN)
+
+		if err != nil {
+			return err
 		}
 
 		return nil
 	}
 }
 
-func testAccCustomerManagedPolicyAttachmentBaseConfig(rName string, rNameFoo string, rNameBar string) string {
+func testAccCustomerManagedPolicyAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2 string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_ssoadmin_instances" "test" {}
 
 resource "aws_ssoadmin_permission_set" "test" {
-  name         = %q
+  name         = %[1]q
   instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
 }
 
-resource "aws_iam_policy" "test_foo" {
-  name        = %q
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
   path        = "/"
   description = "My test policy"
   policy = jsonencode({
@@ -270,8 +259,8 @@ resource "aws_iam_policy" "test_foo" {
   })
 }
 
-resource "aws_iam_policy" "test_bar" {
-  name        = %q
+resource "aws_iam_policy" "test2" {
+  name        = %[3]q
   path        = "/"
   description = "My test policy"
   policy = jsonencode({
@@ -287,56 +276,50 @@ resource "aws_iam_policy" "test_bar" {
     ]
   })
 }
-
-
-`, rName, rNameFoo, rNameBar)
+`, rName, rNamePolicy1, rNamePolicy2)
 }
 
-func testAccCustomerManagedPolicyAttachmentConfig_basic(rName string, rNameFoo string, rNameBar string) string {
-	return acctest.ConfigCompose(
-		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar), `
+func testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2 string) string {
+	return acctest.ConfigCompose(testAccCustomerManagedPolicyAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2), `
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
+
   customer_managed_policy_reference {
-    name = aws_iam_policy.test_foo.name
+    name = aws_iam_policy.test1.name
     path = "/"
   }
 }
-`,
-	)
+`)
 }
 
-func testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName string, rNameFoo string, rNameBar string) string {
-	return acctest.ConfigCompose(
-		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar), `
+func testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName, rNamePolicy1, rNamePolicy2 string) string {
+	return acctest.ConfigCompose(testAccCustomerManagedPolicyAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2), `
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
+
   customer_managed_policy_reference {
-    name = aws_iam_policy.test_bar.name
+    name = aws_iam_policy.test2.name
     path = "/"
   }
 }
-`,
-	)
+`)
 }
 
-func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string, rNameFoo string, rNameBar string, rNameOther string) string {
-	return acctest.ConfigCompose(
-		testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
-		fmt.Sprintf(`
-resource "aws_ssoadmin_customer_managed_policy_attachment" "other" {
+func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName, rNamePolicy1, rNamePolicy2, rNamePolicy3 string) string {
+	return acctest.ConfigCompose(testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2), fmt.Sprintf(`
+resource "aws_ssoadmin_customer_managed_policy_attachment" "test2" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
   customer_managed_policy_reference {
-    name = aws_iam_policy.test_other.name
+    name = aws_iam_policy.test3.name
     path = "/"
   }
 }
 
-resource "aws_iam_policy" "test_other" {
-  name        = %q
+resource "aws_iam_policy" "test3" {
+  name        = %[1]q
   path        = "/"
   description = "My other test policy"
   policy = jsonencode({
@@ -352,6 +335,5 @@ resource "aws_iam_policy" "test_other" {
     ]
   })
 }
-`, rNameOther),
-	)
+`, rNamePolicy3))
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -33,7 +33,7 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_name", rNameFoo),
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_reference.0.name", rNameFoo),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
@@ -71,7 +71,7 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_name", rNameBar),
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_reference.0.name", rNameBar),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
@@ -161,7 +161,7 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies(t *t
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 					testAccCheckCustomerManagedPolicyAttachmentExists(otherResourceName),
 					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(otherResourceName, "customer_managed_policy_name", rNameOther),
+					resource.TestCheckResourceAttr(otherResourceName, "customer_managed_policy_reference.0.name", rNameOther),
 					resource.TestCheckResourceAttrPair(otherResourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(otherResourceName, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
@@ -299,8 +299,11 @@ func testAccCustomerManagedPolicyAttachmentConfig_basic(rName string, rNameFoo s
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
-  customer_managed_policy_name = aws_iam_policy.test_foo.name
-  customer_managed_policy_path = "/"
+  customer_managed_policy_reference {
+	name = aws_iam_policy.test_foo.name
+	path = "/"
+  }
+  
 }
 
 
@@ -314,8 +317,10 @@ func testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName string, rNameFo
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
 	instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
 	permission_set_arn = aws_ssoadmin_permission_set.test.arn
-	customer_managed_policy_name = aws_iam_policy.test_bar.name
-	customer_managed_policy_path = "/"
+	customer_managed_policy_reference {
+		name = aws_iam_policy.test_bar.name
+		path = "/"
+	  }
 	}
 `)
 }
@@ -327,14 +332,16 @@ func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string, rNameFo
 resource "aws_ssoadmin_customer_managed_policy_attachment" "other" {
 	instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
 	permission_set_arn = aws_ssoadmin_permission_set.test.arn
-	customer_managed_policy_name = aws_iam_policy.other.name
-	customer_managed_policy_path = "/"
+	customer_managed_policy_reference {
+		name = aws_iam_policy.test_other.name
+		path = "/"
+	  }
 }
 
-resource "aws_iam_policy" "other" {
+resource "aws_iam_policy" "test_other" {
 	name        = %q
 	path        = "/"
-	description = "My test policy"
+	description = "My other test policy"
 	policy = jsonencode({
 	  Version = "2012-10-17"
 	  Statement = [

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -182,7 +182,7 @@ func testAccCheckCustomerManagedPolicyAttachmentDestroy(s *terraform.State) erro
 			continue
 		}
 
-		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.ParseCustomerManagedPolicyAttachmentID(rs.Primary.ID)
+		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.CustomerManagedPolicyAttachmentParseResourceID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
 		}
@@ -219,7 +219,7 @@ func testAccCheckCustomerManagedPolicyAttachmentExists(resourceName string) reso
 			return fmt.Errorf("Resource (%s) ID not set", resourceName)
 		}
 
-		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.ParseCustomerManagedPolicyAttachmentID(rs.Primary.ID)
+		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.CustomerManagedPolicyAttachmentParseResourceID(rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -2,7 +2,7 @@ package ssoadmin_test
 
 import (
 	"fmt"
-	"regexp"
+	// "regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
@@ -19,6 +19,8 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
@@ -27,11 +29,11 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
 					//lintignore:AWSAT001
-					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_name", "TestPolicy"),
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_name", rNameFoo),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
 				),
@@ -45,42 +47,43 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 	})
 }
 
-// func TestAccSSOAdminManagedPolicyAttachment_forceNew(t *testing.T) {
-// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
-// 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
-// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
+	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameFoo := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-// 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
-// 				),
-// 			},
-// 			{
-// 				Config: testAccManagedPolicyAttachmentConfig_forceNew(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
-// 					//lintignore:AWSAT001
-// 					resource.TestMatchResourceAttr(resourceName, "managed_policy_arn", regexp.MustCompile(`policy/AmazonCognitoReadOnly`)),
-// 					resource.TestCheckResourceAttr(resourceName, "managed_policy_name", "AmazonCognitoReadOnly"),
-// 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
-// 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
-// 				),
-// 			},
-// 			{
-// 				ResourceName:      resourceName,
-// 				ImportState:       true,
-// 				ImportStateVerify: true,
-// 			},
-// 		},
-// 	})
-// }
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+				),
+			},
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName, rNameFoo, rNameBar),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+					//lintignore:AWSAT001
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_name", rNameBar),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
 // func TestAccSSOAdminManagedPolicyAttachment_disappears(t *testing.T) {
 // 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
@@ -90,10 +93,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 // 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
 // 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
 // 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
 // 		Steps: []resource.TestStep{
 // 			{
-// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
 // 				Check: resource.ComposeTestCheckFunc(
 // 					testAccCheckManagedPolicyAttachmentExists(resourceName),
 // 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourceManagedPolicyAttachment(), resourceName),
@@ -113,10 +116,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 // 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
 // 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
 // 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
 // 		Steps: []resource.TestStep{
 // 			{
-// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
 // 				Check: resource.ComposeTestCheckFunc(
 // 					testAccCheckManagedPolicyAttachmentExists(resourceName),
 // 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionSet(), permissionSetResourceName),
@@ -137,16 +140,16 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 // 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
 // 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
 // 		ProviderFactories: acctest.ProviderFactories,
-// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
 // 		Steps: []resource.TestStep{
 // 			{
-// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
 // 				Check: resource.ComposeTestCheckFunc(
 // 					testAccCheckManagedPolicyAttachmentExists(resourceName),
 // 				),
 // 			},
 // 			{
-// 				Config: testAccManagedPolicyAttachmentConfig_multiple(rName),
+// 				Config: testAccCustomerManagedPolicyAttachmentConfig_multiple(rName),
 // 				Check: resource.ComposeTestCheckFunc(
 // 					testAccCheckManagedPolicyAttachmentExists(resourceName),
 // 					testAccCheckManagedPolicyAttachmentExists(otherResourceName),
@@ -166,39 +169,39 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 // 	})
 // }
 
-// func testAccCheckManagedPolicyAttachmentDestroy(s *terraform.State) error {
-// 	conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
+func testAccCheckCustomerManagedPolicyAttachmentDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
 
-// 	for _, rs := range s.RootModule().Resources {
-// 		if rs.Type != "aws_ssoadmin_managed_policy_attachment" {
-// 			continue
-// 		}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ssoadmin_managed_policy_attachment" {
+			continue
+		}
 
-// 		managedPolicyArn, permissionSetArn, instanceArn, err := tfssoadmin.ParseManagedPolicyAttachmentID(rs.Primary.ID)
-// 		if err != nil {
-// 			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
-// 		}
+		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.ParseCustomerManagedPolicyAttachmentID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
+		}
 
-// 		policy, err := tfssoadmin.FindManagedPolicy(conn, managedPolicyArn, permissionSetArn, instanceArn)
+		policy, err := tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetArn, instanceArn)
 
-// 		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
-// 			continue
-// 		}
+		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+			continue
+		}
 
-// 		if err != nil {
-// 			return err
-// 		}
+		if err != nil {
+			return err
+		}
 
-// 		if policy == nil {
-// 			continue
-// 		}
+		if policy == nil {
+			continue
+		}
 
-// 		return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) still exists", managedPolicyArn, permissionSetArn)
+		return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) still exists", policyName, permissionSetArn)
 
-// 	}
+	}
 
-// 	return nil
-// }
+	return nil
+}
 
 func testAccCheckCustomerManagedPolicyAttachmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -211,7 +214,7 @@ func testAccCheckCustomerManagedPolicyAttachmentExists(resourceName string) reso
 			return fmt.Errorf("Resource (%s) ID not set", resourceName)
 		}
 
-		managedPolicyArn, permissionSetArn, instanceArn, err := tfssoadmin.ParseManagedPolicyAttachmentID(rs.Primary.ID)
+		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.ParseCustomerManagedPolicyAttachmentID(rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
@@ -219,21 +222,21 @@ func testAccCheckCustomerManagedPolicyAttachmentExists(resourceName string) reso
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
 
-		policy, err := tfssoadmin.FindManagedPolicy(conn, managedPolicyArn, permissionSetArn, instanceArn)
+		policy, err := tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetArn, instanceArn)
 
 		if err != nil {
 			return err
 		}
 
 		if policy == nil {
-			return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) not found", managedPolicyArn, permissionSetArn)
+			return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) not found", policyName, permissionSetArn)
 		}
 
 		return nil
 	}
 }
 
-func testAccManagedPolicyAttachmentBaseConfig(rName string) string {
+func testAccCustomerManagedPolicyAttachmentBaseConfig(rName string, rNameFoo string, rNameBar string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -244,53 +247,76 @@ resource "aws_ssoadmin_permission_set" "test" {
   instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
 }
 
-resource "aws_iam_policy" "test" {
-	name = "TestPolicy"
-  
-	policy = <<EOF
-  {
-	"Version": "2012-10-17",
-	"Statement": [
-	  {
-		"Action": "*",
-		"Effect": "Allow",
-		"Resource": "*"
-	  }
-	]
+resource "aws_iam_policy" "test_foo" {
+	name        = %q
+	path        = "/"
+	description = "My test policy"
+	policy = jsonencode({
+	  Version = "2012-10-17"
+	  Statement = [
+		{
+		  Action = [
+			"ec2:Describe*",
+		  ]
+		  Effect   = "Allow"
+		  Resource = "*"
+		},
+	  ]
+	})
   }
-  EOF
+
+  resource "aws_iam_policy" "test_bar" {
+	name        = %q
+	path        = "/"
+	description = "My test policy"
+	policy = jsonencode({
+	  Version = "2012-10-17"
+	  Statement = [
+		{
+		  Action = [
+			"ec2:Describe*",
+		  ]
+		  Effect   = "Allow"
+		  Resource = "*"
+		},
+	  ]
+	})
   }
-`, rName)
+
+`, rName, rNameFoo, rNameBar)
 }
 
-func testAccManagedPolicyAttachmentConfig_basic(rName string) string {
+func testAccCustomerManagedPolicyAttachmentConfig_basic(rName string, rNameFoo string, rNameBar string) string {
 	return acctest.ConfigCompose(
-		testAccManagedPolicyAttachmentBaseConfig(rName),
+		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar),
 		`
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
-  customer_managed_policy_name = aws_iam_policy.test.name
+  customer_managed_policy_name = aws_iam_policy.test_foo.name
   customer_managed_policy_path = "/"
 }
+
+
 `)
 }
 
-// func testAccManagedPolicyAttachmentConfig_forceNew(rName string) string {
-// 	return acctest.ConfigCompose(
-// 		testAccManagedPolicyAttachmentBaseConfig(rName),
-// 		`
-// resource "aws_ssoadmin_managed_policy_attachment" "test" {
-//   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
-//   managed_policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonCognitoReadOnly"
-//   permission_set_arn = aws_ssoadmin_permission_set.test.arn
-// }
-// `)
-// }
+func testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName string, rNameFoo string, rNameBar string) string {
+	return acctest.ConfigCompose(
+		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar),
+		`
+resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
+	instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+	permission_set_arn = aws_ssoadmin_permission_set.test.arn
+	customer_managed_policy_name = aws_iam_policy.test_bar.name
+	customer_managed_policy_path = "/"
+	}
+`)
+}
 
-// func testAccManagedPolicyAttachmentConfig_multiple(rName string) string {
+// func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string) string {
 // 	return acctest.ConfigCompose(
-// 		testAccManagedPolicyAttachmentConfig_basic(rName),
+// 		testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
 // 		`
 // resource "aws_ssoadmin_managed_policy_attachment" "other" {
 //   instance_arn       = tolist(data.aws_ssoadmin_instances.test.arns)[0]

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -179,13 +179,13 @@ func testAccCheckCustomerManagedPolicyAttachmentDestroy(s *terraform.State) erro
 	conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_ssoadmin_managed_policy_attachment" {
+		if rs.Type != "aws_ssoadmin_customer_managed_policy_attachment" {
 			continue
 		}
 
 		policyName, policyPath, permissionSetArn, instanceArn, err := tfssoadmin.ParseCustomerManagedPolicyAttachmentID(rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
+			return fmt.Errorf("error parsing SSO Customer Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
 		}
 
 		policy, err := tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetArn, instanceArn)

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -222,11 +222,7 @@ func testAccCheckCustomerManagedPolicyAttachmentExists(n string) resource.TestCh
 
 		_, err = tfssoadmin.FindCustomerManagedPolicy(conn, policyName, policyPath, permissionSetARN, instanceARN)
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -1,0 +1,301 @@
+package ssoadmin_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+)
+
+func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
+	resourceName := "aws_ssoadmin_customer_managed_policy_attachment.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerManagedPolicyAttachmentExists(resourceName),
+					//lintignore:AWSAT001
+					resource.TestCheckResourceAttr(resourceName, "customer_managed_policy_name", "TestPolicy"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// func TestAccSSOAdminManagedPolicyAttachment_forceNew(t *testing.T) {
+// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
+// 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccManagedPolicyAttachmentConfig_forceNew(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
+// 					//lintignore:AWSAT001
+// 					resource.TestMatchResourceAttr(resourceName, "managed_policy_arn", regexp.MustCompile(`policy/AmazonCognitoReadOnly`)),
+// 					resource.TestCheckResourceAttr(resourceName, "managed_policy_name", "AmazonCognitoReadOnly"),
+// 					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+// 					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+// 				),
+// 			},
+// 			{
+// 				ResourceName:      resourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccSSOAdminManagedPolicyAttachment_disappears(t *testing.T) {
+// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
+// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
+// 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourceManagedPolicyAttachment(), resourceName),
+// 				),
+// 				ExpectNonEmptyPlan: true,
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccSSOAdminManagedPolicyAttachment_Disappears_permissionSet(t *testing.T) {
+// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
+// 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
+// 					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionSet(), permissionSetResourceName),
+// 				),
+// 				ExpectNonEmptyPlan: true,
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccSSOAdminManagedPolicyAttachment_multipleManagedPolicies(t *testing.T) {
+// 	resourceName := "aws_ssoadmin_managed_policy_attachment.test"
+// 	otherResourceName := "aws_ssoadmin_managed_policy_attachment.other"
+// 	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		CheckDestroy:      testAccCheckManagedPolicyAttachmentDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccManagedPolicyAttachmentConfig_basic(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccManagedPolicyAttachmentConfig_multiple(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckManagedPolicyAttachmentExists(resourceName),
+// 					testAccCheckManagedPolicyAttachmentExists(otherResourceName),
+// 					//lintignore:AWSAT001
+// 					resource.TestMatchResourceAttr(otherResourceName, "managed_policy_arn", regexp.MustCompile(`policy/AmazonDynamoDBReadOnlyAccess`)),
+// 					resource.TestCheckResourceAttr(otherResourceName, "managed_policy_name", "TestPolicy"),
+// 					resource.TestCheckResourceAttrPair(otherResourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+// 					resource.TestCheckResourceAttrPair(otherResourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+// 				),
+// 			},
+// 			{
+// 				ResourceName:      otherResourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 		},
+// 	})
+// }
+
+// func testAccCheckManagedPolicyAttachmentDestroy(s *terraform.State) error {
+// 	conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
+
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "aws_ssoadmin_managed_policy_attachment" {
+// 			continue
+// 		}
+
+// 		managedPolicyArn, permissionSetArn, instanceArn, err := tfssoadmin.ParseManagedPolicyAttachmentID(rs.Primary.ID)
+// 		if err != nil {
+// 			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
+// 		}
+
+// 		policy, err := tfssoadmin.FindManagedPolicy(conn, managedPolicyArn, permissionSetArn, instanceArn)
+
+// 		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+// 			continue
+// 		}
+
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		if policy == nil {
+// 			continue
+// 		}
+
+// 		return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) still exists", managedPolicyArn, permissionSetArn)
+
+// 	}
+
+// 	return nil
+// }
+
+func testAccCheckCustomerManagedPolicyAttachmentExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		managedPolicyArn, permissionSetArn, instanceArn, err := tfssoadmin.ParseManagedPolicyAttachmentID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("error parsing SSO Managed Policy Attachment ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
+
+		policy, err := tfssoadmin.FindManagedPolicy(conn, managedPolicyArn, permissionSetArn, instanceArn)
+
+		if err != nil {
+			return err
+		}
+
+		if policy == nil {
+			return fmt.Errorf("Managed Policy (%s) for SSO Permission Set (%s) not found", managedPolicyArn, permissionSetArn)
+		}
+
+		return nil
+	}
+}
+
+func testAccManagedPolicyAttachmentBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_permission_set" "test" {
+  name         = %q
+  instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+
+resource "aws_iam_policy" "test" {
+	name = "TestPolicy"
+  
+	policy = <<EOF
+  {
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+		"Action": "*",
+		"Effect": "Allow",
+		"Resource": "*"
+	  }
+	]
+  }
+  EOF
+  }
+`, rName)
+}
+
+func testAccManagedPolicyAttachmentConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccManagedPolicyAttachmentBaseConfig(rName),
+		`
+resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+  customer_managed_policy_name = aws_iam_policy.test.name
+  customer_managed_policy_path = "/"
+}
+`)
+}
+
+// func testAccManagedPolicyAttachmentConfig_forceNew(rName string) string {
+// 	return acctest.ConfigCompose(
+// 		testAccManagedPolicyAttachmentBaseConfig(rName),
+// 		`
+// resource "aws_ssoadmin_managed_policy_attachment" "test" {
+//   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+//   managed_policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonCognitoReadOnly"
+//   permission_set_arn = aws_ssoadmin_permission_set.test.arn
+// }
+// `)
+// }
+
+// func testAccManagedPolicyAttachmentConfig_multiple(rName string) string {
+// 	return acctest.ConfigCompose(
+// 		testAccManagedPolicyAttachmentConfig_basic(rName),
+// 		`
+// resource "aws_ssoadmin_managed_policy_attachment" "other" {
+//   instance_arn       = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+//   managed_policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
+//   permission_set_arn = aws_ssoadmin_permission_set.test.arn
+// }
+// `)
+// }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -2,7 +2,6 @@ package ssoadmin_test
 
 import (
 	"fmt"
-	// "regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ssoadmin"

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -254,40 +254,40 @@ resource "aws_ssoadmin_permission_set" "test" {
 }
 
 resource "aws_iam_policy" "test_foo" {
-	name        = %q
-	path        = "/"
-	description = "My test policy"
-	policy = jsonencode({
-	  Version = "2012-10-17"
-	  Statement = [
-		{
-		  Action = [
-			"ec2:Describe*",
-		  ]
-		  Effect   = "Allow"
-		  Resource = "*"
+  name        = %q
+  path        = "/"
+  description = "My test policy"
+  policy 	  = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [
+	  {
+	    Action = [
+		  "ec2:Describe*",
+		]
+		Effect   = "Allow"
+		Resource = "*"
 		},
 	  ]
 	})
   }
 
-  resource "aws_iam_policy" "test_bar" {
-	name        = %q
-	path        = "/"
-	description = "My test policy"
-	policy = jsonencode({
-	  Version = "2012-10-17"
-	  Statement = [
-		{
-		  Action = [
-			"ec2:Describe*",
-		  ]
-		  Effect   = "Allow"
-		  Resource = "*"
-		},
-	  ]
-	})
-  }
+resource "aws_iam_policy" "test_bar" {
+  name        = %q
+  path        = "/"
+  description = "My test policy"
+  policy 	  = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [
+  	{
+  	  Action = [
+  		"ec2:Describe*",
+  	  ]
+  	  Effect   = "Allow"
+  	  Resource = "*"
+  	},
+    ]
+  })
+}
 
 `, rName, rNameFoo, rNameBar)
 }
@@ -302,11 +302,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   customer_managed_policy_reference {
 	name = aws_iam_policy.test_foo.name
 	path = "/"
-  }
-  
+  }  
 }
-
-
 `)
 }
 
@@ -315,13 +312,13 @@ func testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName string, rNameFo
 		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar),
 		`
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
-	instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
-	permission_set_arn = aws_ssoadmin_permission_set.test.arn
-	customer_managed_policy_reference {
-		name = aws_iam_policy.test_bar.name
-		path = "/"
-	  }
-	}
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+  customer_managed_policy_reference {
+	name = aws_iam_policy.test_bar.name
+	path = "/"
+  }
+}
 `)
 }
 
@@ -330,31 +327,31 @@ func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string, rNameFo
 		testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
 		fmt.Sprintf(`
 resource "aws_ssoadmin_customer_managed_policy_attachment" "other" {
-	instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
-	permission_set_arn = aws_ssoadmin_permission_set.test.arn
-	customer_managed_policy_reference {
-		name = aws_iam_policy.test_other.name
-		path = "/"
-	  }
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+  customer_managed_policy_reference {
+	name = aws_iam_policy.test_other.name
+	path = "/"
+  }
 }
 
 resource "aws_iam_policy" "test_other" {
-	name        = %q
-	path        = "/"
-	description = "My other test policy"
-	policy = jsonencode({
-	  Version = "2012-10-17"
-	  Statement = [
-		{
-		  Action = [
-			"ec2:Describe*",
-		  ]
-		  Effect   = "Allow"
-		  Resource = "*"
-		},
-	  ]
-	})
-  }
+  name        = %q
+  path        = "/"
+  description = "My other test policy"
+  policy      = jsonencode({
+	Version   = "2012-10-17"
+	Statement = [
+	  {
+	    Action = [
+		  "ec2:Describe*",
+		]
+		Effect   = "Allow"
+		Resource = "*"
+	  },
+	]
+  })
+}
 `, rNameOther),
 	)
 }

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -257,69 +257,70 @@ resource "aws_iam_policy" "test_foo" {
   name        = %q
   path        = "/"
   description = "My test policy"
-  policy 	  = jsonencode({
-    Version   = "2012-10-17"
+  policy = jsonencode({
+    Version = "2012-10-17"
     Statement = [
-	  {
-	    Action = [
-		  "ec2:Describe*",
-		]
-		Effect   = "Allow"
-		Resource = "*"
-		},
-	  ]
-	})
-  }
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
 
 resource "aws_iam_policy" "test_bar" {
   name        = %q
   path        = "/"
   description = "My test policy"
-  policy 	  = jsonencode({
-    Version   = "2012-10-17"
+  policy = jsonencode({
+    Version = "2012-10-17"
     Statement = [
-  	{
-  	  Action = [
-  		"ec2:Describe*",
-  	  ]
-  	  Effect   = "Allow"
-  	  Resource = "*"
-  	},
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
     ]
   })
 }
+
 
 `, rName, rNameFoo, rNameBar)
 }
 
 func testAccCustomerManagedPolicyAttachmentConfig_basic(rName string, rNameFoo string, rNameBar string) string {
 	return acctest.ConfigCompose(
-		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar),
-		`
+		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar), `
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
   customer_managed_policy_reference {
-	name = aws_iam_policy.test_foo.name
-	path = "/"
-  }  
+    name = aws_iam_policy.test_foo.name
+    path = "/"
+  }
 }
-`)
+`,
+	)
 }
 
 func testAccCustomerManagedPolicyAttachmentConfig_forceNew(rName string, rNameFoo string, rNameBar string) string {
 	return acctest.ConfigCompose(
-		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar),
-		`
+		testAccCustomerManagedPolicyAttachmentBaseConfig(rName, rNameFoo, rNameBar), `
 resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
   customer_managed_policy_reference {
-	name = aws_iam_policy.test_bar.name
-	path = "/"
+    name = aws_iam_policy.test_bar.name
+    path = "/"
   }
 }
-`)
+`,
+	)
 }
 
 func testAccCustomerManagedPolicyAttachmentConfig_multiple(rName string, rNameFoo string, rNameBar string, rNameOther string) string {
@@ -330,8 +331,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "other" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
   customer_managed_policy_reference {
-	name = aws_iam_policy.test_other.name
-	path = "/"
+    name = aws_iam_policy.test_other.name
+    path = "/"
   }
 }
 
@@ -339,17 +340,17 @@ resource "aws_iam_policy" "test_other" {
   name        = %q
   path        = "/"
   description = "My other test policy"
-  policy      = jsonencode({
-	Version   = "2012-10-17"
-	Statement = [
-	  {
-	    Action = [
-		  "ec2:Describe*",
-		]
-		Effect   = "Allow"
-		Resource = "*"
-	  },
-	]
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
   })
 }
 `, rNameOther),

--- a/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment_test.go
@@ -23,10 +23,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_basic(t *testing.T) {
 	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
@@ -55,10 +55,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew(t *testing.T) {
 	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
@@ -92,10 +92,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_disappears(t *testing.T) {
 	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
@@ -117,10 +117,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet(t *
 	rNameBar := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),
@@ -144,10 +144,10 @@ func TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies(t *t
 	rNameOther := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, ssoadmin.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckCustomerManagedPolicyAttachmentDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomerManagedPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomerManagedPolicyAttachmentConfig_basic(rName, rNameFoo, rNameBar),

--- a/internal/service/ssoadmin/find.go
+++ b/internal/service/ssoadmin/find.go
@@ -89,7 +89,7 @@ func FindCustomerManagedPolicy(conn *ssoadmin.SSOAdmin, policyName, policyPath, 
 				continue
 			}
 
-			if aws.StringValue(policy.Name) == policyName {
+			if aws.StringValue(policy.Name) == policyName && aws.StringValue(policy.Path) == policyPath {
 				attachedPolicy = policy
 				return false
 			}

--- a/internal/service/ssoadmin/find.go
+++ b/internal/service/ssoadmin/find.go
@@ -70,7 +70,6 @@ func FindManagedPolicy(conn *ssoadmin.SSOAdmin, managedPolicyArn, permissionSetA
 	return attachedPolicy, err
 }
 
-
 // FindCustomerManagedPolicy returns the customer managed policy attached to a permission set within a specified SSO instance.
 // Returns an error if no customer managed policy is found.
 func FindCustomerManagedPolicy(conn *ssoadmin.SSOAdmin, policyName, policyPath, permissionSetArn, instanceArn string) (*ssoadmin.CustomerManagedPolicyReference, error) {

--- a/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
@@ -56,12 +56,14 @@ The following arguments are supported:
 
 * `instance_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed.
 * `permission_set_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Permission Set.
-* `customer_managed_policy_reference` - (Required, Forces new resource) Specifies the name and path of a customer managed policy. You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your permission set. See below.
+* `customer_managed_policy_reference` - (Required, Forces new resource) Specifies the name and path of a customer managed policy. See below.
 
-### `customer_managed_policy_reference`
+### Customer Managed Policy Reference
+
+The `customer_managed_policy_reference` config block describes a customer managed IAM policy. You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set. 
 
 * `name` - (Required, Forces new resource) Name of the customer managed IAM Policy to be attached.
-* `path` - (Optional, Forces new resource) The path to the IAM policy to be attached. The default is `/`.
+* `path` - (Optional, Forces new resource) The path to the IAM policy to be attached. The default is `/`. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names) for more information.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
@@ -76,5 +76,5 @@ In addition to all arguments above, the following attributes are exported:
 SSO Managed Policy Attachments can be imported using the `name`, `path`, `permission_set_arn`, and `instance_arn` separated by a comma (`,`) e.g.,
 
 ```
-$ terraform import TestPolicy,/,arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72
+$ terraform import aws_ssoadmin_customer_managed_policy_attachment.example TestPolicy,/,arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72
 ```

--- a/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 ### Customer Managed Policy Reference
 
-The `customer_managed_policy_reference` config block describes a customer managed IAM policy. You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set. 
+The `customer_managed_policy_reference` config block describes a customer managed IAM policy. You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set.
 
 * `name` - (Required, Forces new resource) Name of the customer managed IAM Policy to be attached.
 * `path` - (Optional, Forces new resource) The path to the IAM policy to be attached. The default is `/`. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names) for more information.

--- a/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
@@ -46,7 +46,6 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "example" {
     name = aws_iam_policy.example.name
     path = "/"
   }
-
 }
 ```
 

--- a/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
@@ -42,8 +42,11 @@ resource "aws_iam_policy" "example" {
 resource "aws_ssoadmin_customer_managed_policy_attachment" "example" {
 	instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
 	permission_set_arn = aws_ssoadmin_permission_set.example.arn
-	customer_managed_policy_name = aws_iam_policy.example.name
-	customer_managed_policy_path = "/"
+	customer_managed_policy_reference {
+		name = aws_iam_policy.example.name
+		path = "/"
+	}
+
 }
 ```
 
@@ -53,8 +56,12 @@ The following arguments are supported:
 
 * `instance_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed.
 * `permission_set_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Permission Set.
-* `customer_managed_policy_name` - (Required, Forces new resource) Name of the customer managed IAM Policy to be attached.
-* `customer_managed_policy_path` - (Optional, Forces new resource) The path to the IAM policy to be attached. The default is `/`.
+* `customer_managed_policy_reference` - (Required, Forces new resource) Specifies the name and path of a customer managed policy. You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your permission set. See below.
+
+### `customer_managed_policy_reference`
+
+* `name` - (Required, Forces new resource) Name of the customer managed IAM Policy to be attached.
+* `path` - (Optional, Forces new resource) The path to the IAM policy to be attached. The default is `/`.
 
 ## Attributes Reference
 
@@ -64,7 +71,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SSO Managed Policy Attachments can be imported using the `customer_managed_policy_name`, `customer_managed_policy_path`, `permission_set_arn`, and `instance_arn` separated by a comma (`,`) e.g.,
+SSO Managed Policy Attachments can be imported using the `name`, `path`, `permission_set_arn`, and `instance_arn` separated by a comma (`,`) e.g.,
 
 ```
 $ terraform import TestPolicy,/,arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72

--- a/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_customer_managed_policy_attachment.html.markdown
@@ -23,29 +23,29 @@ resource "aws_ssoadmin_permission_set" "example" {
 }
 
 resource "aws_iam_policy" "example" {
-	name        = "TestPolicy"
-	description = "My test policy"
-	policy = jsonencode({
-	  Version = "2012-10-17"
-	  Statement = [
-		{
-		  Action = [
-			"ec2:Describe*",
-		  ]
-		  Effect   = "Allow"
-		  Resource = "*"
-		},
-	  ]
-	})
-  }
+  name        = "TestPolicy"
+  description = "My test policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
 
 resource "aws_ssoadmin_customer_managed_policy_attachment" "example" {
-	instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
-	permission_set_arn = aws_ssoadmin_permission_set.example.arn
-	customer_managed_policy_reference {
-		name = aws_iam_policy.example.name
-		path = "/"
-	}
+  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+  customer_managed_policy_reference {
+    name = aws_iam_policy.example.name
+    path = "/"
+  }
 
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25904.
Closes #26068.

This is my first contribution and first time working with Go, so thank you in advance for your feedback.
I have added `aws_ssoadmin_customer_managed_policy_attachment` and manually tested that it is working, creating the following resource:
```
resource "aws_ssoadmin_customer_managed_policy_attachment" "example" {
  customer_managed_policy_name         = aws_iam_policy.example.name
  customer_managed_policy_path         = "/" # optional
  instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
  permission_set_arn = aws_ssoadmin_permission_set.example.arn
}
```
I based the acceptance tests on `managed_policy_attachment_test.go`. They are passing (see below), however there are a couple of areas I am unsure about:
- I have used some random names in the test resources being created, to avoid conflicts, however am unsure if I'm doing this properly?
- Not all of the resources are being destroyed after the tests, I assume this could be related to the above and `testAccCheckCustomerManagedPolicyAttachmentDestroy`?

***Update: The tests are working and all resources being destroyed properly. I have marked the PR ready for review***

Thanks for bearing with me as I get used to the repo and I hope this PR is helpful.

Output from acceptance testing:

```
$ make testacc TESTS=TestAccSSOAdminCustomerManagedPolicyAttachment PKG=ssoadmin

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminCustomerManagedPolicyAttachment'  -timeout 5m
=== RUN   TestAccSSOAdminCustomerManagedPolicyAttachment_basic
=== PAUSE TestAccSSOAdminCustomerManagedPolicyAttachment_basic
=== RUN   TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew
=== PAUSE TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew
=== RUN   TestAccSSOAdminCustomerManagedPolicyAttachment_disappears
--- PASS: TestAccSSOAdminCustomerManagedPolicyAttachment_disappears (27.91s)
=== RUN   TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet
--- PASS: TestAccSSOAdminCustomerManagedPolicyAttachment_Disappears_permissionSet (22.14s)
=== RUN   TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies
=== PAUSE TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies
=== CONT  TestAccSSOAdminCustomerManagedPolicyAttachment_basic
=== CONT  TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies
=== CONT  TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew
--- PASS: TestAccSSOAdminCustomerManagedPolicyAttachment_basic (31.19s)
--- PASS: TestAccSSOAdminCustomerManagedPolicyAttachment_multipleManagedPolicies (51.96s)
--- PASS: TestAccSSOAdminCustomerManagedPolicyAttachment_forceNew (56.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	106.228s

```
