### PR TITLE
aws_chime_voice_connector_logging - Enable Media Metrics Logging

### DIFF
--- a/.changelog/26283.txt
+++ b/.changelog/26283.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_chime_voice_connector_logging: Add `enable_media_metric_logs` argument
+```

--- a/internal/service/chime/voice_connector_logging.go
+++ b/internal/service/chime/voice_connector_logging.go
@@ -24,6 +24,11 @@ func ResourceVoiceConnectorLogging() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"enable_media_metric_logs": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"enable_sip_logs": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -45,7 +50,8 @@ func resourceVoiceConnectorLoggingCreate(ctx context.Context, d *schema.Resource
 	input := &chime.PutVoiceConnectorLoggingConfigurationInput{
 		VoiceConnectorId: aws.String(vcId),
 		LoggingConfiguration: &chime.LoggingConfiguration{
-			EnableSIPLogs: aws.Bool(d.Get("enable_sip_logs").(bool)),
+			EnableMediaMetricLogs: aws.Bool(d.Get("enable_media_metric_logs").(bool)),
+			EnableSIPLogs:         aws.Bool(d.Get("enable_sip_logs").(bool)),
 		},
 	}
 
@@ -74,7 +80,7 @@ func resourceVoiceConnectorLoggingRead(ctx context.Context, d *schema.ResourceDa
 	if err != nil || resp.LoggingConfiguration == nil {
 		return diag.Errorf("error getting Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
 	}
-
+	d.Set("enable_media_metric_logs", resp.LoggingConfiguration.EnableMediaMetricLogs)
 	d.Set("enable_sip_logs", resp.LoggingConfiguration.EnableSIPLogs)
 	d.Set("voice_connector_id", d.Id())
 
@@ -84,11 +90,12 @@ func resourceVoiceConnectorLoggingRead(ctx context.Context, d *schema.ResourceDa
 func resourceVoiceConnectorLoggingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ChimeConn
 
-	if d.HasChange("enable_sip_logs") {
+	if d.HasChanges("enable_sip_logs", "enable_media_metric_logs") {
 		input := &chime.PutVoiceConnectorLoggingConfigurationInput{
 			VoiceConnectorId: aws.String(d.Id()),
 			LoggingConfiguration: &chime.LoggingConfiguration{
-				EnableSIPLogs: aws.Bool(d.Get("enable_sip_logs").(bool)),
+				EnableMediaMetricLogs: aws.Bool(d.Get("enable_media_metric_logs").(bool)),
+				EnableSIPLogs:         aws.Bool(d.Get("enable_sip_logs").(bool)),
 			},
 		}
 
@@ -106,7 +113,8 @@ func resourceVoiceConnectorLoggingDelete(ctx context.Context, d *schema.Resource
 	input := &chime.PutVoiceConnectorLoggingConfigurationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 		LoggingConfiguration: &chime.LoggingConfiguration{
-			EnableSIPLogs: aws.Bool(false),
+			EnableSIPLogs:         aws.Bool(false),
+			EnableMediaMetricLogs: aws.Bool(false),
 		},
 	}
 

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -29,6 +29,7 @@ func TestAccChimeVoiceConnectorLogging_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVoiceConnectorLoggingExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable_sip_logs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_media_metric_logs", "true"),
 				),
 			},
 			{
@@ -83,6 +84,7 @@ func TestAccChimeVoiceConnectorLogging_update(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVoiceConnectorLoggingExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable_sip_logs", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_media_metric_logs", "false"),
 				),
 			},
 			{
@@ -102,8 +104,9 @@ resource "aws_chime_voice_connector" "chime" {
 }
 
 resource "aws_chime_voice_connector_logging" "test" {
-  voice_connector_id = aws_chime_voice_connector.chime.id
-  enable_sip_logs    = true
+  voice_connector_id       = aws_chime_voice_connector.chime.id
+  enable_sip_logs          = true
+  enable_media_metric_logs = true
 }
 `, name)
 }
@@ -116,8 +119,9 @@ resource "aws_chime_voice_connector" "chime" {
 }
 
 resource "aws_chime_voice_connector_logging" "test" {
-  voice_connector_id = aws_chime_voice_connector.chime.id
-  enable_sip_logs    = false
+  voice_connector_id       = aws_chime_voice_connector.chime.id
+  enable_sip_logs          = false
+  enable_media_metric_logs = false
 }
 `, name)
 }

--- a/website/docs/r/chime_voice_connector_logging.html.markdown
+++ b/website/docs/r/chime_voice_connector_logging.html.markdown
@@ -19,9 +19,9 @@ resource "aws_chime_voice_connector" "default" {
 }
 
 resource "aws_chime_voice_connector_logging" "default" {
-  enable_sip_logs    = true
-  enable_media_metric_logs    = true
-  voice_connector_id = aws_chime_voice_connector.default.id
+  enable_sip_logs          = true
+  enable_media_metric_logs = true
+  voice_connector_id       = aws_chime_voice_connector.default.id
 }
 ```
 

--- a/website/docs/r/chime_voice_connector_logging.html.markdown
+++ b/website/docs/r/chime_voice_connector_logging.html.markdown
@@ -20,6 +20,7 @@ resource "aws_chime_voice_connector" "default" {
 
 resource "aws_chime_voice_connector_logging" "default" {
   enable_sip_logs    = true
+  enable_media_metric_logs    = true
   voice_connector_id = aws_chime_voice_connector.default.id
 }
 ```
@@ -30,6 +31,7 @@ The following arguments are supported:
 
 * `voice_connector_id` - (Required) The Amazon Chime Voice Connector ID.
 * `enable_sip_logs` - (Optional) When true, enables SIP message logs for sending to Amazon CloudWatch Logs.
+* `enable_media_metric_logs` - (Optional) When true, enables logging of detailed media metrics for Voice Connectors to Amazon CloudWatch logs.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds an attribute to allow control of media metric monitoring.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccChimeVoiceConnectorLogging_' PKG=chime
go test ./internal/service/chime/... -v -count 1 -parallel 20  -run=TestAccChimeVoiceConnectorLogging_ -timeout 180m
=== RUN   TestAccChimeVoiceConnectorLogging_basic
=== PAUSE TestAccChimeVoiceConnectorLogging_basic
=== RUN   TestAccChimeVoiceConnectorLogging_disappears
=== PAUSE TestAccChimeVoiceConnectorLogging_disappears
=== RUN   TestAccChimeVoiceConnectorLogging_update
=== PAUSE TestAccChimeVoiceConnectorLogging_update
=== CONT  TestAccChimeVoiceConnectorLogging_basic
=== CONT  TestAccChimeVoiceConnectorLogging_update
=== CONT  TestAccChimeVoiceConnectorLogging_disappears
--- PASS: TestAccChimeVoiceConnectorLogging_basic (16.20s)
--- PASS: TestAccChimeVoiceConnectorLogging_update (24.40s)
--- PASS: TestAccChimeVoiceConnectorLogging_disappears (33.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	38.704s
```
