### PR TITLE
d/aws_organizations_policy_attachments - new data source

### DIFF
--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -69,6 +69,9 @@ func TestAccOrganizations_serial(t *testing.T) {
 			"SkipDestroy":        testAccPolicyAttachment_skipDestroy,
 			"disappears":         testAccPolicyAttachment_disappears,
 		},
+		"PolicyAttachments": {
+			"DataSource": testAccPolicyAttachmentsDataSource_basic,
+		},
 		"DelegatedAdministrator": {
 			"basic":      testAccDelegatedAdministrator_basic,
 			"disappears": testAccDelegatedAdministrator_disappears,

--- a/internal/service/organizations/policy_attachments_data_source.go
+++ b/internal/service/organizations/policy_attachments_data_source.go
@@ -1,0 +1,115 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+// @SDKDataSource("aws_organizations_policy_attachments")
+func DataSourcePolicyAttachments() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourcePolicyAttachmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"target_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"filter": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(organizations.PolicyType_Values(), false),
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"aws_managed": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePolicyAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).OrganizationsConn()
+
+	target_id := d.Get("target_id").(string)
+	filter := d.Get("filter").(string)
+
+	params := &organizations.ListPoliciesForTargetInput{
+		TargetId: aws.String(target_id),
+		Filter:   aws.String(filter),
+	}
+
+	var policies []*organizations.PolicySummary
+
+	err := conn.ListPoliciesForTargetPagesWithContext(ctx, params,
+		func(page *organizations.ListPoliciesForTargetOutput, lastPage bool) bool {
+			policies = append(policies, page.Policies...)
+
+			return !lastPage
+		})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error listing Policy Attachments for target (%s): %w", target_id, err))
+	}
+
+	if err := d.Set("policies", flattenPolicySummaries(policies)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting policies: %w", err))
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", target_id, filter))
+
+	return nil
+}
+
+func flattenPolicySummaries(summaries []*organizations.PolicySummary) []map[string]interface{} {
+	if len(summaries) == 0 {
+		return nil
+	}
+	var result []map[string]interface{}
+	for _, summary := range summaries {
+		result = append(result, map[string]interface{}{
+			"arn":         aws.StringValue(summary.Arn),
+			"aws_managed": aws.BoolValue(summary.AwsManaged),
+			"description": aws.StringValue(summary.Description),
+			"id":          aws.StringValue(summary.Id),
+			"name":        aws.StringValue(summary.Name),
+			"type":        aws.StringValue(summary.Type),
+		})
+	}
+	return result
+}

--- a/internal/service/organizations/policy_attachments_data_source_test.go
+++ b/internal/service/organizations/policy_attachments_data_source_test.go
@@ -1,0 +1,60 @@
+package organizations_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/organizations"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func testAccPolicyAttachmentsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_organizations_policy.test"
+	dataSourceName := "data.aws_organizations_policy_attachments.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationsAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, organizations.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAttachmentsDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "policies.#", "2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "filter", dataSourceName, "policies.0.type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "filter", dataSourceName, "policies.1.type"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "policies.*", map[string]string{
+						"aws_managed": "true",
+						"id":          "p-FullAWSAccess",
+						"name":        "FullAWSAccess",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "policies.*", map[string]string{
+						"aws_managed": "false",
+						"name":        rName,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "policies.*.arn", resourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "policies.*.id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPolicyAttachmentsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_organizations_policy_attachments" "test" {
+  target_id = aws_organizations_organizational_unit.test.id
+  filter    = "SERVICE_CONTROL_POLICY"
+
+  depends_on = [aws_organizations_policy_attachment.test]
+}
+`, testAccPolicyAttachmentConfig_organizationalUnit(rName))
+}

--- a/internal/service/organizations/service_package_gen.go
+++ b/internal/service/organizations/service_package_gen.go
@@ -46,6 +46,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_organizations_organizational_units",
 		},
 		{
+			Factory:  DataSourcePolicyAttachments,
+			TypeName: "aws_organizations_policy_attachments",
+		},
+		{
 			Factory:  DataSourceResourceTags,
 			TypeName: "aws_organizations_resource_tags",
 		},

--- a/website/docs/d/organizations_policy_attachments.html.markdown
+++ b/website/docs/d/organizations_policy_attachments.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Organizations"
+layout: "aws"
+page_title: "AWS: aws_organizations_policy_attachments"
+description: |-
+  Get all policies that are attached to the specified target root, organizational unit (OU), or account.
+---
+
+# Data Source: aws_organizations_policy_attachments
+
+Get all policies that are attached to the specified target root, organizational unit (OU), or account.
+
+## Example Usage
+
+```terraform
+data "aws_organizations_organization" "org" {}
+
+data "aws_organizations_policy_attachments" "attachments" {
+  target_id = data.aws_organizations_organization.org.roots[0].id
+  filter    = "SERVICE_CONTROL_POLICY"
+}
+```
+
+## Argument Reference
+
+* `target_id` - (Required) The unique identifier (ID) of the root, organizational unit, or account whose policies you want to list.
+* `filter` - (Required) The type of policy that you want to include in the returned list. Valid values are `SERVICE_CONTROL_POLICY`, `TAG_POLICY`, `BACKUP_POLICY`, and `AISERVICES_OPT_OUT_POLICY`.
+
+## Attributes Reference
+
+* `policies` - List of child organizational units, which have the following attributes:
+    * `arn` - Amazon Resource Name (ARN) of the policy
+    * `aws_managed` - boolean value that indicates whether the specified policy is an AWS managed policy
+    * `description` - description of the policy
+    * `id` - unique identifier (ID) of the policy
+    * `name` - friendly name of the policy
+    * `type` - type of policy.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS='TestAccOrganizations_serial/PolicyAttachments' PKG=organizations
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/organizations/... -v -count 1 -parallel 20 -run='TestAccOrganizations_serial/PolicyAttachments'  -timeout 180m
=== RUN   TestAccOrganizations_serial
=== RUN   TestAccOrganizations_serial/PolicyAttachments
=== RUN   TestAccOrganizations_serial/PolicyAttachments/DataSource
=== PAUSE TestAccOrganizations_serial/PolicyAttachments/DataSource
=== CONT  TestAccOrganizations_serial/PolicyAttachments/DataSource
--- PASS: TestAccOrganizations_serial (41.87s)
    --- PASS: TestAccOrganizations_serial/PolicyAttachments (0.00s)
        --- PASS: TestAccOrganizations_serial/PolicyAttachments/DataSource (41.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/organizations      46.113s
...
```
