### PR TITLE
provider: Add functions to convert AWS SDK v2 enums to strings

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -815,3 +815,13 @@ rules:
         - pattern: fmt.Errorf(..., $ERR.Code(), ...)
         - pattern: fmt.Errorf(..., $ERR.Message(), ...)
     severity: WARNING
+
+  - id: typed-enum-conversion
+    languages: [go]
+    message: Prefer using `enum.Slice()` to convert a slice of typed string enums to a slice of strings
+    paths:
+      include:
+        - internal/
+    patterns:
+      - pattern: "[]string{..., string($X), ...}"
+    severity: WARNING

--- a/internal/enum/validate.go
+++ b/internal/enum/validate.go
@@ -1,0 +1,10 @@
+package enum
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func Validate[T valueser[T]]() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.StringInSlice(Values[T](), false))
+}

--- a/internal/enum/values.go
+++ b/internal/enum/values.go
@@ -1,0 +1,17 @@
+package enum
+
+type valueser[T ~string] interface {
+	~string
+	Values() []T
+}
+
+func Values[T valueser[T]]() []string {
+	l := T("").Values()
+
+	result := make([]string, len(l))
+	for i, v := range l {
+		result[i] = string(v)
+	}
+
+	return result
+}

--- a/internal/enum/values.go
+++ b/internal/enum/values.go
@@ -8,6 +8,10 @@ type valueser[T ~string] interface {
 func Values[T valueser[T]]() []string {
 	l := T("").Values()
 
+	return Slice(l...)
+}
+
+func Slice[T valueser[T]](l ...T) []string {
 	result := make([]string, len(l))
 	for i, v := range l {
 		result[i] = string(v)

--- a/internal/service/kendra/experience.go
+++ b/internal/service/kendra/experience.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -330,8 +331,8 @@ func resourceExperienceDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 func waitExperienceCreated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{string(types.ExperienceStatusCreating)},
-		Target:                    []string{string(types.ExperienceStatusActive)},
+		Pending:                   enum.Slice(types.ExperienceStatusCreating),
+		Target:                    enum.Slice(types.ExperienceStatusActive),
 		Refresh:                   statusExperience(ctx, conn, id, indexId),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -351,7 +352,7 @@ func waitExperienceCreated(ctx context.Context, conn *kendra.Client, id, indexId
 func waitExperienceUpdated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{},
-		Target:                    []string{string(types.ExperienceStatusActive)},
+		Target:                    enum.Slice(types.ExperienceStatusActive),
 		Refresh:                   statusExperience(ctx, conn, id, indexId),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -370,7 +371,7 @@ func waitExperienceUpdated(ctx context.Context, conn *kendra.Client, id, indexId
 
 func waitExperienceDeleted(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{string(types.ExperienceStatusDeleting)},
+		Pending: enum.Slice(types.ExperienceStatusDeleting),
 		Target:  []string{},
 		Refresh: statusExperience(ctx, conn, id, indexId),
 		Timeout: timeout,

--- a/internal/service/kendra/faq.go
+++ b/internal/service/kendra/faq.go
@@ -325,8 +325,8 @@ func resourceFaqDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 func waitFaqCreated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeFaqOutput, error) {
 
 	stateConf := &resource.StateChangeConf{
-		Pending:                   FaqStatusValues(types.FaqStatusCreating, "PENDING_CREATION"), // API currently returns PENDING_CREATION instead of CREATING
-		Target:                    FaqStatusValues(types.FaqStatusActive),
+		Pending:                   enum.Slice(types.FaqStatusCreating, "PENDING_CREATION"), // API currently returns PENDING_CREATION instead of CREATING
+		Target:                    enum.Slice(types.FaqStatusActive),
 		Timeout:                   timeout,
 		Refresh:                   statusFaq(ctx, conn, id, indexId),
 		NotFoundChecks:            20,
@@ -347,7 +347,7 @@ func waitFaqCreated(ctx context.Context, conn *kendra.Client, id, indexId string
 
 func waitFaqDeleted(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeFaqOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: FaqStatusValues(types.FaqStatusDeleting, "PENDING_DELETION"), // API currently returns PENDING_DELETION instead of DELETING
+		Pending: enum.Slice(types.FaqStatusDeleting, "PENDING_DELETION"), // API currently returns PENDING_DELETION instead of DELETING
 		Target:  []string{},
 		Timeout: timeout,
 		Refresh: statusFaq(ctx, conn, id, indexId),
@@ -419,17 +419,4 @@ func flattenS3Path(apiObject *types.S3Path) []interface{} {
 	}
 
 	return []interface{}{m}
-}
-
-func FaqStatusValues(input ...types.FaqStatus) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	output = append(output, "PENDING_CREATION")
-	output = append(output, "PENDING_DELETION")
-
-	return output
 }

--- a/internal/service/kendra/faq.go
+++ b/internal/service/kendra/faq.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -61,10 +62,10 @@ func ResourceFaq() *schema.Resource {
 				Computed: true,
 			},
 			"file_format": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(faqFileFormatValues(types.FaqFileFormat("").Values()...), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: enum.Validate[types.FaqFileFormat](),
 			},
 			"index_id": {
 				Type:     schema.TypeString,
@@ -418,17 +419,6 @@ func flattenS3Path(apiObject *types.S3Path) []interface{} {
 	}
 
 	return []interface{}{m}
-}
-
-// Helpers added. Could be generated or somehow use go 1.18 generics?
-func faqFileFormatValues(input ...types.FaqFileFormat) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
 }
 
 func FaqStatusValues(input ...types.FaqStatus) []string {

--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -638,8 +638,8 @@ func statusIndex(ctx context.Context, conn *kendra.Client, id string) resource.S
 func waitIndexCreated(ctx context.Context, conn *kendra.Client, id string, timeout time.Duration) (*kendra.DescribeIndexOutput, error) {
 
 	stateConf := &resource.StateChangeConf{
-		Pending: IndexStatusValues(types.IndexStatusCreating),
-		Target:  IndexStatusValues(types.IndexStatusActive),
+		Pending: enum.Slice(types.IndexStatusCreating),
+		Target:  enum.Slice(types.IndexStatusActive),
 		Timeout: timeout,
 		Refresh: statusIndex(ctx, conn, id),
 	}
@@ -659,8 +659,8 @@ func waitIndexCreated(ctx context.Context, conn *kendra.Client, id string, timeo
 func waitIndexUpdated(ctx context.Context, conn *kendra.Client, id string, timeout time.Duration) (*kendra.DescribeIndexOutput, error) {
 
 	stateConf := &resource.StateChangeConf{
-		Pending: IndexStatusValues(types.IndexStatusUpdating),
-		Target:  IndexStatusValues(types.IndexStatusActive),
+		Pending: enum.Slice(types.IndexStatusUpdating),
+		Target:  enum.Slice(types.IndexStatusActive),
 		Timeout: timeout,
 		Refresh: statusIndex(ctx, conn, id),
 	}
@@ -679,7 +679,7 @@ func waitIndexUpdated(ctx context.Context, conn *kendra.Client, id string, timeo
 
 func waitIndexDeleted(ctx context.Context, conn *kendra.Client, id string, timeout time.Duration) (*kendra.DescribeIndexOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: IndexStatusValues(types.IndexStatusDeleting),
+		Pending: enum.Slice(types.IndexStatusDeleting),
 		Target:  []string{},
 		Timeout: timeout,
 		Refresh: statusIndex(ctx, conn, id),
@@ -1038,14 +1038,4 @@ func flattenJwtTokenTypeConfiguration(jwtTokenTypeConfiguration *types.JwtTokenT
 	}
 
 	return []interface{}{values}
-}
-
-func IndexStatusValues(input ...types.IndexStatus) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
 }

--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -152,11 +153,11 @@ func ResourceIndex() *schema.Resource {
 				},
 			},
 			"edition": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      string(types.IndexEditionEnterpriseEdition),
-				ValidateFunc: validation.StringInSlice(indexEditionValues(types.IndexEdition("").Values()...), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          string(types.IndexEditionEnterpriseEdition),
+				ValidateDiagFunc: enum.Validate[types.IndexEdition](),
 			},
 			"error_message": {
 				Type:     schema.TypeString,
@@ -239,10 +240,10 @@ func ResourceIndex() *schema.Resource {
 				Computed: true,
 			},
 			"user_context_policy": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      string(types.UserContextPolicyAttributeFilter),
-				ValidateFunc: validation.StringInSlice(userContextPolicyValues(types.UserContextPolicy("").Values()...), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          string(types.UserContextPolicyAttributeFilter),
+				ValidateDiagFunc: enum.Validate[types.UserContextPolicy](),
 			},
 			"user_group_resolution_configuration": {
 				Type:     schema.TypeList,
@@ -251,9 +252,9 @@ func ResourceIndex() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"user_group_resolution_mode": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(userGroupResolutionModeValues(types.UserGroupResolutionMode("").Values()...), false),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.UserGroupResolutionMode](),
 						},
 					},
 				},
@@ -305,9 +306,9 @@ func ResourceIndex() *schema.Resource {
 										ValidateFunc: validation.StringLenBetween(1, 65),
 									},
 									"key_location": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice(keyLocationValues(types.KeyLocation("").Values()...), false),
+										Type:             schema.TypeString,
+										Required:         true,
+										ValidateDiagFunc: enum.Validate[types.KeyLocation](),
 									},
 									"secrets_manager_arn": {
 										Type:         schema.TypeString,
@@ -1037,47 +1038,6 @@ func flattenJwtTokenTypeConfiguration(jwtTokenTypeConfiguration *types.JwtTokenT
 	}
 
 	return []interface{}{values}
-}
-
-// Helpers added. Could be generated or somehow use go 1.18 generics?
-func indexEditionValues(input ...types.IndexEdition) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
-}
-
-func userContextPolicyValues(input ...types.UserContextPolicy) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
-}
-
-func userGroupResolutionModeValues(input ...types.UserGroupResolutionMode) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
-}
-
-func keyLocationValues(input ...types.KeyLocation) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
 }
 
 func IndexStatusValues(input ...types.IndexStatus) []string {

--- a/internal/service/kendra/query_suggestions_block_list.go
+++ b/internal/service/kendra/query_suggestions_block_list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -332,8 +333,8 @@ func statusQuerySuggestionsBlockList(ctx context.Context, conn *kendra.Client, i
 
 func waitQuerySuggestionsBlockListCreated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeQuerySuggestionsBlockListOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{string(types.QuerySuggestionsBlockListStatusCreating)},
-		Target:                    []string{string(types.QuerySuggestionsBlockListStatusActive)},
+		Pending:                   enum.Slice(types.QuerySuggestionsBlockListStatusCreating),
+		Target:                    enum.Slice(types.QuerySuggestionsBlockListStatusActive),
 		Refresh:                   statusQuerySuggestionsBlockList(ctx, conn, id, indexId),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -353,8 +354,8 @@ func waitQuerySuggestionsBlockListCreated(ctx context.Context, conn *kendra.Clie
 
 func waitQuerySuggestionsBlockListUpdated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeQuerySuggestionsBlockListOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{string(types.QuerySuggestionsBlockListStatusUpdating)},
-		Target:                    []string{string(types.QuerySuggestionsBlockListStatusActive)},
+		Pending:                   enum.Slice(types.QuerySuggestionsBlockListStatusUpdating),
+		Target:                    enum.Slice(types.QuerySuggestionsBlockListStatusActive),
 		Refresh:                   statusQuerySuggestionsBlockList(ctx, conn, id, indexId),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -374,7 +375,7 @@ func waitQuerySuggestionsBlockListUpdated(ctx context.Context, conn *kendra.Clie
 
 func waitQuerySuggestionsBlockListDeleted(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeQuerySuggestionsBlockListOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{string(types.QuerySuggestionsBlockListStatusDeleting)},
+		Pending: enum.Slice(types.QuerySuggestionsBlockListStatusDeleting),
 		Target:  []string{},
 		Refresh: statusQuerySuggestionsBlockList(ctx, conn, id, indexId),
 		Timeout: timeout,

--- a/internal/service/kendra/thesaurus.go
+++ b/internal/service/kendra/thesaurus.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -330,8 +331,8 @@ func statusThesaurus(ctx context.Context, conn *kendra.Client, id, indexId strin
 
 func waitThesaurusCreated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeThesaurusOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{string(types.ThesaurusStatusCreating)},
-		Target:                    []string{string(types.ThesaurusStatusActive)},
+		Pending:                   enum.Slice(types.ThesaurusStatusCreating),
+		Target:                    enum.Slice(types.ThesaurusStatusActive),
 		Refresh:                   statusThesaurus(ctx, conn, id, indexId),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -351,8 +352,8 @@ func waitThesaurusCreated(ctx context.Context, conn *kendra.Client, id, indexId 
 
 func waitThesaurusUpdated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeThesaurusOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{string(types.QuerySuggestionsBlockListStatusUpdating)},
-		Target:                    []string{string(types.QuerySuggestionsBlockListStatusActive)},
+		Pending:                   enum.Slice(types.QuerySuggestionsBlockListStatusUpdating),
+		Target:                    enum.Slice(types.QuerySuggestionsBlockListStatusActive),
 		Refresh:                   statusThesaurus(ctx, conn, id, indexId),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -372,7 +373,7 @@ func waitThesaurusUpdated(ctx context.Context, conn *kendra.Client, id, indexId 
 
 func waitThesaurusDeleted(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeThesaurusOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{string(types.QuerySuggestionsBlockListStatusDeleting)},
+		Pending: enum.Slice(types.QuerySuggestionsBlockListStatusDeleting),
 		Target:  []string{},
 		Refresh: statusThesaurus(ctx, conn, id, indexId),
 		Timeout: timeout,

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -710,8 +710,8 @@ func statusOperation(ctx context.Context, conn *route53domains.Client, id string
 
 func waitOperationSucceeded(ctx context.Context, conn *route53domains.Client, id string, timeout time.Duration) (*route53domains.GetOperationDetailOutput, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending: operationStatusValues(types.OperationStatusSubmitted, types.OperationStatusInProgress),
-		Target:  operationStatusValues(types.OperationStatusSuccessful),
+		Pending: enum.Slice(types.OperationStatusSubmitted, types.OperationStatusInProgress),
+		Target:  enum.Slice(types.OperationStatusSuccessful),
 		Timeout: timeout,
 		Refresh: statusOperation(ctx, conn, id),
 	}
@@ -965,14 +965,4 @@ func flattenNameservers(apiObjects []types.Nameserver) []interface{} {
 	}
 
 	return tfList
-}
-
-func operationStatusValues(input ...types.OperationStatus) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
 }

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -51,16 +52,16 @@ func ResourceRegisteredDomain() *schema.Resource {
 					ValidateFunc: validation.StringLenBetween(0, 255),
 				},
 				"contact_type": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringInSlice(contactTypeValues(types.ContactType("").Values()...), false),
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.ContactType](),
 				},
 				"country_code": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringInSlice(countryCodeValues(types.CountryCode("").Values()...), false),
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.CountryCode](),
 				},
 				"email": {
 					Type:         schema.TypeString,
@@ -964,27 +965,6 @@ func flattenNameservers(apiObjects []types.Nameserver) []interface{} {
 	}
 
 	return tfList
-}
-
-// Helpers added. Could be generated or somehow use go 1.18 generics?
-func contactTypeValues(input ...types.ContactType) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
-}
-
-func countryCodeValues(input ...types.CountryCode) []string {
-	var output []string
-
-	for _, v := range input {
-		output = append(output, string(v))
-	}
-
-	return output
 }
 
 func operationStatusValues(input ...types.OperationStatus) []string {


### PR DESCRIPTION
The AWS SDK for Go v2 uses strongly-typed string enums. This means we need to add conversion functions to strings for various uses, such as validation and waiter functions.

Adds:

* `enum.Validate[T]() schema.SchemaValidateDiagFunc` for field validation
* `enum.Values[T]() []string` to return list of all values as slice of strings
* `enum.Slice[T](l ...T) []string` to convert a slice of enum values to a slice of strings

Usage Examples

```diff
- ValidateFunc: validation.StringInSlice(faqFileFormatValues(types.FaqFileFormat("").Values()...), false),
+ ValidateDiagFunc: enum.Validate[types.FaqFileFormat](),
```

```diff
stateConf := &resource.StateChangeConf{
- 	Pending: FaqStatusValues(types.FaqStatusCreating, "PENDING_CREATION"), // API currently returns PENDING_CREATION instead of CREATING
- 	Target:  FaqStatusValues(types.FaqStatusActive),
+ 	Pending: enum.Slice(types.FaqStatusCreating, "PENDING_CREATION"), // API currently returns PENDING_CREATION instead of CREATING
+ 	Target:  enum.Slice(types.FaqStatusActive),
	...
}

-func FaqStatusValues(input ...types.FaqStatus) []string {
-	var output []string
-
- 	for _, v := range input {
- 		output = append(output, string(v))
- 	}
-
- 	output = append(output, "PENDING_CREATION")
- 	output = append(output, "PENDING_DELETION")
-
- 	return output
-}
```

Documentation update to come after #25304 is merged
 
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS='TestAccRoute53Domains|TestAccKendra'

--- PASS: TestAccRoute53Domains_serial (0.00s)
    --- PASS: TestAccRoute53Domains_serial/RegisteredDomain (0.00s)
        --- SKIP: TestAccRoute53Domains_serial/RegisteredDomain/tags (0.00s)
        --- SKIP: TestAccRoute53Domains_serial/RegisteredDomain/autoRenew (0.00s)
        --- SKIP: TestAccRoute53Domains_serial/RegisteredDomain/contacts (0.00s)
        --- SKIP: TestAccRoute53Domains_serial/RegisteredDomain/contactPrivacy (0.00s)
        --- SKIP: TestAccRoute53Domains_serial/RegisteredDomain/nameservers (0.00s)
        --- SKIP: TestAccRoute53Domains_serial/RegisteredDomain/transferLock (0.00s)
--- PASS: TestAccKendra_serial (46059.14s)
    --- PASS: TestAccKendra_serial/Experience (8.74s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_ContentSourceConfigurationAndUserIdentityConfiguration (0.00s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_ContentSourceConfigurationWithUserIdentityConfigurationRemoved (0.00s)
        --- SKIP: TestAccKendra_serial/Experience/DataSource_basic (0.84s)
        --- SKIP: TestAccKendra_serial/Experience/basic (0.17s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_ContentSourceConfiguration_DirectPutContent (1.16s)
        --- SKIP: TestAccKendra_serial/Experience/Name (1.29s)
        --- SKIP: TestAccKendra_serial/Experience/RoleARN (1.31s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_ContentSourceConfiguration_FaqIDs (0.18s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_ContentSourceConfiguration_updateFaqIDs (0.96s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_UserIdentityConfiguration (0.00s)
        --- SKIP: TestAccKendra_serial/Experience/Configuration_UserIdentityConfigurationWithContentSourceConfigurationRemoved (0.00s)
        --- SKIP: TestAccKendra_serial/Experience/disappears (1.42s)
        --- SKIP: TestAccKendra_serial/Experience/Description (1.40s)
    --- PASS: TestAccKendra_serial/Faq (7435.10s)
        --- PASS: TestAccKendra_serial/Faq/tags (954.74s)
        --- PASS: TestAccKendra_serial/Faq/Description (966.77s)
        --- PASS: TestAccKendra_serial/Faq/FileFormat (962.50s)
        --- PASS: TestAccKendra_serial/Faq/LanguageCode (1198.17s)
        --- PASS: TestAccKendra_serial/Faq/DataSource_basic (954.62s)
        --- PASS: TestAccKendra_serial/Faq/basic (1468.46s)
        --- PASS: TestAccKendra_serial/Faq/disappears (929.84s)
    --- PASS: TestAccKendra_serial/Index (17856.90s)
        --- PASS: TestAccKendra_serial/Index/ServerSideEncryption (1947.48s)
        --- PASS: TestAccKendra_serial/Index/tags (1117.99s)
        --- PASS: TestAccKendra_serial/Index/CapacityUnits (4639.28s)
        --- PASS: TestAccKendra_serial/Index/Name (753.20s)
        --- PASS: TestAccKendra_serial/Index/RoleARN (1637.09s)
        --- PASS: TestAccKendra_serial/Index/DataSource_basic (1986.65s)
        --- PASS: TestAccKendra_serial/Index/basic (678.50s)
        --- PASS: TestAccKendra_serial/Index/disappears (1689.62s)
        --- PASS: TestAccKendra_serial/Index/Description (1268.33s)
        --- PASS: TestAccKendra_serial/Index/UserTokenJSON (2138.76s)
    --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList (12731.87s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/basic (2460.43s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/disappears (1557.76s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/tags (1641.59s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/Description (1502.36s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/Name (1142.07s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/RoleARN (1296.33s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/SourceS3Path (1493.10s)
        --- PASS: TestAccKendra_serial/QuerySuggestionsBlockList/DataSource_basic (1638.22s)
    --- PASS: TestAccKendra_serial/Thesaurus (8026.53s)
        --- PASS: TestAccKendra_serial/Thesaurus/Description (961.07s)
        --- PASS: TestAccKendra_serial/Thesaurus/Name (1179.11s)
        --- PASS: TestAccKendra_serial/Thesaurus/RoleARN (925.35s)
        --- PASS: TestAccKendra_serial/Thesaurus/SourceS3Path (905.21s)
        --- PASS: TestAccKendra_serial/Thesaurus/DataSource_basic (1039.43s)
        --- PASS: TestAccKendra_serial/Thesaurus/basic (1009.61s)
        --- PASS: TestAccKendra_serial/Thesaurus/disappears (879.13s)
        --- PASS: TestAccKendra_serial/Thesaurus/tags (1127.60s)
```
