### PR TITLE
d/github/pr: fix faq & contrib guide links in the PR workflow

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -54,8 +54,8 @@ jobs:
           pr-message: |-
             Welcome @${{github.actor}} :wave:
 
-            It looks like this is your first Pull Request submission to the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws)! If you haven’t already done so please make sure you have checked out our [CONTRIBUTING](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing) guide and [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md) to make sure your contribution is adhering to best practice and has all the necessary elements in place for a successful approval.
+            It looks like this is your first Pull Request submission to the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws)! If you haven’t already done so please make sure you have checked out our [CONTRIBUTOR](https://hashicorp.github.io/terraform-provider-aws/) guide and [FAQ](https://hashicorp.github.io/terraform-provider-aws/faq/) to make sure your contribution is adhering to best practice and has all the necessary elements in place for a successful approval.
 
-            Also take a look at our [FAQ](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md) which details how we prioritize Pull Requests for inclusion.
+            Also take a look at our [FAQ](https://hashicorp.github.io/terraform-provider-aws/faq/) which details how we prioritize Pull Requests for inclusion.
 
             Thanks again, and welcome to the community! :smiley:


### PR DESCRIPTION
Signed-off-by: Stano Bocinec <stano@redpanda.com>

### Description

This PR fixes the incorrect FAQ and Contributor guide links in the `PullRequestComments` step in the `pul_requests` github-actions workflow. Currently, the links returns 404.

Changes:

* FAQ: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/faq.md -> https://hashicorp.github.io/terraform-provider-aws/faq/
* CONTRIBUTOR GUIDE: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing -> https://hashicorp.github.io/terraform-provider-aws/


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
