### PR TITLE
d/aws_networkmanager_core_network_policy_document attachment-policy.action.require-acceptance can only be true or omitted 

### DIFF
--- a/.changelog/26010.txt
+++ b/.changelog/26010.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_networkmanager_core_network_policy_document: Fix bug where bool values for `attachment-policy.action.require-acceptance` can only be `true` or omitted
+```

--- a/internal/service/networkmanager/core_network_policy_document_data_source_test.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source_test.go
@@ -360,8 +360,7 @@ func testAccPolicyDocumentExpectedJSON() string {
       "rule-number": 1,
       "action": {
         "association-method": "tag",
-        "tag-value-of-key": "segment",
-        "require-acceptance": false
+        "tag-value-of-key": "segment"
       },
       "conditions": [
         {
@@ -442,8 +441,7 @@ func testAccPolicyDocumentExpectedJSON() string {
       "rule-number": 72,
       "action": {
         "association-method": "constant",
-        "segment": "GoodSegmentSpecification",
-        "require-acceptance": false
+        "segment": "GoodSegmentSpecification"
       },
       "conditions": [
         {

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -35,7 +35,7 @@ type CoreNetworkAttachmentPolicyAction struct {
 	AssociationMethod string `json:"association-method,omitempty"`
 	Segment           string `json:"segment,omitempty"`
 	TagValueOfKey     string `json:"tag-value-of-key,omitempty"`
-	RequireAcceptance bool   `json:"require-acceptance"`
+	RequireAcceptance bool   `json:"require-acceptance,omitempty"`
 }
 
 type CoreNetworkAttachmentPolicyCondition struct {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26009

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic PKG=networkmanager
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (19.56s)
PASS

...
```
