### PR TITLE
Attempt to fix #23601

### DIFF
--- a/.changelog/25982.txt
+++ b/.changelog/25982.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_neptune_cluster:Fix error when trying to modify the engine version of Neptune cluster that has just been restored from a snapshot.
+```

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -638,7 +638,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		requestUpdate = true
 	}
 
-	if d.HasChange("engine_version") {
+	if !d.IsNewResource() && d.HasChange("engine_version") {
 		req.EngineVersion = aws.String(d.Get("engine_version").(string))
 		requestUpdate = true
 	}


### PR DESCRIPTION
When a cluster is restored from a snapshot, resourceClusterUpdate is called, passing the engine-version along to ModifyDBCluster. This will always fail, even when the engine-version has not changed. The solution might be to omit the version from the arguments in case the resource has been freshly created.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23601

