### PR TITLE
linting: Add `yamllint`

### DIFF
--- a/.ci/.semgrep-caps-aws-ec2.yml
+++ b/.ci/.semgrep-caps-aws-ec2.yml
@@ -82,7 +82,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "(Cloudformation|ElasticSearch|Autoscaling|Elasticache|ApiGateway|Cloudfront|Cloudwatch|Workspaces|Appconfig|Guardduty|Sagemaker|Workgroup|DynamoDb|Dynamodb|Gamelift|Opsworks|Precheck|Rabbitmq|Worklink|Appmesh|Appsync)"
+            - pattern-regex: "(Cloudformation|ElasticSearch|Autoscaling|Elasticache|ApiGateway|Cloudfront|Cloudwatch|Workspaces|Appconfig|Guardduty|Sagemaker|Workgroup|DynamoDb|Dynamodb|Gamelift|Opsworks|Precheck|Rabbitmq|Worklink|Appmesh|Appsync)"
     severity: WARNING
   - id: caps1-in-func-name
     languages:
@@ -124,7 +124,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "(Graphql|Haproxy|AcmPca|Acmpca|Dnssec|Byoip|Cname|DocDb|Docdb|Fqdns|Https|Ipset|Iscsi|Mysql|Oauth|Posix|Wafv2|Cidr|Coip|Dhcp|Dkim)"
+            - pattern-regex: "(Graphql|Haproxy|AcmPca|Acmpca|Dnssec|Byoip|Cname|DocDb|Docdb|Fqdns|Https|Ipset|Iscsi|Mysql|Oauth|Posix|Wafv2|Cidr|Coip|Dhcp|Dkim)"
     severity: WARNING
   - id: caps2-in-func-name
     languages:
@@ -166,7 +166,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "(Ecmp|Fifo|Grpc|Http|Ipam|Jdbc|Json|Mwaa|Oidc|Pitr|Qldb|Sasl|Smtp|Voip|Xray|Yaml|Acl|Acm|Ami|Api|Arn)"
+            - pattern-regex: "(Ecmp|Fifo|Grpc|Http|Ipam|Jdbc|Json|Mwaa|Oidc|Pitr|Qldb|Sasl|Smtp|Voip|Xray|Yaml|Acl|Acm|Ami|Api|Arn)"
     severity: WARNING
   - id: caps3-in-func-name
     languages:
@@ -208,7 +208,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "(Asg|Asn|Bgp|Cmk|Cpu|Css|Csv|Dax|Dlm|Dms|Dns|Ebs|Ec2|Ecr|Ecs|Efs|Eip|Eks|Elb|Emr|FSX)"
+            - pattern-regex: "(Asg|Asn|Bgp|Cmk|Cpu|Css|Csv|Dax|Dlm|Dms|Dns|Ebs|Ec2|Ecr|Ecs|Efs|Eip|Eks|Elb|Emr|FSX)"
     severity: WARNING
   - id: caps4-in-func-name
     languages:
@@ -250,7 +250,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "(Fms|Fsx|Gcm|Gp2|Gp3|Hsm|Hvm|Iam|Iot|Kms|Mfa|Msk|Nfs|Php|Rds|Rfc|Sfn|Smb|Sms|Sns|Sql)"
+            - pattern-regex: "(Fms|Fsx|Gcm|Gp2|Gp3|Hsm|Hvm|Iam|Iot|Kms|Mfa|Msk|Nfs|Php|Rds|Rfc|Sfn|Smb|Sms|Sns|Sql)"
     severity: WARNING
   - id: caps5-in-func-name
     languages:
@@ -292,7 +292,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "(Sqs|Ssh|Ssl|Ssm|Sso|Sts|Swf|Tcp|Tls|Ttl|Uri|Url|Vgw|Vpc|Vpn|Waf|Xss|Db|Ip)"
+            - pattern-regex: "(Sqs|Ssh|Ssl|Ssm|Sso|Sts|Swf|Tcp|Tls|Ttl|Uri|Url|Vgw|Vpc|Vpn|Waf|Xss|Db|Ip)"
     severity: WARNING
   - id: ec2-in-func-name
     languages:

--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -62,18 +62,18 @@ rules:
         - "internal/service/**/*_test.go"
     patterns:
       - pattern-either:
-        - pattern: '$LHS == *$RHS'
-        - pattern: '$LHS != *$RHS'
-        - pattern: '$LHS > *$RHS'
-        - pattern: '$LHS < *$RHS'
-        - pattern: '$LHS >= *$RHS'
-        - pattern: '$LHS <= *$RHS'
-        - pattern: '*$LHS == $RHS'
-        - pattern: '*$LHS != $RHS'
-        - pattern: '*$LHS > $RHS'
-        - pattern: '*$LHS < $RHS'
-        - pattern: '*$LHS >= $RHS'
-        - pattern: '*$LHS <= $RHS'
+          - pattern: '$LHS == *$RHS'
+          - pattern: '$LHS != *$RHS'
+          - pattern: '$LHS > *$RHS'
+          - pattern: '$LHS < *$RHS'
+          - pattern: '$LHS >= *$RHS'
+          - pattern: '$LHS <= *$RHS'
+          - pattern: '*$LHS == $RHS'
+          - pattern: '*$LHS != $RHS'
+          - pattern: '*$LHS > $RHS'
+          - pattern: '*$LHS < $RHS'
+          - pattern: '*$LHS >= $RHS'
+          - pattern: '*$LHS <= $RHS'
     severity: WARNING
 
   - id: aws-go-sdk-pointer-conversion-ResourceData-SetId
