### PR TITLE
aws_elasticsearch_domain add throughput attr 26045

### DIFF
--- a/.changelog/26045.txt
+++ b/.changelog/26045.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_elasticsearch_domain: Add `throughput` attribute to the `ebs_options` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_elasticsearch_domain: Add `throughput` attribute to the `ebs_options` configuration block
+```

--- a/.changelog/26045.txt
+++ b/.changelog/26045.txt
@@ -5,3 +5,11 @@ resource/aws_elasticsearch_domain: Add `throughput` attribute to the `ebs_option
 ```release-note:enhancement
 data-source/aws_elasticsearch_domain: Add `throughput` attribute to the `ebs_options` configuration block
 ```
+
+```release-note:enhancement
+resource/aws_opensearch_domain: Add `throughput` attribute to the `ebs_options` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_opensearch_domain: Add `throughput` attribute to the `ebs_options` configuration block
+```

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -385,6 +385,12 @@ func ResourceDomain() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"throughput": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(125, 1000),
+						},
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,

--- a/internal/service/elasticsearch/domain_data_source.go
+++ b/internal/service/elasticsearch/domain_data_source.go
@@ -215,6 +215,10 @@ func DataSourceDomain() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"throughput": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Computed: true,

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -41,6 +41,7 @@ func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.zone_awareness_enabled", resourceName, "cluster_config.0.zone_awareness_enabled"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.#", resourceName, "ebs_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.ebs_enabled", resourceName, "ebs_options.0.ebs_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.throughput", resourceName, "ebs_options.0.throughput"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_type", resourceName, "ebs_options.0.volume_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_size", resourceName, "ebs_options.0.volume_size"),
 					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.#", resourceName, "snapshot_options.#"),
@@ -150,7 +151,7 @@ POLICY
   }
 
   cluster_config {
-    instance_type            = "t2.small.elasticsearch"
+    instance_type            = "t3.small.elasticsearch"
     instance_count           = 2
     dedicated_master_enabled = false
 
@@ -163,7 +164,9 @@ POLICY
 
   ebs_options {
     ebs_enabled = true
-    volume_type = "gp2"
+    iops        = 3000
+    throughput  = 125
+    volume_type = "gp3"
     volume_size = 20
   }
 

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -1358,11 +1358,13 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_clusterUpdateEBSVolume(rName, 24),
+				Config: testAccDomainConfig_clusterUpdateEBSVolume(rName, 24, 250, 3500),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &input),
 					testAccCheckEBSVolumeEnabled(true, &input),
 					testAccCheckEBSVolumeSize(24, &input),
+					testAccCheckEBSVolumeThroughput(250, &input),
+					testAccCheckEBSVolumeIops(3500, &input),
 				),
 			},
 			{
@@ -1379,11 +1381,13 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDomainConfig_clusterUpdateEBSVolume(rName, 12),
+				Config: testAccDomainConfig_clusterUpdateEBSVolume(rName, 12, 125, 3000),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &input),
 					testAccCheckEBSVolumeEnabled(true, &input),
 					testAccCheckEBSVolumeSize(12, &input),
+					testAccCheckEBSVolumeThroughput(125, &input),
+					testAccCheckEBSVolumeIops(3000, &input),
 				),
 			},
 		}})
@@ -1537,6 +1541,26 @@ func testAccCheckNumberOfSecurityGroups(numberOfSecurityGroups int, status *elas
 		count := len(status.VPCOptions.SecurityGroupIds)
 		if count != numberOfSecurityGroups {
 			return fmt.Errorf("Number of security groups differ. Given: %d, Expected: %d", count, numberOfSecurityGroups)
+		}
+		return nil
+	}
+}
+
+func testAccCheckEBSVolumeThroughput(ebsVolumeThroughput int, status *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conf := status.EBSOptions
+		if *conf.Throughput != int64(ebsVolumeThroughput) {
+			return fmt.Errorf("EBS throughput differ. Given: %d, Expected: %d", *conf.Throughput, ebsVolumeThroughput)
+		}
+		return nil
+	}
+}
+
+func testAccCheckEBSVolumeIops(ebsVolumeIops int, status *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conf := status.EBSOptions
+		if *conf.Iops != int64(ebsVolumeIops) {
+			return fmt.Errorf("EBS IOPS differ. Given: %d, Expected: %d", *conf.Iops, ebsVolumeIops)
 		}
 		return nil
 	}
