### PR TITLE
Add additional supported values to `aws_glue_connection.connection_types`

### DIFF
--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `catalog_id` – (Optional) The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.
 * `connection_properties` – (Optional) A map of key-value pairs used as parameters for this connection.
-* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`, and `NETWORK`. Defaults to `JBDC`.
+* `connection_type` – (Optional) The type of the connection. Supported are: `CUSTOM`, `JDBC`, `KAFKA`, `MARKETPLACE`, `MONGODB`, and `NETWORK`. Defaults to `JBDC`.
 * `description` – (Optional) Description of the connection.
 * `match_criteria` – (Optional) A list of criteria that can be used in selecting this connection.
 * `name` – (Required) The name of the connection.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25928

Output from acceptance testing: N/a, docs

### Information

The `aws_glue_connection` resource had an outdated list of supported `connection_types`. This PR aims to update and alphabetize the list of supported types.

### References

- [`aws_glue_connection` resource schema](https://github.com/hashicorp/terraform-provider-aws/blob/632cff7679cb6e1e14076b9aac3e68b73f584b70/internal/service/glue/connection.go#L50-L55)
- [`glue.ConnectionInput` API documentation](https://docs.aws.amazon.com/glue/latest/webapi/API_ConnectionInput.html), shows valid values for connection type