### PR TITLE
f-data-aws_dx_location-add-macsec

### DIFF
--- a/.changelog/26110.txt
+++ b/.changelog/26110.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_dx_location: Add `available_macsec_port_speeds` attribute
+```

--- a/internal/service/directconnect/location_data_source.go
+++ b/internal/service/directconnect/location_data_source.go
@@ -14,6 +14,12 @@ func DataSourceLocation() *schema.Resource {
 		Read: dataSourceLocationRead,
 
 		Schema: map[string]*schema.Schema{
+			"available_macsec_port_speeds": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"available_port_speeds": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -54,6 +60,7 @@ func dataSourceLocationRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(locationCode)
+	d.Set("available_macsec_port_speeds", aws.StringValueSlice(location.AvailableMacSecPortSpeeds))
 	d.Set("available_port_speeds", aws.StringValueSlice(location.AvailablePortSpeeds))
 	d.Set("available_providers", aws.StringValueSlice(location.AvailableProviders))
 	d.Set("location_code", location.LocationCode)

--- a/internal/service/directconnect/location_data_source_test.go
+++ b/internal/service/directconnect/location_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccDirectConnectLocationDataSource_basic(t *testing.T) {
 			{
 				Config: testAccLocationDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dsResourceName, "available_macsec_port_speeds.#"),
 					resource.TestCheckResourceAttrSet(dsResourceName, "available_port_speeds.#"),
 					resource.TestCheckResourceAttrSet(dsResourceName, "available_providers.#"),
 					resource.TestCheckResourceAttrSet(dsResourceName, "location_code"),

--- a/website/docs/d/dx_location.html.markdown
+++ b/website/docs/d/dx_location.html.markdown
@@ -29,6 +29,7 @@ data "aws_dx_location" "example" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `available_macsec_port_speeds` - The available MAC Security (MACsec) port speeds for the location.
 * `available_port_speeds` - The available port speeds for the location.
 * `available_providers` - The names of the service providers for the location.
 * `location_name` - The name of the location. This includes the name of the colocation partner and the physical site of the building.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->
Adds support for retrieving available MACsec port speeds with the `aws_dx_location` data source
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21082

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDirectConnectLocationDataSource_basic PKG=directconnect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectLocationDataSource_basic'  -timeout 180m
=== RUN   TestAccDirectConnectLocationDataSource_basic
=== PAUSE TestAccDirectConnectLocationDataSource_basic
=== CONT  TestAccDirectConnectLocationDataSource_basic
--- PASS: TestAccDirectConnectLocationDataSource_basic (15.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      18.166s
```
