### PR TITLE
Docs for Target Group Attachment use function_name

### DIFF
--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -37,7 +37,7 @@ resource "aws_instance" "test" {
 resource "aws_lambda_permission" "with_lb" {
   statement_id  = "AllowExecutionFromlb"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.test.arn
+  function_name = aws_lambda_function.test.function_name
   principal     = "elasticloadbalancing.amazonaws.com"
   source_arn    = aws_lb_target_group.test.arn
 }


### PR DESCRIPTION
Looks like this was a typo [when the example was first introduced](https://github.com/hashicorp/terraform-provider-aws/commit/c1829d1ce400330e514ff3137e9b7b9c40dfbf41).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