@@ -95,11 +95,11 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: '*aws.Bool($VALUE)'
-        - pattern: '*aws.Float64($VALUE)'
-        - pattern: '*aws.Int64($VALUE)'
-        - pattern: '*aws.String($VALUE)'
-        - pattern: '*aws.Time($VALUE)'
+          - pattern: '*aws.Bool($VALUE)'
+          - pattern: '*aws.Float64($VALUE)'
+          - pattern: '*aws.Int64($VALUE)'
+          - pattern: '*aws.String($VALUE)'
+          - pattern: '*aws.Time($VALUE)'
     severity: WARNING
 
   - id: data-source-with-resource-read
@@ -128,8 +128,8 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: const $CONST = fmt.Sprintf(..., <... acctest.RandInt() ...>, ...)
-        - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandInt() ...>, ...)
+          - pattern: const $CONST = fmt.Sprintf(..., <... acctest.RandInt() ...>, ...)
+          - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandInt() ...>, ...)
     severity: WARNING
 
   - id: helper-acctest-RandString-compiled
@@ -140,8 +140,8 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: const $CONST = fmt.Sprintf(..., <... acctest.RandString(...) ...>, ...)
-        - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandString(...) ...>, ...)
+          - pattern: const $CONST = fmt.Sprintf(..., <... acctest.RandString(...) ...>, ...)
+          - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandString(...) ...>, ...)
     severity: WARNING
 
   - id: helper-acctest-RandomWithPrefix-compiled
@@ -152,8 +152,8 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: const $CONST = fmt.Sprintf(..., <... acctest.RandomWithPrefix(...) ...>, ...)
-        - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandomWithPrefix(...) ...>, ...)
+          - pattern: const $CONST = fmt.Sprintf(..., <... acctest.RandomWithPrefix(...) ...>, ...)
+          - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandomWithPrefix(...) ...>, ...)
     severity: WARNING
 
   - id: helper-schema-Set-extraneous-NewSet-with-flattenStringList
@@ -173,11 +173,11 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: flex.ExpandStringList($SET.List())
-        - pattern: |
-            $LIST := $SET.List()
-            ...
-            flex.ExpandStringList($LIST)
+          - pattern: flex.ExpandStringList($SET.List())
+          - pattern: |
+              $LIST := $SET.List()
+              ...
+              flex.ExpandStringList($LIST)
     severity: WARNING
 
   - id: helper-schema-ResourceData-GetOk-with-extraneous-conditional
@@ -188,11 +188,11 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(bool) { $BODY }
-        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) != 0 { $BODY }
-        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) > 0 { $BODY }
-        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(string) != "" { $BODY }
-        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && len($VALUE.(string)) > 0 { $BODY }
+          - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(bool) { $BODY }
+          - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) != 0 { $BODY }
+          - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) > 0 { $BODY }
+          - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(string) != "" { $BODY }
+          - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && len($VALUE.(string)) > 0 { $BODY }
     severity: WARNING
 
   - id: helper-schema-ResourceData-Set-extraneous-value-pointer-conversion
@@ -328,10 +328,10 @@ rules:
         - internal/service/xray
     patterns:
       - pattern-either:
