### PR TITLE
b-aws_appstream_fleet

### DIFF
--- a/.changelog/26058.txt
+++ b/.changelog/26058.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_fleet: Fix IAM InvalidRoleException error
+```

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -262,6 +262,10 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 				return resource.RetryableError(err)
 			}
 
+			// Retry for IAM eventual consistency on error:
+			if tfawserr.ErrMessageContains(err, appstream.ErrCodeInvalidRoleException, "encountered an error because your IAM role") {
+				return resource.RetryableError(err)
+			}
 			return resource.NonRetryableError(err)
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25388

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppStreamFleet_basic PKG=appstream
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamFleet_basic'  -timeout 180m
=== RUN   TestAccAppStreamFleet_basic
=== PAUSE TestAccAppStreamFleet_basic
=== CONT  TestAccAppStreamFleet_basic
--- PASS: TestAccAppStreamFleet_basic (752.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	754.893s
...
```
