### PR TITLE
r/aws_security_group_rule: Prevent crash when empty strings in `prefix_list_ids`

### DIFF
--- a/.changelog/26220.txt
+++ b/.changelog/26220.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_security_group_rule: Disallow empty strings in `prefix_list_ids`
+```

--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -83,10 +83,13 @@ func ResourceSecurityGroupRule() *schema.Resource {
 				AtLeastOneOf:  []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "self", "source_security_group_id"},
 			},
 			"prefix_list_ids": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				ForceNew:     true,
-				Elem:         &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
 				AtLeastOneOf: []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "self", "source_security_group_id"},
 			},
 			"protocol": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26191.

Before fix:

```console
% make testacc TESTARGS='-run=TestAccVPCSecurityGroupRule_prefixListEmptyString' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCSecurityGroupRule_prefixListEmptyString -timeout 180m
=== RUN   TestAccVPCSecurityGroupRule_prefixListEmptyString
=== PAUSE TestAccVPCSecurityGroupRule_prefixListEmptyString
=== CONT  TestAccVPCSecurityGroupRule_prefixListEmptyString
panic: interface conversion: interface {} is nil, not string

goroutine 1917 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.expandIpPermission(0x0?, 0xc0064bbe30)
	/Users/ewbankkit/altsrc.2/github.com/terraform-providers/terraform-provider-aws/internal/service/ec2/vpc_security_group_rule.go:718 +0xf25
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.resourceSecurityGroupRuleCreate(0x0?, {0x98c5bc0?, 0xc004ac0a80?})
	/Users/ewbankkit/altsrc.2/github.com/terraform-providers/terraform-provider-aws/internal/service/ec2/vpc_security_group_rule.go:155 +0x227
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xbce7060?, {0xbce7060?, 0xc0022d4090?}, 0xd?, {0x98c5bc0?, 0xc004ac0a80?})
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.20.0/helper/schema/resource.go:695 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0032bfce0, {0xbce7060, 0xc0022d4090}, 0xc0015ef5f0, 0xc0055e8d00, {0x98c5bc0, 0xc004ac0a80})
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.20.0/helper/schema/resource.go:837 +0xa7a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0030cab58, {0xbce7060?, 0xc0022d1fb0?}, 0xc0005c9310)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.20.0/helper/schema/grpc_provider.go:1021 +0xe3c
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.muxServer.ApplyResourceChange({0xc0027d4ea0, 0xc0027d4f00, {0xc0005c5900, 0x2, 0x2}, 0xc0027d4ed0, 0xc00309f3c0, 0xc005a8fc50, 0xc0027d4f30}, {0xbce7060, ...}, ...)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.7.0/tf5muxserver/mux_server_ApplyResourceChange.go:27 +0x142
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc002ed2460, {0xbce7060?, 0xc0022c59b0?}, 0xc000b19960)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.13.0/tfprotov5/tf5server/server.go:813 +0x4fc
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xab5f2c0?, 0xc002ed2460}, {0xbce7060, 0xc0022c59b0}, 0xc000b19810, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.13.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000005a0, {0xbcec808, 0xc00624a680}, 0xc0021818c0, 0xc00223ef60, 0x115062e0, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1295 +0xb0b
google.golang.org/grpc.(*Server).handleStream(0xc0000005a0, {0xbcec808, 0xc00624a680}, 0xc0021818c0, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1636 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:932 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:930 +0x28a
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	13.934s
FAIL
make: *** [testacc] Error 1
```

Now:

```console
% make testacc TESTARGS='-run=TestAccVPCSecurityGroupRule_prefixList' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVPCSecurityGroupRule_prefixList -timeout 180m
=== RUN   TestAccVPCSecurityGroupRule_prefixListEgress
=== PAUSE TestAccVPCSecurityGroupRule_prefixListEgress
=== RUN   TestAccVPCSecurityGroupRule_prefixListEmptyString
=== PAUSE TestAccVPCSecurityGroupRule_prefixListEmptyString
=== CONT  TestAccVPCSecurityGroupRule_prefixListEgress
=== CONT  TestAccVPCSecurityGroupRule_prefixListEmptyString
--- PASS: TestAccVPCSecurityGroupRule_prefixListEmptyString (1.76s)
--- PASS: TestAccVPCSecurityGroupRule_prefixListEgress (34.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	39.095s
```