### PR TITLE
cloudwatch_log_subscription_filter: better filter_pattern description

### DIFF
--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `name` - (Required) A name for the subscription filter
 * `destination_arn` - (Required) The ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN.
-* `filter_pattern` - (Required) A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
+* `filter_pattern` - (Required) A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events. Use empty string `""` to match everything. For more information, see the [Amazon CloudWatch Logs User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).
 * `log_group_name` - (Required) The name of the log group to associate the subscription filter with
 * `role_arn` - (Optional) The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. If you use Lambda as a destination, you should skip this argument and use `aws_lambda_permission` resource for granting access from CloudWatch logs to the destination Lambda function.
 * `distribution` - (Optional) The method used to distribute log data to the destination. By default log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream. Valid values are "Random" and "ByLogStream".


### PR DESCRIPTION
Working example for those, who don't want to filter anything. Filter pattern ""
is the correct way to do it. This should prevent people trying filter pattern " "
mentioned in Amazon documentation.

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #26319 

Output from acceptance testing:

I did not run any tests :innocent: 