-        - pattern: |
-            d.SetId("")
-            ...
-            return nil
+          - pattern: |
+              d.SetId("")
+              ...
+              return nil
       - pattern-not-inside: |
           if ... {
             if <... d.IsNewResource() ...> { ... }
@@ -355,74 +355,74 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - patterns:
-          - pattern-either:
-            - pattern: |
-                $ERR := resource.Retry(...)
-                ...
-                return ...
-            - pattern: |
-                $ERR = resource.Retry(...)
-                ...
-                return ...
-          - pattern-not: |
-              $ERR := resource.Retry(...)
-              ...
-              if isResourceTimeoutError($ERR) { ... }
-              ...
-              return ...
-          - pattern-not: |
-              $ERR = resource.Retry(...)
-              ...
-              if isResourceTimeoutError($ERR) { ... }
-              ...
-              return ...
-          - pattern-not: |
-              $ERR := resource.Retry(...)
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-              ...
-              return ...
-          - pattern-not: |
-              $ERR = resource.Retry(...)
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-              ...
-              return ...
-        - patterns:
-          - pattern-either:
-            - pattern: |
-                $ERR := resource.RetryContext(...)
-                ...
-                return ...
-            - pattern: |
-                $ERR = resource.RetryContext(...)
-                ...
-                return ...
-          - pattern-not: |
-              $ERR := resource.RetryContext(...)
-              ...
-              if isResourceTimeoutError($ERR) { ... }
-              ...
-              return ...
-          - pattern-not: |
-              $ERR = resource.RetryContext(...)
-              ...
-              if isResourceTimeoutError($ERR) { ... }
-              ...
-              return ...
-          - pattern-not: |
-              $ERR := resource.RetryContext(...)
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-              ...
-              return ...
-          - pattern-not: |
-              $ERR = resource.RetryContext(...)
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-              ...
-              return ...
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      $ERR := resource.Retry(...)
+                      ...
+                      return ...
+                  - pattern: |
+                      $ERR = resource.Retry(...)
+                      ...
+                      return ...
+              - pattern-not: |
+                  $ERR := resource.Retry(...)
+                  ...
+                  if isResourceTimeoutError($ERR) { ... }
+                  ...
+                  return ...
+              - pattern-not: |
+                  $ERR = resource.Retry(...)
+                  ...
+                  if isResourceTimeoutError($ERR) { ... }
+                  ...
+                  return ...
+              - pattern-not: |
+                  $ERR := resource.Retry(...)
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+                  ...
+                  return ...
+              - pattern-not: |
+                  $ERR = resource.Retry(...)
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+                  ...
+                  return ...
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      $ERR := resource.RetryContext(...)
+                      ...
+                      return ...
+                  - pattern: |
+                      $ERR = resource.RetryContext(...)
+                      ...
+                      return ...
+              - pattern-not: |
+                  $ERR := resource.RetryContext(...)
+                  ...
+                  if isResourceTimeoutError($ERR) { ... }
+                  ...
+                  return ...
+              - pattern-not: |
+                  $ERR = resource.RetryContext(...)
+                  ...
+                  if isResourceTimeoutError($ERR) { ... }
+                  ...
+                  return ...
+              - pattern-not: |
+                  $ERR := resource.RetryContext(...)
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+                  ...
+                  return ...
+              - pattern-not: |
+                  $ERR = resource.RetryContext(...)
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+                  ...
+                  return ...
     severity: WARNING
 
   - id: helper-schema-TimeoutError-check-doesnt-return-output
@@ -435,64 +435,64 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - patterns:
-          - pattern: |
-              if isResourceTimeoutError($ERR) {
-                _, $ERR = $CONN.$FUNC(...)
-              }
-          - pattern-not-inside: |
-              $ERR = resource.Retry(..., func() *resource.RetryError {
-                ...
-                _, $ERR2 = $CONN.$FUNC(...)
-                ...
-              })
-              ...
-              if isResourceTimeoutError($ERR) { ... }
-          - pattern-not-inside: |
-              $ERR = resource.RetryContext(..., func() *resource.RetryError {
-                ...
-                _, $ERR2 = $CONN.$FUNC(...)
-                ...
-              })
-              ...
-              if isResourceTimeoutError($ERR) { ... }
-          - pattern-not-inside: |
-              $ERR = tfresource.RetryConfigContext(..., func() *resource.RetryError {
-                ...
-                _, $ERR2 = $CONN.$FUNC(...)
-                ...
-              })
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-        - patterns:
-          - pattern: |
-              if tfresource.TimedOut($ERR) {
-                _, $ERR = $CONN.$FUNC(...)
-              }
-          - pattern-not-inside: |
-              $ERR = resource.Retry(..., func() *resource.RetryError {
-                ...
-                _, $ERR2 = $CONN.$FUNC(...)
-                ...
-              })
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-          - pattern-not-inside: |
-              $ERR = resource.RetryContext(..., func() *resource.RetryError {
-                ...
-                _, $ERR2 = $CONN.$FUNC(...)
-                ...
-              })
-              ...
-              if tfresource.TimedOut($ERR) { ... }
-          - pattern-not-inside: |
-              $ERR = tfresource.RetryConfigContext(..., func() *resource.RetryError {
-                ...
-                _, $ERR2 = $CONN.$FUNC(...)
-                ...
-              })
-              ...
-              if tfresource.TimedOut($ERR) { ... }
+          - patterns:
+              - pattern: |
+                  if isResourceTimeoutError($ERR) {
+                    _, $ERR = $CONN.$FUNC(...)
+                  }
+              - pattern-not-inside: |
+                  $ERR = resource.Retry(..., func() *resource.RetryError {
+                    ...
+                    _, $ERR2 = $CONN.$FUNC(...)
+                    ...
+                  })
+                  ...
+                  if isResourceTimeoutError($ERR) { ... }
+              - pattern-not-inside: |
+                  $ERR = resource.RetryContext(..., func() *resource.RetryError {
+                    ...
+                    _, $ERR2 = $CONN.$FUNC(...)
+                    ...
+                  })
+                  ...
+                  if isResourceTimeoutError($ERR) { ... }
+              - pattern-not-inside: |
+                  $ERR = tfresource.RetryConfigContext(..., func() *resource.RetryError {
+                    ...
+                    _, $ERR2 = $CONN.$FUNC(...)
+                    ...
+                  })
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+          - patterns:
+              - pattern: |
+                  if tfresource.TimedOut($ERR) {
+                    _, $ERR = $CONN.$FUNC(...)
+                  }
+              - pattern-not-inside: |
+                  $ERR = resource.Retry(..., func() *resource.RetryError {
+                    ...
+                    _, $ERR2 = $CONN.$FUNC(...)
+                    ...
+                  })
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+              - pattern-not-inside: |
+                  $ERR = resource.RetryContext(..., func() *resource.RetryError {
+                    ...
+                    _, $ERR2 = $CONN.$FUNC(...)
+                    ...
+                  })
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
+              - pattern-not-inside: |
+                  $ERR = tfresource.RetryConfigContext(..., func() *resource.RetryError {
+                    ...
+                    _, $ERR2 = $CONN.$FUNC(...)
+                    ...
+                  })
+                  ...
+                  if tfresource.TimedOut($ERR) { ... }
     severity: WARNING
 
   - id: is-not-found-error
@@ -503,20 +503,20 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - patterns:
-          - pattern: |
-              var $CAST *resource.NotFoundError
-              ...
-              errors.As($ERR, &$CAST)
-          - pattern-not-inside: |
-              var $CAST *resource.NotFoundError
-              ...
-              errors.As($ERR, &$CAST)
-              ...
-              $CAST.$FIELD
-        - patterns:
-          - pattern: |
-              $X, $Y := $ERR.(*resource.NotFoundError)
+          - patterns:
+              - pattern: |
+                  var $CAST *resource.NotFoundError
+                  ...
+                  errors.As($ERR, &$CAST)
+              - pattern-not-inside: |
+                  var $CAST *resource.NotFoundError
+                  ...
+                  errors.As($ERR, &$CAST)
+                  ...
+                  $CAST.$FIELD
+          - patterns:
+              - pattern: |
+                  $X, $Y := $ERR.(*resource.NotFoundError)
     severity: WARNING
 
   - id: time-equality
@@ -527,22 +527,22 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: |
-            aws.TimeValue($X) == $Y
-        - pattern: |
-            aws.TimeValue($X) != $Y
-        - pattern: |
-            ($X : time.Time) == $Y
-        - pattern: |
-            ($X : time.Time) != $Y
-        - pattern: |
-            $X == aws.TimeValue($Y)
-        - pattern: |
-            $X != aws.TimeValue($Y)
-        - pattern: |
-            $X == ($Y : time.Time)
-        - pattern: |
-            $X != ($Y : time.Time)
+          - pattern: |
+              aws.TimeValue($X) == $Y
+          - pattern: |
+              aws.TimeValue($X) != $Y
+          - pattern: |
+              ($X : time.Time) == $Y
+          - pattern: |
+              ($X : time.Time) != $Y
+          - pattern: |
+              $X == aws.TimeValue($Y)
+          - pattern: |
+              $X != aws.TimeValue($Y)
+          - pattern: |
+              $X == ($Y : time.Time)
+          - pattern: |
+              $X != ($Y : time.Time)
     severity: WARNING
 
   - id: prefer-pagination-bool-var-last-page
@@ -580,12 +580,12 @@ rules:
         - internal/generate/
     patterns:
       - pattern-either:
-        - pattern: |
-            fmt.Print(...)
-        - pattern: |
-            fmt.Printf(...)
-        - pattern: |
-            fmt.Println(...)
+          - pattern: |
+              fmt.Print(...)
+          - pattern: |
+              fmt.Printf(...)
+          - pattern: |
+              fmt.Println(...)
     severity: WARNING
 
   - id: domain-names
@@ -611,7 +611,7 @@ rules:
         - "internal/service/**/*_test.go"
     patterns:
       - patterns:
-        - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
+          - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
       - pattern-inside: '($X : string)'
       - pattern-not-regex: 'amazonaws\.com'
       - pattern-not-regex: 'awsapps\.com'
@@ -799,11 +799,11 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: if $AWSERR, $OK := $ORIGINALERR.(awserr.Error); $OK && $AWSERR.Code() == $CODE { $BODY }
-        - pattern: |
-            if $AWSERR, $OK := $ORIGINALERR.(awserr.Error); $OK {
-              if $AWSERR.Code() == $CODE { $BODY }
-            }
+          - pattern: if $AWSERR, $OK := $ORIGINALERR.(awserr.Error); $OK && $AWSERR.Code() == $CODE { $BODY }
+          - pattern: |
+              if $AWSERR, $OK := $ORIGINALERR.(awserr.Error); $OK {
+                if $AWSERR.Code() == $CODE { $BODY }
+              }
     severity: WARNING
 
   - id: fmt-Errorf-awserr-Error-Code
@@ -814,8 +814,8 @@ rules:
         - internal/
     patterns:
       - pattern-either:
-        - pattern: fmt.Errorf(..., $ERR.Code(), ...)
-        - pattern: fmt.Errorf(..., $ERR.Message(), ...)
+          - pattern: fmt.Errorf(..., $ERR.Code(), ...)
+          - pattern: fmt.Errorf(..., $ERR.Message(), ...)
     severity: WARNING
 
   - id: typed-enum-conversion

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,16 +17,16 @@ jobs:
     env:
       UV_THREADPOOL_SIZE: 128
     steps:
-    - uses: actions/checkout@v3
-    - uses: YakDriver/md-check-links@v2.0.5
-      with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        config-file: '.ci/.markdownlinkcheck.json'
-        folder-path: 'docs'
-        file-extension: '.md'
-        base-branch: "main"
-        check-modified-files-only: "yes"
+      - uses: actions/checkout@v3
+      - uses: YakDriver/md-check-links@v2.0.5
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.ci/.markdownlinkcheck.json'
+          folder-path: 'docs'
+          file-extension: '.md'
+          base-branch: "main"
+          check-modified-files-only: "yes"
   markdown-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,65 +22,65 @@ jobs:
       matrix:
         terraform_version: ["0.12.31", "1.0.6"]
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-    - uses: actions/setup-go@v3
-      with:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - uses: actions/setup-go@v3
+        with:
           go-version-file: .go-version
-    - name: go build
-      run: go build -o terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 .
-    - name: override plugin
-      run: |
-        # For Terraform v0.12
-        mkdir -p ~/.terraform.d/plugins
-        cp terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 ~/.terraform.d/plugins
-        # For newer versions
-        mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/99.99.99/$(go env GOOS)_$(go env GOARCH)/
-        cp terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/99.99.99/$(go env GOOS)_$(go env GOARCH)/
-    - uses: hashicorp/setup-terraform@v2
-      with:
-        terraform_version: ${{ matrix.terraform_version }}
-        # Needed to use the output of `terraform validate -json`
-        terraform_wrapper: false
+      - name: go build
+        run: go build -o terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 .
+      - name: override plugin
+        run: |
+          # For Terraform v0.12
+          mkdir -p ~/.terraform.d/plugins
+          cp terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 ~/.terraform.d/plugins
+          # For newer versions
+          mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/99.99.99/$(go env GOOS)_$(go env GOARCH)/
+          cp terraform-plugin-dir/terraform-provider-aws_v99.99.99_x5 ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/99.99.99/$(go env GOOS)_$(go env GOARCH)/
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform_version }}
+          # Needed to use the output of `terraform validate -json`
+          terraform_wrapper: false
 
