### PR TITLE
r/aws_location_tracker_association: new resource

### DIFF
--- a/.changelog/26061.txt
+++ b/.changelog/26061.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_location_tracker_association
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1681,6 +1681,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_location_place_index":         location.ResourcePlaceIndex(),
 			"aws_location_route_calculator":    location.ResourceRouteCalculator(),
 			"aws_location_tracker":             location.ResourceTracker(),
+			"aws_location_tracker_association": location.ResourceTrackerAssociation(),
 
 			"aws_macie_member_account_association": macie.ResourceMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":      macie.ResourceS3BucketAssociation(),

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -85,12 +85,12 @@ func resourceTrackerAssociationCreate(ctx context.Context, d *schema.ResourceDat
 func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LocationConn
 
-	trackerAssociationId, err := TrackerAssociationParseId(d.Id())
+	trackerAssociationId, err := TrackerAssociationParseID(d.Id())
 	if err != nil {
 		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
-	err = FindTrackerAssociationByTrackerNameAndConsumerArn(ctx, conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerArn)
+	err = FindTrackerAssociationByTrackerNameAndConsumerARN(ctx, conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Location TrackerAssociation (%s) not found, removing from state", d.Id())
@@ -102,7 +102,7 @@ func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData,
 		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
-	d.Set("consumer_arn", trackerAssociationId.ConsumerArn)
+	d.Set("consumer_arn", trackerAssociationId.ConsumerARN)
 	d.Set("tracker_name", trackerAssociationId.TrackerName)
 
 	return nil
@@ -113,13 +113,13 @@ func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[INFO] Deleting Location TrackerAssociation %s", d.Id())
 
-	trackerAssociationId, err := TrackerAssociationParseId(d.Id())
+	trackerAssociationId, err := TrackerAssociationParseID(d.Id())
 	if err != nil {
 		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	_, err = conn.DisassociateTrackerConsumerWithContext(ctx, &locationservice.DisassociateTrackerConsumerInput{
-		ConsumerArn: aws.String(trackerAssociationId.ConsumerArn),
+		ConsumerArn: aws.String(trackerAssociationId.ConsumerARN),
 		TrackerName: aws.String(trackerAssociationId.TrackerName),
 	})
 
@@ -134,8 +134,8 @@ func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-// FindTrackerAssociationByTrackerNameAndConsumerArn returns an error if an association for specified tracker and consumer cannot be found
-func FindTrackerAssociationByTrackerNameAndConsumerArn(ctx context.Context, conn *locationservice.LocationService, trackerName, consumerArn string) error {
+// FindTrackerAssociationByTrackerNameAndConsumerARN returns an error if an association for specified tracker and consumer cannot be found
+func FindTrackerAssociationByTrackerNameAndConsumerARN(ctx context.Context, conn *locationservice.LocationService, trackerName, consumerARN string) error {
 	in := &locationservice.ListTrackerConsumersInput{
 		TrackerName: aws.String(trackerName),
 	}
@@ -147,7 +147,7 @@ func FindTrackerAssociationByTrackerNameAndConsumerArn(ctx context.Context, conn
 		}
 
 		for _, arn := range page.ConsumerArns {
-			if aws.StringValue(arn) == consumerArn {
+			if aws.StringValue(arn) == consumerARN {
 				found = true
 				return false
 			}
@@ -169,16 +169,16 @@ func FindTrackerAssociationByTrackerNameAndConsumerArn(ctx context.Context, conn
 	return nil
 }
 
-type TrackerAssociationId struct {
+type TrackerAssociationID struct {
 	TrackerName string
-	ConsumerArn string
+	ConsumerARN string
 }
 
-func TrackerAssociationParseId(id string) (TrackerAssociationId, error) {
+func TrackerAssociationParseID(id string) (TrackerAssociationID, error) {
 	idParts := strings.Split(id, "|")
 	if len(idParts) != 2 {
-		return TrackerAssociationId{}, fmt.Errorf("please make sure the ID is in the form TRACKERNAME|CONSUMERARN")
+		return TrackerAssociationID{}, fmt.Errorf("please make sure the ID is in the form TRACKERNAME|CONSUMERARN")
 	}
 
-	return TrackerAssociationId{idParts[0], idParts[1]}, nil
+	return TrackerAssociationID{idParts[0], idParts[1]}, nil
 }

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -70,11 +71,11 @@ func resourceTrackerAssociationCreate(ctx context.Context, d *schema.ResourceDat
 
 	out, err := conn.AssociateTrackerConsumerWithContext(ctx, in)
 	if err != nil {
-		return names.DiagError(names.Location, names.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), err)
+		return create.DiagError(names.Location, create.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), err)
 	}
 
 	if out == nil {
-		return names.DiagError(names.Location, names.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), errors.New("empty output"))
+		return create.DiagError(names.Location, create.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s", trackerName, consumerArn))
@@ -87,7 +88,7 @@ func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData,
 
 	trackerAssociationId, err := TrackerAssociationParseID(d.Id())
 	if err != nil {
-		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+		return create.DiagError(names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	err = FindTrackerAssociationByTrackerNameAndConsumerARN(ctx, conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
@@ -99,7 +100,7 @@ func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+		return create.DiagError(names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	d.Set("consumer_arn", trackerAssociationId.ConsumerARN)
@@ -115,7 +116,7 @@ func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceDat
 
 	trackerAssociationId, err := TrackerAssociationParseID(d.Id())
 	if err != nil {
-		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+		return create.DiagError(names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	_, err = conn.DisassociateTrackerConsumerWithContext(ctx, &locationservice.DisassociateTrackerConsumerInput{
@@ -128,7 +129,7 @@ func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return names.DiagError(names.Location, names.ErrActionDeleting, ResNameTrackerAssociation, d.Id(), err)
+		return create.DiagError(names.Location, create.ErrActionDeleting, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -33,7 +33,6 @@ func ResourceTrackerAssociation() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -1,0 +1,185 @@
+package location
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceTrackerAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTrackerAssociationCreate,
+		ReadContext:   resourceTrackerAssociationRead,
+		DeleteContext: resourceTrackerAssociationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"consumer_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"tracker_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+		},
+	}
+}
+
+const (
+	ResNameTrackerAssociation = "Tracker Association"
+)
+
+func resourceTrackerAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	consumerArn := d.Get("consumer_arn").(string)
+	trackerName := d.Get("tracker_name").(string)
+
+	in := &locationservice.AssociateTrackerConsumerInput{
+		ConsumerArn: aws.String(consumerArn),
+		TrackerName: aws.String(trackerName),
+	}
+
+	out, err := conn.AssociateTrackerConsumerWithContext(ctx, in)
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return names.DiagError(names.Location, names.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(fmt.Sprintf("%s|%s", trackerName, consumerArn))
+
+	return resourceTrackerAssociationRead(ctx, d, meta)
+}
+
+func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	trackerAssociationId, err := TrackerAssociationParseId(d.Id())
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+	}
+
+	err = FindTrackerAssociationByTrackerNameAndConsumerArn(ctx, conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerArn)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Location TrackerAssociation (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+	}
+
+	d.Set("consumer_arn", trackerAssociationId.ConsumerArn)
+	d.Set("tracker_name", trackerAssociationId.TrackerName)
+
+	return nil
+}
+
+func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	log.Printf("[INFO] Deleting Location TrackerAssociation %s", d.Id())
+
+	trackerAssociationId, err := TrackerAssociationParseId(d.Id())
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+	}
+
+	_, err = conn.DisassociateTrackerConsumerWithContext(ctx, &locationservice.DisassociateTrackerConsumerInput{
+		ConsumerArn: aws.String(trackerAssociationId.ConsumerArn),
+		TrackerName: aws.String(trackerAssociationId.TrackerName),
+	})
+
+	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return names.DiagError(names.Location, names.ErrActionDeleting, ResNameTrackerAssociation, d.Id(), err)
+	}
+
+	return nil
+}
+
+// FindTrackerAssociationByTrackerNameAndConsumerArn returns an error if an association for specified tracker and consumer cannot be found
+func FindTrackerAssociationByTrackerNameAndConsumerArn(ctx context.Context, conn *locationservice.LocationService, trackerName, consumerArn string) error {
+	in := &locationservice.ListTrackerConsumersInput{
+		TrackerName: aws.String(trackerName),
+	}
+
+	found := false
+	fn := func(page *locationservice.ListTrackerConsumersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, arn := range page.ConsumerArns {
+			if aws.StringValue(arn) == consumerArn {
+				found = true
+				return false
+			}
+		}
+
+		return !lastPage
+	}
+
+	err := conn.ListTrackerConsumersPagesWithContext(ctx, in, fn)
+
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return &resource.NotFoundError{}
+	}
+
+	return nil
+}
+
+type TrackerAssociationId struct {
+	TrackerName string
+	ConsumerArn string
+}
+
+func TrackerAssociationParseId(id string) (TrackerAssociationId, error) {
+	idParts := strings.Split(id, "|")
+	if len(idParts) != 2 {
+		return TrackerAssociationId{}, fmt.Errorf("please make sure the ID is in the form TRACKERNAME|CONSUMERARN")
+	}
+
+	return TrackerAssociationId{idParts[0], idParts[1]}, nil
+}

--- a/internal/service/location/tracker_association_test.go
+++ b/internal/service/location/tracker_association_test.go
@@ -1,0 +1,195 @@
+package location_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestTrackerAssociationParseId(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected tflocation.TrackerAssociationId
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: tflocation.TrackerAssociationId{},
+			Error:    true,
+		},
+		{
+			TestName: "no pipe",
+			Input:    "trackerNameConsumerArn",
+			Expected: tflocation.TrackerAssociationId{},
+			Error:    true,
+		},
+		{
+			TestName: "valid",
+			Input:    "trackerName|consumerArn",
+			Expected: tflocation.TrackerAssociationId{
+				TrackerName: "trackerName",
+				ConsumerArn: "consumerArn",
+			},
+			Error: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tflocation.TrackerAssociationParseId(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestAccLocationTrackerAssociation_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_tracker_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrackerAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "consumer_arn", "aws_location_geofence_collection.test", "collection_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "tracker_name", "aws_location_tracker.test", "tracker_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationTrackerAssociation_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_location_tracker_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTrackerAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerAssociationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tflocation.ResourceTrackerAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTrackerAssociationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_location_tracker_association" {
+			continue
+		}
+
+		trackerAssociationId, err := tflocation.TrackerAssociationParseId(rs.Primary.ID)
+
+		if err != nil {
+			return names.Error(names.Location, names.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
+		}
+
+		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerArn(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerArn)
+
+		if err != nil {
+			if tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
+				return nil
+			}
+			return err
+		}
+
+		return names.Error(names.Location, names.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckTrackerAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not set"))
+		}
+
+		trackerAssociationId, err := tflocation.TrackerAssociationParseId(rs.Primary.ID)
+
+		if err != nil {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, err)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
+
+		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerArn(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerArn)
+
+		if err != nil {
+			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccTrackerAssociationConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+  collection_name = %[1]q
+}
+
+resource "aws_location_tracker" "test" {
+  tracker_name = %[1]q
+}
+
+resource "aws_location_tracker_association" "test" {
+  consumer_arn = aws_location_geofence_collection.test.collection_arn
+  tracker_name = aws_location_tracker.test.tracker_name
+}
+`, rName)
+}

--- a/internal/service/location/tracker_association_test.go
+++ b/internal/service/location/tracker_association_test.go
@@ -18,31 +18,31 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestTrackerAssociationParseId(t *testing.T) {
+func TestTrackerAssociationParseID(t *testing.T) {
 	testCases := []struct {
 		TestName string
 		Input    string
-		Expected tflocation.TrackerAssociationId
+		Expected tflocation.TrackerAssociationID
 		Error    bool
 	}{
 		{
 			TestName: "empty",
 			Input:    "",
-			Expected: tflocation.TrackerAssociationId{},
+			Expected: tflocation.TrackerAssociationID{},
 			Error:    true,
 		},
 		{
 			TestName: "no pipe",
-			Input:    "trackerNameConsumerArn",
-			Expected: tflocation.TrackerAssociationId{},
+			Input:    "trackerNameConsumerARN",
+			Expected: tflocation.TrackerAssociationID{},
 			Error:    true,
 		},
 		{
 			TestName: "valid",
-			Input:    "trackerName|consumerArn",
-			Expected: tflocation.TrackerAssociationId{
+			Input:    "trackerName|consumerARN",
+			Expected: tflocation.TrackerAssociationID{
 				TrackerName: "trackerName",
-				ConsumerArn: "consumerArn",
+				ConsumerARN: "consumerARN",
 			},
 			Error: false,
 		},
@@ -53,7 +53,7 @@ func TestTrackerAssociationParseId(t *testing.T) {
 		t.Run(testCase.TestName, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := tflocation.TrackerAssociationParseId(testCase.Input)
+			got, err := tflocation.TrackerAssociationParseID(testCase.Input)
 
 			if err != nil && !testCase.Error {
 				t.Errorf("got error (%s), expected no error", err)
@@ -127,13 +127,13 @@ func testAccCheckTrackerAssociationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		trackerAssociationId, err := tflocation.TrackerAssociationParseId(rs.Primary.ID)
+		trackerAssociationId, err := tflocation.TrackerAssociationParseID(rs.Primary.ID)
 
 		if err != nil {
 			return names.Error(names.Location, names.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
 		}
 
-		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerArn(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerArn)
+		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
 
 		if err != nil {
 			if tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
@@ -159,7 +159,7 @@ func testAccCheckTrackerAssociationExists(name string) resource.TestCheckFunc {
 			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not set"))
 		}
 
-		trackerAssociationId, err := tflocation.TrackerAssociationParseId(rs.Primary.ID)
+		trackerAssociationId, err := tflocation.TrackerAssociationParseID(rs.Primary.ID)
 
 		if err != nil {
 			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, err)
@@ -167,7 +167,7 @@ func testAccCheckTrackerAssociationExists(name string) resource.TestCheckFunc {
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
 
-		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerArn(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerArn)
+		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
 
 		if err != nil {
 			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)

--- a/internal/service/location/tracker_association_test.go
+++ b/internal/service/location/tracker_association_test.go
@@ -75,10 +75,10 @@ func TestAccLocationTrackerAssociation_basic(t *testing.T) {
 	resourceName := "aws_location_tracker_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckTrackerAssociationDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrackerAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTrackerAssociationConfig_basic(rName),
@@ -102,10 +102,10 @@ func TestAccLocationTrackerAssociation_disappears(t *testing.T) {
 	resourceName := "aws_location_tracker_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, locationservice.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckTrackerAssociationDestroy,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrackerAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTrackerAssociationConfig_basic(rName),

--- a/internal/service/location/tracker_association_test.go
+++ b/internal/service/location/tracker_association_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -130,10 +131,10 @@ func testAccCheckTrackerAssociationDestroy(s *terraform.State) error {
 		trackerAssociationId, err := tflocation.TrackerAssociationParseID(rs.Primary.ID)
 
 		if err != nil {
-			return names.Error(names.Location, names.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
+			return create.Error(names.Location, create.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
 		}
 
-		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
+		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.Background(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
 
 		if err != nil {
 			if tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
@@ -142,7 +143,7 @@ func testAccCheckTrackerAssociationDestroy(s *terraform.State) error {
 			return err
 		}
 
-		return names.Error(names.Location, names.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, errors.New("not destroyed"))
+		return create.Error(names.Location, create.ErrActionCheckingDestroyed, tflocation.ResNameTrackerAssociation, rs.Primary.ID, errors.New("not destroyed"))
 	}
 
 	return nil
@@ -152,17 +153,17 @@ func testAccCheckTrackerAssociationExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not found"))
+			return create.Error(names.Location, create.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not found"))
 		}
 
 		if rs.Primary.ID == "" {
-			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not set"))
+			return create.Error(names.Location, create.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, errors.New("not set"))
 		}
 
 		trackerAssociationId, err := tflocation.TrackerAssociationParseID(rs.Primary.ID)
 
 		if err != nil {
-			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, err)
+			return create.Error(names.Location, create.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, name, err)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
@@ -170,7 +171,7 @@ func testAccCheckTrackerAssociationExists(name string) resource.TestCheckFunc {
 		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
 
 		if err != nil {
-			return names.Error(names.Location, names.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
+			return create.Error(names.Location, create.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)
 		}
 
 		return nil

--- a/website/docs/r/location_tracker_association.html.markdown
+++ b/website/docs/r/location_tracker_association.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_tracker_association"
+description: |-
+  Terraform resource for managing an AWS Location Tracker Association.
+---
+
+# Resource: aws_location_tracker_association
+
+Terraform resource for managing an AWS Location Tracker Association.
+
+## Example Usage
+
+```terraform
+resource "aws_location_geofence_collection" "example" {
+  collection_name = "example"
+}
+
+resource "aws_location_tracker" "example" {
+  tracker_name = "example"
+}
+
+resource "aws_location_tracker_association" "example" {
+  consumer_arn = aws_location_geofence_collection.example.collection_arn
+  tracker_name = aws_location_tracker.example.tracker_name
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `consumer_arn` - (Required) The Amazon Resource Name (ARN) for the geofence collection to be associated to tracker resource. Used when you need to specify a resource across all AWS.
+* `tracker_name` - (Required) The name of the tracker resource to be associated with a geofence collection.
+
+## Timeouts
+
+`aws_location_tracker_association` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Optional, Default: `30m`)
+* `delete` - (Optional, Default: `30m`)
+
+## Import
+
+Location Tracker Association can be imported using the `tracker_name|consumer_arn`, e.g.,
+
+```
+$ terraform import aws_location_tracker_association.example "tracker_name|consumer_arn"
+```

--- a/website/docs/r/location_tracker_association.html.markdown
+++ b/website/docs/r/location_tracker_association.html.markdown
@@ -34,6 +34,10 @@ The following arguments are required:
 * `consumer_arn` - (Required) The Amazon Resource Name (ARN) for the geofence collection to be associated to tracker resource. Used when you need to specify a resource across all AWS.
 * `tracker_name` - (Required) The name of the tracker resource to be associated with a geofence collection.
 
+## Attributes Reference
+
+No additional attributes are exported.
+
 ## Timeouts
 
 `aws_location_tracker_association` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationTrackerAssociation_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationTrackerAssociation_'  -timeout 180m
=== RUN   TestAccLocationTrackerAssociation_basic
=== PAUSE TestAccLocationTrackerAssociation_basic
=== RUN   TestAccLocationTrackerAssociation_disappears
=== PAUSE TestAccLocationTrackerAssociation_disappears
=== CONT  TestAccLocationTrackerAssociation_basic
=== CONT  TestAccLocationTrackerAssociation_disappears
--- PASS: TestAccLocationTrackerAssociation_disappears (25.01s)
--- PASS: TestAccLocationTrackerAssociation_basic (29.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   31.114s
```
```
TEST=./internal/service/location TESTARGS="-run=TestTrackerAssociationParseId" make test
==> Checking that code complies with gofmt requirements...
go test ./internal/service/location -run=TestTrackerAssociationParseId -timeout=5m
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   (cached)
```
