### PR TITLE
Guardduty: organization malware protection configuration #25992

### DIFF
--- a/.changelog/25992.txt
+++ b/.changelog/25992.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_guardduty_organization_configuration: Add `malware protection` attribute to the `datasources` configuration block
+resource/aws_guardduty_organization_configuration: Add `malware_protection` attribute to the `datasources` configuration block
 ```

--- a/.changelog/25992.txt
+++ b/.changelog/25992.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_guardduty_organization_configuration: Add `malware protection` attribute to the `datasources` configuration block
+```

--- a/internal/service/guardduty/guardduty_test.go
+++ b/internal/service/guardduty/guardduty_test.go
@@ -33,9 +33,10 @@ func TestAccGuardDuty_serial(t *testing.T) {
 			"basic": testAccOrganizationAdminAccount_basic,
 		},
 		"OrganizationConfiguration": {
-			"basic":      testAccOrganizationConfiguration_basic,
-			"s3Logs":     testAccOrganizationConfiguration_s3logs,
-			"kubernetes": testAccOrganizationConfiguration_kubernetes,
+			"basic":             testAccOrganizationConfiguration_basic,
+			"s3Logs":            testAccOrganizationConfiguration_s3logs,
+			"kubernetes":        testAccOrganizationConfiguration_kubernetes,
+			"malwareProtection": testAccOrganizationConfiguration_malwareprotection,
 		},
 		"ThreatIntelSet": {
 			"basic": testAccThreatintelset_basic,

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -366,3 +366,45 @@ func flattenOrganizationKubernetesAuditLogsConfiguration(apiObject *guardduty.Or
 
 	return tfMap
 }
+
+func flattenOrganizationMalwareProtectionConfigurationResult(apiObject *guardduty.OrganizationMalwareProtectionConfigurationResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ScanEc2InstanceWithFindings; v != nil {
+		tfMap["scan_ec2_instance_with_findings"] = []interface{}{flattenOrganizationMalwareProtectionScanEC2InstanceWithFindingsResult(v)}
+	}
+
+	return tfMap
+}
+
+func flattenOrganizationMalwareProtectionScanEC2InstanceWithFindingsResult(apiObject *guardduty.OrganizationScanEc2InstanceWithFindingsResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.EbsVolumes; v != nil {
+		tfMap["ebs_volumes"] = []interface{}{flattenOrganizationMalwareProtectionEBSVolumesResult(v)}
+	}
+
+	return tfMap
+}
+
+func flattenOrganizationMalwareProtectionEBSVolumesResult(apiObject *guardduty.OrganizationEbsVolumesResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.AutoEnable; v != nil {
+		tfMap["auto_enable"] = aws.BoolValue(v)
+	}
+
+	return tfMap
+}

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -197,6 +197,10 @@ func expandOrganizationDataSourceConfigurations(tfMap map[string]interface{}) *g
 		apiObject.Kubernetes = expandOrganizationKubernetesConfiguration(v[0].(map[string]interface{}))
 	}
 
+	if v, ok := tfMap["malware_protection"].([]interface{}); ok && len(v) > 0 {
+		apiObject.MalwareProtection = expandOrganizationMalwareProtectionConfiguration(v[0].(map[string]interface{}))
+	}
+
 	return apiObject
 }
 

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -73,6 +73,38 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"malware_protection": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scan_ec2_instance_with_findings": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ebs_volumes": {
+													Type:     schema.TypeList,
+													Required: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"auto_enable": {
+																Type:     schema.TypeBool,
+																Required: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -238,6 +238,60 @@ func expandOrganizationKubernetesConfiguration(tfMap map[string]interface{}) *gu
 	}
 }
 
