### PR TITLE
aws_acm_certificate - Add validity dates

### DIFF
--- a/.changelog/26281.txt
+++ b/.changelog/26281.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_acm_certificate: Add `not_before` argument
+```
+
+```release-note:enhancement
+resource/aws_acm_certificate: Add `not_after` argument
+```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -109,6 +109,14 @@ func ResourceCertificate() *schema.Resource {
 				},
 				Set: domainValidationOptionsHash,
 			},
+			"not_after": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"not_before": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -361,6 +369,16 @@ func resourceCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("domain_name", certificate.DomainName)
 	if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
 		return fmt.Errorf("error setting domain_validation_options: %w", err)
+	}
+	if certificate.NotBefore != nil {
+		d.Set("not_before", aws.TimeValue(certificate.NotBefore).Format(time.RFC3339))
+	} else {
+		d.Set("not_before", nil)
+	}
+	if certificate.NotAfter != nil {
+		d.Set("not_after", aws.TimeValue(certificate.NotAfter).Format(time.RFC3339))
+	} else {
+		d.Set("not_after", nil)
 	}
 	if certificate.Options != nil {
 		if err := d.Set("options", []interface{}{flattenCertificateOptions(certificate.Options)}); err != nil {

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -42,6 +42,8 @@ func TestAccACMCertificate_emailValidation(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "validation_emails.0", regexp.MustCompile(`^[^@]+@.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodEmail),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "not_before", "0"),
+					resource.TestCheckResourceAttr(resourceName, "not_after", "0"),
 				),
 			},
 			{
@@ -197,6 +199,8 @@ func TestAccACMCertificate_privateCert(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_authority_arn", certificateAuthorityResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "not_before", ""),
+					resource.TestCheckResourceAttr(resourceName, "not_after", ""),
 				),
 			},
 			{
@@ -625,6 +629,8 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 					testAccCheckCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", commonName),
+					resource.TestCheckResourceAttrSet(resourceName, "not_before"),
+					resource.TestCheckResourceAttrSet(resourceName, "not_after"),
 				),
 			},
 			{

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -656,6 +656,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 	})
 }
 
+// lintignore:AT002
 func TestAccACMCertificate_Imported_validityDates(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	commonName := "example.com"

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -154,6 +154,8 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the certificate
 * `domain_name` - The domain name for which the certificate is issued
 * `domain_validation_options` - Set of domain validation objects which can be used to complete certificate validation. Can have more than one element, e.g., if SANs are defined. Only set if `DNS`-validation was used.
+* `not_after` - The expiration date and time of the certificate.
+* `not_before` - The start of the validity period of the certificate.
 * `status` - Status of the certificate.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `validation_emails` - A list of addresses that received a validation E-Mail. Only set if `EMAIL`-validation was used.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccACMCertificate_' PKG=acm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMCertificate_'  -timeout 180m
=== RUN   TestAccACMCertificate_Imported_domainName
=== PAUSE TestAccACMCertificate_Imported_domainName
=== RUN   TestAccACMCertificate_Imported_validityDates
=== PAUSE TestAccACMCertificate_Imported_validityDates
=== RUN   TestAccACMCertificate_Imported_ipAddress
=== PAUSE TestAccACMCertificate_Imported_ipAddress
=== RUN   TestAccACMCertificate_PrivateKey_tags
=== PAUSE TestAccACMCertificate_PrivateKey_tags
=== CONT  TestAccACMCertificate_privateCert
=== CONT  TestAccACMCertificate_Imported_ipAddress
=== CONT  TestAccACMCertificate_Imported_validityDates
=== CONT  TestAccACMCertificate_Imported_domainName
=== CONT  TestAccACMCertificate_PrivateKey_tags
--- PASS: TestAccACMCertificate_Imported_ipAddress (16.85s)
--- PASS: TestAccACMCertificate_Imported_validityDates (18.46s)
--- PASS: TestAccACMCertificate_privateCert (22.96s)
--- PASS: TestAccACMCertificate_Imported_domainName (33.10s)
--- PASS: TestAccACMCertificate_PrivateKey_tags (40.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acm	44.662s
```
