### PR TITLE
fix(ec2_eip): Fix default tags not set, #25567

### DIFF
--- a/.changelog/26308.txt
+++ b/.changelog/26308.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eip: Include any provider-level configured `default_tags` on resource Create
+```

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -142,7 +142,7 @@ func resourceEIPCreate(d *schema.ResourceData, meta interface{}) error {
 		Domain: aws.String(domainOpt),
 	}
 
-	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+	if len(tags) > 0 {
 		supportedPlatforms := meta.(*conns.AWSClient).SupportedPlatforms
 		if domainOpt != ec2.DomainTypeVpc && len(supportedPlatforms) > 0 && conns.HasEC2Classic(supportedPlatforms) {
 			return fmt.Errorf("tags cannot be set for a standard-domain EIP - must be a VPC-domain EIP")


### PR DESCRIPTION
Signed-off-by: Stano Bocinec <stano@redpanda.com>

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #25567

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```shell
$ make testacc TESTS=TestAccEC2EIP_Tags PKG=ec2 AWS_REGION=eu-north-1                                                                  ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2EIP_Tags'  -timeout 180m
=== RUN   TestAccEC2EIP_TagsEC2VPC_withVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2VPC_withVPCTrue
=== RUN   TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue
=== RUN   TestAccEC2EIP_TagsEC2Classic_withVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2Classic_withVPCTrue
=== RUN   TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
=== PAUSE TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
=== CONT  TestAccEC2EIP_TagsEC2VPC_withVPCTrue
=== CONT  TestAccEC2EIP_TagsEC2Classic_withVPCTrue
=== CONT  TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue
=== CONT  TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
=== CONT  TestAccEC2EIP_TagsEC2Classic_withVPCTrue
    ec2_classic.go:62: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIP_TagsEC2Classic_withVPCTrue (4.19s)
=== CONT  TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue
    ec2_classic.go:62: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIP_TagsEC2Classic_withoutVPCTrue (4.19s)
--- PASS: TestAccEC2EIP_TagsEC2VPC_withVPCTrue (39.31s)
--- PASS: TestAccEC2EIP_TagsEC2VPC_withoutVPCTrue (39.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	39.370s
...
```

## Rationale

The `default_tags` set on the provider level are not applied on the `aws_eip` resource created. This bug fires when there are only default_tags set as the resource implementation is actually not properly checking length of merged tags (default + resource level). This PR fixes this