### PR TITLE
Guardduty detector configuration: enable malware protection as data source #25994

### DIFF
--- a/.changelog/25994.txt
+++ b/.changelog/25994.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_guardduty_detector: Add `malware protection` attribute to the `datasources` configuration block
+```

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -373,6 +373,10 @@ func flattenDataSourceConfigurationsResult(apiObject *guardduty.DataSourceConfig
 		tfMap["kubernetes"] = []interface{}{flattenKubernetesConfiguration(v)}
 	}
 
+	if v := apiObject.MalwareProtection; v != nil {
+		tfMap["malware_protection"] = []interface{}{flattenMalwareProtectionConfiguration(v)}
+	}
+
 	return tfMap
 }
 

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -82,6 +82,38 @@ func ResourceDetector() *schema.Resource {
 								},
 							},
 						},
+						"malware_protection": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scan_ec2_instance_with_findings": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ebs_volumes": {
+													Type:     schema.TypeList,
+													Required: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"enable": {
+																Type:     schema.TypeBool,
+																Required: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -358,6 +358,61 @@ func expandKubernetesAuditLogsConfiguration(tfMap map[string]interface{}) *guard
 	return apiObject
 }
 
+func expandMalwareProtectionConfiguration(tfMap map[string]interface{}) *guardduty.MalwareProtectionConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	l, ok := tfMap["scan_ec2_instance_with_findings"].([]interface{})
+	if !ok || len(l) == 0 {
+		return nil
+	}
+
+	m, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return &guardduty.MalwareProtectionConfiguration{
+		ScanEc2InstanceWithFindings: expandMalwareProtectionScanEc2InstanceWithFindingsConfiguration(m),
+	}
+}
+
+func expandMalwareProtectionScanEc2InstanceWithFindingsConfiguration(tfMap map[string]interface{}) *guardduty.ScanEc2InstanceWithFindings {
+	if tfMap == nil {
+		return nil
+	}
+
+	l, ok := tfMap["ebs_volumes"].([]interface{})
+	if !ok || len(l) == 0 {
+		return nil
+	}
+
+	m, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	apiObject := &guardduty.ScanEc2InstanceWithFindings{
+		EbsVolumes: expandMalwareProtectionEbsVolumesConfiguration(m),
+	}
+	return apiObject
+}
+
+func expandMalwareProtectionEbsVolumesConfiguration(tfMap map[string]interface{}) *bool {
+	if tfMap == nil {
+		return nil
+	}
+
+	var apiObject *bool
+
+	if v, ok := tfMap["enable"].(bool); ok {
+		apiObject = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
 func flattenDataSourceConfigurationsResult(apiObject *guardduty.DataSourceConfigurationsResult) map[string]interface{} {
 	if apiObject == nil {
 		return nil

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -304,7 +304,9 @@ func expandDataSourceConfigurations(tfMap map[string]interface{}) *guardduty.Dat
 	if v, ok := tfMap["kubernetes"].([]interface{}); ok && len(v) > 0 {
 		apiObject.Kubernetes = expandKubernetesConfiguration(v[0].(map[string]interface{}))
 	}
-
+	if v, ok := tfMap["malware_protection"].([]interface{}); ok && len(v) > 0 {
+		apiObject.MalwareProtection = expandMalwareProtectionConfiguration(v[0].(map[string]interface{}))
+	}
 	return apiObject
 }
 

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -476,3 +476,45 @@ func flattenKubernetesAuditLogsConfiguration(apiObject *guardduty.KubernetesAudi
 
 	return tfMap
 }
+
+func flattenMalwareProtectionConfiguration(apiObject *guardduty.MalwareProtectionConfigurationResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ScanEc2InstanceWithFindings; v != nil {
+		tfMap["scan_ec2_instance_with_findings"] = []interface{}{flattenMalwareProtectionScanEc2InstanceWithFindingsConfigurationResult(v)}
+	}
+
+	return tfMap
+}
+
+func flattenMalwareProtectionScanEc2InstanceWithFindingsConfigurationResult(apiObject *guardduty.ScanEc2InstanceWithFindingsResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.EbsVolumes; v != nil {
+		tfMap["ebs_volumes"] = []interface{}{flattenMalwareProtectionEbsVolumesConfigurationResult(v)}
+	}
+
+	return tfMap
+}
+
+func flattenMalwareProtectionEbsVolumesConfigurationResult(apiObject *guardduty.EbsVolumesResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Status; v != nil {
+		tfMap["enable"] = aws.StringValue(v) == guardduty.DataSourceStatusEnabled
+	}
+
+	return tfMap
+}

--- a/internal/service/guardduty/detector_test.go
+++ b/internal/service/guardduty/detector_test.go
@@ -192,7 +192,7 @@ func testAccDetector_datasources_all(t *testing.T) {
 		CheckDestroy:             testAccCheckDetectorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDetectorConfig_datasourcesAll(true, false),
+				Config: testAccDetectorConfig_datasourcesAll(true, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
@@ -200,6 +200,8 @@ func testAccDetector_datasources_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable", "true"),
 				),
 			},
 			{
@@ -208,7 +210,7 @@ func testAccDetector_datasources_all(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDetectorConfig_datasourcesAll(true, true),
+				Config: testAccDetectorConfig_datasourcesAll(true, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
@@ -216,10 +218,12 @@ func testAccDetector_datasources_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable", "true"),
 				),
 			},
 			{
-				Config: testAccDetectorConfig_datasourcesAll(false, false),
+				Config: testAccDetectorConfig_datasourcesAll(false, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
@@ -227,10 +231,12 @@ func testAccDetector_datasources_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable", "false"),
 				),
 			},
 			{
-				Config: testAccDetectorConfig_datasourcesAll(false, true),
+				Config: testAccDetectorConfig_datasourcesAll(false, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
@@ -238,6 +244,8 @@ func testAccDetector_datasources_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable", "false"),
 				),
 			},
 		},
@@ -368,7 +376,7 @@ resource "aws_guardduty_detector" "test" {
 `, enable)
 }
 
