### PR TITLE
storagegateway: Rate limit error fix

### DIFF
--- a/.changelog/25922.txt
+++ b/.changelog/25922.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_gateway: Only manage `average_download_rate_limit_in_bits_per_sec` and `average_upload_rate_limit_in_bits_per_sec` when gateway type supports rate limits
+```

--- a/internal/service/storagegateway/gateway.go
+++ b/internal/service/storagegateway/gateway.go
@@ -452,23 +452,26 @@ func resourceGatewayCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	bandwidthInput := &storagegateway.UpdateBandwidthRateLimitInput{
-		GatewayARN: aws.String(d.Id()),
-	}
+	switch d.Get("gateway_type").(string) {
+	case gatewayTypeCached, gatewayTypeStored, gatewayTypeVTL, gatewayTypeVTLSnow:
+		bandwidthInput := &storagegateway.UpdateBandwidthRateLimitInput{
+			GatewayARN: aws.String(d.Id()),
+		}
 
-	if v, ok := d.GetOk("average_download_rate_limit_in_bits_per_sec"); ok {
-		bandwidthInput.AverageDownloadRateLimitInBitsPerSec = aws.Int64(int64(v.(int)))
-	}
+		if v, ok := d.GetOk("average_download_rate_limit_in_bits_per_sec"); ok {
+			bandwidthInput.AverageDownloadRateLimitInBitsPerSec = aws.Int64(int64(v.(int)))
+		}
 
-	if v, ok := d.GetOk("average_upload_rate_limit_in_bits_per_sec"); ok {
-		bandwidthInput.AverageUploadRateLimitInBitsPerSec = aws.Int64(int64(v.(int)))
-	}
+		if v, ok := d.GetOk("average_upload_rate_limit_in_bits_per_sec"); ok {
+			bandwidthInput.AverageUploadRateLimitInBitsPerSec = aws.Int64(int64(v.(int)))
+		}
 
-	if bandwidthInput.AverageDownloadRateLimitInBitsPerSec != nil || bandwidthInput.AverageUploadRateLimitInBitsPerSec != nil {
-		log.Printf("[DEBUG] Storage Gateway Gateway %q setting Bandwidth Rate Limit: %#v", d.Id(), bandwidthInput)
-		_, err := conn.UpdateBandwidthRateLimit(bandwidthInput)
-		if err != nil {
-			return fmt.Errorf("error setting Bandwidth Rate Limit: %s", err)
+		if bandwidthInput.AverageDownloadRateLimitInBitsPerSec != nil || bandwidthInput.AverageUploadRateLimitInBitsPerSec != nil {
+			log.Printf("[DEBUG] Storage Gateway Gateway %q setting Bandwidth Rate Limit: %#v", d.Id(), bandwidthInput)
+			_, err := conn.UpdateBandwidthRateLimit(bandwidthInput)
+			if err != nil {
+				return fmt.Errorf("error setting Bandwidth Rate Limit: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25917

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccStorageGatewayGateway_GatewayType PKG=storagegateway 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/storagegateway/... -v -count 1 -parallel 20 -run='TestAccStorageGatewayGateway_GatewayType'  -timeout 180m
--- PASS: TestAccStorageGatewayGateway_GatewayType_vtl (210.73s)
--- PASS: TestAccStorageGatewayGateway_GatewayType_stored (241.19s)
--- PASS: TestAccStorageGatewayGateway_GatewayType_cached (252.28s)
--- PASS: TestAccStorageGatewayGateway_GatewayType_fileS3 (281.62s)
--- PASS: TestAccStorageGatewayGateway_GatewayType_fileFSxSMB (472.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	473.423s
```
