### PR TITLE
Docs: update aws_lb_listener_certificate import documentation to make…

### DIFF
--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -50,7 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Listener Certificates can be imported using their id, e.g.,
+Listener Certificates can be imported by using the listener arn and certificate arn, separated by an underscore (`_`), e.g.,
 
 ```
 $ terraform import aws_lb_listener_certificate.example arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:iam::123456789012:server-certificate/tf-acc-test-6453083910015726063


### PR DESCRIPTION
This PR updates the documentation for the `aws_lb_listener_certificate` resource to make import steps more clear and match the rest of the documentation for similar resources like the [`aws_ec2_transit_gateway_prefix_list_reference` resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_prefix_list_reference#import).

The current import steps for the `aws_lb_listener_certificate` resource do not make it clear that you need to specify the listener arn and certificate arn, seperated by an underscore. The error message received upon a failed import also makes this clear, however this does not match the documentation.

Error message returned on a failed import:

```
Error: parsing ELBv2 Listener Certificate ID (test): unexpected format for ID ("test"), expected listener-arn_certificate-arn
```

The language added in this pull request follows the pattern of the language in the documentation for the `aws_ec2_transit_gateway_prefix_list_reference` resource, which is very similar in the context of importing to the `aws_lb_listener_certificate` resource.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
