### PR TITLE
Increase dependabot open PR limit from 5 to 30 for `/go.mod`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       - dependency-name: "google.golang.org/grpc"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
   - package-ecosystem: "gomod"
     directory: "/.ci/providerlint"
     ignore:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
For the root `go.mod`:

<img width="742" alt="Screenshot 2022-08-13 093012" src="https://user-images.githubusercontent.com/2404182/184496313-34349a5e-a074-44fd-876c-88e571ef76b7.png">

