### PR TITLE
dynamodb_table: Fix `replica.*propagate_tags` bug

### DIFF
--- a/.changelog/26257.txt
+++ b/.changelog/26257.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix `replica.*.propagate_tags` not propagating tags to newly added replicas
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -974,54 +974,6 @@ func resourceTableDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 // custom diff
-/*
-func replicaTagsDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	if v, ok := tfMap["propagate_tags"].(bool); ok && v {
-		if aws.StringValue(conn.Config.Region) != region {
-			session, err := conns.NewSessionForRegion(&conn.Config, region, terraformVersion)
-			if err != nil {
-				return fmt.Errorf("updating replica (%s) tags: %w", region, err)
-			}
-
-			conn = dynamodb.New(session)
-		}
-	}
-
-	resourceTags := tftags.New(diff.Get("tags").(map[string]interface{}))
-
-	if defaultTagsConfig.TagsEqual(resourceTags) {
-		return fmt.Errorf(`"tags" are identical to those in the "default_tags" configuration block of the provider: please de-duplicate and try again`)
-	}
-
-	allTags := defaultTagsConfig.MergeTags(resourceTags).IgnoreConfig(ignoreTagsConfig)
-
-	// To ensure "tags_all" is correctly computed, we explicitly set the attribute diff
-	// when the merger of resource-level tags onto provider-level tags results in n > 0 tags,
-	// otherwise we mark the attribute as "Computed" only when their is a known diff (excluding an empty map)
-	// or a change for "tags_all".
-	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18366
-	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19005
-	if len(allTags) > 0 {
-		if err := diff.SetNew("tags_all", allTags.Map()); err != nil {
-			return fmt.Errorf("error setting new tags_all diff: %w", err)
-		}
-	} else if len(diff.Get("tags_all").(map[string]interface{})) > 0 {
-		if err := diff.SetNewComputed("tags_all"); err != nil {
-			return fmt.Errorf("error setting tags_all to computed: %w", err)
-		}
-	} else if diff.HasChange("tags_all") {
-		if err := diff.SetNewComputed("tags_all"); err != nil {
-			return fmt.Errorf("error setting tags_all to computed: %w", err)
-		}
-	}
-
-	return nil
-}
-*/
 
 func isTableOptionDisabled(v interface{}) bool {
 	options := v.([]interface{})

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3182,8 +3182,8 @@ resource "aws_dynamodb_table" "test" {
   }
 
   tags = {
-    Name  = %[1]q
-    Pozo  = "Amargo"
+    Name = %[1]q
+    Pozo = "Amargo"
   }
 }
 `, rName, region1, propagate1))
@@ -3216,8 +3216,8 @@ resource "aws_dynamodb_table" "test" {
   }
 
   tags = {
-    Name  = %[1]q
-    Pozo  = "Amargo"
+    Name = %[1]q
+    Pozo = "Amargo"
   }
 }
 `, rName, region1, propagate1, region2, propagate2))
@@ -3245,8 +3245,8 @@ resource "aws_dynamodb_table" "test" {
   }
 
   tags = {
-    Name  = %[1]q
-    Pozo  = "Amargo"
+    Name = %[1]q
+    Pozo = "Amargo"
   }
 }
 `, rName, region1))
@@ -3384,7 +3384,7 @@ resource "aws_dynamodb_table" "test" {
   }
 
   tags = {
-    Name  = %[1]q
+    Name = %[1]q
   }
 }
 `, rName, region1, region2))

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1,7 +1,6 @@
 package dynamodb_test
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -1622,8 +1621,8 @@ func TestAccDynamoDBTable_Replica_tagsOneOfTwo(t *testing.T) {
 				Config: testAccTableConfig_replicaTags(rName, "benny", "smiles", true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
-					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), true),
-					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), false),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 3),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 0),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
 						"region_name":    acctest.AlternateRegion(),
