### PR TITLE
r/iam_role_policy: add plan time validation to role argument

### DIFF
--- a/.changelog/26082.txt
+++ b/.changelog/26082.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_role_policy: Add plan time validation to `role` argument
+```

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -56,9 +56,10 @@ func ResourceRolePolicy() *schema.Resource {
 				ValidateFunc:  validResourceName(rolePolicyNamePrefixMaxLen),
 			},
 			"role": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validRolePolicyRole,
 			},
 		},
 	}

--- a/internal/service/iam/validate.go
+++ b/internal/service/iam/validate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 var validRolePolicyName = validResourceName(rolePolicyNameMaxLen)
@@ -45,6 +46,17 @@ var validOpenIDURL = validation.All(
 		}
 		if len(u.Query()) > 0 {
 			es = append(es, fmt.Errorf("%q cannot contain query parameters per the OIDC standard", k))
+		}
+		return
+	},
+)
+
+var validRolePolicyRole = validation.All(
+	validation.StringLenBetween(1, 128),
+	validation.StringMatch(regexp.MustCompile(`[\w+=,.@-]+`), ""),
+	func(v interface{}, k string) (ws []string, es []error) {
+		if _, errs := verify.ValidARN(v, k); len(errs) == 0 {
+			es = append(es, fmt.Errorf("%q must be the role's name not its ARN", k))
 		}
 		return
 	},

--- a/internal/service/iam/validate_test.go
+++ b/internal/service/iam/validate_test.go
@@ -92,3 +92,29 @@ func TestValidOpenIDURL(t *testing.T) {
 		}
 	}
 }
+
+func TestValidRolePolicyRoleName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value: "S3Access",
+		},
+		{
+			Value: "role/S3Access",
+		},
+		{
+			Value:    "arn:aws:iam::123456789012:role/S3Access",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validRolePolicyRole(tc.Value, "role")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d Role Policy role name validation errors, got %d", tc.ErrCount, len(errors))
+		}
+	}
+}

--- a/internal/service/iam/validate_test.go
+++ b/internal/service/iam/validate_test.go
@@ -105,7 +105,7 @@ func TestValidRolePolicyRoleName(t *testing.T) {
 			Value: "role/S3Access",
 		},
 		{
-			Value:    "arn:aws:iam::123456789012:role/S3Access",
+			Value:    "arn:aws:iam::123456789012:role/S3Access", // lintignore:AWSAT005
 			ErrCount: 1,
 		},
 	}

--- a/website/docs/r/iam_role_policy.html.markdown
+++ b/website/docs/r/iam_role_policy.html.markdown
@@ -63,7 +63,7 @@ assign a random, unique name.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified
   prefix. Conflicts with `name`.
 * `policy` - (Required) The inline policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy)
-* `role` - (Required) The IAM role to attach to the policy.
+* `role` - (Required) The name of the IAM role to attach to the policy.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/26081

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIAMRolePolicy_' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20  -run=TestAccIAMRolePolicy_ -timeout 180m
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_disappears
=== PAUSE TestAccIAMRolePolicy_disappears
=== RUN   TestAccIAMRolePolicy_policyOrder
=== PAUSE TestAccIAMRolePolicy_policyOrder
=== RUN   TestAccIAMRolePolicy_namePrefix
=== PAUSE TestAccIAMRolePolicy_namePrefix
=== RUN   TestAccIAMRolePolicy_generatedName
=== PAUSE TestAccIAMRolePolicy_generatedName
=== RUN   TestAccIAMRolePolicy_invalidJSON
=== PAUSE TestAccIAMRolePolicy_invalidJSON
=== RUN   TestAccIAMRolePolicy_Policy_invalidResource
=== PAUSE TestAccIAMRolePolicy_Policy_invalidResource
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicy_generatedName
=== CONT  TestAccIAMRolePolicy_namePrefix
=== CONT  TestAccIAMRolePolicy_disappears
=== CONT  TestAccIAMRolePolicy_invalidJSON
=== CONT  TestAccIAMRolePolicy_policyOrder
=== CONT  TestAccIAMRolePolicy_Policy_invalidResource
--- PASS: TestAccIAMRolePolicy_invalidJSON (3.40s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (10.97s)
--- PASS: TestAccIAMRolePolicy_disappears (17.68s)
--- PASS: TestAccIAMRolePolicy_policyOrder (25.71s)
--- PASS: TestAccIAMRolePolicy_namePrefix (31.85s)
--- PASS: TestAccIAMRolePolicy_generatedName (31.90s)
--- PASS: TestAccIAMRolePolicy_basic (31.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	35.626s
```
