### PR TITLE
Add missing attribute to iam policy data source docs

### DIFF
--- a/website/docs/d/iam_policy.html.markdown
+++ b/website/docs/d/iam_policy.html.markdown
@@ -43,6 +43,7 @@ data "aws_iam_policy" "example" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the policy.
 * `path` - The path to the policy.
 * `description` - The description of the policy.
 * `policy` - The policy document of the policy.


### PR DESCRIPTION
The documentation page for the `aws_iam_policy` data source does not mention the `arn` attribute. However, the attribute is available on the data source as you can also see [here](https://github.com/hashicorp/terraform-provider-aws/blob/v4.24.0/internal/service/iam/policy_data_source.go#L101).

This PR adds `arn` to the Attributes Reference.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request