@@ -1661,8 +1660,196 @@ func TestAccDynamoDBTable_Replica_tagsTwoOfTwo(t *testing.T) {
 				Config: testAccTableConfig_replicaTags(rName, "Structure", "Adobe", true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
-					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), true),
-					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), true),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 3),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 3),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.ThirdRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_Replica_tagsNext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf dynamodb.DescribeTableOutput
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckMultipleRegion(t, 2) },
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(t, 3),
+		CheckDestroy:             testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_replicaTagsNext1(rName, acctest.AlternateRegion(), true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 2),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsNext2(rName, acctest.AlternateRegion(), true, acctest.ThirdRegion(), true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 2),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 2),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.ThirdRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsNext1(rName, acctest.AlternateRegion(), true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 2),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsNext2(rName, acctest.AlternateRegion(), true, acctest.ThirdRegion(), false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 2),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 0),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.ThirdRegion(),
+						"propagate_tags": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsNext2(rName, acctest.AlternateRegion(), false, acctest.ThirdRegion(), false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 2),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 0),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.ThirdRegion(),
+						"propagate_tags": "false",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_Replica_tagsUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf dynamodb.DescribeTableOutput
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckMultipleRegion(t, 2) },
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(t, 3),
+		CheckDestroy:             testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_replicaTagsUpdate1(rName, acctest.AlternateRegion()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 2),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsUpdate2(rName, acctest.AlternateRegion()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 4),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsUpdate3(rName, acctest.AlternateRegion(), acctest.ThirdRegion()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 4),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 4),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.ThirdRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsUpdate4(rName, acctest.AlternateRegion(), acctest.ThirdRegion()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 6),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 6),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.AlternateRegion(),
+						"propagate_tags": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
+						"region_name":    acctest.ThirdRegion(),
+						"propagate_tags": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaTagsUpdate5(rName, acctest.AlternateRegion(), acctest.ThirdRegion()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					testAccCheckReplicaHasTags(resourceName, acctest.AlternateRegion(), 1),
+					testAccCheckReplicaHasTags(resourceName, acctest.ThirdRegion(), 1),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]string{
 						"region_name":    acctest.AlternateRegion(),
@@ -1854,15 +2041,15 @@ func testAccCheckInitialTableExists(n string, table *dynamodb.DescribeTableOutpu
 	}
 }
 
-func testAccCheckReplicaHasTags(n string, region string, should bool) resource.TestCheckFunc {
+func testAccCheckReplicaHasTags(n string, region string, count int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No DynamoDB table name specified!")
+			return fmt.Errorf("no DynamoDB table name specified!")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn
@@ -1889,12 +2076,8 @@ func testAccCheckReplicaHasTags(n string, region string, should bool) resource.T
 			return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.Attributes["arn"], err)
 		}
 
-		if len(tags.Keys()) > 0 && !should {
-			return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.Attributes["arn"], errors.New("replica should not have tags but does"))
-		}
-
-		if len(tags.Keys()) == 0 && should {
-			return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.Attributes["arn"], errors.New("replica should have tags but does not"))
+		if len(tags.Keys()) != count {
+			return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.Attributes["arn"], fmt.Errorf("expected %d tags on replica, found %d", count, len(tags.Keys())))
 		}
 
 		return nil