-func testAccDetectorConfig_datasourcesAll(enableK8s, enableS3 bool) string {
+func testAccDetectorConfig_datasourcesAll(enableK8s, enableS3, enableMalware bool) string {
 	return fmt.Sprintf(`
 resource "aws_guardduty_detector" "test" {
   datasources {
@@ -380,7 +388,15 @@ resource "aws_guardduty_detector" "test" {
     s3_logs {
       enable = %[2]t
     }
+
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          enable = %[3]t
+        }
+      }
+    }
   }
 }
-`, enableK8s, enableS3)
+`, enableK8s, enableS3, enableMalware)
 }

--- a/internal/service/guardduty/guardduty_test.go
+++ b/internal/service/guardduty/guardduty_test.go
@@ -11,6 +11,7 @@ func TestAccGuardDuty_serial(t *testing.T) {
 			"basic":                             testAccDetector_basic,
 			"datasources_s3logs":                testAccDetector_datasources_s3logs,
 			"datasources_kubernetes_audit_logs": testAccDetector_datasources_kubernetes_audit_logs,
+			"datasources_malware_protection":    testAccDetector_datasources_malware_protection,
 			"datasources_all":                   testAccDetector_datasources_all,
 			"tags":                              testAccDetector_tags,
 			"datasource_basic":                  testAccDetectorDataSource_basic,

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -27,6 +27,13 @@ resource "aws_guardduty_detector" "MyDetector" {
         enable = false
       }
     }
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          enable = true
+        }
+      }
+    }
   }
 }
 ```
@@ -48,6 +55,8 @@ The `datasources` block supports the following:
   See [S3 Logs](#s3-logs) below for more details.
 * `kubernetes` - (Optional) Configures [Kubernetes protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html).
   See [Kubernetes](#kubernetes) and [Kubernetes Audit Logs](#kubernetes-audit-logs) below for more details.
+* `malware_protection` - (Optional) Configures [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html).
+  See [Malware Protection](#malware-protection), [Scan EC2 instance with findings](#scan-ec2-instance-with-findings) and [EBS volumes](#ebs-volumes) below for more details.
 
 ### S3 Logs
 
@@ -68,6 +77,24 @@ The `kubernetes` block supports the following:
 The `audit_logs` block supports the following:
 
 * `enable` - (Required) If true, enables Kubernetes audit logs as a data source for [Kubernetes protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html).
+  Defaults to `true`.
+
+### Malware Protection
+`malware_protection` block supports the following:
+
+* `scan_ec2_instance_with_findings` - (Required) Configure whether [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) is enabled as data source for EC2 instances with findings for the detector.
+  See [Scan EC2 instance with findings](#scan-ec2-instance-with-findings) below for more details.
+
+#### Scan EC2 instance with findings
+The `scan_ec2_instance_with_findings` block supports the following:
+
+* `ebs_volumes` - (Required) Configure whether scanning EBS volumes is enabled as data source for the detector for instances with findings.
+  See [EBS volumes](#ebs-volumes) below for more details.
+
+#### EBS volumes
+The `ebs_volumes` block supports the following:
+
+* `enable` - (Required) If true, enables [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) as data source for the detector.
   Defaults to `true`.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25994

Output from acceptance testing:
**_Requires update to 1.44.63_** Tested with 1.44.63



<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccGuardDuty_serial/Detector/datasources_malware_protection' PKG=guardduty ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/guardduty/... -v -count 1 -parallel 1  -run=TestAccGuardDuty_serial/Detector/datasources_malware_protection -timeout 180m
=== RUN   TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/Detector
=== RUN   TestAccGuardDuty_serial/Detector/datasources_malware_protection
--- PASS: TestAccGuardDuty_serial (22.15s)
    --- PASS: TestAccGuardDuty_serial/Detector (22.15s)
        --- PASS: TestAccGuardDuty_serial/Detector/datasources_malware_protection (22.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  23.826s

nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccGuardDuty_serial/Detector/datasources_all' PKG=guardduty ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/guardduty/... -v -count 1 -parallel 1  -run=TestAccGuardDuty_serial/Detector/datasources_all -timeout 180m
=== RUN   TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/Detector
=== RUN   TestAccGuardDuty_serial/Detector/datasources_all
--- PASS: TestAccGuardDuty_serial (40.33s)
    --- PASS: TestAccGuardDuty_serial/Detector (40.33s)
        --- PASS: TestAccGuardDuty_serial/Detector/datasources_all (40.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  42.020s

...
```
