### PR TITLE
fix(26271): a changed provisioning_artifact_name is now taken into account and triggers are an update in AWS for a provisioned_product

### DIFF
--- a/internal/service/servicecatalog/provisioned_product.go
+++ b/internal/service/servicecatalog/provisioned_product.go
@@ -499,10 +499,13 @@ func resourceProvisionedProductUpdate(d *schema.ResourceData, meta interface{}) 
 		input.ProductName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("provisioning_artifact_id"); ok {
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/26271
+	if d.HasChange("provisioning_artifact_name") {
+		if v, ok := d.GetOk("provisioning_artifact_name"); ok {
+			input.ProvisioningArtifactName = aws.String(v.(string))
+		}
+	} else if v, ok := d.GetOk("provisioning_artifact_id"); ok {
 		input.ProvisioningArtifactId = aws.String(v.(string))
-	} else if v, ok := d.GetOk("provisioning_artifact_name"); ok {
-		input.ProvisioningArtifactName = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("provisioning_parameters"); ok && len(v.([]interface{})) > 0 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26271

Output from acceptance testing:

```
export TF_LOG=; export AWS_PROFILE=default; export AWS_REGION=eu-central-1; export AWS_DEFAULT_REGION=eu-central-1; make testacc TESTS=TestAccServiceCatalogProvisionedProduct PKG=servicecatalog                              
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged'  -timeout 180m
=== RUN   TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged
=== PAUSE TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged
=== CONT  TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged
--- PASS: TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged (207.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	207.589s
```

```
$ export TF_LOG=; export AWS_PROFILE=default; export AWS_REGION=eu-central-1; export AWS_DEFAULT_REGION=eu-central-1; export ACCTEST_PARALLELISM=4; make testacc TESTS=TestAccServiceCatalogProvisionedProduct PKG=servicecatalog
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 4 -run='TestAccServiceCatalogProvisionedProduct'  -timeout 180m
=== RUN   TestAccServiceCatalogProvisionedProduct_basic
=== PAUSE TestAccServiceCatalogProvisionedProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_update
=== PAUSE TestAccServiceCatalogProvisionedProduct_update
=== RUN   TestAccServiceCatalogProvisionedProduct_disappears
=== PAUSE TestAccServiceCatalogProvisionedProduct_disappears
=== RUN   TestAccServiceCatalogProvisionedProduct_tags
=== PAUSE TestAccServiceCatalogProvisionedProduct_tags
=== RUN   TestAccServiceCatalogProvisionedProduct_tainted
=== PAUSE TestAccServiceCatalogProvisionedProduct_tainted
=== RUN   TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged
=== PAUSE TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged
=== CONT  TestAccServiceCatalogProvisionedProduct_basic
=== CONT  TestAccServiceCatalogProvisionedProduct_tags
=== CONT  TestAccServiceCatalogProvisionedProduct_disappears
=== CONT  TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (126.82s)
=== CONT  TestAccServiceCatalogProvisionedProduct_update
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (134.49s)
=== CONT  TestAccServiceCatalogProvisionedProduct_tainted
--- PASS: TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactNameChanged (206.58s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (208.60s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tainted (189.25s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (206.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	333.874s
```
