### PR TITLE
Macie Macie2 Classification Results - Export Configuration #19856

### DIFF
--- a/.changelog/19856.txt
+++ b/.changelog/19856.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_macie2_classification_export_configuration
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1683,13 +1683,14 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_macie_member_account_association": macie.ResourceMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":      macie.ResourceS3BucketAssociation(),
 
-			"aws_macie2_account":                    macie2.ResourceAccount(),
-			"aws_macie2_classification_job":         macie2.ResourceClassificationJob(),
-			"aws_macie2_custom_data_identifier":     macie2.ResourceCustomDataIdentifier(),
-			"aws_macie2_findings_filter":            macie2.ResourceFindingsFilter(),
-			"aws_macie2_invitation_accepter":        macie2.ResourceInvitationAccepter(),
-			"aws_macie2_member":                     macie2.ResourceMember(),
-			"aws_macie2_organization_admin_account": macie2.ResourceOrganizationAdminAccount(),
+			"aws_macie2_account":                             macie2.ResourceAccount(),
+			"aws_macie2_classification_job":                  macie2.ResourceClassificationJob(),
+			"aws_macie2_custom_data_identifier":              macie2.ResourceCustomDataIdentifier(),
+			"aws_macie2_findings_filter":                     macie2.ResourceFindingsFilter(),
+			"aws_macie2_invitation_accepter":                 macie2.ResourceInvitationAccepter(),
+			"aws_macie2_member":                              macie2.ResourceMember(),
+			"aws_macie2_organization_admin_account":          macie2.ResourceOrganizationAdminAccount(),
+			"aws_macie2_classification_export_configuration": macie2.ResourceClassificationExportConfiguration(),
 
 			"aws_media_convert_queue": mediaconvert.ResourceQueue(),
 

