### PR TITLE
Generate fixed-length OpenSearch & Elasticsearch random domain names in acceptance tests

### DIFF
--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -304,10 +304,8 @@ POLICY
     security_group_ids = [
       aws_security_group.test.id
     ]
-    subnet_ids = [
-      aws_subnet.test.id,
-      aws_subnet.test2.id
-    ]
+
+    subnet_ids = aws_subnet.test[*].id
   }
 
   advanced_security_options {

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
+func TestAccElasticsearchDomainDataSource_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -52,7 +52,7 @@ func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
 	})
 }
 
-func TestAccElasticsearchDomainDataSource_Data_advanced(t *testing.T) {
+func TestAccElasticsearchDomainDataSource_advanced(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -316,6 +316,8 @@ POLICY
   tags = {
     Name = local.random_name
   }
+
+  depends_on = [aws_cloudwatch_log_resource_policy.test]
 }
 
 data "aws_elasticsearch_domain" "test" {

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_elasticsearch_domain.test"
 	resourceName := "aws_elasticsearch_domain.test"
@@ -57,7 +57,7 @@ func TestAccElasticsearchDomainDataSource_Data_advanced(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_elasticsearch_domain.test"
 	resourceName := "aws_elasticsearch_domain.test"

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
@@ -15,7 +14,7 @@ func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rInt := sdkacctest.RandInt()
+	rName := randomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_elasticsearch_domain.test"
 	resourceName := "aws_elasticsearch_domain.test"
@@ -26,7 +25,7 @@ func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainDataSourceConfig_basic(rInt, autoTuneStartAtTime),
+				Config: testAccDomainDataSourceConfig_basic(rName, autoTuneStartAtTime),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "processing", "false"),
 					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch_version", resourceName, "elasticsearch_version"),
@@ -58,7 +57,7 @@ func TestAccElasticsearchDomainDataSource_Data_advanced(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rInt := sdkacctest.RandInt()
+	rName := randomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_elasticsearch_domain.test"
 	resourceName := "aws_elasticsearch_domain.test"
@@ -69,7 +68,7 @@ func TestAccElasticsearchDomainDataSource_Data_advanced(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainDataSourceConfig_advanced(rInt, autoTuneStartAtTime),
+				Config: testAccDomainDataSourceConfig_advanced(rName, autoTuneStartAtTime),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch_version", resourceName, "elasticsearch_version"),
 					resource.TestCheckResourceAttrPair(datasourceName, "auto_tune_options.#", resourceName, "auto_tune_options.#"),
@@ -97,10 +96,10 @@ func TestAccElasticsearchDomainDataSource_Data_advanced(t *testing.T) {
 	})
 }
 
-func testAccDomainDataSourceConfig_basic(rInt int, autoTuneStartAtTime string) string {
+func testAccDomainDataSourceConfig_basic(rName, autoTuneStartAtTime string) string {
 	return fmt.Sprintf(`
 locals {
-  random_name = "test-es-%d"
+  random_name = %[1]q
 }
 
 data "aws_partition" "current" {}
@@ -138,7 +137,7 @@ POLICY
     desired_state = "ENABLED"
 
     maintenance_schedule {
-      start_at = "%s"
+      start_at = %[2]q
       duration {
         value = "2"
         unit  = "HOURS"
@@ -178,11 +177,11 @@ POLICY
 data "aws_elasticsearch_domain" "test" {
   domain_name = aws_elasticsearch_domain.test.domain_name
 }
-		`, rInt, autoTuneStartAtTime)
+`, rName, autoTuneStartAtTime)
 }
 
-func testAccDomainDataSourceConfig_advanced(rInt int, autoTuneStartAtTime string) string {
-	return acctest.ConfigAvailableAZsNoOptIn() + fmt.Sprintf(`
+func testAccDomainDataSourceConfig_advanced(rName, autoTuneStartAtTime string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
@@ -190,7 +189,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  random_name = "test-es-%d"
+  random_name = %[1]q
 }
 
 resource "aws_cloudwatch_log_group" "test" {
@@ -221,25 +220,13 @@ resource "aws_cloudwatch_log_resource_policy" "test" {
 CONFIG
 }
 
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = "10.0.0.0/24"
-  vpc_id            = aws_vpc.test.id
-}
-
-resource "aws_subnet" "test2" {
-  availability_zone = data.aws_availability_zones.available.names[1]
-  cidr_block        = "10.0.1.0/24"
-  vpc_id            = aws_vpc.test.id
-}
-
 resource "aws_security_group" "test" {
   name   = local.random_name
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = local.random_name
+  }
 }
 
 resource "aws_security_group_rule" "test" {
@@ -274,7 +261,7 @@ POLICY
     desired_state = "ENABLED"
 
     maintenance_schedule {
-      start_at = "%s"
+      start_at = %[2]q
       duration {
         value = "2"
         unit  = "HOURS"
@@ -329,12 +316,12 @@ POLICY
   }
 
   tags = {
-    Domain = "TestDomain"
+    Name = local.random_name
   }
 }
 
 data "aws_elasticsearch_domain" "test" {
   domain_name = aws_elasticsearch_domain.test.domain_name
 }
-`, rInt, autoTuneStartAtTime)
+`, rName, autoTuneStartAtTime))
 }

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -28,7 +28,7 @@ func TestAccElasticsearchDomain_basic(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -59,7 +59,7 @@ func TestAccElasticsearchDomain_basic(t *testing.T) {
 
 func TestAccElasticsearchDomain_requireHTTPS(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -97,7 +97,7 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
@@ -148,7 +148,7 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 
 func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 	var domain1, domain2, domain3, domain4 elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,7 +207,7 @@ func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 
 func TestAccElasticsearchDomain_warm(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -264,7 +264,7 @@ func TestAccElasticsearchDomain_warm(t *testing.T) {
 
 func TestAccElasticsearchDomain_withColdStorageOptions(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -301,7 +301,7 @@ func TestAccElasticsearchDomain_withColdStorageOptions(t *testing.T) {
 
 func TestAccElasticsearchDomain_withDedicatedMaster(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -344,7 +344,7 @@ func TestAccElasticsearchDomain_duplicate(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -397,7 +397,7 @@ func TestAccElasticsearchDomain_v23(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -430,7 +430,7 @@ func TestAccElasticsearchDomain_complex(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -461,7 +461,7 @@ func TestAccElasticsearchDomain_vpc(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -488,7 +488,7 @@ func TestAccElasticsearchDomain_vpc(t *testing.T) {
 
 func TestAccElasticsearchDomain_VPC_update(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -527,7 +527,7 @@ func TestAccElasticsearchDomain_internetToVPCEndpoint(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -564,7 +564,7 @@ func TestAccElasticsearchDomain_AutoTuneOptions(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	resourceName := "aws_elasticsearch_domain.test"
 
@@ -608,7 +608,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -645,7 +645,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -682,7 +682,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -719,7 +719,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T)
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -754,7 +754,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -789,7 +789,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testin
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -824,7 +824,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -861,7 +861,7 @@ func TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -904,7 +904,7 @@ func TestAccElasticsearchDomain_cognitoOptionsUpdate(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -948,7 +948,7 @@ func TestAccElasticsearchDomain_policy(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -979,7 +979,7 @@ func TestAccElasticsearchDomain_policyIgnoreEquivalent(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1008,7 +1008,7 @@ func TestAccElasticsearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1040,7 +1040,7 @@ func TestAccElasticsearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1071,7 +1071,7 @@ func TestAccElasticsearchDomain_Encryption_atRestEnable(t *testing.T) {
 	}
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1112,7 +1112,7 @@ func TestAccElasticsearchDomain_Encryption_atRestEnableLegacy(t *testing.T) {
 	}
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1146,7 +1146,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNode(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1178,7 +1178,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1219,7 +1219,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) 
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1258,7 +1258,7 @@ func TestAccElasticsearchDomain_tags(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1308,7 +1308,7 @@ func TestAccElasticsearchDomain_update(t *testing.T) {
 	}
 
 	var input elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1348,7 +1348,7 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 	}
 
 	var input elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1401,7 +1401,7 @@ func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1434,7 +1434,7 @@ func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
 
 func TestAccElasticsearchDomain_Update_version(t *testing.T) {
 	var domain1, domain2, domain3 elasticsearch.ElasticsearchDomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1480,7 +1480,7 @@ func TestAccElasticsearchDomain_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1500,7 +1500,7 @@ func TestAccElasticsearchDomain_disappears(t *testing.T) {
 	})
 }
 
-func randomDomainName() string {
+func testAccRandomDomainName() string {
 	return fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1)))
 }
 

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -28,7 +28,7 @@ func TestAccElasticsearchDomain_basic(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -50,7 +50,7 @@ func TestAccElasticsearchDomain_basic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -59,7 +59,7 @@ func TestAccElasticsearchDomain_basic(t *testing.T) {
 
 func TestAccElasticsearchDomain_requireHTTPS(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -77,7 +77,7 @@ func TestAccElasticsearchDomain_requireHTTPS(t *testing.T) {
 			{
 				ResourceName:      "aws_elasticsearch_domain.test",
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -97,9 +97,9 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
-	customEndpoint := fmt.Sprintf("%s.example.com", rName[:28])
+	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
 	certKey := acctest.TLSRSAPrivateKeyPEM(2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(certKey, customEndpoint)
@@ -123,7 +123,7 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -148,7 +148,7 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 
 func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 	var domain1, domain2, domain3, domain4 elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -169,7 +169,7 @@ func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -207,7 +207,7 @@ func TestAccElasticsearchDomain_Cluster_zoneAwareness(t *testing.T) {
 
 func TestAccElasticsearchDomain_warm(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -237,7 +237,7 @@ func TestAccElasticsearchDomain_warm(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -264,7 +264,7 @@ func TestAccElasticsearchDomain_warm(t *testing.T) {
 
 func TestAccElasticsearchDomain_withColdStorageOptions(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -284,7 +284,7 @@ func TestAccElasticsearchDomain_withColdStorageOptions(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -301,7 +301,7 @@ func TestAccElasticsearchDomain_withColdStorageOptions(t *testing.T) {
 
 func TestAccElasticsearchDomain_withDedicatedMaster(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -319,7 +319,7 @@ func TestAccElasticsearchDomain_withDedicatedMaster(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -344,7 +344,7 @@ func TestAccElasticsearchDomain_duplicate(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -354,7 +354,7 @@ func TestAccElasticsearchDomain_duplicate(t *testing.T) {
 		CheckDestroy: func(s *terraform.State) error {
 			conn := acctest.Provider.Meta().(*conns.AWSClient).ElasticsearchConn
 			_, err := conn.DeleteElasticsearchDomain(&elasticsearch.DeleteElasticsearchDomainInput{
-				DomainName: aws.String(rName[:28]),
+				DomainName: aws.String(rName),
 			})
 			return err
 		},
@@ -364,7 +364,7 @@ func TestAccElasticsearchDomain_duplicate(t *testing.T) {
 					// Create duplicate
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ElasticsearchConn
 					_, err := conn.CreateElasticsearchDomain(&elasticsearch.CreateElasticsearchDomainInput{
-						DomainName: aws.String(rName[:28]),
+						DomainName: aws.String(rName),
 						EBSOptions: &elasticsearch.EBSOptions{
 							EBSEnabled: aws.Bool(true),
 							VolumeSize: aws.Int64(10),
@@ -374,7 +374,7 @@ func TestAccElasticsearchDomain_duplicate(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					err = tfelasticsearch.WaitForDomainCreation(conn, rName[:28], 60*time.Minute)
+					err = tfelasticsearch.WaitForDomainCreation(conn, rName, 60*time.Minute)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -397,7 +397,7 @@ func TestAccElasticsearchDomain_v23(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -417,7 +417,7 @@ func TestAccElasticsearchDomain_v23(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -430,7 +430,7 @@ func TestAccElasticsearchDomain_complex(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -448,7 +448,7 @@ func TestAccElasticsearchDomain_complex(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -461,7 +461,7 @@ func TestAccElasticsearchDomain_vpc(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -479,7 +479,7 @@ func TestAccElasticsearchDomain_vpc(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -488,7 +488,7 @@ func TestAccElasticsearchDomain_vpc(t *testing.T) {
 
 func TestAccElasticsearchDomain_VPC_update(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -507,7 +507,7 @@ func TestAccElasticsearchDomain_VPC_update(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -527,7 +527,7 @@ func TestAccElasticsearchDomain_internetToVPCEndpoint(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -545,7 +545,7 @@ func TestAccElasticsearchDomain_internetToVPCEndpoint(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -564,7 +564,7 @@ func TestAccElasticsearchDomain_AutoTuneOptions(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	resourceName := "aws_elasticsearch_domain.test"
 
@@ -595,7 +595,7 @@ func TestAccElasticsearchDomain_AutoTuneOptions(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -608,7 +608,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -627,7 +627,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeElasticsearchDomainConfig
 				ImportStateVerifyIgnore: []string{
@@ -645,7 +645,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -664,7 +664,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeElasticsearchDomainConfig
 				ImportStateVerifyIgnore: []string{
@@ -682,7 +682,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -701,7 +701,7 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeElasticsearchDomainConfig
 				ImportStateVerifyIgnore: []string{
@@ -719,7 +719,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T)
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -741,7 +741,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T)
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -754,7 +754,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -776,7 +776,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -789,7 +789,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testin
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -811,7 +811,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testin
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -824,7 +824,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -846,7 +846,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeElasticsearchDomainConfig
 				ImportStateVerifyIgnore: []string{"advanced_security_options.0.master_user_options"},
@@ -861,7 +861,7 @@ func TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -884,7 +884,7 @@ func TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -904,7 +904,7 @@ func TestAccElasticsearchDomain_cognitoOptionsUpdate(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -927,7 +927,7 @@ func TestAccElasticsearchDomain_cognitoOptionsUpdate(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -948,7 +948,7 @@ func TestAccElasticsearchDomain_policy(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -965,7 +965,7 @@ func TestAccElasticsearchDomain_policy(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -979,7 +979,7 @@ func TestAccElasticsearchDomain_policyIgnoreEquivalent(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1008,7 +1008,7 @@ func TestAccElasticsearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1026,7 +1026,7 @@ func TestAccElasticsearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1040,7 +1040,7 @@ func TestAccElasticsearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1058,7 +1058,7 @@ func TestAccElasticsearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1071,7 +1071,7 @@ func TestAccElasticsearchDomain_Encryption_atRestEnable(t *testing.T) {
 	}
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1112,7 +1112,7 @@ func TestAccElasticsearchDomain_Encryption_atRestEnableLegacy(t *testing.T) {
 	}
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1146,7 +1146,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNode(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1164,7 +1164,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNode(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1178,7 +1178,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1219,7 +1219,7 @@ func TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) 
 
 	var domain1, domain2 elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1258,7 +1258,7 @@ func TestAccElasticsearchDomain_tags(t *testing.T) {
 	}
 
 	var domain elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1278,7 +1278,7 @@ func TestAccElasticsearchDomain_tags(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1308,7 +1308,7 @@ func TestAccElasticsearchDomain_update(t *testing.T) {
 	}
 
 	var input elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1328,7 +1328,7 @@ func TestAccElasticsearchDomain_update(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1348,7 +1348,7 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 	}
 
 	var input elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1370,7 +1370,7 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1401,7 +1401,7 @@ func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
 
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRoleEs(t) },
@@ -1425,7 +1425,7 @@ func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1434,7 +1434,7 @@ func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
 
 func TestAccElasticsearchDomain_Update_version(t *testing.T) {
 	var domain1, domain2, domain3 elasticsearch.ElasticsearchDomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1453,7 +1453,7 @@ func TestAccElasticsearchDomain_Update_version(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1480,7 +1480,7 @@ func TestAccElasticsearchDomain_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1498,6 +1498,10 @@ func TestAccElasticsearchDomain_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func randomDomainName() string {
+	return fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1)))
 }
 
 func testAccCheckDomainEndpointOptions(enforceHTTPS bool, tls string, status *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
@@ -1791,7 +1795,7 @@ func testAccPreCheckIAMServiceLinkedRoleEs(t *testing.T) {
 func testAccDomainConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -1804,7 +1808,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_autoTuneOptions(rName, autoTuneStartAtTime string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "6.7"
 
   ebs_options {
@@ -1834,7 +1838,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_disabledEBSNullVolumeType(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "6.0"
 
   cluster_config {
@@ -1854,7 +1858,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_endpointOptions(rName string, enforceHttps bool, tlsSecurityPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   domain_endpoint_options {
     enforce_https       = %[2]t
@@ -1877,7 +1881,7 @@ resource "aws_acm_certificate" "test" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   domain_endpoint_options {
     enforce_https                   = %[2]t
@@ -1898,7 +1902,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterZoneAwarenessAvailabilityZoneCount(rName string, availabilityZoneCount int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   cluster_config {
     instance_type          = "t2.small.elasticsearch"
@@ -1921,7 +1925,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterZoneAwarenessEnabled(rName string, zoneAwarenessEnabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   cluster_config {
     instance_type          = "t2.small.elasticsearch"
@@ -1948,7 +1952,7 @@ func testAccDomainConfig_warm(rName, warmType string, enabled bool, warmCnt int)
 
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "6.8"
 
   cluster_config {
@@ -1978,7 +1982,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_dedicatedClusterMaster(rName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   cluster_config {
     instance_type            = "t2.small.elasticsearch"
@@ -2016,7 +2020,7 @@ func testAccDomainConfig_coldStorageOptions(rName string, dMasterEnabled bool, w
 
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = "7.9"
 
@@ -2044,7 +2048,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterUpdate(rName string, instanceInt, snapshotInt int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   advanced_options = {
     "indices.fielddata.cache.size" = 80
@@ -2075,7 +2079,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterUpdateEBSVolume(rName string, volumeSize int, volumeThroughput int, volumeIops int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = "6.0"
 
@@ -2103,7 +2107,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterUpdateVersion(rName, version string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = "%v"
 
@@ -2124,7 +2128,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterUpdateInstanceStore(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = "6.0"
 
@@ -2148,7 +2152,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2165,7 +2169,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
   ebs_options {
     ebs_enabled = true
     volume_size = 10
@@ -2183,7 +2187,7 @@ func testAccDomainConfig_policy(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2225,7 +2229,7 @@ func testAccDomainConfig_policyOrder(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2276,7 +2280,7 @@ func testAccDomainConfig_policyNewOrder(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2325,7 +2329,7 @@ data "aws_iam_policy_document" "test" {
 func testAccDomainConfig_encryptAtRestDefaultKey(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = %[2]q
 
@@ -2354,7 +2358,7 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = %[2]q
 
@@ -2379,7 +2383,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_nodeToNodeEncryption(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = %[2]q
 
@@ -2402,7 +2406,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_complex(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   advanced_options = {
     "indices.fielddata.cache.size" = 80
@@ -2433,7 +2437,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_v23(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2486,7 +2490,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2568,7 +2572,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2650,7 +2654,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2712,7 +2716,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2736,7 +2740,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_advancedSecurityOptionsUserDB(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "7.1"
 
   cluster_config {
@@ -2780,7 +2784,7 @@ resource "aws_iam_user" "test" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "7.1"
 
   cluster_config {
@@ -2819,7 +2823,7 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_advancedSecurityOptionsDisabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "7.1"
 
   cluster_config {
@@ -2914,7 +2918,7 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
 	}
 	return acctest.ConfigCompose(testAccDomain_LogPublishingOptions_BaseConfig(rName), fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = substr(%[1]q, 0, 28)
+  domain_name           = %[1]q
   elasticsearch_version = "7.1" # needed for ESApplication/Audit Log Types
 
   ebs_options {
@@ -2992,7 +2996,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   elasticsearch_version = "6.0"
 

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
@@ -15,7 +14,7 @@ func TestAccOpenSearchDomainDataSource_Data_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_opensearch_domain.test"
 	resourceName := "aws_opensearch_domain.test"
@@ -59,7 +58,7 @@ func TestAccOpenSearchDomainDataSource_Data_advanced(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_opensearch_domain.test"
 	resourceName := "aws_opensearch_domain.test"
@@ -107,7 +106,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  domain_substr = substr(%[1]q, 0, 28)
+  domain_substr = %[1]q
 }
 
 resource "aws_opensearch_domain" "test" {
@@ -252,7 +251,7 @@ resource "aws_security_group_rule" "test" {
 }
 
 locals {
-  domain_substr = substr(%[1]q, 0, 28)
+  domain_substr = %[1]q
 }
 
 resource "aws_opensearch_domain" "test" {

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccOpenSearchDomainDataSource_Data_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_opensearch_domain.test"
 	resourceName := "aws_opensearch_domain.test"
@@ -58,7 +58,7 @@ func TestAccOpenSearchDomainDataSource_Data_advanced(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_opensearch_domain.test"
 	resourceName := "aws_opensearch_domain.test"

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -81,7 +81,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -103,7 +103,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -112,7 +112,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 
 func TestAccOpenSearchDomain_requireHTTPS(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -130,7 +130,7 @@ func TestAccOpenSearchDomain_requireHTTPS(t *testing.T) {
 			{
 				ResourceName:      "aws_opensearch_domain.test",
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -150,9 +150,9 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
-	customEndpoint := fmt.Sprintf("%s.example.com", rName[:28])
+	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
 	certKey := acctest.TLSRSAPrivateKeyPEM(2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(certKey, customEndpoint)
@@ -176,7 +176,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -201,7 +201,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 
 func TestAccOpenSearchDomain_Cluster_zoneAwareness(t *testing.T) {
 	var domain1, domain2, domain3, domain4 opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -222,7 +222,7 @@ func TestAccOpenSearchDomain_Cluster_zoneAwareness(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -264,7 +264,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -284,7 +284,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -301,7 +301,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 
 func TestAccOpenSearchDomain_Cluster_warm(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -331,7 +331,7 @@ func TestAccOpenSearchDomain_Cluster_warm(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -358,7 +358,7 @@ func TestAccOpenSearchDomain_Cluster_warm(t *testing.T) {
 
 func TestAccOpenSearchDomain_Cluster_dedicatedMaster(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -376,7 +376,7 @@ func TestAccOpenSearchDomain_Cluster_dedicatedMaster(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -401,7 +401,7 @@ func TestAccOpenSearchDomain_Cluster_update(t *testing.T) {
 	}
 
 	var input opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -421,7 +421,7 @@ func TestAccOpenSearchDomain_Cluster_update(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -441,7 +441,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -451,7 +451,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 		CheckDestroy: func(s *terraform.State) error {
 			conn := acctest.Provider.Meta().(*conns.AWSClient).OpenSearchConn
 			_, err := conn.DeleteDomain(&opensearchservice.DeleteDomainInput{
-				DomainName: aws.String(rName[:28]),
+				DomainName: aws.String(rName),
 			})
 			return err
 		},
@@ -461,7 +461,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 					// Create duplicate
 					conn := acctest.Provider.Meta().(*conns.AWSClient).OpenSearchConn
 					_, err := conn.CreateDomain(&opensearchservice.CreateDomainInput{
-						DomainName: aws.String(rName[:28]),
+						DomainName: aws.String(rName),
 						EBSOptions: &opensearchservice.EBSOptions{
 							EBSEnabled: aws.Bool(true),
 							VolumeSize: aws.Int64(10),
@@ -471,7 +471,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					err = tfopensearch.WaitForDomainCreation(conn, rName[:28], 60*time.Minute)
+					err = tfopensearch.WaitForDomainCreation(conn, rName, 60*time.Minute)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -492,7 +492,7 @@ func TestAccOpenSearchDomain_v23(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -512,7 +512,7 @@ func TestAccOpenSearchDomain_v23(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -525,7 +525,7 @@ func TestAccOpenSearchDomain_complex(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -543,7 +543,7 @@ func TestAccOpenSearchDomain_complex(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -556,7 +556,7 @@ func TestAccOpenSearchDomain_VPC_basic(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -574,7 +574,7 @@ func TestAccOpenSearchDomain_VPC_basic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -583,7 +583,7 @@ func TestAccOpenSearchDomain_VPC_basic(t *testing.T) {
 
 func TestAccOpenSearchDomain_VPC_update(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -602,7 +602,7 @@ func TestAccOpenSearchDomain_VPC_update(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -622,7 +622,7 @@ func TestAccOpenSearchDomain_VPC_internetToVPCEndpoint(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -640,7 +640,7 @@ func TestAccOpenSearchDomain_VPC_internetToVPCEndpoint(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -659,7 +659,7 @@ func TestAccOpenSearchDomain_autoTuneOptions(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	resourceName := "aws_opensearch_domain.test"
 
@@ -689,7 +689,7 @@ func TestAccOpenSearchDomain_autoTuneOptions(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -702,7 +702,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -721,7 +721,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeDomainConfig
 				ImportStateVerifyIgnore: []string{
@@ -739,7 +739,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -758,7 +758,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeDomainConfig
 				ImportStateVerifyIgnore: []string{
@@ -776,7 +776,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -795,7 +795,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeDomainConfig
 				ImportStateVerifyIgnore: []string{
@@ -813,7 +813,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -835,7 +835,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -848,7 +848,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -870,7 +870,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -883,7 +883,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_applicationLogs(t *testing.T) 
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -905,7 +905,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_applicationLogs(t *testing.T) 
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -918,7 +918,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -940,7 +940,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 				// MasterUserOptions are not returned from DescribeDomainConfig
 				ImportStateVerifyIgnore: []string{"advanced_security_options.0.master_user_options"},
@@ -955,7 +955,7 @@ func TestAccOpenSearchDomain_CognitoOptions_createAndRemove(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -978,7 +978,7 @@ func TestAccOpenSearchDomain_CognitoOptions_createAndRemove(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -998,7 +998,7 @@ func TestAccOpenSearchDomain_CognitoOptions_update(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1021,7 +1021,7 @@ func TestAccOpenSearchDomain_CognitoOptions_update(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1042,7 +1042,7 @@ func TestAccOpenSearchDomain_Policy_basic(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1059,7 +1059,7 @@ func TestAccOpenSearchDomain_Policy_basic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1073,7 +1073,7 @@ func TestAccOpenSearchDomain_Policy_ignoreEquivalent(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1102,7 +1102,7 @@ func TestAccOpenSearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1120,7 +1120,7 @@ func TestAccOpenSearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1134,7 +1134,7 @@ func TestAccOpenSearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1152,7 +1152,7 @@ func TestAccOpenSearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1165,7 +1165,7 @@ func TestAccOpenSearchDomain_Encryption_atRestEnable(t *testing.T) {
 	}
 
 	var domain1, domain2 opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1206,7 +1206,7 @@ func TestAccOpenSearchDomain_Encryption_atRestEnableLegacy(t *testing.T) {
 	}
 
 	var domain1, domain2 opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1240,7 +1240,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNode(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1258,7 +1258,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNode(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1272,7 +1272,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 
 	var domain1, domain2 opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1313,7 +1313,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) {
 
 	var domain1, domain2 opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1352,7 +1352,7 @@ func TestAccOpenSearchDomain_tags(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1372,7 +1372,7 @@ func TestAccOpenSearchDomain_tags(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1402,7 +1402,7 @@ func TestAccOpenSearchDomain_VolumeType_update(t *testing.T) {
 	}
 
 	var input opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1424,7 +1424,7 @@ func TestAccOpenSearchDomain_VolumeType_update(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1455,7 +1455,7 @@ func TestAccOpenSearchDomain_VolumeType_missing(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1479,7 +1479,7 @@ func TestAccOpenSearchDomain_VolumeType_missing(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1488,7 +1488,7 @@ func TestAccOpenSearchDomain_VolumeType_missing(t *testing.T) {
 
 func TestAccOpenSearchDomain_versionUpdate(t *testing.T) {
 	var domain1, domain2, domain3 opensearchservice.DomainStatus
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1507,7 +1507,7 @@ func TestAccOpenSearchDomain_versionUpdate(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     rName[:28],
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{
@@ -1534,7 +1534,7 @@ func TestAccOpenSearchDomain_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := randomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1552,6 +1552,10 @@ func TestAccOpenSearchDomain_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func randomDomainName() string {
+	return fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1)))
 }
 
 func testAccCheckDomainEndpointOptions(enforceHTTPS bool, tls string, status *opensearchservice.DomainStatus) resource.TestCheckFunc {
@@ -1896,7 +1900,7 @@ func testAccCheckELBDestroy(s *terraform.State) error {
 func testAccDomainConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -1909,7 +1913,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_autoTuneOptions(rName, autoTuneStartAtTime string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_6.7"
 
   ebs_options {
@@ -1939,7 +1943,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_disabledEBSNullVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_6.0"
 
   cluster_config {
@@ -1959,7 +1963,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_endpointOptions(rName string, enforceHttps bool, tlsSecurityPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   domain_endpoint_options {
     enforce_https       = %[2]t
@@ -1982,7 +1986,7 @@ resource "aws_acm_certificate" "test" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   domain_endpoint_options {
     enforce_https                   = %[2]t
@@ -2003,7 +2007,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_clusterZoneAwarenessAZCount(rName string, availabilityZoneCount int) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_1.5"
 
   cluster_config {
@@ -2044,7 +2048,7 @@ func testAccDomainConfig_clusterColdStorageOptions(rName string, warmEnabled boo
 
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_7.9"
 
   cluster_config {
@@ -2075,7 +2079,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_clusterZoneAwarenessEnabled(rName string, zoneAwarenessEnabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_1.5"
 
   cluster_config {
@@ -2103,7 +2107,7 @@ func testAccDomainConfig_clusterWarm(rName, warmType string, enabled bool, warmC
 
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_6.8"
 
   cluster_config {
@@ -2133,7 +2137,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_dedicatedClusterMaster(rName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   cluster_config {
     instance_type            = "t2.small.search"
@@ -2154,7 +2158,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_clusterUpdate(rName string, instanceInt, snapshotInt int) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   advanced_options = {
     "indices.fielddata.cache.size" = 80
@@ -2185,7 +2189,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_clusterUpdateEBSVolume(rName string, volumeSize int, volumeThroughput int, volumeIops int) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = "Elasticsearch_6.0"
 
@@ -2213,7 +2217,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_clusterUpdateVersion(rName, version string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = %[2]q
 
@@ -2234,7 +2238,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_clusterUpdateInstanceStore(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = "Elasticsearch_6.0"
 
@@ -2258,7 +2262,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2275,7 +2279,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
   ebs_options {
     ebs_enabled = true
     volume_size = 10
@@ -2293,7 +2297,7 @@ func testAccDomainConfig_policy(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2336,7 +2340,7 @@ func testAccDomainConfig_policyOrder(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2387,7 +2391,7 @@ func testAccDomainConfig_policyNewOrder(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2436,7 +2440,7 @@ data "aws_iam_policy_document" "test" {
 func testAccDomainConfig_encryptAtRestDefaultKey(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = %[2]q
 
@@ -2464,7 +2468,7 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = %[2]q
 
@@ -2489,7 +2493,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_nodeToNodeEncryption(rName, version string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = %[2]q
 
@@ -2512,7 +2516,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_complex(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   advanced_options = {
     "indices.fielddata.cache.size" = 80
@@ -2543,7 +2547,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_v23(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2596,7 +2600,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2678,7 +2682,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2760,7 +2764,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2822,7 +2826,7 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   ebs_options {
     ebs_enabled = true
@@ -2846,7 +2850,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_advancedSecurityOptionsUserDB(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_7.1"
 
   cluster_config {
@@ -2890,7 +2894,7 @@ resource "aws_iam_user" "test" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_7.1"
 
   cluster_config {
@@ -2929,7 +2933,7 @@ resource "aws_opensearch_domain" "test" {
 func testAccDomainConfig_advancedSecurityOptionsDisabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_7.1"
 
   cluster_config {
@@ -3026,7 +3030,7 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
 	}
 	return acctest.ConfigCompose(testAccDomain_logPublishingOptionsBase(rName), fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
-  domain_name    = substr(%[1]q, 0, 28)
+  domain_name    = %[1]q
   engine_version = "Elasticsearch_7.1" # needed for ESApplication/Audit Log Types
 
   ebs_options {
@@ -3105,7 +3109,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 }
 
 resource "aws_opensearch_domain" "test" {
-  domain_name = substr(%[1]q, 0, 28)
+  domain_name = %[1]q
 
   engine_version = "OpenSearch_1.1"
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -81,7 +81,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -112,7 +112,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 
 func TestAccOpenSearchDomain_requireHTTPS(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -150,7 +150,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
@@ -201,7 +201,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 
 func TestAccOpenSearchDomain_Cluster_zoneAwareness(t *testing.T) {
 	var domain1, domain2, domain3, domain4 opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -264,7 +264,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -301,7 +301,7 @@ func TestAccOpenSearchDomain_Cluster_coldStorage(t *testing.T) {
 
 func TestAccOpenSearchDomain_Cluster_warm(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -358,7 +358,7 @@ func TestAccOpenSearchDomain_Cluster_warm(t *testing.T) {
 
 func TestAccOpenSearchDomain_Cluster_dedicatedMaster(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -401,7 +401,7 @@ func TestAccOpenSearchDomain_Cluster_update(t *testing.T) {
 	}
 
 	var input opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -441,7 +441,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -492,7 +492,7 @@ func TestAccOpenSearchDomain_v23(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -525,7 +525,7 @@ func TestAccOpenSearchDomain_complex(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -556,7 +556,7 @@ func TestAccOpenSearchDomain_VPC_basic(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -583,7 +583,7 @@ func TestAccOpenSearchDomain_VPC_basic(t *testing.T) {
 
 func TestAccOpenSearchDomain_VPC_update(t *testing.T) {
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -622,7 +622,7 @@ func TestAccOpenSearchDomain_VPC_internetToVPCEndpoint(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -659,7 +659,7 @@ func TestAccOpenSearchDomain_autoTuneOptions(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	resourceName := "aws_opensearch_domain.test"
 
@@ -702,7 +702,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -739,7 +739,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -776,7 +776,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -813,7 +813,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -848,7 +848,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -883,7 +883,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_applicationLogs(t *testing.T) 
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -918,7 +918,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -955,7 +955,7 @@ func TestAccOpenSearchDomain_CognitoOptions_createAndRemove(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -998,7 +998,7 @@ func TestAccOpenSearchDomain_CognitoOptions_update(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1042,7 +1042,7 @@ func TestAccOpenSearchDomain_Policy_basic(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1073,7 +1073,7 @@ func TestAccOpenSearchDomain_Policy_ignoreEquivalent(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1102,7 +1102,7 @@ func TestAccOpenSearchDomain_Encryption_atRestDefaultKey(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1134,7 +1134,7 @@ func TestAccOpenSearchDomain_Encryption_atRestSpecifyKey(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1165,7 +1165,7 @@ func TestAccOpenSearchDomain_Encryption_atRestEnable(t *testing.T) {
 	}
 
 	var domain1, domain2 opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1206,7 +1206,7 @@ func TestAccOpenSearchDomain_Encryption_atRestEnableLegacy(t *testing.T) {
 	}
 
 	var domain1, domain2 opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1240,7 +1240,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNode(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1272,7 +1272,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNodeEnable(t *testing.T) {
 
 	var domain1, domain2 opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1313,7 +1313,7 @@ func TestAccOpenSearchDomain_Encryption_nodeToNodeEnableLegacy(t *testing.T) {
 
 	var domain1, domain2 opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1352,7 +1352,7 @@ func TestAccOpenSearchDomain_tags(t *testing.T) {
 	}
 
 	var domain opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1402,7 +1402,7 @@ func TestAccOpenSearchDomain_VolumeType_update(t *testing.T) {
 	}
 
 	var input opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1455,7 +1455,7 @@ func TestAccOpenSearchDomain_VolumeType_missing(t *testing.T) {
 
 	var domain opensearchservice.DomainStatus
 	resourceName := "aws_opensearch_domain.test"
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
@@ -1488,7 +1488,7 @@ func TestAccOpenSearchDomain_VolumeType_missing(t *testing.T) {
 
 func TestAccOpenSearchDomain_versionUpdate(t *testing.T) {
 	var domain1, domain2, domain3 opensearchservice.DomainStatus
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1534,7 +1534,7 @@ func TestAccOpenSearchDomain_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := randomDomainName()
+	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1554,7 +1554,7 @@ func TestAccOpenSearchDomain_disappears(t *testing.T) {
 	})
 }
 
-func randomDomainName() string {
+func testAccRandomDomainName() string {
 	return fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1)))
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26249.

```console
% ACCTEST_TIMEOUT=600m make testacc TESTARGS='-run=TestAccOpenSearchDomain_basic' PKG=opensearch ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 3  -run=TestAccOpenSearchDomain_basic -timeout 600m
=== RUN   TestAccOpenSearchDomain_basic
=== PAUSE TestAccOpenSearchDomain_basic
=== CONT  TestAccOpenSearchDomain_basic
--- PASS: TestAccOpenSearchDomain_basic (1409.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearch	1413.499s
% ACCTEST_TIMEOUT=600m make testacc TESTARGS='-run=TestAccElasticsearchDomain_basic\|TestAccElasticsearchDomainDataSource_advanced' PKG=elasticsearch ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 3  -run=TestAccElasticsearchDomain_basic\|TestAccElasticsearchDomainDataSource_advanced -timeout 600m
=== RUN   TestAccElasticsearchDomainDataSource_advanced
=== PAUSE TestAccElasticsearchDomainDataSource_advanced
=== RUN   TestAccElasticsearchDomain_basic
=== PAUSE TestAccElasticsearchDomain_basic
=== CONT  TestAccElasticsearchDomainDataSource_advanced
=== CONT  TestAccElasticsearchDomain_basic
--- PASS: TestAccElasticsearchDomainDataSource_advanced (1947.62s)
--- PASS: TestAccElasticsearchDomain_basic (1315.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	1319.645s
```