### PR TITLE
Set `aws_route53_record` resource example `ttl` properties to all integers

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -19,7 +19,7 @@ resource "aws_route53_record" "www" {
   zone_id = aws_route53_zone.primary.zone_id
   name    = "www.example.com"
   type    = "A"
-  ttl     = "300"
+  ttl     = 300
   records = [aws_eip.lb.public_ip]
 }
 ```
@@ -32,7 +32,7 @@ resource "aws_route53_record" "www-dev" {
   zone_id = aws_route53_zone.primary.zone_id
   name    = "www"
   type    = "CNAME"
-  ttl     = "5"
+  ttl     = 5
 
   weighted_routing_policy {
     weight = 10
@@ -46,7 +46,7 @@ resource "aws_route53_record" "www-live" {
   zone_id = aws_route53_zone.primary.zone_id
   name    = "www"
   type    = "CNAME"
-  ttl     = "5"
+  ttl     = 5
 
   weighted_routing_policy {
     weight = 90
@@ -167,7 +167,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `name` - The name of the record.
 * `fqdn` - [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) built using the zone domain and `name`.
-
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

# Details

Update documentation for `aws_route53_record` - the `ttl` property is always numeric - so update all string usages to be integers for consistency.