### PR TITLE
appmesh: added missing nil checks on rewrite configuration properties

### DIFF
--- a/.changelog/26012.txt
+++ b/.changelog/26012.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appmesh_gateway_route: Fix crash when only one of hostname rewrite or path rewrite is configured
+```

--- a/internal/service/appmesh/gateway_route.go
+++ b/internal/service/appmesh/gateway_route.go
@@ -779,7 +779,7 @@ func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []interface{}) *appmesh.Htt
 	mRouteRewrite := vHttpRouteRewrite[0].(map[string]interface{})
 	routeRewrite := &appmesh.HttpGatewayRouteRewrite{}
 
-	if vRouteHostnameRewrite, ok := mRouteRewrite["hostname"].([]interface{}); ok {
+	if vRouteHostnameRewrite, ok := mRouteRewrite["hostname"].([]interface{}); ok && len(vRouteHostnameRewrite) > 0 && vRouteHostnameRewrite[0] != nil {
 		mRouteHostnameRewrite := vRouteHostnameRewrite[0].(map[string]interface{})
 		routeHostnameRewrite := &appmesh.GatewayRouteHostnameRewrite{}
 		if vDefaultTargetHostname, ok := mRouteHostnameRewrite["default_target_hostname"].(string); ok && vDefaultTargetHostname != "" {
@@ -788,7 +788,7 @@ func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []interface{}) *appmesh.Htt
 		routeRewrite.Hostname = routeHostnameRewrite
 	}
 
-	if vRoutePrefixRewrite, ok := mRouteRewrite["prefix"].([]interface{}); ok {
+	if vRoutePrefixRewrite, ok := mRouteRewrite["prefix"].([]interface{}); ok && len(vRoutePrefixRewrite) > 0 && vRoutePrefixRewrite[0] != nil {
 		mRoutePrefixRewrite := vRoutePrefixRewrite[0].(map[string]interface{})
 		routePrefixRewrite := &appmesh.HttpGatewayRoutePrefixRewrite{}
 		if vDefaultPrefix, ok := mRoutePrefixRewrite["default_prefix"].(string); ok && vDefaultPrefix != "" {


### PR DESCRIPTION
fixes the following error when using the app mesh rewrite configuration:
```
Stack trace from the terraform-provider-aws_v4.23.0_x5 plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 403 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/appmesh.expandHTTPGatewayRouteRewrite({0xc0033f4ae0, 0xc002f78bc0, 0xa5dbe7c})
        github.com/hashicorp/terraform-provider-aws/internal/service/appmesh/gateway_route.go:783 +0x3c9
github.com/hashicorp/terraform-provider-aws/internal/service/appmesh.expandHTTPGatewayRoute({0xc0033f4a40, 0xc002f751d0, 0xa5e66c8})
        github.com/hashicorp/terraform-provider-aws/internal/service/appmesh/gateway_route.go:854 +0x195
github.com/hashicorp/terraform-provider-aws/internal/service/appmesh.expandGatewayRouteSpec({0xc0033f4a10, 0xa5d6340, 0xb78d2c0})
        github.com/hashicorp/terraform-provider-aws/internal/service/appmesh/gateway_route.go:709 +0x165
github.com/hashicorp/terraform-provider-aws/internal/service/appmesh.resourceGatewayRouteCreate(0x0, {0x90c5fc0, 0xc000f92000})
        github.com/hashicorp/terraform-provider-aws/internal/service/appmesh/gateway_route.go:498 +0x1bc
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xb78d2c0, {0xb78d2c0, 0xc0024972f0}, 0xd, {0x90c5fc0, 0xc000f92000})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.19.0/helper/schema/resource.go:695 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000bf80e0, {0xb78d2c0, 0xc0024972f0}, 0xc003378820, 0xc00323ff00, {0x90c5fc0, 0xc000f92000})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.19.0/helper/schema/resource.go:837 +0xc29
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc00020c138, {0xb78d2c0, 0xc002497170}, 0xc00327dc20)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.19.0/helper/schema/grpc_provider.go:1021 +0xe3c
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.muxServer.ApplyResourceChange({0xc001b7dc80, 0xc001b7dce0, {0xc002836ee0, 0x2, 0x2}, 0xc001b7dcb0, 0xc001bac9a0, 0xc0023fb1a0, 0xc001b7dd10}, {0xb78d2c0, ...}, ...)
        github.com/hashicorp/terraform-plugin-mux@v0.7.0/tf5muxserver/mux_server_ApplyResourceChange.go:27 +0x142
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0015adcc0, {0xb78d2c0, 0xc002496510}, 0xc003339ea0)
        github.com/hashicorp/terraform-plugin-go@v0.12.0/tfprotov5/tf5server/server.go:813 +0x551
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xa31ec40, 0xc0015adcc0}, {0xb78d2c0, 0xc002496510}, 0xc003339e30, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.12.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00288e1c0, {0xb89f1b0, 0xc00289c680}, 0xc0033659e0, 0xc002887a10, 0x11781500, 0x0)
        google.golang.org/grpc@v1.48.0/server.go:1295 +0xb03
