### PR TITLE
documentation - backup_vault_aws - Fix length validation error handling for vault_name parameter

### DIFF
--- a/internal/service/backup/vault.go
+++ b/internal/service/backup/vault.go
@@ -42,7 +42,10 @@ func ResourceVault() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
+				ValidateFunc: validation.All(
+					      	validation.StringLenBetween(1, 50),
+						validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]$`), "must consist of lowercase letters, numbers, and hyphens."),
+					      )
 			},
 			"recovery_points": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Hello!

Usecase:
in `backup_aws_vault`, if you set the variable `vault_name` with a string of more than 50 characters, instead of a length error, it raises:
`"must consist of lowercase letters, numbers, and hyphens."`

I think it should raise something along the line of:
`expected length of name to be in the range (1 - 50)`

I think this regex is to blame (the last part of the regex):
`^[a-zA-Z0-9\-\_\.]{1, 50}$`

Proposed solution:
Split the validation into syntax validation and length validation

PS: I might edit this PR later on to comply with guidelines (meanwhile I let this PR in draft).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
