### PR TITLE
usage plan association resource

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -966,6 +966,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_api_gateway_stage":                 apigateway.ResourceStage(),
 			"aws_api_gateway_usage_plan":            apigateway.ResourceUsagePlan(),
 			"aws_api_gateway_usage_plan_key":        apigateway.ResourceUsagePlanKey(),
+			"aws_api_gateway_usage_plan_assocation": apigateway.ResourceUsagePlanAssociation(),
 			"aws_api_gateway_vpc_link":              apigateway.ResourceVPCLink(),
 
 			"aws_apigatewayv2_api":                  apigatewayv2.ResourceAPI(),

--- a/internal/service/apigateway/usage_plan_association.go
+++ b/internal/service/apigateway/usage_plan_association.go
@@ -1,0 +1,172 @@
+package apigateway
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceUsagePlanAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUsagePlanAssociationCreate,
+		Read:   resourceUsagePlanAssociationRead,
+		Delete: resourceUsagePlanAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"usage_plan_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"api_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"stage": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceUsagePlanAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).APIGatewayConn
+
+	operations := make([]*apigateway.PatchOperation, 0)
+
+	api_stage := fmt.Sprintf("%s:%s", d.Get("api_id"), d.Get("stage"))
+	operations = append(operations, &apigateway.PatchOperation{
+		Op:    aws.String(apigateway.OpAdd),
+		Path:  aws.String("/apiStages"),
+		Value: aws.String(api_stage),
+	})
+	input := &apigateway.UpdateUsagePlanInput{
+		UsagePlanId:     aws.String(fmt.Sprintf("%s", d.Get("usage_plan_id"))),
+		PatchOperations: operations,
+	}
+	log.Printf("[DEBUG] UsagePlanAssociation creation input: %#v", input)
+
+	var up *apigateway.UsagePlan
+	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
+		var err error
+		up, err = conn.UpdateUsagePlan(input)
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error creating UsagePlanAssociation: %s for plan %s", err, d.Get("usage_plan_id"))
+	}
+
+	log.Printf("[DEBUG] UsagePlan creation response: %s", up)
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", d.Get("usage_plan_id"), d.Get("api_id"), d.Get("stage")))
+
+	return resourceUsagePlanAssociationRead(d, meta)
+}
+
+func resourceUsagePlanAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).APIGatewayConn
+
+	spl := strings.Split(d.Id(), "/")
+	input := &apigateway.GetUsagePlanInput{
+		UsagePlanId: aws.String(spl[0]),
+	}
+
+	output, err := conn.GetUsagePlan(input)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] API Gateway UsagePlanAssociation (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	for _, stage := range output.ApiStages {
+		if aws.StringValue(stage.ApiId) == spl[1] && aws.StringValue(stage.Stage) == spl[2] {
+			d.Set("usage_plan_id", spl[0])
+			d.Set("api_id", aws.StringValue(stage.ApiId))
+			d.Set("stage", aws.StringValue(stage.Stage))
+			return nil
+		}
+	}
+
+	return err
+}
+
+func resourceUsagePlanAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).APIGatewayConn
+
+	input := &apigateway.GetUsagePlanInput{
+		UsagePlanId: aws.String(fmt.Sprintf("%s", d.Get("usage_plan_id"))),
+	}
+
+	output, err := conn.GetUsagePlan(input)
+	if tfresource.NotFound(err) {
+		return nil
+	}
+
+	found := false
+	for _, stage := range output.ApiStages {
+		if aws.StringValue(stage.ApiId) == d.Get("api_id").(string) && aws.StringValue(stage.Stage) == d.Get("stage").(string) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+
+	operations := make([]*apigateway.PatchOperation, 0)
+
+	api_stage := fmt.Sprintf("%s:%s", d.Get("api_id"), d.Get("stage"))
+	operations = append(operations, &apigateway.PatchOperation{
+		Op:    aws.String(apigateway.OpRemove),
+		Path:  aws.String("/apiStages"),
+		Value: aws.String(api_stage),
+	})
+
+	req := &apigateway.UpdateUsagePlanInput{
+		UsagePlanId:     aws.String(fmt.Sprintf("%s", d.Get("usage_plan_id"))),
+		PatchOperations: operations,
+	}
+
+	err = resource.Retry(propagationTimeout, func() *resource.RetryError {
+		var err error
+		_, err = conn.UpdateUsagePlan(req)
+
+		if tfresource.NotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting UsagePlan Stage: %s for plan %s", err, d.Get("usage_plan_id"))
+	}
+
+	return nil
+}

--- a/internal/service/apigateway/usage_plan_association_test.go
+++ b/internal/service/apigateway/usage_plan_association_test.go
@@ -1,0 +1,167 @@
+package apigateway_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func TestAccAPIGatewayUsagePlanAssociation_basic(t *testing.T) {
+	var conf apigateway.ApiStage
+	resourceName := "aws_api_gateway_usage_plan_assocation.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, apigateway.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUsagePlanAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsagePlanAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUsagePlanAssociationExists(resourceName, &conf),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckUsagePlanAssociationExists(n string, res *apigateway.ApiStage) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway Usage Plan Stage ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayConn
+
+		spl := strings.Split(rs.Primary.ID, "/")
+		req := &apigateway.GetUsagePlanInput{
+			UsagePlanId: aws.String(spl[0]),
+		}
+
+		up, err := conn.GetUsagePlan(req)
+		if err != nil {
+			return err
+		}
+
+		for _, stage := range up.ApiStages {
+			if aws.StringValue(stage.ApiId) == spl[1] && aws.StringValue(stage.Stage) == spl[2] {
+				*res = *stage
+				return nil
+			}
+		}
+
+		return fmt.Errorf("APIGateway Usage Plan Stage not found")
+	}
+}
+
+func testAccCheckUsagePlanAssociationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_api_gateway_usage_plan_assocation" {
+			continue
+		}
+
+		spl := strings.Split(rs.Primary.ID, "/")
+		req := &apigateway.GetUsagePlanInput{
+			UsagePlanId: aws.String(spl[0]),
+		}
+
+		up, err := conn.GetUsagePlan(req)
+		if err != nil {
+			return err
+		}
+
+		for _, stage := range up.ApiStages {
+			if aws.StringValue(stage.ApiId) == spl[1] && aws.StringValue(stage.Stage) == spl[2] {
+				return fmt.Errorf("API Gateway Usage Plan Stage still exists")
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccUsagePlanAssociationConfig() string {
+	return `
+resource "aws_api_gateway_rest_api" "test" {
+	name = "tf-acc-test-usage-plan-stage"
+
+	endpoint_configuration {
+		types = ["REGIONAL"]
+	}
+}
+
+resource "aws_api_gateway_resource" "test" {
+	rest_api_id = aws_api_gateway_rest_api.test.id
+	parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+	path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+	rest_api_id   = aws_api_gateway_rest_api.test.id
+	resource_id   = aws_api_gateway_resource.test.id
+	http_method   = "GET"
+	authorization = "NONE"
+}
+
+resource "aws_api_gateway_stage" "test" {
+	deployment_id = aws_api_gateway_deployment.test.id
+	rest_api_id   = aws_api_gateway_rest_api.test.id
+	stage_name    = "test"
+  
+}
+
+resource "aws_api_gateway_integration" "test" {
+	http_method             = aws_api_gateway_method.test.http_method
+	resource_id             = aws_api_gateway_resource.test.id
+	rest_api_id             = aws_api_gateway_rest_api.test.id
+	type                    = "MOCK"
+}
+
+resource "aws_api_gateway_deployment" "test" {
+	depends_on = [aws_api_gateway_integration.test]
+
+	rest_api_id = aws_api_gateway_rest_api.test.id
+	lifecycle {
+	  create_before_destroy = true
+	}
+}
+
+resource "aws_api_gateway_usage_plan" "test" {
+	name = "tf-acc-test-usage-plan"
+	lifecycle {
+		ignore_changes = [api_stages]
+	}
+}
+`
+}
+
+func testAccUsagePlanAssociationConfig_basic() string {
+	return testAccUsagePlanAssociationConfig() + `
+resource "aws_api_gateway_usage_plan_assocation" "test" {
+  usage_plan_id = aws_api_gateway_usage_plan.test.id
+  api_id = aws_api_gateway_rest_api.test.id
+  stage = aws_api_gateway_stage.test.stage_name
+}`
+}

--- a/website/docs/r/api_gateway_usage_plan_association.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan_association.html.markdown
@@ -1,0 +1,109 @@
+---
+subcategory: "API Gateway"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_usage_plan_assocation"
+description: |-
+  Provides an API Gateway Usage Plan Association.
+---
+
+# Resource: aws_api_gateway_usage_plan_assocation
+
+Provides an API Gateway Usage Plan Association.
+
+## Example Usage
+
+```terraform
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.example.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "development" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "development"
+}
+
+resource "aws_api_gateway_stage" "production" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "production"
+}
+
+resource "aws_api_gateway_usage_plan" "example" {
+  name         = "my-usage-plan"
+  description  = "my description"
+  product_code = "MYCODE"
+
+  # Important to prevent overwriting stages linked via aws_api_gateway_usage_plan_assocation resources
+	lifecycle {
+		ignore_changes = [api_stages]
+	}
+
+  quota_settings {
+    limit  = 20
+    offset = 2
+    period = "WEEK"
+  }
+
+  throttle_settings {
+    burst_limit = 5
+    rate_limit  = 10
+  }
+}
+
+resource "aws_api_gateway_usage_plan_assocation" "example" {
+  usage_plan_id = aws_api_gateway_usage_plan.example.id
+  api_id = aws_api_gateway_rest_api.example.id
+  stage  = aws_api_gateway_stage.production.stage_name
+}
+```
+
+## Argument Reference
+
+The API Gateway Usage Plan Association argument layout is a structure composed of several sub-resources - these resources are laid out below.
+
+### Top-Level Arguments
+
+* `api_id` (Required) - API Id of the associated API stage in a usage plan.
+* `stage` (Required) - API stage name of the associated API stage in a usage plan.
+* `throttle` - (Optional) The [throttling limits](#throttle) of the usage plan.
+
+## Import
+
+AWS API Gateway Usage Plan Association can be imported using the `usage_plan_id`, `api_id` and `stage`, e.g.,
+
+```sh
+$ terraform import aws_api_gateway_usage_plan.myusageplan <usage_plan_id>/<api_id>/<stage>
+```


### PR DESCRIPTION
Add usage plan association resource to allow linking usage plans to rest api stages outside of the usage_plan resource

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9512.

Output from acceptance testing:
```
$ make testacc TESTS=TestAccAPIGatewayUsagePlanAssociation_basic PKG=apigateway

...
```
