### PR TITLE
Fix aws_ce_anomaly_subscription crash on update of monitor_arn_list

### DIFF
--- a/.changelog/25941.txt
+++ b/.changelog/25941.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ce_anomaly_subscription:Fix crash upon adding or removing monitor ARNs to `monitor_arn_list`.
+```

--- a/internal/service/ce/anomaly_subscription.go
+++ b/internal/service/ce/anomaly_subscription.go
@@ -184,7 +184,7 @@ func resourceAnomalySubscriptionUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if d.HasChange("monitor_arn_list") {
-		input.MonitorArnList = aws.StringSlice(d.Get("monitor_arn_list").([]string))
+		input.MonitorArnList = aws.StringSlice(expandAnomalySubscriptionMonitorARNList(d.Get("monitor_arn_list").([]interface{})))
 		requestUpdate = true
 	}
 

--- a/internal/service/ce/anomaly_subscription_test.go
+++ b/internal/service/ce/anomaly_subscription_test.go
@@ -432,7 +432,7 @@ resource "aws_ce_anomaly_monitor" "test2" {
 resource "aws_ce_anomaly_subscription" "test" {
   name      = %[1]q
   threshold = 100
-  frequency = "DAILY"
+  frequency = "WEEKLY"
 
   monitor_arn_list = [
     aws_ce_anomaly_monitor.test.arn,

--- a/internal/service/ce/anomaly_subscription_test.go
+++ b/internal/service/ce/anomaly_subscription_test.go
@@ -120,7 +120,6 @@ func TestAccCEAnomalySubscription_MonitorARNList(t *testing.T) {
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	domain := acctest.RandomDomainName()
 	address := acctest.RandomEmailAddress(domain)
 
@@ -143,7 +142,7 @@ func TestAccCEAnomalySubscription_MonitorARNList(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAnomalySubscriptionConfig_monitorARNList(rName2, rName3, address),
+				Config: testAccAnomalySubscriptionConfig_monitorARNList(rName, rName2, address),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAnomalySubscriptionExists(resourceName, &subscription),
 					resource.TestCheckResourceAttrPair(resourceName, "monitor_arn_list.0", "aws_ce_anomaly_monitor.test", "arn"),
@@ -433,7 +432,7 @@ resource "aws_ce_anomaly_monitor" "test2" {
 resource "aws_ce_anomaly_subscription" "test" {
   name      = %[1]q
   threshold = 100
-  frequency = "WEEKLY"
+  frequency = "DAILY"
 
   monitor_arn_list = [
     aws_ce_anomaly_monitor.test.arn,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25930

Output from acceptance testing:
```
$ make testacc TESTS=TestAccCEAnomalySubscription_MonitorARNList PKG=ce
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ce/... -v -count 1 -parallel 20 -run='TestAccCEAnomalySubscription_MonitorARNList'  -timeout 180m
=== RUN   TestAccCEAnomalySubscription_MonitorARNList
=== PAUSE TestAccCEAnomalySubscription_MonitorARNList
=== CONT  TestAccCEAnomalySubscription_MonitorARNList
--- PASS: TestAccCEAnomalySubscription_MonitorARNList (42.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ce 42.893s

...
```
