### PR TITLE
Fix links in pull request welcome message

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -54,8 +54,8 @@ jobs:
           pr-message: |-
             Welcome @${{github.actor}} :wave:
 
-            It looks like this is your first Pull Request submission to the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws)! If you haven’t already done so please make sure you have checked out our [CONTRIBUTING](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing) guide and [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md) to make sure your contribution is adhering to best practice and has all the necessary elements in place for a successful approval.
+            It looks like this is your first Pull Request submission to the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws)! If you haven’t already done so please make sure you have checked out our [CONTRIBUTING](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/index.md) guide and [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/faq.md) to make sure your contribution is adhering to best practice and has all the necessary elements in place for a successful approval.
 
-            Also take a look at our [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md) which details how we prioritize Pull Requests for inclusion.
+            Also take a look at our [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/faq.md) which details how we prioritize Pull Requests for inclusion.
 
             Thanks again, and welcome to the community! :smiley:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Noticed some broken links in the github actions [message for first-time contributors](https://github.com/hashicorp/terraform-provider-aws/pull/26254#pullrequestreview-1070305496). Took a guess and replaced the contributing and FAQ links with the following

https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/index.md 
https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/faq.md