### PR TITLE
Run `go mod tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.12.0
+	github.com/hashicorp/terraform-plugin-log v0.6.0
 	github.com/hashicorp/terraform-plugin-mux v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
@@ -66,7 +67,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.17.2 // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.6.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #26027.

Fixes [for example](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true):

```
==> Checking source code with go mod tidy...
go: downloading github.com/hashicorp/terraform-plugin-go v0.12.0
go: downloading github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
go: downloading github.com/aws/aws-sdk-go v1.44.63
go: downloading github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.17
go: downloading github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.16
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.8
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.12.8
go: downloading github.com/aws/aws-sdk-go-v2 v1.16.7
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.12.8
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.0
go: downloading github.com/mitchellh/go-testing-interface v1.14.1
go: downloading golang.org/x/tools v0.1.9
go: downloading github.com/hashicorp/hcl/v2 v2.13.0
go: downloading github.com/hashicorp/terraform-plugin-framework v0.[10](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:11).0
go: downloading github.com/google/go-cmp v0.5.8
go: downloading github.com/hashicorp/terraform-plugin-mux v0.7.0
go: downloading github.com/hashicorp/go-multierror v1.1.1
go: downloading github.com/hashicorp/awspolicyequivalence v1.6.0
go: downloading github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
go: downloading github.com/shopspring/decimal v1.3.1
go: downloading github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.17.0
go: downloading github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/mitchellh/copystructure v1.2.0
go: downloading github.com/hashicorp/go-version v1.6.0
go: downloading golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
go: downloading github.com/pquerna/otp v1.3.0
go: downloading github.com/hashicorp/go-hclog v1.2.1
go: downloading github.com/hashicorp/go-plugin v1.4.4
go: downloading github.com/hashicorp/terraform-plugin-log v0.6.0
go: downloading google.golang.org/grpc v1.48.0
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/mitchellh/mapstructure v1.5.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/apparentlymart/go-cidr v1.1.0
go: downloading github.com/hashicorp/terraform-exec v0.17.2
go: downloading github.com/hashicorp/terraform-json v0.14.0
go: downloading github.com/hashicorp/go-uuid v1.0.3
go: downloading github.com/mitchellh/reflectwalk v1.0.2
go: downloading github.com/aws/smithy-go v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.14
go: downloading golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
go: downloading github.com/aws/aws-sdk-go-v2/config v1.15.4
go: downloading github.com/hashicorp/go-cleanhttp v0.5.2
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.16.4
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.18.4
go: downloading github.com/vmihailenco/msgpack/v4 v4.3.12
go: downloading github.com/vmihailenco/msgpack v4.0.4+incompatible
go: downloading github.com/beevik/etree v1.1.0
go: downloading github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
go: downloading github.com/hashicorp/errwrap v1.1.0
go: downloading golang.org/x/text v0.3.7
go: downloading github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
go: downloading github.com/xeipuuv/gojsonschema v1.2.0
go: downloading github.com/evanphx/json-patch v0.5.2
go: downloading github.com/stretchr/testify v1.7.2
go: downloading golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading github.com/fatih/color v1.13.0
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading github.com/golang/protobuf v1.5.2
go: downloading github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
go: downloading github.com/oklog/run v1.0.0
go: downloading github.com/jhump/protoreflect v1.6.0
go: downloading github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
go: downloading google.golang.org/protobuf v1.28.0
go: downloading gopkg.in/check.v1 v1.0.0-2020[11](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:12)30134442-10cb98267c6c
go: downloading github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
go: downloading github.com/hashicorp/hc-install v0.4.0
go: downloading github.com/zclconf/go-cty v1.10.0
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.8
go: downloading github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.11.4
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4
go: downloading github.com/agext/levenshtein v1.2.2
go: downloading github.com/apparentlymart/go-textseg/v13 v13.0.0
go: downloading github.com/mitchellh/go-wordwrap v1.0.0
go: downloading github.com/go-test/deep v1.0.3
go: downloading github.com/kr/pretty v0.2.1
go: downloading github.com/kylelemons/godebug v1.1.0
go: downloading github.com/vmihailenco/tagparser v0.1.1
go: downloading google.golang.org/appengine v1.6.6
go: downloading github.com/xeipuuv/gojsonreference v0.0.0-20180[12](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:13)7040603-bd5ef7bd5415
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading golang.org/x/mod v0.5.1
go: downloading github.com/boombuler/barcode v1.0.1-0.20190219062509-6c8245[13](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:14)bacc
go: downloading github.com/jmespath/go-jmespath/internal/testify v1.5.1
go: downloading google.golang.org/genproto v0.0.0-2020071102[14](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:15)54-869866162049
go: downloading github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
go: downloading golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
go: downloading github.com/hashicorp/logutils v1.0.0
go: downloading github.com/hashicorp/go-checkpoint v0.5.0
go: downloading github.com/sergi/go-diff v1.2.0
go: downloading github.com/kr/text v0.2.0
go: downloading github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
go: downloading github.com/go-git/go-git/v5 v5.4.2
go: downloading github.com/go-git/go-billy/v5 v5.3.1
go: downloading github.com/imdario/mergo v0.3.12
go: downloading github.com/emirpasic/gods v1.12.0
go: downloading github.com/acomagu/bufpipe v1.0.3
go: downloading github.com/jbenet/go-context v0.0.0-20[15](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:16)0711004518-d14ea06fba99
go: downloading github.com/go-git/gcfg v1.5.0
go: downloading github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351
go: downloading github.com/xanzy/ssh-agent v0.3.0
go: downloading gopkg.in/warnings.v0 v0.1.2
go: downloading github.com/Microsoft/go-winio v0.4.[16](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:17)
diff --git a/go.mod b/go.mod
index 25cfe84..ca49355 100644
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.12.0
+	github.com/hashicorp/terraform-plugin-log v0.6.0
 	github.com/hashicorp/terraform-plugin-mux v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
@@ -66,7 +67,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.[17](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:18).2 // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.6.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20[18](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:19)1012175058-2f1d1f[20](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:21)f[75](https://github.com/hashicorp/terraform-provider-aws/runs/7612547469?check_suite_focus=true#step:4:76)d // indirect

Unexpected difference in go.mod/go.sum files. Run 'go mod tidy' command or revert any go.mod/go.sum changes and commit.
```