### PR TITLE
Add `ip_address_type` support to elbv2 target group

### DIFF
--- a/.changelog/26320.txt
+++ b/.changelog/26320.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_lb_target_group: Add `ip_address_type` argument
+```
+

--- a/.changelog/26320.txt
+++ b/.changelog/26320.txt
@@ -1,4 +1,3 @@
 ```release-note:enhancement
 resource/aws_lb_target_group: Add `ip_address_type` argument
 ```
-

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -256,6 +256,13 @@ func ResourceTargetGroup() *schema.Resource {
 					},
 				},
 			},
+			"ip_address_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(elbv2.TargetGroupIpAddressTypeEnum_Values(), false),
+			},
 			"target_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -318,6 +325,12 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 			params.ProtocolVersion = aws.String(d.Get("protocol_version").(string))
 		}
 		params.VpcId = aws.String(d.Get("vpc_id").(string))
+
+		if d.Get("target_type").(string) == elbv2.TargetTypeEnumIp {
+			if _, ok := d.GetOk("ip_address_type"); ok {
+				params.IpAddressType = aws.String(d.Get("ip_address_type").(string))
+			}
+		}
 	}
 
 	if healthChecks := d.Get("health_check").([]interface{}); len(healthChecks) == 1 {

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -254,6 +254,29 @@ func TestAccELBV2TargetGroup_HealthCheck_tcp(t *testing.T) {
 	})
 }
 
+func TestAccELBV2TargetGroup_ipAddressType(t *testing.T) {
+	var targetGroup1 elbv2.TargetGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elbv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetGroupConfig_ipAddressType(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTargetGroupExists(resourceName, &targetGroup1),
+					resource.TestCheckResourceAttr(resourceName, "target_type", "ip"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv6"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccELBV2TargetGroup_tls(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2343,6 +2366,40 @@ resource "aws_lb_target_group" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccTargetGroupConfig_ipAddressType(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name            = %[1]q
+  port            = 443
+  protocol        = "TLS"
+  vpc_id          = aws_vpc.test.id
+
+  target_type     = "ip"
+  ip_address_type = "ipv6"
+
+  health_check {
+    interval            = 10
+    port                = "traffic-port"
+    protocol            = "TCP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+  }
 
   tags = {
     Name = %[1]q

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -2385,10 +2385,10 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name            = %[1]q
-  port            = 443
-  protocol        = "TLS"
-  vpc_id          = aws_vpc.test.id
+  name     = %[1]q
+  port     = 443
+  protocol = "TLS"
+  vpc_id   = aws_vpc.test.id
 
   target_type     = "ip"
   ip_address_type = "ipv6"

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -94,6 +94,7 @@ The following arguments are supported:
   Network Load Balancers do not support the `lambda` target type.
 
   Application Load Balancers do not support the `alb` target type.
+* `ip_address_type` (Optional, forces new resource) The type of IP addresses used by the target group, only supported when target type is set to `ip`. Possible values are `ipv4` or `ipv6`.
 * `vpc_id` - (Optional, Forces new resource) Identifier of the VPC in which to create the target group. Required when `target_type` is `instance`, `ip` or `alb`. Does not apply when `target_type` is `lambda`.
 
 ### health_check


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26312

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccELBV2TargetGroup_basic\|TestAccELBV2TargetGroup_udp\|TestAccELBV2TargetGroup_ALBAlias_lambda\|TestAccELBV2TargetGroup_backwardsCompatibility\|TestAccELBV2TargetGroup_ipAddressType' PKG=elbv2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 3  -run=TestAccELBV2TargetGroup_basic\|TestAccELBV2TargetGroup_udp\|TestAccELBV2TargetGroup_ALBAlias_lambda\|TestAccELBV2TargetGroup_backwardsCompatibility\|TestAccELBV2TargetGroup_ipAddressType -timeout 180m
=== RUN   TestAccELBV2TargetGroup_backwardsCompatibility
=== PAUSE TestAccELBV2TargetGroup_backwardsCompatibility
=== RUN   TestAccELBV2TargetGroup_ipAddressType
=== PAUSE TestAccELBV2TargetGroup_ipAddressType
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== RUN   TestAccELBV2TargetGroup_udp
=== PAUSE TestAccELBV2TargetGroup_udp
=== RUN   TestAccELBV2TargetGroup_ALBAlias_lambda
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_lambda
=== RUN   TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled
=== CONT  TestAccELBV2TargetGroup_backwardsCompatibility
=== CONT  TestAccELBV2TargetGroup_udp
=== CONT  TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled
--- PASS: TestAccELBV2TargetGroup_udp (70.25s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_lambda
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (71.55s)
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambda (41.56s)
=== CONT  TestAccELBV2TargetGroup_ipAddressType
--- PASS: TestAccELBV2TargetGroup_basic (43.36s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled (130.70s)
--- PASS: TestAccELBV2TargetGroup_ipAddressType (50.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      164.092s
```
