### PR TITLE
Fixed import example for aws_cognito_identity_pool_roles_attachment

### DIFF
--- a/website/docs/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/docs/r/cognito_identity_pool_roles_attachment.markdown
@@ -128,5 +128,5 @@ In addition to all arguments above, the following attributes are exported:
 Cognito Identity Pool Roles Attachment can be imported using the Identity Pool ID, e.g.,
 
 ```
-$ terraform import aws_cognito_identity_pool_roles_attachment.example us-west-2_abc123
+$ terraform import aws_cognito_identity_pool_roles_attachment.example us-west-2:b64805ad-cb56-40ba-9ffc-f5d8207e6d42
 ```


### PR DESCRIPTION
I noticed that the identity pool ID in the import example for aws_cognito_identity_pool_roles_attachment isn't formatted correctly. It looks more like a user pool ID and doesn't pass the validation for the [GetIdentityPoolRoles](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetIdentityPoolRoles.html#API_GetIdentityPoolRoles_RequestSyntax) API call. I figured I would open a PR since it misled me into trying to use the wrong ID for a good 30 minutes.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