google.golang.org/grpc.(*Server).handleStream(0xc00288e1c0, {0xb89f1b0, 0xc00289c680}, 0xc0033659e0, 0x0)
        google.golang.org/grpc@v1.48.0/server.go:1636 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.48.0/server.go:932 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.48.0/server.go:930 +0x294

Error: The terraform-provider-aws_v4.23.0_x5 plugin crashed!
```

i missed some nil checks in my last [PR](https://github.com/hashicorp/terraform-provider-aws/pull/25819) causing the crash on a configuration with only one of hostname rewrite **or** path rewrite explicitly defined like

```
resource "aws_appmesh_gateway_route" "test" {
  name                 = %[1]q
  mesh_name            = aws_appmesh_mesh.test.name
  virtual_gateway_name = aws_appmesh_virtual_gateway.test.name

  spec {
    http_route {
      action {
        target {
          virtual_service {
            virtual_service_name = aws_appmesh_virtual_service.test[0].name
          }
        }
        rewrite {
          hostname {
            default_target_hostname = "DISABLED"
          }
        }
      }

      match {
        prefix = "/"
      }
    }
  }
}
```
or
```
resource "aws_appmesh_gateway_route" "test" {
  name                 = %[1]q
  mesh_name            = aws_appmesh_mesh.test.name
  virtual_gateway_name = aws_appmesh_virtual_gateway.test.name

  spec {
    http_route {
      action {
        target {
          virtual_service {
            virtual_service_name = aws_appmesh_virtual_service.test[0].name
          }
        }
        rewrite {
          prefix {
            default_prefix = "DISABLED"
          }
        }
      }

      match {
        prefix = "/"
      }
    }
  }
}
```

explicitly set them both works without any issues in the current version
```
resource "aws_appmesh_gateway_route" "test" {
  name                 = %[1]q
  mesh_name            = aws_appmesh_mesh.test.name
  virtual_gateway_name = aws_appmesh_virtual_gateway.test.name

  spec {
    http_route {
      action {
        target {
          virtual_service {
            virtual_service_name = aws_appmesh_virtual_service.test[0].name
          }
        }
        rewrite {
          hostname {
            default_target_hostname = "ENABLED"
          }
          prefix {
            default_prefix = "DISABLED"
          }
        }
      }

      match {
        prefix = "/"
      }
    }
  }
}
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20272

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./internal/service/appmesh/... -v -count 1 -parallel 20 -run='TestAccAppMesh_serial/GatewayRoute'  -timeout 180m
=== RUN   TestAccAppMesh_serial
=== RUN   TestAccAppMesh_serial/GatewayRoute
=== RUN   TestAccAppMesh_serial/GatewayRoute/http2Route
=== RUN   TestAccAppMesh_serial/GatewayRoute/tags
=== RUN   TestAccAppMesh_serial/GatewayRoute/basic
=== RUN   TestAccAppMesh_serial/GatewayRoute/disappears
=== RUN   TestAccAppMesh_serial/GatewayRoute/grpcRoute
=== RUN   TestAccAppMesh_serial/GatewayRoute/httpRoute
--- PASS: TestAccAppMesh_serial (159.89s)
    --- PASS: TestAccAppMesh_serial/GatewayRoute (159.89s)
        --- PASS: TestAccAppMesh_serial/GatewayRoute/http2Route (40.39s)
        --- PASS: TestAccAppMesh_serial/GatewayRoute/tags (31.45s)
        --- PASS: TestAccAppMesh_serial/GatewayRoute/basic (12.78s)
        --- PASS: TestAccAppMesh_serial/GatewayRoute/disappears (12.62s)
        --- PASS: TestAccAppMesh_serial/GatewayRoute/grpcRoute (23.35s)
        --- PASS: TestAccAppMesh_serial/GatewayRoute/httpRoute (39.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appmesh    162.322s

...
```
