### PR TITLE
inspector: Add support for SNS subscriptions

### DIFF
--- a/.changelog/26334.txt
+++ b/.changelog/26334.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_inspector_assessment_template: Add `event_subscription` configuration block
+```

--- a/internal/service/inspector/assessment_template.go
+++ b/internal/service/inspector/assessment_template.go
@@ -8,10 +8,17 @@ import (
 	// "github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	ResNameAssessmentTemplate = "Assessment Template"
 )
 
 func ResourceAssessmentTemplate() *schema.Resource {
@@ -51,6 +58,24 @@ func ResourceAssessmentTemplate() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"event_subscription": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(inspector.Event_Values(), false),
+						},
+						"topic_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -83,6 +108,16 @@ func resourceAssessmentTemplateCreate(d *schema.ResourceData, meta interface{}) 
 		if err := updateTags(conn, d.Id(), nil, tags); err != nil {
 			return fmt.Errorf("error adding Inspector assessment template (%s) tags: %s", d.Id(), err)
 		}
+	}
+
+	input := []*inspector.SubscribeToEventInput{}
+
+	if v, ok := d.GetOk("event_subscription"); ok && v.(*schema.Set).Len() > 0 {
+		input = expandEventSubscriptions(v.(*schema.Set).List(), resp.AssessmentTemplateArn)
+	}
+
+	if err := subscribeToEvents(conn, input); err != nil {
+		return create.Error(names.Inspector, create.ErrActionCreating, ResNameAssessmentTemplate, d.Id(), err)
 	}
 
 	return resourceAssessmentTemplateRead(d, meta)
@@ -135,6 +170,16 @@ func resourceAssessmentTemplateRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
+	output, err := findSubscriptionsByAssessmentTemplateARN(conn, arn)
+
+	if err != nil {
+		return create.Error(names.Inspector, create.ErrActionReading, ResNameAssessmentTemplate, d.Id(), err)
+	}
+
+	if err := d.Set("event_subscription", flattenSubscriptions(output)); err != nil {
+		return create.Error(names.Inspector, create.ErrActionSetting, ResNameAssessmentTemplate, d.Id(), err)
+	}
+
 	return nil
 }
 
@@ -149,6 +194,28 @@ func resourceAssessmentTemplateUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
+	if d.HasChange("event_subscription") {
+		old, new := d.GetChange("event_subscription")
+		oldSet := old.(*schema.Set)
+		newSet := new.(*schema.Set)
+
+		eventSubscriptionsToAdd := newSet.Difference(oldSet)
+		eventSubscriptionsToRemove := oldSet.Difference(newSet)
+
+		templateId := aws.String(d.Id())
+
+		addEventSubscriptionsInput := expandEventSubscriptions(eventSubscriptionsToAdd.List(), templateId)
+		removeEventSubscriptionsInput := expandEventSubscriptions(eventSubscriptionsToRemove.List(), templateId)
+
+		if err := subscribeToEvents(conn, addEventSubscriptionsInput); err != nil {
+			return create.Error(names.Inspector, create.ErrActionUpdating, ResNameAssessmentTemplate, d.Id(), err)
+		}
+
+		if err := unsubscribeFromEvents(conn, removeEventSubscriptionsInput); err != nil {
+			return create.Error(names.Inspector, create.ErrActionUpdating, ResNameAssessmentTemplate, d.Id(), err)
+		}
+	}
+
 	return resourceAssessmentTemplateRead(d, meta)
 }
 
@@ -160,6 +227,109 @@ func resourceAssessmentTemplateDelete(d *schema.ResourceData, meta interface{}) 
 	})
 	if err != nil {
 		return fmt.Errorf("error deleting Inspector assessment template (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandEventSubscriptions(tfList []interface{}, templateArn *string) []*inspector.SubscribeToEventInput {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var eventSubscriptions []*inspector.SubscribeToEventInput
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		eventSubscription := expandEventSubscription(tfMap, templateArn)
+
+		eventSubscriptions = append(eventSubscriptions, eventSubscription)
+	}
+
+	return eventSubscriptions
+}
+
+func expandEventSubscription(tfMap map[string]interface{}, templateArn *string) *inspector.SubscribeToEventInput {
+	if tfMap == nil {
+		return nil
+	}
+
+	eventSubscription := &inspector.SubscribeToEventInput{
+		Event:       aws.String(tfMap["event"].(string)),
+		ResourceArn: templateArn,
+		TopicArn:    aws.String(tfMap["topic_arn"].(string)),
+	}
+
+	return eventSubscription
+}
+
+func flattenSubscriptions(subscriptions []*inspector.Subscription) []interface{} {
+	if len(subscriptions) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, subscription := range subscriptions {
+		if subscription == nil {
+			continue
+		}
+
+		for _, eventSubscription := range subscription.EventSubscriptions {
+			if eventSubscription == nil {
+				continue
+			}
+
+			tfList = append(tfList, flattenEventSubscription(eventSubscription, subscription.TopicArn))
+		}
+	}
+
+	return tfList
+}
+
+func flattenEventSubscription(eventSubscription *inspector.EventSubscription, topicArn *string) map[string]interface{} {
+	if eventSubscription == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	tfMap["event"] = eventSubscription.Event
+	tfMap["topic_arn"] = topicArn
+
+	return tfMap
+}
+
+func subscribeToEvents(conn *inspector.Inspector, eventSubscriptions []*inspector.SubscribeToEventInput) error {
+	for _, eventSubscription := range eventSubscriptions {
+		_, err := conn.SubscribeToEvent(eventSubscription)
+
+		if err != nil {
+			return create.Error(names.Inspector, create.ErrActionCreating, ResNameAssessmentTemplate, *eventSubscription.TopicArn, err)
+		}
+	}
+
+	return nil
+}
+
+func unsubscribeFromEvents(conn *inspector.Inspector, eventSubscriptions []*inspector.SubscribeToEventInput) error {
+	for _, eventSubscription := range eventSubscriptions {
+		input := &inspector.UnsubscribeFromEventInput{
+			Event:       eventSubscription.Event,
+			ResourceArn: eventSubscription.ResourceArn,
+			TopicArn:    eventSubscription.TopicArn,
+		}
+
+		_, err := conn.UnsubscribeFromEvent(input)
+
+		if err != nil {
+			return create.Error(names.Inspector, create.ErrActionDeleting, ResNameAssessmentTemplate, *eventSubscription.TopicArn, err)
+		}
 	}
 
 	return nil

--- a/internal/service/inspector/assessment_template_test.go
+++ b/internal/service/inspector/assessment_template_test.go
@@ -122,6 +122,63 @@ func TestAccInspectorAssessmentTemplate_tags(t *testing.T) {
 	})
 }
 
+func TestAccInspectorAssessmentTemplate_eventSubscription(t *testing.T) {
+	var v inspector.AssessmentTemplate
+	resourceName := "aws_inspector_assessment_template.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	event1 := "ASSESSMENT_RUN_STARTED"
+	event1Updated := "ASSESSMENT_RUN_COMPLETED"
+	event2 := "ASSESSMENT_RUN_STATE_CHANGED"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, inspector.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssessmentTemplateConfig_eventSubscription(rName, event1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "event_subscription.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_subscription.0.event", event1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAssessmentTemplateConfig_eventSubscription(rName, event1Updated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "event_subscription.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_subscription.0.event", event1Updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAssessmentTemplateConfig_eventSubscriptionMultiple(rName, event1, event2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "event_subscription.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTemplateDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).InspectorConn
 
@@ -257,4 +314,82 @@ resource "aws_inspector_assessment_template" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAssessmentTemplateBase_eventSubscription(rName string) string {
+	return acctest.ConfigCompose(
+		testAccTemplateAssessmentBase(rName),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "SNS:Publish"
+    ]
+
+    resources = [aws_sns_topic.test.arn]
+  }
+}
+
+resource "aws_sns_topic_policy" "test" {
+  arn    = aws_sns_topic.test.arn
+  policy = data.aws_iam_policy_document.test.json
+}
+		`, rName),
+	)
+}
+
+func testAccAssessmentTemplateConfig_eventSubscription(rName, event string) string {
+	return acctest.ConfigCompose(
+		testAccAssessmentTemplateBase_eventSubscription(rName),
+		fmt.Sprintf(`
+resource "aws_inspector_assessment_template" "test" {
+  name       = %[1]q
+  target_arn = aws_inspector_assessment_target.test.arn
+  duration   = 3600
+
+  rules_package_arns = data.aws_inspector_rules_packages.available.arns
+
+  event_subscription {
+    event     = %[2]q
+    topic_arn = aws_sns_topic.test.arn
+  }
+}
+		`, rName, event),
+	)
+}
+
+func testAccAssessmentTemplateConfig_eventSubscriptionMultiple(rName, event1, event2 string) string {
+	return acctest.ConfigCompose(
+		testAccAssessmentTemplateBase_eventSubscription(rName),
+		fmt.Sprintf(`
+resource "aws_inspector_assessment_template" "test" {
+  name       = %[1]q
+  target_arn = aws_inspector_assessment_target.test.arn
+  duration   = 3600
+
+  rules_package_arns = data.aws_inspector_rules_packages.available.arns
+
+  event_subscription {
+    event     = %[2]q
+    topic_arn = aws_sns_topic.test.arn
+  }
+
+  event_subscription {
+    event     = %[3]q
+    topic_arn = aws_sns_topic.test.arn
+  }
+}
+		`, rName, event1, event2),
+	)
 }