-    - name: install tflint
-      run: cd .ci/tools && go install github.com/terraform-linters/tflint
+      - name: install tflint
+        run: cd .ci/tools && go install github.com/terraform-linters/tflint
 
-    - uses: actions/cache@v3
-      name: Cache plugin dir
-      with:
-        path: ~/.tflint.d/plugins
-        key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
+      - uses: actions/cache@v3
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
 
-    - name: terraform
-      run: |
-        TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
-        for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u); do
-          pushd "$DIR"
-          if [ -f terraform.template.tfvars ]; then
-            cp terraform.template.tfvars terraform.tfvars
-          fi
-          echo; echo -e "\e[1;35m===> Initializing Example: $DIR <===\e[0m"; echo
-          terraform init
-          echo; echo -e "\e[1;35m===> Format Checking Example: $DIR <===\e[0m"; echo
-          terraform fmt -check
-          echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
-          # Catch errors
-          terraform validate
-          # Terraform syntax checks
-          # We don't want to exit on the first tflint error
-          set +e
-          tflint --config=$TFLINT_CONFIG \
-            --enable-rule=terraform_deprecated_interpolation \
-            --enable-rule=terraform_deprecated_index \
-            --enable-rule=terraform_unused_declarations \
-            --enable-rule=terraform_comment_syntax \
-            --enable-rule=terraform_required_version
-          set -e
-          popd
-        done
+      - name: terraform
+        run: |
+          TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
+          for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u); do
+            pushd "$DIR"
+            if [ -f terraform.template.tfvars ]; then
+              cp terraform.template.tfvars terraform.tfvars
+            fi
+            echo; echo -e "\e[1;35m===> Initializing Example: $DIR <===\e[0m"; echo
+            terraform init
+            echo; echo -e "\e[1;35m===> Format Checking Example: $DIR <===\e[0m"; echo
+            terraform fmt -check
+            echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
+            # Catch errors
+            terraform validate
+            # Terraform syntax checks
+            # We don't want to exit on the first tflint error
+            set +e
+            tflint --config=$TFLINT_CONFIG \
+              --enable-rule=terraform_deprecated_interpolation \
+              --enable-rule=terraform_deprecated_index \
+              --enable-rule=terraform_unused_declarations \
+              --enable-rule=terraform_comment_syntax \
+              --enable-rule=terraform_required_version
+            set -e
+            popd
+          done