@@ -2048,7 +2072,7 @@ resource "aws_elasticsearch_domain" "test" {
 `, rName, instanceInt, snapshotInt)
 }
 
-func testAccDomainConfig_clusterUpdateEBSVolume(rName string, volumeSize int) string {
+func testAccDomainConfig_clusterUpdateEBSVolume(rName string, volumeSize int, volumeThroughput int, volumeIops int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
   domain_name = substr(%[1]q, 0, 28)
@@ -2062,15 +2086,18 @@ resource "aws_elasticsearch_domain" "test" {
   ebs_options {
     ebs_enabled = true
     volume_size = %d
+    throughput  = %d
+    volume_type = "gp3"
+    iops        = %d
   }
 
   cluster_config {
     instance_count         = 2
     zone_awareness_enabled = true
-    instance_type          = "t2.small.elasticsearch"
+    instance_type          = "t3.small.elasticsearch"
   }
 }
-`, rName, volumeSize)
+`, rName, volumeSize, volumeThroughput, volumeIops)
 }
 
 func testAccDomainConfig_clusterUpdateVersion(rName, version string) string {

--- a/internal/service/elasticsearch/flex.go
+++ b/internal/service/elasticsearch/flex.go
@@ -80,6 +80,9 @@ func expandEBSOptions(m map[string]interface{}) *elasticsearch.EBSOptions {
 			if v, ok := m["iops"]; ok && v.(int) > 0 {
 				options.Iops = aws.Int64(int64(v.(int)))
 			}
+			if v, ok := m["throughput"]; ok && v.(int) > 0 {
+				options.Throughput = aws.Int64(int64(v.(int)))
+			}
 			if v, ok := m["volume_size"]; ok && v.(int) > 0 {
 				options.VolumeSize = aws.Int64(int64(v.(int)))
 			}
@@ -164,6 +167,9 @@ func flattenEBSOptions(o *elasticsearch.EBSOptions) []map[string]interface{} {
 	if aws.BoolValue(o.EBSEnabled) {
 		if o.Iops != nil {
 			m["iops"] = aws.Int64Value(o.Iops)
+		}
+		if o.Throughput != nil {
+			m["throughput"] = aws.Int64Value(o.Throughput)
 		}
 		if o.VolumeSize != nil {
 			m["volume_size"] = aws.Int64Value(o.VolumeSize)

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -384,6 +384,12 @@ func ResourceDomain() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"throughput": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(125, 1000),
+						},
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -123,6 +123,10 @@ func DataSourceDomain() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"throughput": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Computed: true,

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -166,7 +166,7 @@ POLICY
   ebs_options {
     ebs_enabled = true
     iops        = 3000
-	throughput  = 125
+    throughput  = 125
     volume_type = "gp3"
     volume_size = 20
   }

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -41,8 +41,10 @@ func TestAccOpenSearchDomainDataSource_Data_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.zone_awareness_enabled", resourceName, "cluster_config.0.zone_awareness_enabled"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.#", resourceName, "ebs_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.ebs_enabled", resourceName, "ebs_options.0.ebs_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.throughput", resourceName, "ebs_options.0.throughput"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_type", resourceName, "ebs_options.0.volume_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_size", resourceName, "ebs_options.0.volume_size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.iops", resourceName, "ebs_options.0.iops"),
 					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.#", resourceName, "snapshot_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.0.automated_snapshot_start_hour", resourceName, "snapshot_options.0.automated_snapshot_start_hour"),
 					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.#", resourceName, "advanced_security_options.#"),
@@ -150,7 +152,7 @@ POLICY
   }
 
   cluster_config {
-    instance_type            = "t2.small.search"
+    instance_type            = "t3.small.search"
     instance_count           = 2
     dedicated_master_enabled = false
 
@@ -163,7 +165,9 @@ POLICY
 
   ebs_options {
     ebs_enabled = true
-    volume_type = "gp2"
+    iops        = 3000
+	throughput  = 125
+    volume_type = "gp3"
     volume_size = 20
   }
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -2196,9 +2196,9 @@ resource "aws_opensearch_domain" "test" {
   ebs_options {
     ebs_enabled = true
     volume_size = %d
-	throughput  = %d
-	volume_type = "gp3"
-	iops        = %d
+    throughput  = %d
+    volume_type = "gp3"
+    iops        = %d
   }
 
   cluster_config {

--- a/internal/service/opensearch/flex.go
+++ b/internal/service/opensearch/flex.go
@@ -80,6 +80,9 @@ func expandEBSOptions(m map[string]interface{}) *opensearchservice.EBSOptions {
 			if v, ok := m["iops"]; ok && v.(int) > 0 {
 				options.Iops = aws.Int64(int64(v.(int)))
 			}
+			if v, ok := m["throughput"]; ok && v.(int) > 0 {
+				options.Throughput = aws.Int64(int64(v.(int)))
+			}
 			if v, ok := m["volume_size"]; ok && v.(int) > 0 {
 				options.VolumeSize = aws.Int64(int64(v.(int)))
 			}
@@ -164,6 +167,9 @@ func flattenEBSOptions(o *opensearchservice.EBSOptions) []map[string]interface{}
 	if aws.BoolValue(o.EBSEnabled) {
 		if o.Iops != nil {
 			m["iops"] = aws.Int64Value(o.Iops)
+		}
+		if o.Throughput != nil {
+			m["throughput"] = aws.Int64Value(o.Throughput)
 		}
 		if o.VolumeSize != nil {
 			m["volume_size"] = aws.Int64Value(o.VolumeSize)

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -68,6 +68,7 @@ The following attributes are exported:
 * `domain_id` – Unique identifier for the domain.
 * `ebs_options` - EBS Options for the instances in the domain.
     * `ebs_enabled` - Whether EBS volumes are attached to data nodes in the domain.
+    * `throughput` - The throughput (in MiB/s) of the EBS volumes attached to data nodes.
     * `volume_type` - The type of EBS volumes attached to data nodes.
     * `volume_size` - The size of EBS volumes attached to data nodes (in GB).
     * `iops` - The baseline input/output (I/O) performance of EBS volumes attached to data nodes.

--- a/website/docs/d/opensearch_domain.html.markdown
+++ b/website/docs/d/opensearch_domain.html.markdown
@@ -68,6 +68,7 @@ The following attributes are exported:
 * `domain_id` – Unique identifier for the domain.
 * `ebs_options` - EBS Options for the instances in the domain.
     * `ebs_enabled` - Whether EBS volumes are attached to data nodes in the domain.
+    * `throughput` - The throughput (in MiB/s) of the EBS volumes attached to data nodes.
     * `volume_type` - Type of EBS volumes attached to data nodes.
     * `volume_size` - Size of EBS volumes attached to data nodes (in GB).
     * `iops` - Baseline input/output (I/O) performance of EBS volumes attached to data nodes.

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -293,7 +293,8 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 ### ebs_options
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
-* `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
+* `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the GP3 and Provisioned IOPS EBS volume types.
+* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`.
 * `volume_size` - (Required if `ebs_enabled` is set to `true`.) Size of EBS volumes attached to data nodes (in GiB).
 * `volume_type` - (Optional) Type of EBS volumes attached to data nodes.
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -310,7 +310,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 ### ebs_options
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
-* `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
+* `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the GP3 and Provisioned IOPS EBS volume types.
 * `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`
 * `volume_size` - (Required if `ebs_enabled` is set to `true`.) Size of EBS volumes attached to data nodes (in GiB).
 * `volume_type` - (Optional) Type of EBS volumes attached to data nodes.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -311,6 +311,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
 * `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
+* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`
 * `volume_size` - (Required if `ebs_enabled` is set to `true`.) Size of EBS volumes attached to data nodes (in GiB).
 * `volume_type` - (Optional) Type of EBS volumes attached to data nodes.
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -311,7 +311,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
 * `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the GP3 and Provisioned IOPS EBS volume types.
-* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`
+* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`.
 * `volume_size` - (Required if `ebs_enabled` is set to `true`.) Size of EBS volumes attached to data nodes (in GiB).
 * `volume_type` - (Optional) Type of EBS volumes attached to data nodes.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26045

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccOpenSearchDomainDataSource_Data_basic' PKG=opensearch ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 1  -run=TestAccOpenSearchDomainDataSource_Data_basic -timeout 180m
=== RUN   TestAccOpenSearchDomainDataSource_Data_basic
=== PAUSE TestAccOpenSearchDomainDataSource_Data_basic
=== CONT  TestAccOpenSearchDomainDataSource_Data_basic
--- PASS: TestAccOpenSearchDomainDataSource_Data_basic (1426.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1428.214s

nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccOpenSearchDomainDataSource_Data_advanced' PKG=opensearch ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 1  -run=TestAccOpenSearchDomainDataSource_Data_advanced -timeout 180m
=== RUN   TestAccOpenSearchDomainDataSource_Data_advanced
=== PAUSE TestAccOpenSearchDomainDataSource_Data_advanced
=== CONT  TestAccOpenSearchDomainDataSource_Data_advanced
--- PASS: TestAccOpenSearchDomainDataSource_Data_advanced (1838.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1840.528s


nick@nick1 terraform-provider-aws % make testacc TESTARGS='-run=TestAccOpenSearchDomain_VolumeType_update' PKG=opensearch ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 1  -run=TestAccOpenSearchDomain_VolumeType_update -timeout 180m
=== RUN   TestAccOpenSearchDomain_VolumeType_update
=== PAUSE TestAccOpenSearchDomain_VolumeType_update
=== CONT  TestAccOpenSearchDomain_VolumeType_update
--- PASS: TestAccOpenSearchDomain_VolumeType_update (3450.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 3451.857s
```
