### PR TITLE
d/aws_arn: Additional acceptance test to ensure backwards compatibility (TF Plugin FW)

### DIFF
--- a/internal/service/meta/arn_data_source_test.go
+++ b/internal/service/meta/arn_data_source_test.go
@@ -4,24 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
 )
 
 func TestAccMetaARNDataSource_basic(t *testing.T) {
-	resourceName := "data.aws_arn.test"
-
-	testARN := arn.ARN{
-		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
-		Resource:  "db:mysql-db",
-		Service:   "rds",
-	}
+	arn := "arn:aws:rds:eu-west-1:123456789012:db:mysql-db"
+	dataSourceName := "data.aws_arn.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -29,35 +19,24 @@ func TestAccMetaARNDataSource_basic(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccARNDataSourceConfig_basic(testARN.String()),
-				Check: resource.ComposeTestCheckFunc(
-					testAccARNDataSource(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "account", testARN.AccountID),
-					resource.TestCheckResourceAttr(resourceName, "partition", testARN.Partition),
-					resource.TestCheckResourceAttr(resourceName, "region", testARN.Region),
-					resource.TestCheckResourceAttr(resourceName, "resource", testARN.Resource),
-					resource.TestCheckResourceAttr(resourceName, "service", testARN.Service),
+				Config: testAccARNDataSourceConfig_basic(arn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "account", "123456789012"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", arn),
+					resource.TestCheckResourceAttr(dataSourceName, "partition", "aws"),
+					resource.TestCheckResourceAttr(dataSourceName, "region", "eu-west-1"),
+					resource.TestCheckResourceAttr(dataSourceName, "resource", "db:mysql-db"),
+					resource.TestCheckResourceAttr(dataSourceName, "service", "rds"),
 				),
 			},
 		},
 	})
 }
 
-func testAccARNDataSource(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		return nil
-	}
-}
-
 func testAccARNDataSourceConfig_basic(arn string) string {
 	return fmt.Sprintf(`
 data "aws_arn" "test" {
-  arn = %q
+  arn = %[1]q
 }
 `, arn)
 }

--- a/internal/service/meta/arn_data_source_test.go
+++ b/internal/service/meta/arn_data_source_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccMetaARNDataSource_basic(t *testing.T) {
-	arn := "arn:aws:rds:eu-west-1:123456789012:db:mysql-db"
+	arn := "arn:aws:rds:eu-west-1:123456789012:db:mysql-db" // lintignore:AWSAT003,AWSAT005
 	dataSourceName := "data.aws_arn.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,7 +24,7 @@ func TestAccMetaARNDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "account", "123456789012"),
 					resource.TestCheckResourceAttr(dataSourceName, "id", arn),
 					resource.TestCheckResourceAttr(dataSourceName, "partition", "aws"),
-					resource.TestCheckResourceAttr(dataSourceName, "region", "eu-west-1"),
+					resource.TestCheckResourceAttr(dataSourceName, "region", "eu-west-1"), // lintignore:AWSAT003
 					resource.TestCheckResourceAttr(dataSourceName, "resource", "db:mysql-db"),
 					resource.TestCheckResourceAttr(dataSourceName, "service", "rds"),
 				),

--- a/internal/service/meta/arn_data_source_test.go
+++ b/internal/service/meta/arn_data_source_test.go
@@ -33,6 +33,30 @@ func TestAccMetaARNDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccMetaARNDataSource_s3Bucket(t *testing.T) {
+	arn := "arn:aws:s3:::my_corporate_bucket/Development/*" // lintignore:AWSAT005
+	dataSourceName := "data.aws_arn.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccARNDataSourceConfig_basic(arn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "account", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "id", arn),
+					resource.TestCheckResourceAttr(dataSourceName, "partition", "aws"),
+					resource.TestCheckResourceAttr(dataSourceName, "region", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "resource", "my_corporate_bucket/Development/*"),
+					resource.TestCheckResourceAttr(dataSourceName, "service", "s3"),
+				),
+			},
+		},
+	})
+}
+
 func testAccARNDataSourceConfig_basic(arn string) string {
 	return fmt.Sprintf(`
 data "aws_arn" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

```console
% make testacc TESTARGS='-run=TestAccMetaARNDataSource_' PKG=meta ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/meta/... -v -count 1 -parallel 2  -run=TestAccMetaARNDataSource_ -timeout 180m
=== RUN   TestAccMetaARNDataSource_basic
=== PAUSE TestAccMetaARNDataSource_basic
=== RUN   TestAccMetaARNDataSource_s3Bucket
=== PAUSE TestAccMetaARNDataSource_s3Bucket
=== CONT  TestAccMetaARNDataSource_basic
=== CONT  TestAccMetaARNDataSource_s3Bucket
--- PASS: TestAccMetaARNDataSource_s3Bucket (10.59s)
--- PASS: TestAccMetaARNDataSource_basic (10.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	14.652s
```