--- a/.github/workflows/firewatch.yml
+++ b/.github/workflows/firewatch.yml
@@ -1,4 +1,3 @@
-
 on:
   schedule:
     - cron: '0 * * * *'
@@ -9,18 +8,18 @@ jobs:
     if: github.repository_owner == 'hashicorp'
     runs-on: ubuntu-latest
     steps:
-    - name: Firewatch
-      uses: breathingdust/firewatch@v2
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        alert_threshold: 10
-        issue_age_months: 3
-        slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-        slack_channel: ${{ secrets.SLACK_CHANNEL }}
-    - name: UploadArtifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: firewatch
-        path: firewatch.data
-        if-no-files-found: error
-        retention-days: 1
+      - name: Firewatch
+        uses: breathingdust/firewatch@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          alert_threshold: 10
+          issue_age_months: 3
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_CHANNEL }}
+      - name: UploadArtifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: firewatch
+          path: firewatch.data
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -23,6 +23,6 @@ jobs:
             git config --local user.email changelogbot@hashicorp.com
             git config --local user.name changelogbot
             git add CHANGELOG.md
-            git commit -m "$MSG" 
+            git commit -m "$MSG"
             git push
           fi

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -11,17 +11,17 @@ jobs:
   markIssuesForTriage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Apply Issue needs-triage Label
-      if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
-      uses: github/issue-labeler@v2.5
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/labeler-issue-needs-triage.yml
-        enable-versioned-regex: 0
-    - name: Apply Issue Triage Labels
-      uses: github/issue-labeler@v2.5
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/labeler-issue-triage.yml
-        enable-versioned-regex: 0
+      - uses: actions/checkout@v3
+      - name: Apply Issue needs-triage Label
+        if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
+        uses: github/issue-labeler@v2.5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler-issue-needs-triage.yml
+          enable-versioned-regex: 0
+      - name: Apply Issue Triage Labels
+        uses: github/issue-labeler@v2.5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler-issue-triage.yml
+          enable-versioned-regex: 0

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
             echo ::set-output name=current_milestone::v$(head -1 CHANGELOG.md | cut -d " " -f 2)
       - run: echo ${{ steps.get-current-milestone.outputs.current_milestone }}
-      - id: get-milestone-id 
+      - id: get-milestone-id
         run: |
           echo ::set-output name=milestone_id::$(curl -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/milestones | jq 'map(select(.title == "${{ steps.get-current-milestone.outputs.current_milestone }}"))[0].number')
       - run: echo ${{ steps.get-milestone-id.outputs.milestone_id }}

--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -33,7 +33,7 @@ jobs:
             echo ::set-output name=tag::$value
           fi
   tidy-asana:
-    needs: [ on-success-or-workflow-dispatch ]
+    needs: [on-success-or-workflow-dispatch]
     runs-on: ubuntu-latest
     steps:
       - name: Tidy Asana
@@ -47,7 +47,7 @@ jobs:
           github_release_name: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   archive-release-cards:
-    needs: [ on-success-or-workflow-dispatch ]
+    needs: [on-success-or-workflow-dispatch]
     runs-on: ubuntu-latest
     steps:
       - name: Archive Release Cards

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -11,10 +11,10 @@ jobs:
   WorkingBoardReview:
     runs-on: ubuntu-latest
     steps:
-    - name: Move team PRs to Review column
-      uses: alex-page/github-project-automation-plus@v0.8.1
-      if: env.IN_MAINTAINER_LIST == 'true' && github.event.pull_request.draft == false
-      with:
-        project: AWS Provider Working Board
-        column: Open Maintainer PR
-        repo-token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}
+      - name: Move team PRs to Review column
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        if: env.IN_MAINTAINER_LIST == 'true' && github.event.pull_request.draft == false
+        with:
+          project: AWS Provider Working Board
+          column: Open Maintainer PR
+          repo-token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,22 +10,22 @@ jobs:
   Labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Apply Labels
