### PR TITLE
Moves `.goreleaser.yml` back to project root

### DIFF
--- a/.github/workflows/goreleaser-ci.yml
+++ b/.github/workflows/goreleaser-ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/goreleaser-ci.yml
-      - .ci/.goreleaser.yml
+      - .goreleaser.yml
       - .go-version
       - go.sum
       - main.go
@@ -31,7 +31,8 @@ jobs:
           filters: |
             goreleaser:
               - '.github/workflows/goreleaser-ci.yml'
-              - '.ci/.goreleaser.yml'
+              - '.goreleaser.yml'
+
   check:
     needs: changes
     if: ${{ needs.changes.outputs.goreleaser == 'true' }}
@@ -51,6 +52,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           args: check
+
   build-32-bit:
     # Run a single compiler check for 32-bit architecture (FreeBSD/ARM)
     # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/8988

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,8 @@ before:
   hooks:
     - 'go mod download'
 builds:
-  - # Binary naming only required for Terraform CLI 0.12
+  -
+    # Binary naming only required for Terraform CLI 0.12
     binary: '{{ .ProjectName }}_v{{ .Version }}_x5'
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Restores `.goreleaser.yml` to project root to prevent release failures.