### PR TITLE
Add AS2 as valid protocol for `aws_transfer_server.protocols`

### DIFF
--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -90,6 +90,7 @@ The following arguments are supported:
 * `certificate` - (Optional) The Amazon Resource Name (ARN) of the AWS Certificate Manager (ACM) certificate. This is required when `protocols` is set to `FTPS`
 * `domain` - (Optional) The domain of the storage system that is used for file transfers. Valid values are: `S3` and `EFS`. The default value is `S3`.
 * `protocols` - (Optional) Specifies the file transfer protocol or protocols over which your file transfer protocol client can connect to your server's endpoint. This defaults to `SFTP` . The available protocols are:
+    * `AS2`: File transfer over Applicability Statement 2
     * `SFTP`: File transfer over SSH
     * `FTPS`: File transfer with TLS encryption
     * `FTP`: Unencrypted file transfer


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26007

Output from acceptance testing: N/a, docs

### Information

AWS [recently added](https://aws.amazon.com/about-aws/whats-new/2022/07/aws-transfer-family-support-applicability-statement-2-as2/) `AS2` as a supported protocol for AWS Transfer Server. This PR updates the `aws_transfer_server` docs to include `AS2` as a valid value in the `protocols` argument.

### References

- `aws_transfer_server.protocols` [uses the `transfer.Protocol_Values()` enum for validation](https://github.com/hashicorp/terraform-provider-aws/blob/7d9e9b84e39904a1a8d35ad6dfb55095851b2cbc/internal/service/transfer/server.go#L176)
- AWS Go SDK `v1.44.63` [adds `AS2` to the `transfer.Protocol_Values()` enum](https://github.com/aws/aws-sdk-go/blob/main/CHANGELOG.md#release-v14463-2022-07-26)
- Dependabot has [already bumped the AWS Go SDK version](https://github.com/hashicorp/terraform-provider-aws/pull/25993), so this will automatically work on next release, when this change will appear as well. 