### PR TITLE
fix(iam): the order of service principals should not matter

### DIFF
--- a/.changelog/25967.txt
+++ b/.changelog/25967.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resources/iam_policy: Ensures that order to principals does not matter when comparing
+```

--- a/.changelog/25967.txt
+++ b/.changelog/25967.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/iam_policy_document: When using multiple principals, sort them to avoid differences based only on order
+data-source/aws_iam_policy_document: When using multiple principals, sort them to avoid differences based only on order
 ```

--- a/.changelog/25967.txt
+++ b/.changelog/25967.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
-resources/iam_policy: Ensures that order to principals does not matter when comparing
+```release-note:bug
+data-source/iam_policy_document: When using multiple principals, sort them to avoid differences based only on order
 ```

--- a/internal/service/iam/policy_model.go
+++ b/internal/service/iam/policy_model.go
@@ -157,6 +157,7 @@ func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 				for _, v := range value.([]interface{}) {
 					values = append(values, v.(string))
 				}
+				sort.Sort(sort.Reverse(sort.StringSlice(values)))
 				out = append(out, IAMPolicyStatementPrincipal{Type: key, Identifiers: values})
 			default:
 				return fmt.Errorf("Unsupported data type %T for IAMPolicyStatementPrincipalSet.Identifiers", vt)

--- a/internal/service/iam/policy_model.go
+++ b/internal/service/iam/policy_model.go
@@ -157,7 +157,7 @@ func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 				for _, v := range value.([]interface{}) {
 					values = append(values, v.(string))
 				}
-				sort.Sort(sort.Reverse(sort.StringSlice(values)))
+				sort.Strings(values)
 				out = append(out, IAMPolicyStatementPrincipal{Type: key, Identifiers: values})
 			default:
 				return fmt.Errorf("Unsupported data type %T for IAMPolicyStatementPrincipalSet.Identifiers", vt)
@@ -270,12 +270,12 @@ func PolicyHasValidAWSPrincipals(policy string) (bool, error) { // nosemgrep:ci.
 	for _, principal := range principals {
 		switch x := principal.(type) {
 		case string:
-			if !isValidPolicyAWSPrincipal(x) {
+			if !IsValidPolicyAWSPrincipal(x) {
 				return false, nil
 			}
 		case []string:
 			for _, s := range x {
-				if !isValidPolicyAWSPrincipal(s) {
+				if !IsValidPolicyAWSPrincipal(s) {
 					return false, nil
 				}
 			}
@@ -285,9 +285,9 @@ func PolicyHasValidAWSPrincipals(policy string) (bool, error) { // nosemgrep:ci.
 	return true, nil
 }
 
-// isValidPolicyAWSPrincipal returns true if a string is a valid AWS Princial for an IAM Policy document
+// IsValidPolicyAWSPrincipal returns true if a string is a valid AWS Princial for an IAM Policy document
 // That is: either an ARN, an AWS account ID, or `*`
-func isValidPolicyAWSPrincipal(principal string) bool { // nosemgrep:ci.aws-in-func-name
+func IsValidPolicyAWSPrincipal(principal string) bool { // nosemgrep:ci.aws-in-func-name
 	if principal == "*" {
 		return true
 	}

--- a/internal/service/iam/policy_model_test.go
+++ b/internal/service/iam/policy_model_test.go
@@ -393,6 +393,8 @@ func TestIAMPolicyStatementConditionSet_MarshalJSON(t *testing.T) { // nosemgrep
 }
 
 func TestPolicyUnmarshalServicePrincipalOrder(t *testing.T) {
+	t.Parallel()
+
 	policy1 := `
 		  {
 			"Action": "sts:AssumeRole",


### PR DESCRIPTION
As depicted here https://github.com/hashicorp/terraform-provider-aws/issues/9042#issuecomment-1132992037

It seems the order of services is not predictable, causing Terraform to think it has changes to perform

This change avoid this by sorting the order always in the same predictable order

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9042
