### PR TITLE
Fix documentation of aws_rolesanywhere_profile

### DIFF
--- a/website/docs/r/rolesanywhere_profile.html.markdown
+++ b/website/docs/r/rolesanywhere_profile.html.markdown
@@ -13,8 +13,6 @@ Terraform resource for managing a Roles Anywhere Profile.
 ## Example Usage
 
 ```terraform
-data "aws_partition" "current" {}
-
 resource "aws_iam_role" "test" {
   name = "test"
   path = "/"
@@ -22,9 +20,13 @@ resource "aws_iam_role" "test" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action = "sts:AssumeRole",
+      Action = [
+        "sts:AssumeRole",
+        "sts:TagSession",
+        "sts:SetSourceIdentity"
+      ]
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "rolesanywhere.amazonaws.com",
       }
       Effect = "Allow"
       Sid    = ""


### PR DESCRIPTION
The IAM role trust policy to use was incorrect, per https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html#getting-started-step1

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request