### PR TITLE
New Resource: aws_transcribe_vocabulary_filter

### DIFF
--- a/.changelog/25918.txt
+++ b/.changelog/25918.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+  aws_transcribe_vocabulary_filter
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2051,6 +2051,7 @@ func Provider() *schema.Provider {
 
 			"aws_transcribe_medical_vocabulary": transcribe.ResourceMedicalVocabulary(),
 			"aws_transcribe_vocabulary":         transcribe.ResourceVocabulary(),
+			"aws_transcribe_vocabulary_filter":  transcribe.ResourceVocabularyFilter(),
 
 			"aws_transfer_access":   transfer.ResourceAccess(),
 			"aws_transfer_server":   transfer.ResourceServer(),

--- a/internal/service/transcribe/sweep.go
+++ b/internal/service/transcribe/sweep.go
@@ -4,13 +4,35 @@
 package transcribe
 
 import (
+	"context"
 	"fmt"
+	"log"
 
+	"github.com/aws/aws-sdk-go-v2/service/transcribe"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 )
 
 func init() {
+	resource.AddTestSweepers("aws_transcribe_medical_vocabulary", &resource.Sweeper{
+		Name: "aws_transcribe_medical_vocabulary",
+		F:    sweepMedicalVocabularies,
+		Dependencies: []string{
+			"aws_s3_bucket",
+		},
+	})
+
+	resource.AddTestSweepers("aws_transcribe_vocabulary", &resource.Sweeper{
+		Name: "aws_transcribe_vocabulary",
+		F:    sweepVocabularies,
+		Dependencies: []string{
+			"aws_s3_bucket",
+		},
+	})
+
 	resource.AddTestSweepers("aws_transcribe_vocabulary_filter", &resource.Sweeper{
 		Name: "aws_transcribe_vocabulary_filter",
 		F:    sweepVocabularyFilters,
@@ -20,11 +42,156 @@ func init() {
 	})
 }
 
-func sweepVocabularyFilters(region string) error {
-	client, err := sweep.SharedRegionalASweepClient(region)
+func sweepMedicalVocabularies(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
 		fmt.Errorf("error getting client: %s", err)
 	}
 
-	return nil
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).TranscribeConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	in := &transcribe.ListMedicalVocabulariesInput{}
+	var errs *multierror.Error
+
+	for {
+		out, err := conn.ListMedicalVocabularies(ctx, in)
+		if sweep.SkipSweepError(err) {
+			log.Println("[WARN] Skipping Transcribe Medical Vocabularies sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving Transcribe Medical Vocabularies: %w", err)
+		}
+
+		for _, vocab := range out.Vocabularies {
+			name := aws.StringValue(vocab.VocabularyName)
+			log.Printf("[INFO] Deleting Transcribe Medical Vocabularies: %s", name)
+
+			r := ResourceMedicalVocabulary()
+			d := r.Data(nil)
+			d.SetId(name)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		if aws.StringValue(out.NextToken) == "" {
+			break
+		}
+		in.NextToken = out.NextToken
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Medical Vocabularies for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Transcribe Medical Vocabularies sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepVocabularies(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		fmt.Errorf("error getting client: %s", err)
+	}
+
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).TranscribeConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	in := &transcribe.ListVocabulariesInput{}
+	var errs *multierror.Error
+
+	for {
+		out, err := conn.ListVocabularies(ctx, in)
+		if sweep.SkipSweepError(err) {
+			log.Println("[WARN] Skipping Transcribe Vocabularies sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving Transcribe Vocabularies: %w", err)
+		}
+
+		for _, vocab := range out.Vocabularies {
+			name := aws.StringValue(vocab.VocabularyName)
+			log.Printf("[INFO] Deleting Transcribe Vocabularies: %s", name)
+
+			r := ResourceVocabulary()
+			d := r.Data(nil)
+			d.SetId(name)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		if aws.StringValue(out.NextToken) == "" {
+			break
+		}
+		in.NextToken = out.NextToken
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Vocabularies for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Transcribe Vocabularies sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepVocabularyFilters(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		fmt.Errorf("error getting client: %s", err)
+	}
+
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).TranscribeConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	in := &transcribe.ListVocabularyFiltersInput{}
+	var errs *multierror.Error
+
+	for {
+		out, err := conn.ListVocabularyFilters(ctx, in)
+		if sweep.SkipSweepError(err) {
+			log.Println("[WARN] Skipping Transcribe Vocabulary Filter sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving Transcribe Vocabulary Filters: %w", err)
+		}
+
+		log.Println(out)
+		for _, filter := range out.VocabularyFilters {
+			name := aws.StringValue(filter.VocabularyFilterName)
+			log.Printf("[INFO] Deleting Transcribe Vocabulary Filter: %s", name)
+
+			r := ResourceVocabularyFilter()
+			d := r.Data(nil)
+			d.SetId(name)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		if aws.StringValue(out.NextToken) == "" {
+			break
+		}
+		in.NextToken = out.NextToken
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Vocabulary Filters for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Transcribe Vocabulary Filters sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
 }

--- a/internal/service/transcribe/sweep.go
+++ b/internal/service/transcribe/sweep.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -65,7 +65,7 @@ func sweepMedicalVocabularies(region string) error {
 		}
 
 		for _, vocab := range out.Vocabularies {
-			name := aws.StringValue(vocab.VocabularyName)
+			name := aws.ToString(vocab.VocabularyName)
 			log.Printf("[INFO] Deleting Transcribe Medical Vocabularies: %s", name)
 
 			r := ResourceMedicalVocabulary()
@@ -75,7 +75,7 @@ func sweepMedicalVocabularies(region string) error {
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 
-		if aws.StringValue(out.NextToken) == "" {
+		if aws.ToString(out.NextToken) == "" {
 			break
 		}
 		in.NextToken = out.NextToken
@@ -116,7 +116,7 @@ func sweepVocabularies(region string) error {
 		}
 
 		for _, vocab := range out.Vocabularies {
-			name := aws.StringValue(vocab.VocabularyName)
+			name := aws.ToString(vocab.VocabularyName)
 			log.Printf("[INFO] Deleting Transcribe Vocabularies: %s", name)
 
 			r := ResourceVocabulary()
@@ -126,7 +126,7 @@ func sweepVocabularies(region string) error {
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 
-		if aws.StringValue(out.NextToken) == "" {
+		if aws.ToString(out.NextToken) == "" {
 			break
 		}
 		in.NextToken = out.NextToken
@@ -168,7 +168,7 @@ func sweepVocabularyFilters(region string) error {
 
 		log.Println(out)
 		for _, filter := range out.VocabularyFilters {
-			name := aws.StringValue(filter.VocabularyFilterName)
+			name := aws.ToString(filter.VocabularyFilterName)
 			log.Printf("[INFO] Deleting Transcribe Vocabulary Filter: %s", name)
 
 			r := ResourceVocabularyFilter()
@@ -178,7 +178,7 @@ func sweepVocabularyFilters(region string) error {
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 
-		if aws.StringValue(out.NextToken) == "" {
+		if aws.ToString(out.NextToken) == "" {
 			break
 		}
 		in.NextToken = out.NextToken

--- a/internal/service/transcribe/sweep.go
+++ b/internal/service/transcribe/sweep.go
@@ -1,0 +1,30 @@
+//go:build sweep
+// +build sweep
+
+package transcribe
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_transcribe_vocabulary_filter", &resource.Sweeper{
+		Name: "aws_transcribe_vocabulary_filter",
+		F:    sweepVocabularyFilters,
+		Dependencies: []string{
+			"aws_s3_bucket",
+		},
+	})
+}
+
+func sweepVocabularyFilters(region string) error {
+	client, err := sweep.SharedRegionalASweepClient(region)
+	if err != nil {
+		fmt.Errorf("error getting client: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/transcribe/test-fixtures/vocabulary_filter_test1.txt
+++ b/internal/service/transcribe/test-fixtures/vocabulary_filter_test1.txt
@@ -1,0 +1,3 @@
+cars
+books
+truck

--- a/internal/service/transcribe/vocabulary_filter.go
+++ b/internal/service/transcribe/vocabulary_filter.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -33,12 +32,6 @@ func ResourceVocabularyFilter() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -120,11 +113,11 @@ func resourceVocabularyFilterCreate(ctx context.Context, d *schema.ResourceData,
 
 	out, err := conn.CreateVocabularyFilter(ctx, in)
 	if err != nil {
-		return names.DiagError(names.Transcribe, names.ErrActionCreating, ResNameVocabularyFilter, d.Get("name").(string), err)
+		return names.DiagError(names.Transcribe, names.ErrActionCreating, ResNameVocabularyFilter, d.Get("vocabulary_filter_name").(string), err)
 	}
 
 	if out == nil {
-		return names.DiagError(names.Transcribe, names.ErrActionCreating, ResNameVocabularyFilter, d.Get("name").(string), errors.New("empty output"))
+		return names.DiagError(names.Transcribe, names.ErrActionCreating, ResNameVocabularyFilter, d.Get("vocabulary_filter_name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.VocabularyFilterName))
@@ -229,7 +222,7 @@ func resourceVocabularyFilterDelete(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 
-		return names.DiagError(names.Comprehend, names.ErrActionDeleting, ResNameVocabularyFilter, d.Id(), err)
+		return names.DiagError(names.Transcribe, names.ErrActionDeleting, ResNameVocabularyFilter, d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/transcribe/vocabulary_filter.go
+++ b/internal/service/transcribe/vocabulary_filter.go
@@ -149,9 +149,15 @@ func resourceVocabularyFilterRead(ctx context.Context, d *schema.ResourceData, m
 	}.String()
 
 	d.Set("arn", arn)
-	d.Set("download_uri", out.DownloadUri)
 	d.Set("vocabulary_filter_name", out.VocabularyFilterName)
 	d.Set("language_code", out.LanguageCode)
+
+	// GovCloud does not set a download URI
+	downloadUri := aws.ToString(out.DownloadUri)
+	if downloadUri == "" {
+		downloadUri = "NONE"
+	}
+	d.Set("download_uri", downloadUri)
 
 	tags, err := ListTags(ctx, conn, arn)
 	if err != nil {

--- a/internal/service/transcribe/vocabulary_filter.go
+++ b/internal/service/transcribe/vocabulary_filter.go
@@ -1,0 +1,340 @@
+package transcribe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/transcribe"
+	"github.com/aws/aws-sdk-go-v2/service/transcribe/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceVocabularyFilter() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceVocabularyFilterCreate,
+		ReadWithoutTimeout:   resourceVocabularyFilterRead,
+		UpdateWithoutTimeout: resourceVocabularyFilterUpdate,
+		DeleteWithoutTimeout: resourceVocabularyFilterDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"download_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"language_code": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(validateLanguageCodes(types.LanguageCode("").Values()), false),
+			},
+			"words": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     256,
+				ExactlyOneOf: []string{"words", "vocabulary_filter_file_uri"},
+				Elem:         &schema.Schema{Type: schema.TypeString},
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"vocabulary_filter_file_uri": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"words", "vocabulary_filter_file_uri"},
+				ValidateFunc: validation.StringLenBetween(1, 2000),
+			},
+			"vocabulary_filter_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 200),
+			},
+		},
+
+		CustomizeDiff: customdiff.Sequence(
+			verify.SetTagsDiff,
+			customdiff.ForceNewIfChange("words", func(_ context.Context, old, new, meta interface{}) bool {
+				return len(old.([]interface{})) > 0 && len(new.([]interface{})) == 0
+			}),
+			customdiff.ForceNewIfChange("vocabulary_filter_file_uri", func(_ context.Context, old, new, meta interface{}) bool {
+				return len(old.(string)) > 0 && len(new.(string)) == 0
+			}),
+		),
+	}
+}
+
+const (
+	ResNameVocabularyFilter = "Vocabulary Filter"
+)
+
+func resourceVocabularyFilterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).TranscribeConn
+
+	in := &transcribe.CreateVocabularyFilterInput{
+		VocabularyFilterName: aws.String(d.Get("vocabulary_filter_name").(string)),
+		LanguageCode:         types.LanguageCode(d.Get("language_code").(string)),
+	}
+
+	if v, ok := d.GetOk("vocabulary_filter_file_uri"); ok {
+		in.VocabularyFilterFileUri = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("words"); ok {
+		in.Words = flex.ExpandStringValueList(v.([]interface{}))
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateVocabularyFilter(ctx, in)
+	if err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionCreating, ResNameVocabularyFilter, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return names.DiagError(names.Transcribe, names.ErrActionCreating, ResNameVocabularyFilter, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.ToString(out.VocabularyFilterName))
+
+	if _, err := waitVocabularyFilterCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionWaitingForCreation, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	return resourceVocabularyFilterRead(ctx, d, meta)
+}
+
+func resourceVocabularyFilterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).TranscribeConn
+
+	out, err := FindVocabularyFilterByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Transcribe VocabularyFilter (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionReading, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	arn := arn.ARN{
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "transcribe",
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("vocabulary-filter/%s", d.Id()),
+	}.String()
+
+	d.Set("arn", arn)
+	d.Set("download_uri", out.DownloadUri)
+	d.Set("vocabulary_filter_name", out.VocabularyFilterName)
+	d.Set("language_code", out.LanguageCode)
+
+	tags, err := ListTags(ctx, conn, arn)
+	if err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionReading, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionSetting, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionSetting, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceVocabularyFilterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).TranscribeConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		in := &transcribe.UpdateVocabularyFilterInput{
+			VocabularyFilterName: aws.String(d.Id()),
+		}
+
+		if d.HasChanges("vocabulary_filter_file_uri", "words") {
+			if d.Get("vocabulary_file_uri").(string) != "" {
+				in.VocabularyFilterFileUri = aws.String(d.Get("vocabulary_filter_file_uri").(string))
+			} else {
+				in.Words = expandPhrases(d.Get("words").([]interface{}))
+			}
+		}
+
+		log.Printf("[DEBUG] Updating Transcribe VocabularyFilter (%s): %#v", d.Id(), in)
+		_, err := conn.UpdateVocabularyFilter(ctx, in)
+		if err != nil {
+			return names.DiagError(names.Transcribe, names.ErrActionUpdating, ResNameVocabularyFilter, d.Id(), err)
+		}
+
+		if _, err := waitVocabularyFilterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return names.DiagError(names.Transcribe, names.ErrActionWaitingForUpdate, ResNameVocabularyFilter, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
+			return diag.Errorf("error updating Transcribe VocabularyFilter (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceVocabularyFilterRead(ctx, d, meta)
+}
+
+func resourceVocabularyFilterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).TranscribeConn
+
+	log.Printf("[INFO] Deleting Transcribe VocabularyFilter %s", d.Id())
+
+	_, err := conn.DeleteVocabularyFilter(ctx, &transcribe.DeleteVocabularyFilterInput{
+		VocabularyFilterName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var bre *types.BadRequestException
+		if errors.As(err, &bre) {
+			return nil
+		}
+
+		return names.DiagError(names.Comprehend, names.ErrActionDeleting, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	if _, err := waitVocabularyFilterDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return names.DiagError(names.Transcribe, names.ErrActionWaitingForDeletion, ResNameVocabularyFilter, d.Id(), err)
+	}
+
+	return nil
+}
+
+func waitVocabularyFilterCreated(ctx context.Context, conn *transcribe.Client, id string, timeout time.Duration) (*transcribe.GetVocabularyFilterOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{},
+		Refresh:                   statusVocabularyFilter(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*transcribe.GetVocabularyFilterOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitVocabularyFilterUpdated(ctx context.Context, conn *transcribe.Client, id string, timeout time.Duration) (*transcribe.GetVocabularyFilterOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{},
+		Refresh:                   statusVocabularyFilter(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*transcribe.GetVocabularyFilterOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitVocabularyFilterDeleted(ctx context.Context, conn *transcribe.Client, id string, timeout time.Duration) (*transcribe.GetVocabularyFilterOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{},
+		Target:  []string{},
+		Refresh: statusVocabularyFilter(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*transcribe.GetVocabularyFilterOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func statusVocabularyFilter(ctx context.Context, conn *transcribe.Client, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := FindVocabularyFilterByName(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, "", nil
+	}
+}
+
+func FindVocabularyFilterByName(ctx context.Context, conn *transcribe.Client, id string) (*transcribe.GetVocabularyFilterOutput, error) {
+	in := &transcribe.GetVocabularyFilterInput{
+		VocabularyFilterName: aws.String(id),
+	}
+	out, err := conn.GetVocabularyFilter(ctx, in)
+	if err != nil {
+		var bre *types.BadRequestException
+		if errors.As(err, &bre) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}

--- a/internal/service/transcribe/vocabulary_filter_test.go
+++ b/internal/service/transcribe/vocabulary_filter_test.go
@@ -1,0 +1,252 @@
+package transcribe_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/transcribe"
+	"github.com/aws/aws-sdk-go-v2/service/transcribe/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftranscribe "github.com/hashicorp/terraform-provider-aws/internal/service/transcribe"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+
+func TestVocabularyFilterExampleUnitTest(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tftranscribe.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestAccTranscribeVocabularyFilter_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var vocabularyfilter transcribe.DescribeVocabularyFilterResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_transcribe_vocabulary_filter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.TranscribeEndpointID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:        acctest.ErrorCheck(t, names.TranscribeEndpointID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckVocabularyFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVocabularyFilterConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVocabularyFilterExists(resourceName, &vocabularyfilter),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "transcribe", regexp.MustCompile(`vocabularyfilter:+.`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccTranscribeVocabularyFilter_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var vocabularyfilter transcribe.DescribeVocabularyFilterResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_transcribe_vocabulary_filter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.TranscribeEndpointID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:        acctest.ErrorCheck(t, names.TranscribeEndpointID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckVocabularyFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVocabularyFilterConfig_basic(rName, testAccVocabularyFilterVersionNewer),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVocabularyFilterExists(resourceName, &vocabularyfilter),
+					acctest.CheckResourceDisappears(acctest.Provider, tftranscribe.ResourceVocabularyFilter(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVocabularyFilterDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).TranscribeConn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_transcribe_vocabulary_filter" {
+			continue
+		}
+
+		input := &transcribe.DescribeVocabularyFilterInput{
+			VocabularyFilterId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.DescribeVocabularyFilter(ctx, &transcribe.DescribeVocabularyFilterInput{
+			VocabularyFilterId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			var nfe *types.ResourceNotFoundException
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			return err
+		}
+
+		return names.Error(names.Transcribe, names.ErrActionCheckingDestroyed, tftranscribe.ResNameVocabularyFilter, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckVocabularyFilterExists(name string, vocabularyfilter *transcribe.DescribeVocabularyFilterResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return names.Error(names.Transcribe, names.ErrActionCheckingExistence, tftranscribe.ResNameVocabularyFilter, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return names.Error(names.Transcribe, names.ErrActionCheckingExistence, tftranscribe.ResNameVocabularyFilter, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).TranscribeConn
+		ctx := context.Background()
+		resp, err := conn.DescribeVocabularyFilter(ctx, &transcribe.DescribeVocabularyFilterInput{
+			VocabularyFilterId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return names.Error(names.Transcribe, names.ErrActionCheckingExistence, tftranscribe.ResNameVocabularyFilter, rs.Primary.ID, err)
+		}
+
+		*vocabularyfilter = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).TranscribeConn
+	ctx := context.Background()
+
+	input := &transcribe.ListVocabularyFiltersInput{}
+	_, err := conn.ListVocabularyFilters(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckVocabularyFilterNotRecreated(before, after *transcribe.DescribeVocabularyFilterResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.StringValue(before.VocabularyFilterId), aws.StringValue(after.VocabularyFilterId); before != after {
+			return names.Error(names.Transcribe, names.ErrActionCheckingNotRecreated, tftranscribe.ResNameVocabularyFilter, aws.StringValue(before.VocabularyFilterId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccVocabularyFilterConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_transcribe_vocabulary_filter" "test" {
+  vocabulary_filter_name             = %[1]q
+  engine_type             = "ActiveTranscribe"
+  engine_version          = %[2]q
+  host_instance_type      = "transcribe.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/internal/service/transcribe/vocabulary_filter_test.go
+++ b/internal/service/transcribe/vocabulary_filter_test.go
@@ -127,6 +127,55 @@ func TestAccTranscribeVocabularyFilter_update(t *testing.T) {
 		},
 	})
 }
+
+func TestAccTranscribeVocabularyFilter_updateTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var vocabularyFilter transcribe.GetVocabularyFilterOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_transcribe_vocabulary_filter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.TranscribeEndpointID, t)
+			testAccVocabularyFiltersPreCheck(t)
+		},
+		ErrorCheck:        acctest.ErrorCheck(t, names.TranscribeEndpointID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckVocabularyFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVocabularyFilterConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVocabularyFilterExists(resourceName, &vocabularyFilter),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccVocabularyFilterConfig_tags2(rName, "key1", "value1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVocabularyFilterExists(resourceName, &vocabularyFilter),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccVocabularyFilterConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVocabularyFilterExists(resourceName, &vocabularyFilter),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTranscribeVocabularyFilter_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/transcribe/vocabulary_filter_test.go
+++ b/internal/service/transcribe/vocabulary_filter_test.go
@@ -311,7 +311,7 @@ resource "aws_transcribe_vocabulary_filter" "test" {
 
 func testAccVocabularyFilterConfig_basicWords(rName string) string {
 	return acctest.ConfigCompose(
-		testAccVocabularyBaseConfig(rName),
+		testAccVocabularyFilterBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_transcribe_vocabulary_filter" "test" {
   vocabulary_filter_name = %[1]q

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -125,6 +125,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/synthetics"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/transcribe"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/transfer"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/waf"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/wafregional"

--- a/website/docs/r/transcribe_vocabulary_filter.html.markdown
+++ b/website/docs/r/transcribe_vocabulary_filter.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Transcribe"
+layout: "aws"
+page_title: "AWS: aws_transcribe_vocabularyfilter"
+description: |-
+  Terraform resource for managing an AWS Transcribe VocabularyFilter.
+---
+
+# Resource: aws_transcribe_vocabularyfilter
+
+Terraform resource for managing an AWS Transcribe VocabularyFilter.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_transcribe_vocabularyfilter" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the VocabularyFilter.
+* `example_attribute` - Concise description.
+
+## Timeouts
+
+`aws_transcribe_vocabularyfilter` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Optional, Default: `60m`)
+* `update` - (Optional, Default: `180m`)
+* `delete` - (Optional, Default: `90m`)
+
+## Import
+
+Transcribe VocabularyFilter can be imported using the `example_id_arg`, e.g.,
+
+```
+$ terraform import aws_transcribe_vocabularyfilter.example rft-8012925589
+```

--- a/website/docs/r/transcribe_vocabulary_filter.html.markdown
+++ b/website/docs/r/transcribe_vocabulary_filter.html.markdown
@@ -37,8 +37,8 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `vocabular_filtery_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom vocabulary filter. Conflicts with `words`.
-* `tags` - (Optional) A map of tags to assign to the Vocabulary. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `vocabulary_filter_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom VocabularyFilter. Conflicts with `words`.
+* `tags` - (Optional) A map of tags to assign to the VocabularyFilter. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
@@ -46,7 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - VocabularyFilter name.
 * `arn` - ARN of the VocabularyFilter.
-* `download_uri` - Concise description.
+* `download_uri` - Generated download URI.
 
 ## Import
 

--- a/website/docs/r/transcribe_vocabulary_filter.html.markdown
+++ b/website/docs/r/transcribe_vocabulary_filter.html.markdown
@@ -31,11 +31,14 @@ resource "aws_transcribe_vocabulary_filter" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description.
+* `language_code` - (Required) The language code you selected for your vocabulary filter. Refer to the [supported languages](https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html) page for accepted codes.
+* `vocabulary_filter_name` - (Required) The name of the VocabularyFilter.
+* `words` - (Required) - A list of terms to include in the vocabulary. Conflicts with `vocabulary_file_uri`
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Concise argument description.
+* `vocabular_filtery_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom vocabulary filter. Conflicts with `words`.
+* `tags` - (Optional) A map of tags to assign to the Vocabulary. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
@@ -43,7 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - VocabularyFilter name.
 * `arn` - ARN of the VocabularyFilter.
-* `example_attribute` - Concise description.
+* `download_uri` - Concise description.
 
 ## Import
 

--- a/website/docs/r/transcribe_vocabulary_filter.html.markdown
+++ b/website/docs/r/transcribe_vocabulary_filter.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Transcribe"
 layout: "aws"
-page_title: "AWS: aws_transcribe_vocabularyfilter"
+page_title: "AWS: aws_transcribe_vocabulary_filter"
 description: |-
   Terraform resource for managing an AWS Transcribe VocabularyFilter.
 ---
 
-# Resource: aws_transcribe_vocabularyfilter
+# Resource: aws_transcribe_vocabulary_filter
 
 Terraform resource for managing an AWS Transcribe VocabularyFilter.
 
@@ -15,7 +15,15 @@ Terraform resource for managing an AWS Transcribe VocabularyFilter.
 ### Basic Usage
 
 ```terraform
-resource "aws_transcribe_vocabularyfilter" "example" {
+resource "aws_transcribe_vocabulary_filter" "example" {
+  vocabulary_filter_name = "example"
+  language_code          = "en-US"
+  words                  = ["cars", "bucket"]
+
+  tags = {
+    tag1 = "value1"
+    tag2 = "value3"
+  }
 }
 ```
 
@@ -33,21 +41,14 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - VocabularyFilter name.
 * `arn` - ARN of the VocabularyFilter.
 * `example_attribute` - Concise description.
 
-## Timeouts
-
-`aws_transcribe_vocabularyfilter` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
-
-* `create` - (Optional, Default: `60m`)
-* `update` - (Optional, Default: `180m`)
-* `delete` - (Optional, Default: `90m`)
-
 ## Import
 
-Transcribe VocabularyFilter can be imported using the `example_id_arg`, e.g.,
+Transcribe VocabularyFilter can be imported using the `vocabulary_filter_name`, e.g.,
 
 ```
-$ terraform import aws_transcribe_vocabularyfilter.example rft-8012925589
+$ terraform import aws_transcribe_vocabulary_filter.example example-name
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #18865

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### Commercial
```console
$ make testacc TESTS=TestAccTranscribeVocabularyFilter_ PKG=transcribe

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transcribe/... -v -count 1 -parallel 20 -run='TestAccTranscribeVocabularyFilter_'  -timeout 180m
=== RUN   TestAccTranscribeVocabularyFilter_basic
=== PAUSE TestAccTranscribeVocabularyFilter_basic
=== RUN   TestAccTranscribeVocabularyFilter_basicWords
=== PAUSE TestAccTranscribeVocabularyFilter_basicWords
=== RUN   TestAccTranscribeVocabularyFilter_update
=== PAUSE TestAccTranscribeVocabularyFilter_update
=== RUN   TestAccTranscribeVocabularyFilter_updateTags
=== PAUSE TestAccTranscribeVocabularyFilter_updateTags
=== RUN   TestAccTranscribeVocabularyFilter_disappears
=== PAUSE TestAccTranscribeVocabularyFilter_disappears
=== CONT  TestAccTranscribeVocabularyFilter_basic
=== CONT  TestAccTranscribeVocabularyFilter_updateTags
=== CONT  TestAccTranscribeVocabularyFilter_update
=== CONT  TestAccTranscribeVocabularyFilter_disappears
=== CONT  TestAccTranscribeVocabularyFilter_basicWords
--- PASS: TestAccTranscribeVocabularyFilter_basicWords (21.99s)
--- PASS: TestAccTranscribeVocabularyFilter_disappears (25.00s)
--- PASS: TestAccTranscribeVocabularyFilter_basic (26.76s)
--- PASS: TestAccTranscribeVocabularyFilter_update (39.72s)
--- PASS: TestAccTranscribeVocabularyFilter_updateTags (56.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transcribe	58.898s
...
```

### Gov Cloud

```console
$ make testacc TESTS=TestAccTranscribeVocabularyFilter_ PKG=transcribe

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transcribe/... -v -count 1 -parallel 20 -run='TestAccTranscribeVocabularyFilter_'  -timeout 180m
=== RUN   TestAccTranscribeVocabularyFilter_basic
=== PAUSE TestAccTranscribeVocabularyFilter_basic
=== RUN   TestAccTranscribeVocabularyFilter_basicWords
=== PAUSE TestAccTranscribeVocabularyFilter_basicWords
=== RUN   TestAccTranscribeVocabularyFilter_update
=== PAUSE TestAccTranscribeVocabularyFilter_update
=== RUN   TestAccTranscribeVocabularyFilter_updateTags
=== PAUSE TestAccTranscribeVocabularyFilter_updateTags
=== RUN   TestAccTranscribeVocabularyFilter_disappears
=== PAUSE TestAccTranscribeVocabularyFilter_disappears
=== CONT  TestAccTranscribeVocabularyFilter_basic
=== CONT  TestAccTranscribeVocabularyFilter_updateTags
=== CONT  TestAccTranscribeVocabularyFilter_disappears
=== CONT  TestAccTranscribeVocabularyFilter_update
=== CONT  TestAccTranscribeVocabularyFilter_basicWords
--- PASS: TestAccTranscribeVocabularyFilter_basicWords (16.89s)
--- PASS: TestAccTranscribeVocabularyFilter_disappears (21.37s)
--- PASS: TestAccTranscribeVocabularyFilter_basic (24.37s)
--- PASS: TestAccTranscribeVocabularyFilter_update (37.06s)
--- PASS: TestAccTranscribeVocabularyFilter_updateTags (52.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transcribe	55.299s
```