-      uses: actions/labeler@v4
-      with:
-        configuration-path: .github/labeler-pr-triage.yml
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Apply Labels
+        uses: actions/labeler@v4
+        with:
+          configuration-path: .github/labeler-pr-triage.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   NeedsTriageLabeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Apply needs-triage Label
-      uses: actions/labeler@v4
-      if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
-      with:
-        configuration-path: .github/labeler-pr-needs-triage.yml
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Apply needs-triage Label
+        uses: actions/labeler@v4
+        if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
+        with:
+          configuration-path: .github/labeler-pr-needs-triage.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   SizeLabeler:
     runs-on: ubuntu-latest
     steps:
@@ -53,9 +53,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: |-
             Welcome @${{github.actor}} :wave:
-            
+
             It looks like this is your first Pull Request submission to the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws)! If you haven’t already done so please make sure you have checked out our [CONTRIBUTING](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing) guide and [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md) to make sure your contribution is adhering to best practice and has all the necessary elements in place for a successful approval.
 
             Also take a look at our [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md) which details how we prioritize Pull Requests for inclusion.
-            
-            Thanks again, and welcome to the community! :smiley:         
+
+            Thanks again, and welcome to the community! :smiley:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       # Product Version (e.g. v1.2.3 or github.ref_name)
       product-version: '${{ github.ref_name }}'
   highest-version-tag:
-    needs: [ terraform-provider-release ]
+    needs: [terraform-provider-release]
     runs-on: macos-latest
     outputs:
       tag: ${{ steps.highest-version-tag.outputs.tag }}
@@ -66,47 +66,47 @@ jobs:
           HIGHEST=$(git tag | sort -V | tail -1)
           echo ::set-output name=tag::$HIGHEST
   changelog-newversion:
-      needs: [terraform-provider-release, highest-version-tag]
-      # write new changelog header only if release tag is the $HIGHEST i.e. exists on main
-      # and not a backport release branch (e.g. release/3.x). This results in
-      # manually updating the CHANGELOG header if releasing from the non-default branch.
-      # TODO: find a more deterministic way to determine release branch from tag commit
-      if: github.ref_name == needs.highest-version-tag.outputs.tag
-      runs-on: macos-latest
-      steps:
-        - uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
-            ref: main
-        - name: Update Changelog Header
-          run: |
-            CHANGELOG_FILE_NAME="CHANGELOG.md"
-            PREVIOUS_RELEASE_TAG=${{ github.ref_name }}
-           
-            # Add Release Date
-            RELEASE_DATE=`date +%B' '%e', '%Y`
-            sed -i -e "1 s/Unreleased/$RELEASE_DATE/" $CHANGELOG_FILE_NAME           
-            
-            # Prepend next release line
-            echo Previous release is: $PREVIOUS_RELEASE_TAG
-            
-            NEW_RELEASE_LINE=$(echo $PREVIOUS_RELEASE_TAG | awk -F. '{
-                $1 = substr($1,2)
-                $2 += 1
-                printf("%s.%01d.0\n\n", $1, $2);
-            }')
-            
-            echo New minor version is: v$NEW_RELEASE_LINE
-            
-            echo -e "## $NEW_RELEASE_LINE (Unreleased)\n$(cat $CHANGELOG_FILE_NAME)" > $CHANGELOG_FILE_NAME
-        - run: |
-              git config --local user.email changelogbot@hashicorp.com
-              git config --local user.name changelogbot
-              git add CHANGELOG.md
-              git commit -m "Update CHANGELOG.md after ${{ github.ref_name }}" 
-              git push
+    needs: [terraform-provider-release, highest-version-tag]
+    # write new changelog header only if release tag is the $HIGHEST i.e. exists on main
+    # and not a backport release branch (e.g. release/3.x). This results in
+    # manually updating the CHANGELOG header if releasing from the non-default branch.
+    # TODO: find a more deterministic way to determine release branch from tag commit
+    if: github.ref_name == needs.highest-version-tag.outputs.tag
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+      - name: Update Changelog Header
+        run: |
+          CHANGELOG_FILE_NAME="CHANGELOG.md"
+          PREVIOUS_RELEASE_TAG=${{ github.ref_name }}
+
+          # Add Release Date
+          RELEASE_DATE=`date +%B' '%e', '%Y`
+          sed -i -e "1 s/Unreleased/$RELEASE_DATE/" $CHANGELOG_FILE_NAME
+
+          # Prepend next release line
+          echo Previous release is: $PREVIOUS_RELEASE_TAG
+
+          NEW_RELEASE_LINE=$(echo $PREVIOUS_RELEASE_TAG | awk -F. '{
+              $1 = substr($1,2)
+              $2 += 1
+              printf("%s.%01d.0\n\n", $1, $2);
+          }')
+
+          echo New minor version is: v$NEW_RELEASE_LINE
+
+          echo -e "## $NEW_RELEASE_LINE (Unreleased)\n$(cat $CHANGELOG_FILE_NAME)" > $CHANGELOG_FILE_NAME
+      - run: |
+            git config --local user.email changelogbot@hashicorp.com
+            git config --local user.name changelogbot
+            git add CHANGELOG.md
+            git commit -m "Update CHANGELOG.md after ${{ github.ref_name }}"
+            git push
   upload-tag-before-post-publish:
-    needs: [ terraform-provider-release ]
+    needs: [terraform-provider-release]
     runs-on: ubuntu-latest
     steps:
       - name: Save Release Tag