--- a/internal/service/inspector/find.go
+++ b/internal/service/inspector/find.go
@@ -1,0 +1,34 @@
+package inspector
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/inspector"
+)
+
+func findSubscriptionsByAssessmentTemplateARN(conn *inspector.Inspector, arn string) ([]*inspector.Subscription, error) {
+	input := &inspector.ListEventSubscriptionsInput{
+		ResourceArn: aws.String(arn),
+	}
+
+	var results []*inspector.Subscription
+
+	err := conn.ListEventSubscriptionsPages(input, func(page *inspector.ListEventSubscriptionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, subscription := range page.Subscriptions {
+			if subscription == nil {
+				continue
+			}
+
+			if aws.StringValue(subscription.ResourceArn) == arn {
+				results = append(results, subscription)
+			}
+		}
+
+		return !lastPage
+	})
+
+	return results, err
+}

--- a/website/docs/r/inspector_assessment_template.html.markdown
+++ b/website/docs/r/inspector_assessment_template.html.markdown
@@ -24,6 +24,11 @@ resource "aws_inspector_assessment_template" "example" {
     "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ",
     "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-vg5GGHSD",
   ]
+
+  event_subscription {
+    event     = "ASSESSMENT_RUN_COMPLETED"
+    topic_arn = aws_sns_topic.example.arn
+  }
 }
 ```
 
@@ -35,7 +40,15 @@ The following arguments are supported:
 * `target_arn` - (Required) The assessment target ARN to attach the template to.
 * `duration` - (Required) The duration of the inspector run.
 * `rules_package_arns` - (Required) The rules to be used during the run.
+* `event_subscription` - (Optional) A block that enables sending notifications about a specified assessment template event to a designated SNS topic. See [Event Subscriptions](#event-subscriptions) for details.
 * `tags` - (Optional) Key-value map of tags for the Inspector assessment template. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Event Subscriptions
+
+The event subscription configuration block supports the following arguments:
+
+* `event` - (Required) The event for which you want to receive SNS notifications. Valid values are `ASSESSMENT_RUN_STARTED`, `ASSESSMENT_RUN_COMPLETED`, `ASSESSMENT_RUN_STATE_CHANGED`, and `FINDING_REPORTED`.
+* `topic_arn` - (Required) The ARN of the SNS topic to which notifications are sent.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support to enable SNS topic subscriptions to specific assessment template events.

Supersedes #12261.
Resolves #843.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
❯ make testacc TESTS=TestAccInspectorAssessmentTemplate PKG=inspector
--- PASS: TestAccInspectorAssessmentTemplate_disappears (21.28s)
--- PASS: TestAccInspectorAssessmentTemplate_basic (22.17s)
--- PASS: TestAccInspectorAssessmentTemplate_eventSubscription (50.69s)
--- PASS: TestAccInspectorAssessmentTemplate_tags (55.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector  55.091s
```