@@ -2899,41 +3082,6 @@ resource "aws_dynamodb_table" "test" {
 `, rName, mainPITR, replica1, replica2))
 }
 
-func testAccTableConfig_replica2(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigMultipleRegionProvider(3),
-		fmt.Sprintf(`
-data "aws_region" "alternate" {
-  provider = "awsalternate"
-}
-
-data "aws_region" "third" {
-  provider = "awsthird"
-}
-
-resource "aws_dynamodb_table" "test" {
-  name             = %[1]q
-  hash_key         = "TestTableHashKey"
-  billing_mode     = "PAY_PER_REQUEST"
-  stream_enabled   = true
-  stream_view_type = "NEW_AND_OLD_IMAGES"
-
-  attribute {
-    name = "TestTableHashKey"
-    type = "S"
-  }
-
-  replica {
-    region_name = data.aws_region.alternate.name
-  }
-
-  replica {
-    region_name = data.aws_region.third.name
-  }
-}
-`, rName))
-}
-
 func testAccTableConfig_replicaTags(rName, key, value string, propagate1, propagate2 bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
@@ -2975,6 +3123,271 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 `, rName, key, value, propagate1, propagate2))
+}
+
+func testAccTableConfig_replica2(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_region" "third" {
+  provider = "awsthird"
+}
+
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = data.aws_region.alternate.name
+  }
+
+  replica {
+    region_name = data.aws_region.third.name
+  }
+}
+`, rName))
+}
+
+func testAccTableConfig_replicaTagsNext1(rName string, region1 string, propagate1 bool) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = %[3]t
+  }
+
+  tags = {
+    Name  = %[1]q
+    Pozo  = "Amargo"
+  }
+}
+`, rName, region1, propagate1))
+}
+
+func testAccTableConfig_replicaTagsNext2(rName, region1 string, propagate1 bool, region2 string, propagate2 bool) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = %[3]t
+  }
+
+  replica {
+    region_name    = %[4]q
+    propagate_tags = %[5]t
+  }
+
+  tags = {
+    Name  = %[1]q
+    Pozo  = "Amargo"
+  }
+}
+`, rName, region1, propagate1, region2, propagate2))
+}
+
+func testAccTableConfig_replicaTagsUpdate1(rName, region1 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = true
+  }
+
+  tags = {
+    Name  = %[1]q
+    Pozo  = "Amargo"
+  }
+}
+`, rName, region1))
+}
+
+func testAccTableConfig_replicaTagsUpdate2(rName, region1 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = true
+  }
+
+  tags = {
+    Name   = %[1]q
+    Pozo   = "Amargo"
+    tyDi   = "Lullaby"
+    Thrill = "Seekers"
+  }
+}
+`, rName, region1))
+}
+
+func testAccTableConfig_replicaTagsUpdate3(rName, region1 string, region2 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = true
+  }
+
+  replica {
+    region_name    = %[3]q
+    propagate_tags = true
+  }
+
+  tags = {
+    Name   = %[1]q
+    Pozo   = "Amargo"
+    tyDi   = "Lullaby"
+    Thrill = "Seekers"
+  }
+}
+`, rName, region1, region2))
+}
+
+func testAccTableConfig_replicaTagsUpdate4(rName, region1 string, region2 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = true
+  }
+
+  replica {
+    region_name    = %[3]q
+    propagate_tags = true
+  }
+
+  tags = {
+    Name    = %[1]q
+    Pozo    = "Amargo"
+    tyDi    = "Lullaby"
+    Thrill  = "Seekers"
+    Tristan = "Joe"
+    Humming = "bird"
+  }
+}
+`, rName, region1, region2))
+}
+
+func testAccTableConfig_replicaTagsUpdate5(rName, region1 string, region2 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name    = %[2]q
+    propagate_tags = true
+  }
+
+  replica {
+    region_name    = %[3]q
+    propagate_tags = true
+  }
+
+  tags = {
+    Name  = %[1]q
+  }
+}
+`, rName, region1, region2))
 }
 
 func testAccTableConfig_lsi(rName, lsiName string) string {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -219,7 +219,7 @@ Optional arguments:
 
 * `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption.
 * `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica. Default is `false`.
-* `propagate_tags` - (Optional) Whether to propagate the main table's tags to a replica. Default is `false`. Changes to tags only move in one direction: from main to replica. In other words, tag drift on a replica will not trigger an update. Tag changes on the main table, whether from drift or configuration changes, are propagated to replicas.
+* `propagate_tags` - (Optional) Whether to propagate the global table's tags to a replica. Default is `false`. Changes to tags only move in one direction: from global (source) to replica. In other words, tag drift on a replica will not trigger an update. Tag or replica changes on the global table, whether from drift or configuration changes, are propagated to replicas. Changing from `true` to `false` on a subsequent `apply` means replica tags are left as they were, unmanaged, not deleted.
 * `region_name` - (Required) Region name of the replica.
 
 ### `server_side_encryption`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26255

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccDynamoDBTable_ PKG=dynamodb 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_'  -timeout 180m
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (48.61s)
--- PASS: TestAccDynamoDBTable_basic (109.48s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (120.01s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (125.09s)
--- PASS: TestAccDynamoDBTable_tags (128.46s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (17.56s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (175.98s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (185.77s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (187.02s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (210.47s)
--- PASS: TestAccDynamoDBTable_encryption (281.11s)
--- PASS: TestAccDynamoDBTable_streamSpecification (141.11s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (141.17s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (136.45s)
--- PASS: TestAccDynamoDBTable_backupEncryption (375.33s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (94.56s)
--- PASS: TestAccDynamoDBTable_enablePITR (110.65s)
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (190.46s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (90.11s)
--- PASS: TestAccDynamoDBTable_disappears (36.92s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (396.85s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (126.71s)
--- PASS: TestAccDynamoDBTable_Replica_single (508.68s)
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (417.11s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (531.46s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (433.89s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (559.72s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (414.54s)
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (755.16s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (797.66s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (981.96s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (983.83s)
--- PASS: TestAccDynamoDBTable_extended (612.88s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (990.37s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (997.41s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (915.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	1042.457s
```