--- a/.github/workflows/roadmap_milestone.yml
+++ b/.github/workflows/roadmap_milestone.yml
@@ -1,4 +1,4 @@
-name: If roadmap milestone is assigned, add to working board. 
+name: If roadmap milestone is assigned, add to working board.
 on:
   issues:
     types: [milestoned]
@@ -6,10 +6,10 @@ jobs:
   AddRoadmapItemsToBoard:
     runs-on: ubuntu-latest
     steps:
-    - name: Move Roadmap Items To Working Board
-      uses: alex-page/github-project-automation-plus@v0.8.1
-      if: github.event.issue.milestone.title == 'Roadmap'
-      with:
-        project: AWS Provider Working Board
-        column: To Do
-        repo-token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}
+      - name: Move Roadmap Items To Working Board
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        if: github.event.issue.milestone.title == 'Roadmap'
+        with:
+          project: AWS Provider Working Board
+          column: To Do
+          repo-token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -19,10 +19,10 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-    - uses: actions/checkout@v3
-      with:
-       fetch-depth: 0
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep.yml
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep.yml
   naming_cae:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
@@ -30,8 +30,8 @@ jobs:
       image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@v3
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep-caps-aws-ec2.yml
+      - uses: actions/checkout@v3
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep-caps-aws-ec2.yml
   naming_tests:
     name: Test Configs Scan
     runs-on: ubuntu-latest
@@ -39,8 +39,8 @@ jobs:
       image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@v3
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep-configs.yml
+      - uses: actions/checkout@v3
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep-configs.yml
   naming_semgrep0:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
@@ -48,8 +48,8 @@ jobs:
       image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@v3
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name0.yml
+      - uses: actions/checkout@v3
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name0.yml
   naming_semgrep1:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
@@ -57,8 +57,8 @@ jobs:
       image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@v3
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name1.yml
+      - uses: actions/checkout@v3
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name1.yml
   naming_semgrep2:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
@@ -66,8 +66,8 @@ jobs:
       image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@v3
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name2.yml
+      - uses: actions/checkout@v3
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name2.yml
   naming_semgrep3:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
@@ -75,5 +75,5 @@ jobs:
       image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@v3
-    - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name3.yml
+      - uses: actions/checkout@v3
+      - run: .ci/scripts/semgrep.sh .ci/.semgrep-service-name3.yml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,27 +1,27 @@
 name: "Stale issues and pull requests"
 on:
   schedule:
-  - cron: "40 17 * * *"
+    - cron: "40 17 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v5
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 720
-        days-before-close: 30
-        exempt-issue-labels: 'needs-triage'
-        exempt-pr-labels: 'needs-triage'
-        operations-per-run: 150
-        stale-issue-label: 'stale'
-        stale-issue-message: |
-          Marking this issue as stale due to inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 720
+          days-before-close: 30
+          exempt-issue-labels: 'needs-triage'
+          exempt-pr-labels: 'needs-triage'
+          operations-per-run: 150
+          stale-issue-label: 'stale'
+          stale-issue-message: |
+            Marking this issue as stale due to inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
 
-          If this issue was automatically closed and you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thank you!
-        stale-pr-label: 'stale'
-        stale-pr-message: |
-          Marking this pull request as stale due to inactivity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
+            If this issue was automatically closed and you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thank you!
+          stale-pr-label: 'stale'
+          stale-pr-message: |
+            Marking this pull request as stale due to inactivity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
 
-          If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!
+            If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!

--- a/.github/workflows/team_slack_bot.yml
+++ b/.github/workflows/team_slack_bot.yml
@@ -2,7 +2,7 @@ name: team-slack-bot
 
 on:
   schedule:
-    - cron:  '0 15 * * 1-5'
+    - cron: '0 15 * * 1-5'
 
 jobs:
   open-pr-stats:
@@ -10,12 +10,12 @@ jobs:
     name: open-pr-stats
     if: github.repository_owner == 'hashicorp'
     steps:
-    - name: open-pr-stats
-      uses: breathingdust/github-team-slackbot@v17
-      with:
-        github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}
-        org: hashicorp
-        repo: terraform-provider-aws
-        team_slug: terraform-aws
-        slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-        slack_channel: ${{ secrets.SLACK_CHANNEL }}
+      - name: open-pr-stats
+        uses: breathingdust/github-team-slackbot@v17
+        with:
+          github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}
+          org: hashicorp
+          repo: terraform-provider-aws
+          team_slug: terraform-aws
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -153,7 +153,7 @@ jobs:
               "--disable-rule=aws_appsync_resolver_invalid_request_template"
               "--disable-rule=aws_appsync_resolver_invalid_response_template"
               "--disable-rule=aws_servicecatalog_portfolio_share_invalid_type"
-              "--disable-rule=aws_s3_object_copy_invalid_source"              
+              "--disable-rule=aws_s3_object_copy_invalid_source"
           )
           while read -r filename; do
             rules=("${shared_rules[@]}")

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,21 @@
+name: YAML Linting
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+    paths:
+      - "**/*.yml"
+      - ".yamllint"
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v3
+        # with:
+        #   file_or_dir: .github/**/*.yml
+        env:
+          LANG: C.UTF-8

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run yamllint
         uses: ibiqlik/action-yamllint@v3
-        # with:
-        #   file_or_dir: .github/**/*.yml
+        with:
+          format: github
         env:
           LANG: C.UTF-8

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+---
+extends: default
+
+ignore: |
+  vendor/
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+
+  document-start: disable
+
+  line-length: disable
+
+  truthy:
+    check-keys: false

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -216,4 +216,7 @@ skaff:
 tfsdk2fw:
 	cd tools/tfsdk2fw && go install github.com/hashicorp/terraform-provider-aws/tools/tfsdk2fw
 
