### PR TITLE
Avoid use of the `aws_arn` data source in the provider's own acceptance tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1209,11 +1209,12 @@ provider "aws" {
 }
 
 const testAccProviderConfigBase = `
-data "aws_partition" "provider_test" {}
+data "aws_region" "provider_test" {}
 
-# Required to initialize the provider
-data "aws_arn" "test" {
-  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
+# Required to initialize the provider.
+data "aws_service" "provider_test" {
+  region     = data.aws_region.provider_test.name
+  service_id = "s3"
 }
 `
 

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -912,11 +912,12 @@ data "aws_caller_identity" "current" {}
 ` //lintignore:AT004
 
 const testAccProviderConfigBase = `
-data "aws_partition" "provider_test" {}
+data "aws_region" "provider_test" {}
 
-# Required to initialize the provider
-data "aws_arn" "test" {
-  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
+# Required to initialize the provider.
+data "aws_service" "provider_test" {
+  region     = data.aws_region.provider_test.name
+  service_id = "s3"
 }
 `
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26098.

```console
% make testacc TESTARGS='-run=TestAccProvider_' PKG_NAME=internal/acctest ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/acctest/... -v -count 1 -parallel 3  -run=TestAccProvider_ -timeout 180m
=== RUN   TestAccProvider_DefaultTags_emptyBlock
=== PAUSE TestAccProvider_DefaultTags_emptyBlock
=== RUN   TestAccProvider_DefaultTagsTags_none
=== PAUSE TestAccProvider_DefaultTagsTags_none
=== RUN   TestAccProvider_DefaultTagsTags_one
=== PAUSE TestAccProvider_DefaultTagsTags_one
=== RUN   TestAccProvider_DefaultTagsTags_multiple
=== PAUSE TestAccProvider_DefaultTagsTags_multiple
=== RUN   TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== PAUSE TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== RUN   TestAccProvider_endpoints
=== PAUSE TestAccProvider_endpoints
=== RUN   TestAccProvider_fipsEndpoint
=== PAUSE TestAccProvider_fipsEndpoint
=== RUN   TestAccProvider_unusualEndpoints
=== PAUSE TestAccProvider_unusualEndpoints
=== RUN   TestAccProvider_IgnoreTags_emptyBlock
=== PAUSE TestAccProvider_IgnoreTags_emptyBlock
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_none
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_none
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_one
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_one
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== RUN   TestAccProvider_IgnoreTagsKeys_none
=== PAUSE TestAccProvider_IgnoreTagsKeys_none
=== RUN   TestAccProvider_IgnoreTagsKeys_one
=== PAUSE TestAccProvider_IgnoreTagsKeys_one
=== RUN   TestAccProvider_IgnoreTagsKeys_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeys_multiple
=== RUN   TestAccProvider_Region_c2s
=== PAUSE TestAccProvider_Region_c2s
=== RUN   TestAccProvider_Region_china
=== PAUSE TestAccProvider_Region_china
=== RUN   TestAccProvider_Region_commercial
=== PAUSE TestAccProvider_Region_commercial
=== RUN   TestAccProvider_Region_govCloud
=== PAUSE TestAccProvider_Region_govCloud
=== RUN   TestAccProvider_Region_sc2s
=== PAUSE TestAccProvider_Region_sc2s
=== RUN   TestAccProvider_Region_stsRegion
=== PAUSE TestAccProvider_Region_stsRegion
=== RUN   TestAccProvider_AssumeRole_empty
=== PAUSE TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_DefaultTags_emptyBlock
=== CONT  TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_Region_stsRegion
--- PASS: TestAccProvider_Region_stsRegion (8.49s)
=== CONT  TestAccProvider_Region_sc2s
--- PASS: TestAccProvider_DefaultTags_emptyBlock (10.88s)
=== CONT  TestAccProvider_Region_govCloud
--- PASS: TestAccProvider_Region_sc2s (7.25s)
=== CONT  TestAccProvider_Region_commercial
--- PASS: TestAccProvider_AssumeRole_empty (17.35s)
=== CONT  TestAccProvider_Region_china
--- PASS: TestAccProvider_Region_govCloud (7.49s)
=== CONT  TestAccProvider_Region_c2s
--- PASS: TestAccProvider_Region_commercial (8.36s)
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
--- PASS: TestAccProvider_Region_china (8.63s)
=== CONT  TestAccProvider_IgnoreTagsKeys_one
--- PASS: TestAccProvider_Region_c2s (9.07s)
=== CONT  TestAccProvider_IgnoreTagsKeys_none
--- PASS: TestAccProvider_IgnoreTagsKeys_multiple (11.07s)
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
--- PASS: TestAccProvider_IgnoreTagsKeys_one (10.67s)
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
--- PASS: TestAccProvider_IgnoreTagsKeys_none (10.41s)
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_multiple (10.85s)
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_one (11.03s)
=== CONT  TestAccProvider_unusualEndpoints
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_none (11.18s)
=== CONT  TestAccProvider_fipsEndpoint
--- PASS: TestAccProvider_IgnoreTags_emptyBlock (10.31s)
=== CONT  TestAccProvider_endpoints
--- PASS: TestAccProvider_unusualEndpoints (10.44s)
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
--- PASS: TestAccProvider_endpoints (10.21s)
=== CONT  TestAccProvider_DefaultTagsTags_multiple
--- PASS: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (9.13s)
=== CONT  TestAccProvider_DefaultTagsTags_one
--- PASS: TestAccProvider_DefaultTagsTags_multiple (8.11s)
=== CONT  TestAccProvider_DefaultTagsTags_none
--- PASS: TestAccProvider_DefaultTagsTags_one (8.35s)
--- PASS: TestAccProvider_DefaultTagsTags_none (7.85s)
--- PASS: TestAccProvider_fipsEndpoint (43.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	98.773s
% go test -v ./internal/acctest 
=== RUN   TestTLSRSAPrivateKeyPEM
--- PASS: TestTLSRSAPrivateKeyPEM (0.40s)
=== RUN   TestTLSRSAPublicKeyPEM
--- PASS: TestTLSRSAPublicKeyPEM (0.21s)
=== RUN   TestTLSRSAX509LocallySignedCertificatePEM
--- PASS: TestTLSRSAX509LocallySignedCertificatePEM (0.40s)
=== RUN   TestTLSRSAX509SelfSignedCACertificatePEM
--- PASS: TestTLSRSAX509SelfSignedCACertificatePEM (0.25s)
=== RUN   TestTLSRSAX509SelfSignedCertificatePEM
--- PASS: TestTLSRSAX509SelfSignedCertificatePEM (0.22s)
=== RUN   TestTLSRSAX509CertificateRequestPEM
--- PASS: TestTLSRSAX509CertificateRequestPEM (0.29s)
=== RUN   TestProvider
--- PASS: TestProvider (0.21s)
=== RUN   TestReverseDNS
=== RUN   TestReverseDNS/empty
=== RUN   TestReverseDNS/amazonaws.com
=== RUN   TestReverseDNS/amazonaws.com.cn
=== RUN   TestReverseDNS/sc2s.sgov.gov
=== RUN   TestReverseDNS/c2s.ic.gov
--- PASS: TestReverseDNS (0.00s)
    --- PASS: TestReverseDNS/empty (0.00s)
    --- PASS: TestReverseDNS/amazonaws.com (0.00s)
    --- PASS: TestReverseDNS/amazonaws.com.cn (0.00s)
    --- PASS: TestReverseDNS/sc2s.sgov.gov (0.00s)
    --- PASS: TestReverseDNS/c2s.ic.gov (0.00s)
=== RUN   TestAccProvider_DefaultTags_emptyBlock
=== PAUSE TestAccProvider_DefaultTags_emptyBlock
=== RUN   TestAccProvider_DefaultTagsTags_none
=== PAUSE TestAccProvider_DefaultTagsTags_none
=== RUN   TestAccProvider_DefaultTagsTags_one
=== PAUSE TestAccProvider_DefaultTagsTags_one
=== RUN   TestAccProvider_DefaultTagsTags_multiple
=== PAUSE TestAccProvider_DefaultTagsTags_multiple
=== RUN   TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== PAUSE TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== RUN   TestAccProvider_endpoints
=== PAUSE TestAccProvider_endpoints
=== RUN   TestAccProvider_fipsEndpoint
=== PAUSE TestAccProvider_fipsEndpoint
=== RUN   TestAccProvider_unusualEndpoints
=== PAUSE TestAccProvider_unusualEndpoints
=== RUN   TestAccProvider_IgnoreTags_emptyBlock
=== PAUSE TestAccProvider_IgnoreTags_emptyBlock
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_none
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_none
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_one
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_one
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== RUN   TestAccProvider_IgnoreTagsKeys_none
=== PAUSE TestAccProvider_IgnoreTagsKeys_none
=== RUN   TestAccProvider_IgnoreTagsKeys_one
=== PAUSE TestAccProvider_IgnoreTagsKeys_one
=== RUN   TestAccProvider_IgnoreTagsKeys_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeys_multiple
=== RUN   TestAccProvider_Region_c2s
=== PAUSE TestAccProvider_Region_c2s
=== RUN   TestAccProvider_Region_china
=== PAUSE TestAccProvider_Region_china
=== RUN   TestAccProvider_Region_commercial
=== PAUSE TestAccProvider_Region_commercial
=== RUN   TestAccProvider_Region_govCloud
=== PAUSE TestAccProvider_Region_govCloud
=== RUN   TestAccProvider_Region_sc2s
=== PAUSE TestAccProvider_Region_sc2s
=== RUN   TestAccProvider_Region_stsRegion
=== PAUSE TestAccProvider_Region_stsRegion
=== RUN   TestAccProvider_AssumeRole_empty
=== PAUSE TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_DefaultTags_emptyBlock
=== CONT  TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== CONT  TestAccProvider_Region_china
=== CONT  TestAccProvider_Region_c2s
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
    provider_test.go:308: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_china
    provider_test.go:406: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
=== CONT  TestAccProvider_Region_c2s
    provider_test.go:384: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
    provider_test.go:365: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_unusualEndpoints
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
    provider_test.go:270: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_sc2s
=== CONT  TestAccProvider_unusualEndpoints
    provider_test.go:231: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_stsRegion
=== CONT  TestAccProvider_IgnoreTagsKeys_none
--- SKIP: TestAccProvider_IgnoreTagsKeyPrefixes_multiple (0.04s)
=== CONT  TestAccProvider_Region_sc2s
    provider_test.go:472: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_Region_china (0.04s)
=== CONT  TestAccProvider_IgnoreTagsKeys_one
--- SKIP: TestAccProvider_Region_c2s (0.04s)
--- SKIP: TestAccProvider_IgnoreTagsKeys_multiple (0.03s)
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
    provider_test.go:250: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultTagsTags_multiple
=== CONT  TestAccProvider_Region_stsRegion
    provider_test.go:494: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_govCloud
=== CONT  TestAccProvider_IgnoreTagsKeys_none
    provider_test.go:327: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultTagsTags_multiple
    provider_test.go:139: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
    provider_test.go:289: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_IgnoreTagsKeyPrefixes_none (0.04s)
--- SKIP: TestAccProvider_IgnoreTagsKeyPrefixes_one (0.04s)
=== CONT  TestAccProvider_IgnoreTagsKeys_one
    provider_test.go:346: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
    provider_test.go:161: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultTagsTags_none
=== CONT  TestAccProvider_DefaultTagsTags_one
--- SKIP: TestAccProvider_Region_sc2s (0.04s)
--- SKIP: TestAccProvider_IgnoreTags_emptyBlock (0.05s)
=== CONT  TestAccProvider_endpoints
=== CONT  TestAccProvider_DefaultTagsTags_one
    provider_test.go:120: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_Region_stsRegion (0.04s)
--- SKIP: TestAccProvider_DefaultTagsTags_one (0.03s)
=== CONT  TestAccProvider_Region_govCloud
    provider_test.go:450: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_IgnoreTagsKeys_none (0.04s)
--- SKIP: TestAccProvider_Region_govCloud (0.04s)
--- SKIP: TestAccProvider_DefaultTagsTags_multiple (0.06s)
=== CONT  TestAccProvider_fipsEndpoint
--- SKIP: TestAccProvider_unusualEndpoints (0.06s)
=== CONT  TestAccProvider_endpoints
    provider_test.go:188: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_IgnoreTagsKeys_one (0.08s)
--- SKIP: TestAccProvider_endpoints (0.04s)
=== CONT  TestAccProvider_Region_commercial
--- SKIP: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (0.04s)
=== CONT  TestAccProvider_DefaultTagsTags_none
    provider_test.go:101: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_DefaultTagsTags_none (0.03s)
=== CONT  TestAccProvider_AssumeRole_empty
    provider_test.go:513: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_AssumeRole_empty (0.00s)
=== CONT  TestAccProvider_Region_commercial
    provider_test.go:428: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_fipsEndpoint
    provider_test.go:208: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_Region_commercial (0.04s)
--- SKIP: TestAccProvider_fipsEndpoint (0.00s)
=== CONT  TestAccProvider_DefaultTags_emptyBlock
    provider_test.go:82: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_DefaultTags_emptyBlock (0.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	8.579s
```