### PR TITLE
Fix semgrep `ci.avoid-context-TODO-in-tests`

### DIFF
--- a/internal/service/location/tracker_association_test.go
+++ b/internal/service/location/tracker_association_test.go
@@ -168,7 +168,7 @@ func testAccCheckTrackerAssociationExists(name string) resource.TestCheckFunc {
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LocationConn
 
-		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.TODO(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
+		err = tflocation.FindTrackerAssociationByTrackerNameAndConsumerARN(context.Background(), conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
 
 		if err != nil {
 			return create.Error(names.Location, create.ErrActionCheckingExistence, tflocation.ResNameTrackerAssociation, rs.Primary.ID, err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/26061.
Relates #26147.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
