### PR TITLE
r/aws_db_instance: Don't call `ModifyDBInstance` when just `final_snapshot_identifier` is changed

### DIFF
--- a/.changelog/26286.txt
+++ b/.changelog/26286.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Prevent `InvalidParameterCombination: No modifications were requested` errors when only `delete_automated_backups`, `final_snapshot_identifier` and/or `skip_final_snapshot` change
+```

--- a/internal/service/rds/find.go
+++ b/internal/service/rds/find.go
@@ -217,6 +217,36 @@ func FindDBProxyByName(conn *rds.RDS, name string) (*rds.DBProxy, error) {
 	return dbProxy, nil
 }
 
+func FindDBSnapshotByID(conn *rds.RDS, id string) (*rds.DBSnapshot, error) {
+	input := &rds.DescribeDBSnapshotsInput{
+		DBInstanceIdentifier: aws.String(id),
+	}
+
+	output, err := conn.DescribeDBSnapshots(input)
+
+	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBSnapshotNotFoundFault) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if output == nil || len(output.DBSnapshots) == 0 || output.DBSnapshots[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	dbSnapshot := output.DBSnapshots[0]
+
+	// Eventual consistency check.
+	if aws.StringValue(dbSnapshot.DBSnapshotIdentifier) != id {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	return dbSnapshot, nil
+}
+
 func FindEventSubscriptionByID(conn *rds.RDS, id string) (*rds.EventSubscription, error) {
 	input := &rds.DescribeEventSubscriptionsInput{
 		SubscriptionName: aws.String(id),

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1525,7 +1525,13 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	// Having allowing_major_version_upgrade by itself should not trigger ModifyDBInstance
 	// as it results in "InvalidParameterCombination: No modifications were requested".
-	if d.HasChangesExcept("allow_major_version_upgrade", "replicate_source_db", "tags", "tags_all") {
+	if d.HasChangesExcept(
+		"allow_major_version_upgrade",
+		"delete_automated_backups",
+		"final_snapshot_identifier",
+		"replicate_source_db",
+		"skip_final_snapshot",
+		"tags", "tags_all") {
 		input := &rds.ModifyDBInstanceInput{
 			ApplyImmediately:     aws.Bool(d.Get("apply_immediately").(bool)),
 			DBInstanceIdentifier: aws.String(d.Id()),

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -4341,7 +4341,7 @@ func testAccCheckInstanceDestroyWithFinalSnapshot(s *terraform.State) error {
 		output, err := tfrds.FindDBSnapshotByID(conn, finalSnapshotID)
 
 		if err != nil {
-			return nil
+			return err
 		}
 
 		tags, err := tfrds.ListTags(conn, aws.StringValue(output.DBSnapshotArn))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26280.

```console
% make testacc TESTARGS='-run=TestAccRDSInstance_finalSnapshotIdentifier\|TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot\|TestAccRDSInstance_noDeleteAutomatedBackups\|TestAccRDSInstance_basic\|TestAccRDSInstance_isAlreadyBeingDeleted' PKG=rds ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 2  -run=TestAccRDSInstance_finalSnapshotIdentifier\|TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot\|TestAccRDSInstance_noDeleteAutomatedBackups\|TestAccRDSInstance_basic\|TestAccRDSInstance_isAlreadyBeingDeleted -timeout 180m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_finalSnapshotIdentifier
=== PAUSE TestAccRDSInstance_finalSnapshotIdentifier
=== RUN   TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== PAUSE TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== RUN   TestAccRDSInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSInstance_noDeleteAutomatedBackups
=== PAUSE TestAccRDSInstance_noDeleteAutomatedBackups
=== CONT  TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_isAlreadyBeingDeleted
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (356.31s)
=== CONT  TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
--- PASS: TestAccRDSInstance_basic (530.53s)
=== CONT  TestAccRDSInstance_finalSnapshotIdentifier
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (879.82s)
=== CONT  TestAccRDSInstance_noDeleteAutomatedBackups
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (971.29s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (652.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1892.981s
```