### PR TITLE
add goreleaser arg to change default parallelism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [go-version, release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2.0.0
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
       hc-releases-key-staging: '${{ secrets.HC_RELEASES_KEY_STAGING }}'
@@ -45,7 +45,7 @@ jobs:
       hc-releases-host-staging: '${{ secrets.HC_RELEASES_HOST_STAGING }}'
       hc-releases-host-prod: '${{ secrets.HC_RELEASES_HOST_PROD }}'
     with:
-      goreleaser-release-args: --timeout 3h
+      goreleaser-release-args: '--timeout 3h --parallelism 8'
       release-notes: true
       setup-go-version: '${{ needs.go-version.outputs.version }}'
       # Product Version (e.g. v1.2.3 or github.ref_name)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Goreleaser, by default, sets parallelism to the number of cores on the machine. This could result in each build not having enough memory to compile successfully.


