### PR TITLE
AppFlow trigger start date being incorrectly set

### DIFF
--- a/.changelog/26289.txt
+++ b/.changelog/26289.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appflow_flow: Correctly specify `trigger_config.trigger_properties.scheduled.schedule_start_time` during create and update
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-* resource/aws_appflow_flow: Fix `trigger_properties.schedule` being set to `trigger_properties.trigger_properties` during resource read ([#26240](https://github.com/hashicorp/terraform-provider-aws/issues/26240))
+* resource/aws_appflow_flow: Fix `trigger_properties.scheduled` being set during resource read ([#26240](https://github.com/hashicorp/terraform-provider-aws/issues/26240))
 * resource/aws_db_instance: Add retries (for handling IAM eventual consistency) when creating database replicas that use enhanced monitoring ([#20926](https://github.com/hashicorp/terraform-provider-aws/issues/20926))
 * resource/aws_db_instance: Apply `monitoring_interval` and `monitoring_role_arn` when creating via `restore_to_point_in_time` ([#20926](https://github.com/hashicorp/terraform-provider-aws/issues/20926))
 * resource/aws_dynamodb_table: Fix `replica.*.propagate_tags` not propagating tags to newly added replicas ([#26257](https://github.com/hashicorp/terraform-provider-aws/issues/26257))

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -2483,7 +2483,7 @@ func expandScheduledTriggerProperties(tfMap map[string]interface{}) *appflow.Sch
 	if v, ok := tfMap["schedule_start_time"].(string); ok && v != "" {
 		v, _ := time.Parse(time.RFC3339, v)
 
-		a.ScheduleEndTime = aws.Time(v)
+		a.ScheduleStartTime = aws.Time(v)
 	}
 
 	if v, ok := tfMap["timezone"].(string); ok && v != "" {

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -52,7 +52,7 @@ func TestAccAppFlowFlow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.data_pull_mode", "Incremental"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_expression", "rate(3hours)"),
-					resource.TestCheckResourceAttrSet(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_start_time"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_start_time", scheduleStartTime),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
@@ -92,6 +92,12 @@ func TestAccAppFlowFlow_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowExists(resourceName, &flowOutput),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_type", "Scheduled"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.data_pull_mode", "Complete"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_expression", "rate(6hours)"),
 				),
 			},
 		},
@@ -376,7 +382,14 @@ resource "aws_appflow_flow" "test" {
   }
 
   trigger_config {
-    trigger_type = "OnDemand"
+    trigger_type = "Scheduled"
+
+    trigger_properties {
+      scheduled {
+        data_pull_mode      = "Complete"
+        schedule_expression = "rate(6hours)"
+      }
+    }
   }
 }
 `, rFlowName, description),

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -48,8 +48,9 @@ func TestAccAppFlowFlow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_type", "Scheduled"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.data_pull_mode", "Complete"),
-					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_expression", "rate(5minutes)"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.data_pull_mode", "Incremental"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_expression", "rate(3hours)"),
+					resource.TestCheckResourceAttrSet(resourceName, "trigger_config.0.trigger_properties.0.scheduled.0.schedule_start_time"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
@@ -316,8 +317,9 @@ resource "aws_appflow_flow" "test" {
 
     trigger_properties {
       scheduled {
-        data_pull_mode      = "Complete"
-        schedule_expression = "rate(5minutes)"
+        data_pull_mode      = "Incremental"
+        schedule_expression = "rate(3hours)"
+        schedule_start_time = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T00:00:00Z"
       }
     }
   }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

When setting up an AppFlow with a Scheduled trigger and setting the `schedule_start_time` value, it actually sets the `scheduled_end_time` value and the app flow is not active

eg.
input
```
trigger_config {
    trigger_type = "Scheduled"
    trigger_properties {
      scheduled {
        data_pull_mode      = "Incremental"
        schedule_expression = "rate(3hours)"
        schedule_start_time = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T00:00:00Z"
      }
    }
  }
```
output
![image](https://user-images.githubusercontent.com/785319/184475751-e61117be-27ed-4494-9388-97afe9c77e90.png)