--- a/internal/service/macie2/classification_export_configuration.go
+++ b/internal/service/macie2/classification_export_configuration.go
@@ -1,0 +1,194 @@
+package macie2
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"log"
+)
+
+func ResourceClassificationExportConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceClassificationExportConfigurationCreate,
+		UpdateWithoutTimeout: resourceClassificationExportConfigurationUpdate,
+		DeleteWithoutTimeout: resourceClassificationExportConfigurationDelete,
+		ReadWithoutTimeout:   resourceClassificationExportConfigurationRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"s3_destination": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				AtLeastOneOf: []string{"s3_destination"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"key_prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"kms_key_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceClassificationExportConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	conn := meta.(*conns.AWSClient).Macie2Conn
+
+	if d.IsNewResource() {
+		output, err := conn.GetClassificationExportConfiguration(&macie2.GetClassificationExportConfigurationInput{})
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("reading Macie classification export configuration failed: %w", err))
+		}
+
+		if (macie2.ClassificationExportConfiguration{}) != *output.Configuration { // nosemgrep: ci.prefer-aws-go-sdk-pointer-conversion-conditional
+			return diag.FromErr(fmt.Errorf("creating Macie classification export configuration: a configuration already exists"))
+		}
+	}
+
+	input := macie2.PutClassificationExportConfigurationInput{
+		Configuration: &macie2.ClassificationExportConfiguration{},
+	}
+
+	if v, ok := d.GetOk("s3_destination"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.Configuration.S3Destination = expandClassificationExportConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] Creating Macie classification export configuration: %s", input)
+
+	_, err := conn.PutClassificationExportConfiguration(&input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("creating Macie classification export configuration failed: %w", err))
+	}
+
+	return resourceClassificationExportConfigurationRead(ctx, d, meta)
+}
+
+func resourceClassificationExportConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Macie2Conn
+
+	input := macie2.PutClassificationExportConfigurationInput{
+		Configuration: &macie2.ClassificationExportConfiguration{},
+	}
+
+	if v, ok := d.GetOk("s3_destination"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.Configuration.S3Destination = expandClassificationExportConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	} else {
+		input.Configuration.S3Destination = nil
+	}
+
+	log.Printf("[DEBUG] Creating Macie classification export configuration: %s", input)
+
+	_, err := conn.PutClassificationExportConfiguration(&input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("creating Macie classification export configuration failed: %w", err))
+	}
+
+	return resourceClassificationExportConfigurationRead(ctx, d, meta)
+}
+
+func resourceClassificationExportConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Macie2Conn
+
+	input := macie2.GetClassificationExportConfigurationInput{} // api does not have a getById() like endpoint.
+	output, err := conn.GetClassificationExportConfiguration(&input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("reading Macie classification export configuration failed: %w", err))
+	}
+
+	if (macie2.ClassificationExportConfiguration{}) != *output.Configuration { // nosemgrep: ci.prefer-aws-go-sdk-pointer-conversion-conditional
+		if (macie2.S3Destination{}) != *output.Configuration.S3Destination { // nosemgrep: ci.prefer-aws-go-sdk-pointer-conversion-conditional
+			var flattenedS3Destination = flattenClassificationExportConfigurationS3DestinationResult(output.Configuration.S3Destination)
+			if err := d.Set("s3_destination", []interface{}{flattenedS3Destination}); err != nil {
+				return diag.FromErr(fmt.Errorf("error setting Macie classification export configuration s3_destination: %w", err))
+			}
+		}
+		d.SetId(fmt.Sprintf("%s:%s:%s", "macie:classification_export_configuration", meta.(*conns.AWSClient).AccountID, meta.(*conns.AWSClient).Region))
+	}
+
+	return nil
+}
+
+func resourceClassificationExportConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).Macie2Conn
+
+	input := macie2.PutClassificationExportConfigurationInput{
+		Configuration: &macie2.ClassificationExportConfiguration{},
+	}
+
+	log.Printf("[DEBUG] deleting Macie classification export configuration: %s", input)
+
+	_, err := conn.PutClassificationExportConfiguration(&input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("deleting Macie classification export configuration failed: %w", err))
+	}
+
+	return nil
+}
+
+func expandClassificationExportConfiguration(tfMap map[string]interface{}) *macie2.S3Destination {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &macie2.S3Destination{}
+
+	if v, ok := tfMap["bucket_name"].(string); ok {
+		apiObject.BucketName = aws.String(v)
+	}
+
+	if v, ok := tfMap["key_prefix"].(string); ok {
+		apiObject.KeyPrefix = aws.String(v)
+	}
+
+	if v, ok := tfMap["kms_key_arn"].(string); ok {
+		apiObject.KmsKeyArn = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenClassificationExportConfigurationS3DestinationResult(apiObject *macie2.S3Destination) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.BucketName; v != nil {
+		tfMap["bucket_name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.KeyPrefix; v != nil {
+		tfMap["key_prefix"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.KmsKeyArn; v != nil {
+		tfMap["kms_key_arn"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}

--- a/internal/service/macie2/classification_export_configuration.go
+++ b/internal/service/macie2/classification_export_configuration.go
@@ -3,13 +3,14 @@ package macie2
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/macie2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
-	"log"
 )
 
 func ResourceClassificationExportConfiguration() *schema.Resource {

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -229,7 +229,7 @@ resource "aws_macie2_classification_export_configuration" "test" {
   ]
   s3_destination {
     bucket_name = aws_s3_bucket.test.bucket
-    key_prefix  = %[1]q == "" ? null : %[1]q
+    key_prefix  = (%[1]q == "") ? null : %[1]q
     kms_key_arn = aws_kms_key.test.arn
   }
 }

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -112,17 +112,6 @@ func testAccCheckClassificationExportConfigurationExists(resourceName string, ma
 	}
 }
 
-func testAccCheckClassificationExportConfigurationNotExists(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return nil
-		}
-
-		return fmt.Errorf("Not expecting but found: %s", resourceName)
-	}
-}
-
 func testAccClassificationExportConfigurationConfig_basic(prefix string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -2,14 +2,14 @@ package macie2_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 func testAccClassificationExportConfiguration_basic(t *testing.T) {

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -189,10 +189,10 @@ resource "aws_s3_bucket_policy" "test" {
             "Service" : "macie.${data.aws_partition.current.dns_suffix}"
           },
           "Action" : "s3:GetBucketLocation",
-          "Resource" : "${aws_s3_bucket.test.arn}",
+          "Resource" : aws_s3_bucket.test.arn,
           "Condition" : {
             "StringEquals" : {
-              "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"
+              "aws:SourceAccount" : data.aws_caller_identity.current.account_id
             },
             "ArnLike" : {
               "aws:SourceArn" : [

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -1,0 +1,237 @@
+package macie2_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func testAccClassificationExportConfiguration_basic(t *testing.T) {
+	var macie2Output macie2.GetClassificationExportConfigurationOutput
+	resourceName := "aws_macie2_classification_export_configuration.test"
+	kmsKeyResourceName := "aws_kms_key.test"
+	macieAccountResourceName := "aws_macie2_account.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClassificationExportConfigurationDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClassificationExportConfigurationConfig_basic("macieprefix/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClassificationExportConfigurationExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttr(macieAccountResourceName, "status", macie2.MacieStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "s3_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_destination.0.bucket_name", s3BucketResourceName, "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "s3_destination.0.key_prefix", "macieprefix/"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_destination.0.kms_key_arn", kmsKeyResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccClassificationExportConfigurationConfig_basic(""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClassificationExportConfigurationExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttr(macieAccountResourceName, "status", macie2.MacieStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "s3_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_destination.0.bucket_name", s3BucketResourceName, "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "s3_destination.0.key_prefix", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_destination.0.kms_key_arn", kmsKeyResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckClassificationExportConfigurationDestroy(s *terraform.State) error {
+
+	conn := acctest.Provider.Meta().(*conns.AWSClient).Macie2Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_classification_export_configuration" {
+			continue
+		}
+
+		input := macie2.GetClassificationExportConfigurationInput{}
+		resp, err := conn.GetClassificationExportConfiguration(&input)
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException, "Macie is not enabled") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if (macie2.GetClassificationExportConfigurationOutput{}) != *resp || resp != nil { // nosemgrep: ci.prefer-aws-go-sdk-pointer-conversion-conditional
+			return fmt.Errorf("macie classification export configuration %q still configured", rs.Primary.ID)
+		}
+
+	}
+
+	return nil
+
+}
+
+func testAccCheckClassificationExportConfigurationExists(resourceName string, macie2CEConfig *macie2.GetClassificationExportConfigurationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Macie2Conn
+		input := macie2.GetClassificationExportConfigurationInput{}
+
+		resp, err := conn.GetClassificationExportConfiguration(&input)
+
+		if err != nil {
+			return err
+		}
+
+		if (macie2.GetClassificationExportConfigurationOutput{}) == *resp || resp == nil { // nosemgrep: ci.prefer-aws-go-sdk-pointer-conversion-conditional
+			return fmt.Errorf("macie classification export configuration %q does not exist", rs.Primary.ID)
+		}
+
+		*macie2CEConfig = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckClassificationExportConfigurationNotExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return nil
+		}
+
+		return fmt.Errorf("Not expecting but found: %s", resourceName)
+	}
+}
+
+func testAccClassificationExportConfigurationConfig_basic(prefix string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Id" : "allow_macie",
+    "Statement" : [
+      {
+        "Sid" : "Allow Macie to use the key",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "macie.${data.aws_partition.current.dns_suffix}"
+        },
+        "Action" : [
+          "kms:GenerateDataKey",
+          "kms:Encrypt"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "Enable IAM User Permissions",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        "Action" : "kms:*",
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket" "test" {
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test.id
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "Deny non-HTTPS access",
+          "Effect" : "Deny",
+          "Principal" : "*",
+          "Action" : "s3:*",
+          "Resource" : "${aws_s3_bucket.test.arn}/*",
+          "Condition" : {
+            "Bool" : {
+              "aws:SecureTransport" : "false"
+            }
+          }
+        },
+        {
+          "Sid" : "Allow Macie to upload objects to the bucket",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "macie.${data.aws_partition.current.dns_suffix}"
+          },
+          "Action" : "s3:PutObject",
+          "Resource" : "${aws_s3_bucket.test.arn}/*"
+        },
+        {
+          "Sid" : "Allow Macie to use the getBucketLocation operation",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "macie.${data.aws_partition.current.dns_suffix}"
+          },
+          "Action" : "s3:GetBucketLocation",
+          "Resource" : "${aws_s3_bucket.test.arn}",
+          "Condition" : {
+            "StringEquals" : {
+              "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"
+            },
+            "ArnLike" : {
+              "aws:SourceArn" : [
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_macie2_account" "test" {}
+
+resource "aws_macie2_classification_export_configuration" "test" {
+  depends_on = [
+    aws_macie2_account.test,
+    aws_kms_key.test,
+    aws_s3_bucket.test,
+    aws_s3_bucket_policy.test
+  ]
+  s3_destination {
+    bucket_name = aws_s3_bucket.test.bucket
+    key_prefix  = %[1]q == "" ? null : %[1]q
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+`, prefix)
+}

--- a/internal/service/macie2/macie2_test.go
+++ b/internal/service/macie2/macie2_test.go
@@ -13,6 +13,9 @@ func TestAccMacie2_serial(t *testing.T) {
 			"finding_and_status":           testAccAccount_WithFindingAndStatus,
 			"disappears":                   testAccAccount_disappears,
 		},
+		"ClassificationExportConfiguration": {
+			"basic": testAccClassificationExportConfiguration_basic,
+		},
 		"ClassificationJob": {
 			"basic":          testAccClassificationJob_basic,
 			"name_generated": testAccClassificationJob_Name_Generated,

--- a/website/docs/r/macie2_classification_export_configuration.html.markdown
+++ b/website/docs/r/macie2_classification_export_configuration.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "Macie"
+layout: "aws"
+page_title: "AWS: aws_macie2_classification_export_configuration"
+description: |-
+  Provides a resource to manage Classification Results - Export Configuration
+---
+
+# Resource: aws_macie2_classification_export_configuration
+
+Provides a resource to manage an [Amazon Macie Classification Export Configuration](https://docs.aws.amazon.com/macie/latest/APIReference/classification-export-configuration.html).
+
+## Example Usage
+
+```terraform
+resource "aws_macie2_account" "example" {}
+
+resource "aws_macie2_classification_export_configuration" "example" {
+  depends_on = [
+    aws_macie2_account.example,
+  ]
+  s3_destination {
+    bucket_name = aws_s3_bucket.example.bucket
+    key_prefix  = "exampleprefix/"
+    kms_key_arn = aws_kms_key.example.arn
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `s3_destination` - (Required) Configuration block for an S3 Destination. Defined below
+
+### s3_destination Configuration Block
+
+The `s3_destination` configuration block supports the following arguments:
+
+* `bucket_name` - (Required) The Amazon S3 bucket name in which Amazon Macie exports the data classification results.
+* `key_prefix` - (Optional) The object key for the bucket in which Amazon Macie exports the data classification results.
+* `kms_key_arn` - (Required) Amazon Resource Name (ARN) of the KMS key to be used to encrypt the data.
+
+Additional information can be found in the [Storing and retaining sensitive data discovery results with Amazon Macie for AWS Macie documentation](https://docs.aws.amazon.com/macie/latest/user/discovery-results-repository-s3.html).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier (ID) of the configuration.
+
+## Import
+
+`aws_macie2_classification_export_configuration` can be imported using the account ID and region, e.g.,
+
+```
+$ terraform import aws_macie2_classification_export_configuration.example 123456789012:us-west-2
+```

--- a/website/docs/r/macie2_classification_export_configuration.html.markdown
+++ b/website/docs/r/macie2_classification_export_configuration.html.markdown
@@ -31,7 +31,7 @@ resource "aws_macie2_classification_export_configuration" "example" {
 
 The following arguments are supported:
 
-* `s3_destination` - (Required) Configuration block for an S3 Destination. Defined below
+* `s3_destination` - (Required) Configuration block for a S3 Destination. Defined below
 
 ### s3_destination Configuration Block
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19856

Two things:
- Import doesn't care about IDs, there's only one resource, the API takes care of not found, etc. Documentation has a [dummy](https://github.com/hashicorp/terraform-provider-aws/compare/main...nickyamanaka:terraform-provider-aws:f-macie-classification-export-configuration-%2319856#diff-9633ced2359ae626d559a836fc7050965c7e891d822fa1613b6535fdd6ea3300R57) value
- Objects returned from the API are not nil (at least the first Configuration property) but empty structs,
```
string=(*macie2.GetClassificationExportConfigurationOutput)(0x140002091e8)({
│   Configuration: {
│ 
│   }
│ })
```
 so my comparison might be [unorthodox ](https://github.com/hashicorp/terraform-provider-aws/compare/main...nickyamanaka:terraform-provider-aws:f-macie-classification-export-configuration-%2319856#diff-ded984b749cc4055e459d4ae43952d38b8dc304cded209fd2f2e4dd6b040f6fbR121) to check if the object are empty or if the resource [already exists](https://github.com/hashicorp/terraform-provider-aws/compare/main...nickyamanaka:terraform-provider-aws:f-macie-classification-export-configuration-%2319856#diff-ded984b749cc4055e459d4ae43952d38b8dc304cded209fd2f2e4dd6b040f6fbR63). Can I get some feedback for this approach? I could go checking `if output.Configuration.SetS3Destination != nil` if that makes more sense.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccMacie2_serial/ClassificationExportConfiguration' PKG=macie2 ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/macie2/... -v -count 1 -parallel 1  -run=TestAccMacie2_serial/ClassificationExportConfiguration -timeout 180m
=== RUN   TestAccMacie2_serial
=== RUN   TestAccMacie2_serial/ClassificationExportConfiguration
=== RUN   TestAccMacie2_serial/ClassificationExportConfiguration/basic
--- PASS: TestAccMacie2_serial (37.65s)
    --- PASS: TestAccMacie2_serial/ClassificationExportConfiguration (37.65s)
        --- PASS: TestAccMacie2_serial/ClassificationExportConfiguration/basic (37.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie2     39.333s


...
```
