### PR TITLE
Add `aws_appstream_stack.access_endpoints` documentation

### DIFF
--- a/website/docs/r/appstream_stack.html.markdown
+++ b/website/docs/r/appstream_stack.html.markdown
@@ -60,6 +60,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `access_endpoints` - (Optional) Set of configuration blocks defining the interface VPC endpoints. Users of the stack can connect to AppStream 2.0 only through the specified endpoints. See below.
 * `application_settings` - (Optional) Settings for application settings persistence.
 * `description` - (Optional) Description for the AppStream stack.
 * `display_name` - (Optional) Stack name to display.
@@ -68,6 +69,11 @@ The following arguments are optional:
 * `redirect_url` - (Optional) URL that users are redirected to after their streaming session ends.
 * `storage_connectors` - (Optional) Configuration block for the storage connectors to enable. See below.
 * `user_settings` - (Optional) Configuration block for the actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled. See below.
+
+### `access_endpoints`
+
+* `endpoint_type` - (Required) The type of the interface endpoint. See the [`AccessEndpoint` AWS API documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_AccessEndpoint.html) for valid values.
+* `vpce_id` - (Optional) The ID of the VPC in which the interface endpoint is used.
 
 ### `storage_connectors`
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25950

Output from acceptance testing: N/a, docs

### Information

As pointed out in the linked issue, the `aws_appstream_stack` resource was missing the documentation for the `access_endpoints` argument block. This PR aims to add the appropriate documentation.

### Relevant docs links

- [Relevant part of the resource schema](https://github.com/hashicorp/terraform-provider-aws/blob/632cff7679cb6e1e14076b9aac3e68b73f584b70/internal/service/appstream/stack.go#L38-L59)
- [`appstream.CreateStackInput` type definition](https://docs.aws.amazon.com/sdk-for-go/api/service/appstream/#CreateStackInput)
- [`appstream.AccessEndpoint` type definition](https://docs.aws.amazon.com/sdk-for-go/api/service/appstream/#AccessEndpoint)
- [`CreateStack` API documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateStack.html)
- [`AccessEndpoint` API documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_AccessEndpoint.html)