### PR TITLE
Correct `aws_rds_global_cluster` 'New MySQL Global Cluster' example

### DIFF
--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -53,6 +53,10 @@ resource "aws_rds_cluster" "secondary" {
   cluster_identifier        = "test-secondary-cluster"
   global_cluster_identifier = aws_rds_global_cluster.example.id
   db_subnet_group_name      = "default"
+
+  depends_on = [
+    aws_rds_cluster_instance.primary
+  ]
 }
 
 resource "aws_rds_cluster_instance" "secondary" {
@@ -63,10 +67,6 @@ resource "aws_rds_cluster_instance" "secondary" {
   cluster_identifier   = aws_rds_cluster.secondary.id
   instance_class       = "db.r4.large"
   db_subnet_group_name = "default"
-
-  depends_on = [
-    aws_rds_cluster_instance.primary
-  ]
 }
 ```
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #26030

Output from acceptance testing: n/a, docs

### Information

This PR aims to fix a dependency issue that caused the following error in the linked issue:

```shell
Error: error creating RDS cluster: InvalidParameterValue: The parameter MasterUsername must be provided and must not be blank.     status code: 400, request id: d2f13469-f46f-4578-bded-4cb6a523b844
  with module.rds.aws_rds_cluster.secondary, 
  on modules\RDS\[main.tf](http://main.tf/) line 38, in resource "aws_rds_cluster" "secondary":
  38: resource "aws_rds_cluster" "secondary" {
```

This was due to the `depends_on` being on the wrong resource (as seen in the example below this one, where the depends on was within `aws_rds_cluster.secondary` rather than `aws_rds_cluster_instance.secondary`).