+func expandOrganizationMalwareProtectionConfiguration(tfMap map[string]interface{}) *guardduty.OrganizationMalwareProtectionConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	l, ok := tfMap["scan_ec2_instance_with_findings"].([]interface{})
+	if !ok || len(l) == 0 {
+		return nil
+	}
+
+	m, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return &guardduty.OrganizationMalwareProtectionConfiguration{
+		ScanEc2InstanceWithFindings: expandOrganizationScanEC2InstanceWithFindingsConfiguration(m),
+	}
+}
+
+func expandOrganizationScanEC2InstanceWithFindingsConfiguration(tfMap map[string]interface{}) *guardduty.OrganizationScanEc2InstanceWithFindings {
+	if tfMap == nil {
+		return nil
+	}
+
+	l, ok := tfMap["ebs_volumes"].([]interface{})
+	if !ok || len(l) == 0 {
+		return nil
+	}
+
+	m, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return &guardduty.OrganizationScanEc2InstanceWithFindings{
+		EbsVolumes: expandOrganizationEBSVolumesConfiguration(m),
+	}
+}
+
+func expandOrganizationEBSVolumesConfiguration(tfMap map[string]interface{}) *guardduty.OrganizationEbsVolumes {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &guardduty.OrganizationEbsVolumes{}
+
+	if v, ok := tfMap["auto_enable"].(bool); ok {
+		apiObject.AutoEnable = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
 func expandOrganizationKubernetesAuditLogsConfiguration(tfMap map[string]interface{}) *guardduty.OrganizationKubernetesAuditLogsConfiguration {
 	if tfMap == nil {
 		return nil

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -265,6 +265,9 @@ func flattenOrganizationDataSourceConfigurationsResult(apiObject *guardduty.Orga
 	if v := apiObject.Kubernetes; v != nil {
 		tfMap["kubernetes"] = []interface{}{flattenOrganizationKubernetesConfigurationResult(v)}
 	}
+	if v := apiObject.MalwareProtection; v != nil {
+		tfMap["malware_protection"] = []interface{}{flattenOrganizationMalwareProtectionConfigurationResult(v)}
+	}
 	return tfMap
 }
 

--- a/internal/service/guardduty/organization_configuration_test.go
+++ b/internal/service/guardduty/organization_configuration_test.go
@@ -133,6 +133,52 @@ func testAccOrganizationConfiguration_kubernetes(t *testing.T) {
 	})
 }
 
+func testAccOrganizationConfiguration_malwareprotection(t *testing.T) {
+	detectorResourceName := "aws_guardduty_detector.test"
+	resourceName := "aws_guardduty_organization_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckOrganizationsAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, guardduty.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDetectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationConfigurationConfig_malwareprotection(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.auto_enable", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOrganizationConfigurationConfig_malwareprotection(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.auto_enable", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccOrganizationConfigurationConfig_autoEnable(autoEnable bool) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
@@ -224,6 +270,44 @@ resource "aws_guardduty_organization_configuration" "test" {
     kubernetes {
       audit_logs {
         enable = %[1]t
+      }
+    }
+  }
+}
+`, autoEnable)
+}
+
+func testAccOrganizationConfigurationConfig_malwareprotection(autoEnable bool) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_guardduty_detector" "test" {}
+
+resource "aws_guardduty_organization_admin_account" "test" {
+  depends_on = [aws_organizations_organization.test]
+
+  admin_account_id = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_guardduty_organization_configuration" "test" {
+  depends_on = [aws_guardduty_organization_admin_account.test]
+
+  auto_enable = true
+  detector_id = aws_guardduty_detector.test.id
+
+  datasources {
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          auto_enable = %[1]t
+        }
       }
     }
   }

--- a/internal/service/guardduty/organization_configuration_test.go
+++ b/internal/service/guardduty/organization_configuration_test.go
@@ -284,7 +284,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_organizations_organization" "test" {
-  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}",  "malware-protection.guardduty.${data.aws_partition.current.dns_suffix}"]
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}", "malware-protection.guardduty.${data.aws_partition.current.dns_suffix}"]
   feature_set                   = "ALL"
 }
 

--- a/internal/service/guardduty/organization_configuration_test.go
+++ b/internal/service/guardduty/organization_configuration_test.go
@@ -284,7 +284,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_organizations_organization" "test" {
-  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}",  "malware-protection.guardduty.${data.aws_partition.current.dns_suffix}"]
   feature_set                   = "ALL"
 }
 

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -32,6 +32,13 @@ resource "aws_guardduty_organization_configuration" "example" {
         enable = true
       }
     }
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          auto_enable = true
+        }
+      }
+    }
   }
 }
 ```
@@ -48,6 +55,7 @@ The following arguments are supported:
 
 * `s3_logs` - (Optional) Enable S3 Protection automatically for new member accounts.
 * `kubernetes` - (Optional) Enable Kubernetes Audit Logs Monitoring automatically for new member accounts.
+* `malware_protection` - (Optional) Enable Malware Protection automatically for new member accounts.
 
 ### S3 Logs
 
@@ -66,6 +74,24 @@ The following arguments are supported:
 The `audit_logs` block supports the following:
 
 * `enable` - (Required) If true, enables Kubernetes audit logs as a data source for [Kubernetes protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html).
+  Defaults to `true`.
+
+### Malware Protection
+`malware_protection` block supports the following:
+
+* `scan_ec2_instance_with_findings` - (Required) Configure whether [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) for EC2 instances with findings should be auto-enabled for new members joining the organization.
+   See [Scan EC2 instance with findings](#scan-ec2-instance-with-findings) below for more details.
+
+#### Scan EC2 instance with findings
+The `scan_ec2_instance_with_findings` block supports the following: 
+
+* `ebs_volumes` - (Required) Configure whether scanning EBS volumes should be auto-enabled for new members joining the organization
+  See [EBS volumes](#ebs-volumes) below for more details.
+
+#### EBS volumes
+The `ebs_volumes` block supports the following:
+
+* `auto_enable` - (Required) If true, enables [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) for all new accounts joining the organization.
   Defaults to `true`.
 
 ## Attributes Reference

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -83,7 +83,7 @@ The `audit_logs` block supports the following:
    See [Scan EC2 instance with findings](#scan-ec2-instance-with-findings) below for more details.
 
 #### Scan EC2 instance with findings
-The `scan_ec2_instance_with_findings` block supports the following: 
+The `scan_ec2_instance_with_findings` block supports the following:
 
 * `ebs_volumes` - (Required) Configure whether scanning EBS volumes should be auto-enabled for new members joining the organization
   See [EBS volumes](#ebs-volumes) below for more details.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25992

Output from acceptance testing:
~**_Requires update to 1.44.63_** Tested with 1.44.63 draft until sdk is updated~

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccGuardDuty_serial/OrganizationConfiguration' PKG=guardduty ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/guardduty/... -v -count 1 -parallel 2  -run=TestAccGuardDuty_serial/OrganizationConfiguration -timeout 180m
=== RUN   TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/malwareProtection
--- PASS: TestAccGuardDuty_serial (49.00s)
    --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration (49.00s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/malwareProtection (49.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  50.679s
nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccGuardDuty_serial/OrganizationConfiguration' PKG=guardduty ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/guardduty/... -v -count 1 -parallel 2  -run=TestAccGuardDuty_serial/OrganizationConfiguration -timeout 180m
=== RUN   TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/basic
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/s3Logs
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/kubernetes
=== RUN   TestAccGuardDuty_serial/OrganizationConfiguration/malwareProtection
--- PASS: TestAccGuardDuty_serial (124.32s)
    --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration (124.32s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/basic (32.36s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/s3Logs (30.57s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/kubernetes (30.13s)
        --- PASS: TestAccGuardDuty_serial/OrganizationConfiguration/malwareProtection (31.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  126.052s
nick@nick1 terraform-provider-aws % 


...
```
