### PR TITLE
r/aws_lb_listener: update tags after creation

### DIFF
--- a/.changelog/26194.txt
+++ b/.changelog/26194.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+ resource/aws_lb_listener: Fix `ValidationError` when tags are added on `create`
+```
+
+ ```release-note:bug
+  resource/aws_lb_target_group: Fix `ValidationError` when tags are added on `create`
+ ```

--- a/.changelog/26194.txt
+++ b/.changelog/26194.txt
@@ -2,6 +2,6 @@
  resource/aws_lb_listener: Fix `ValidationError` when tags are added on `create`
 ```
 
- ```release-note:bug
+```release-note:bug
   resource/aws_lb_target_group: Fix `ValidationError` when tags are added on `create`
- ```
+```

--- a/internal/service/elbv2/const.go
+++ b/internal/service/elbv2/const.go
@@ -1,0 +1,7 @@
+package elbv2
+
+const (
+	ErrValidationError = "ValidationError"
+
+	TagsOnCreationErrMessage = "cannot specify tags on creation"
+)

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -443,7 +443,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Tags are not supported on creation with some load balancer types (i.e. Gateway)
 	// Retry creation without tags
-	if params.Tags != nil && tfawserr.ErrMessageContains(err, "ValidationError", "cannot specify tags on creation") {
+	if params.Tags != nil && tfawserr.ErrMessageContains(err, ErrValidationError, TagsOnCreationErrMessage) {
 		log.Printf("[WARN] ELBv2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
 		params.Tags = nil
 		output, err = retryListenerCreate(conn, params)

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -435,7 +435,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryListenerCreate(conn, params)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
 		params.Tags = nil
 		output, err = retryListenerCreate(conn, params)

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -314,6 +314,7 @@ func TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", lbResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", ""),
 					resource.TestCheckResourceAttr(resourceName, "port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -1237,6 +1238,10 @@ resource "aws_lb_listener" "test" {
   default_action {
     target_group_arn = aws_lb_target_group.test.id
     type             = "forward"
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
 `, rName))

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -374,6 +374,14 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		resp, err = conn.CreateTargetGroup(params)
 	}
 
+	// Tags are not supported on creation with some protocol types(i.e. GENEVE)
+	// Retry creation without tags
+	if params.Tags != nil && tfawserr.ErrMessageContains(err, "ValidationError", "cannot specify tags on creation") {
+		log.Printf("[WARN] ELBv2 Target Group (%s) create failed (%s) with tags. Trying create without tags.", groupName, err)
+		params.Tags = nil
+		resp, err = conn.CreateTargetGroup(params)
+	}
+
 	if err != nil {
 		return fmt.Errorf("creating LB Target Group: %w", err)
 	}

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -376,7 +376,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Tags are not supported on creation with some protocol types(i.e. GENEVE)
 	// Retry creation without tags
-	if params.Tags != nil && tfawserr.ErrMessageContains(err, "ValidationError", "cannot specify tags on creation") {
+	if params.Tags != nil && tfawserr.ErrMessageContains(err, ErrValidationError, TagsOnCreationErrMessage) {
 		log.Printf("[WARN] ELBv2 Target Group (%s) create failed (%s) with tags. Trying create without tags.", groupName, err)
 		params.Tags = nil
 		resp, err = conn.CreateTargetGroup(params)

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -924,6 +924,7 @@ func TestAccELBV2TargetGroup_Geneve_basic(t *testing.T) {
 					testAccCheckTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "port", "6081"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", elbv2.ProtocolEnumGeneve),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
@@ -2163,6 +2164,10 @@ resource "aws_lb_target_group" "test" {
   health_check {
     port     = 80
     protocol = "HTTP"
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
 `, rName)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -54,7 +54,7 @@ const (
 )
 
 func CheckISOErrorTagsUnsupported(partition string, err error) bool {
-	if partition == endpoints.AwsIsoPartitionID {
+	if partition == endpoints.AwsPartitionID {
 		return false
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -114,10 +114,6 @@ func CheckISOErrorTagsUnsupported(partition string, err error) bool {
 		return true
 	}
 
-	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "cannot specify tags on creation") {
-		return true
-	}
-
 	if tfawserr.ErrCodeContains(err, ErrCodeValidationException) {
 		return true
 	}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -54,7 +54,7 @@ const (
 )
 
 func CheckISOErrorTagsUnsupported(partition string, err error) bool {
-	if partition == endpoints.AwsPartitionID {
+	if partition == endpoints.AwsIsoPartitionID {
 		return false
 	}
 
@@ -111,6 +111,10 @@ func CheckISOErrorTagsUnsupported(partition string, err error) bool {
 	}
 
 	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "not support tagging") {
+		return true
+	}
+
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "cannot specify tags on creation") {
 		return true
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19888
Closes #20144

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestAccELBV2Listener_ PKG=elbv2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2Listener_'  -timeout 180m
=== RUN   TestAccELBV2Listener_basic
=== PAUSE TestAccELBV2Listener_basic
=== RUN   TestAccELBV2Listener_tags
=== PAUSE TestAccELBV2Listener_tags
=== RUN   TestAccELBV2Listener_forwardWeighted
=== PAUSE TestAccELBV2Listener_forwardWeighted
=== RUN   TestAccELBV2Listener_Protocol_upd
=== PAUSE TestAccELBV2Listener_Protocol_upd
=== RUN   TestAccELBV2Listener_backwardsCompatibility
=== PAUSE TestAccELBV2Listener_backwardsCompatibility
=== RUN   TestAccELBV2Listener_Protocol_https
=== PAUSE TestAccELBV2Listener_Protocol_https
=== RUN   TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer
=== PAUSE TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer
=== RUN   TestAccELBV2Listener_Protocol_tls
=== PAUSE TestAccELBV2Listener_Protocol_tls
=== RUN   TestAccELBV2Listener_redirect
=== PAUSE TestAccELBV2Listener_redirect
=== RUN   TestAccELBV2Listener_fixedResponse
=== PAUSE TestAccELBV2Listener_fixedResponse
=== RUN   TestAccELBV2Listener_cognito
=== PAUSE TestAccELBV2Listener_cognito
=== RUN   TestAccELBV2Listener_oidc
=== PAUSE TestAccELBV2Listener_oidc
=== RUN   TestAccELBV2Listener_DefaultAction_order
=== PAUSE TestAccELBV2Listener_DefaultAction_order
=== RUN   TestAccELBV2Listener_DefaultAction_orderRecreates
=== PAUSE TestAccELBV2Listener_DefaultAction_orderRecreates
=== CONT  TestAccELBV2Listener_basic
=== CONT  TestAccELBV2Listener_Protocol_tls
=== CONT  TestAccELBV2Listener_oidc
=== CONT  TestAccELBV2Listener_fixedResponse
=== CONT  TestAccELBV2Listener_DefaultAction_orderRecreates
=== CONT  TestAccELBV2Listener_DefaultAction_order
=== CONT  TestAccELBV2Listener_cognito
=== CONT  TestAccELBV2Listener_backwardsCompatibility
=== CONT  TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer
=== CONT  TestAccELBV2Listener_Protocol_https
=== CONT  TestAccELBV2Listener_forwardWeighted
=== CONT  TestAccELBV2Listener_Protocol_upd
=== CONT  TestAccELBV2Listener_tags
=== CONT  TestAccELBV2Listener_redirect
--- PASS: TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer (102.33s)
--- PASS: TestAccELBV2Listener_DefaultAction_orderRecreates (172.66s)
--- PASS: TestAccELBV2Listener_oidc (184.65s)
--- PASS: TestAccELBV2Listener_DefaultAction_order (195.73s)
--- PASS: TestAccELBV2Listener_redirect (209.74s)
--- PASS: TestAccELBV2Listener_basic (215.41s)
--- PASS: TestAccELBV2Listener_Protocol_https (216.52s)
--- PASS: TestAccELBV2Listener_cognito (219.89s)
--- PASS: TestAccELBV2Listener_tags (223.28s)
--- PASS: TestAccELBV2Listener_Protocol_upd (236.04s)
--- PASS: TestAccELBV2Listener_forwardWeighted (239.78s)
--- PASS: TestAccELBV2Listener_backwardsCompatibility (244.94s)
--- PASS: TestAccELBV2Listener_fixedResponse (252.21s)
--- PASS: TestAccELBV2Listener_Protocol_tls (405.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	408.312s
...
```