+yamllint:
+	@yamllint .
+
 .PHONY: providerlint build gen generate-changelog gh-workflows-lint golangci-lint sweep test testacc fmt fmtcheck lint tools test-compile website-link-check website-lint website-lint-fix depscheck docscheck semgrep skaff tfsdk2fw

--- a/examples/ecs-alb/cloud-config.yml
+++ b/examples/ecs-alb/cloud-config.yml
@@ -1,43 +1,43 @@
-#cloud-config
+# cloud-config
 coreos:
   units:
-   - name: update-engine.service
-     command: stop
-   - name: amazon-ecs-agent.service
-     command: start
-     runtime: true
-     content: |
-       [Unit]
-       Description=AWS ECS Agent
-       Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
-       Requires=docker.socket
-       After=docker.socket
+    - name: update-engine.service
+      command: stop
+    - name: amazon-ecs-agent.service
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=AWS ECS Agent
+        Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
+        Requires=docker.socket
+        After=docker.socket
 
-       [Service]
-       Environment=ECS_CLUSTER=${ecs_cluster_name}
-       Environment=ECS_LOGLEVEL=${ecs_log_level}
-       Environment=ECS_VERSION=${ecs_agent_version}
-       Restart=on-failure
-       RestartSec=30
-       RestartPreventExitStatus=5
-       SyslogIdentifier=ecs-agent
-       ExecStartPre=-/bin/mkdir -p /var/log/ecs /var/ecs-data /etc/ecs
-       ExecStartPre=-/usr/bin/docker kill ecs-agent
-       ExecStartPre=-/usr/bin/docker rm ecs-agent
-       ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent:$${ECS_VERSION}
-       ExecStart=/usr/bin/docker run --name ecs-agent \
-                                     --volume=/var/run/docker.sock:/var/run/docker.sock \
-                                     --volume=/var/log/ecs:/log \
-                                     --volume=/var/ecs-data:/data \
-                                     --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
-                                     --volume=/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro \
-                                     --publish=127.0.0.1:51678:51678 \
-                                     --env=ECS_LOGFILE=/log/ecs-agent.log \
-                                     --env=ECS_LOGLEVEL=$${ECS_LOGLEVEL} \
-                                     --env=ECS_DATADIR=/data \
-                                     --env=ECS_CLUSTER=$${ECS_CLUSTER} \
-                                     --env=ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' \
-                                     --log-driver=awslogs \
-                                     --log-opt awslogs-region=${aws_region} \
-                                     --log-opt awslogs-group=${ecs_log_group_name} \
-                                     amazon/amazon-ecs-agent:$${ECS_VERSION}
+        [Service]
+        Environment=ECS_CLUSTER=${ecs_cluster_name}
+        Environment=ECS_LOGLEVEL=${ecs_log_level}
+        Environment=ECS_VERSION=${ecs_agent_version}
+        Restart=on-failure
+        RestartSec=30
+        RestartPreventExitStatus=5
+        SyslogIdentifier=ecs-agent
+        ExecStartPre=-/bin/mkdir -p /var/log/ecs /var/ecs-data /etc/ecs
+        ExecStartPre=-/usr/bin/docker kill ecs-agent
+        ExecStartPre=-/usr/bin/docker rm ecs-agent
+        ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent:$${ECS_VERSION}
+        ExecStart=/usr/bin/docker run --name ecs-agent \
+                                      --volume=/var/run/docker.sock:/var/run/docker.sock \
+                                      --volume=/var/log/ecs:/log \
+                                      --volume=/var/ecs-data:/data \
+                                      --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+                                      --volume=/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro \
+                                      --publish=127.0.0.1:51678:51678 \
+                                      --env=ECS_LOGFILE=/log/ecs-agent.log \
+                                      --env=ECS_LOGLEVEL=$${ECS_LOGLEVEL} \
+                                      --env=ECS_DATADIR=/data \
+                                      --env=ECS_CLUSTER=$${ECS_CLUSTER} \
+                                      --env=ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' \
+                                      --log-driver=awslogs \
+                                      --log-opt awslogs-region=${aws_region} \
+                                      --log-opt awslogs-group=${ecs_log_group_name} \
+                                      amazon/amazon-ecs-agent:$${ECS_VERSION}

--- a/internal/generate/servicesemgrep/main.go
+++ b/internal/generate/servicesemgrep/main.go
@@ -480,7 +480,7 @@ rules:
       - metavariable-pattern:
           metavariable: $NAME
           patterns:
-          - pattern-regex: "({{ $s }})"
+            - pattern-regex: "({{ $s }})"
     severity: WARNING
 {{- end }}
   - id: ec2-in-func-name

--- a/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/resource-role.yaml
+++ b/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/resource-role.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       MaxSessionDuration: 8400
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -19,15 +19,15 @@ Resources:
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
-                - "initech:CreateReport"
-                - "initech:DeleteReport"
-                - "initech:DescribeReport"
-                - "initech:ListReports"
-                - "initech:UpdateReport"
+                  - "initech:CreateReport"
+                  - "initech:DeleteReport"
+                  - "initech:DescribeReport"
+                  - "initech:ListReports"
+                  - "initech:UpdateReport"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/template.yml
+++ b/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/template.yml
@@ -21,7 +21,6 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
-


### PR DESCRIPTION
Adds [`yamllint`](https://yamllint.readthedocs.io/en/stable/) linting for all YAML files.

Uses the [default ruleset](https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration) with the following exceptions:

* Requires only 1 space before comments (default is 2)
* Does not require the document start marker (`---`)
* Does not limit line length
* Does not check for truthy values in keys. Otherwise this would flag the `on` key in GitHub workflows

Adds GitHub workflow and makefile rule