### PR TITLE
Fix single_header validation to match AWS docs

### DIFF
--- a/.changelog/26375.txt
+++ b/.changelog/26375.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_web_acl: Fix single_header validation to match AWS documentation.
+```

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -346,10 +346,10 @@ func fieldToMatchBaseSchema() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 40),
+								validation.StringLenBetween(1, 64),
 								// The value is returned in lower case by the API.
 								// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
-								validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
+								validation.StringMatch(regexp.MustCompile(`.*\S.*`), "must match the pattern specified by https://docs.aws.amazon.com/waf/latest/APIReference/API_SingleHeader.html"),
 							),
 						},
 					},

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -3220,55 +3220,56 @@ func testAccWebACLImportStateIdFunc(resourceName string) resource.ImportStateIdF
 func testAccWebACLConfig_byteMatch(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-	name        = %[1]q
-	description = %[1]q
-	scope       = "REGIONAL"
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
 
-	default_action {
-		allow {}
-	}
+  default_action {
+    allow {}
+  }
 
-	rule {
-		name     = "%[1]s-1"
-		priority = 10
+  rule {
+    name     = "%[1]s-1"
+    priority = 10
 
-		action {
-		count {}
-		}
+    action {
+      count {}
+    }
 
-		statement {
+    statement {
 
-			byte_match_statement {
-				positional_constraint = "EXACTLY"
-				search_string         = "foo*"
+      byte_match_statement {
+        positional_constraint = "EXACTLY"
+        search_string         = "foo*"
 
-				field_to_match {
+        field_to_match {
 
-					single_header {
-						name = "bar*"
-					}
-				}
+          single_header {
+            name = "bar*"
+          }
+        }
 
-				text_transformation {
-					priority = 0
-					type     = "NONE"
-				}
-			}
-		}
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
 
-		visibility_config {
-			cloudwatch_metrics_enabled = false
-			metric_name                = "%[1]s-metric-name-1"
-			sampled_requests_enabled   = false
-		}
-	}
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "%[1]s-metric-name-1"
+      sampled_requests_enabled   = false
+    }
+  }
 
-	visibility_config {
-		cloudwatch_metrics_enabled = false
-		metric_name                = "friendly-metric-name"
-		sampled_requests_enabled   = false
-	}
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
 }
+
 
 `, name)
 }

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -1641,6 +1641,33 @@ func TestAccWAFV2WebACL_Operators_maxNested(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACL_byteMatch(t *testing.T) {
+	var v wafv2.WebACL
+	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckScopeRegional(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, wafv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_byteMatch(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(resourceName, &v),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccCheckWebACLDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_wafv2_web_acl" {
@@ -3188,4 +3215,60 @@ func testAccWebACLImportStateIdFunc(resourceName string) resource.ImportStateIdF
 
 		return fmt.Sprintf("%s/%s/%s", rs.Primary.ID, rs.Primary.Attributes["name"], rs.Primary.Attributes["scope"]), nil
 	}
+}
+
+func testAccWebACLConfig_byteMatch(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+	name        = %[1]q
+	description = %[1]q
+	scope       = "REGIONAL"
+
+	default_action {
+		allow {}
+	}
+
+	rule {
+		name     = "%[1]s-1"
+		priority = 10
+
+		action {
+		count {}
+		}
+
+		statement {
+
+			byte_match_statement {
+				positional_constraint = "EXACTLY"
+				search_string         = "foo*"
+
+				field_to_match {
+
+					single_header {
+						name = "bar*"
+					}
+				}
+
+				text_transformation {
+					priority = 0
+					type     = "NONE"
+				}
+			}
+		}
+
+		visibility_config {
+			cloudwatch_metrics_enabled = false
+			metric_name                = "%[1]s-metric-name-1"
+			sampled_requests_enabled   = false
+		}
+	}
+
+	visibility_config {
+		cloudwatch_metrics_enabled = false
+		metric_name                = "friendly-metric-name"
+		sampled_requests_enabled   = false
+	}
+}
+
+`, name)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This PR fixes the `single_header` schema validation to match what is provided by [AWS](https://docs.aws.amazon.com/waf/latest/APIReference/API_SingleHeader.html). I discovered this while trying to import a WAF ACL with a `*` in the `single_header` field.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Before the fix:
```console
$ make testacc TESTS=TestAccWAFV2WebACL_byteMatch PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_byteMatch'  -timeout 180m
=== RUN   TestAccWAFV2WebACL_byteMatch
=== PAUSE TestAccWAFV2WebACL_byteMatch
=== CONT  TestAccWAFV2WebACL_byteMatch
    web_acl_test.go:1649: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: invalid value for rule.0.statement.0.byte_match_statement.0.field_to_match.0.single_header.0.name (must contain only lowercase alphanumeric characters, underscores, and hyphens)
        
          with aws_wafv2_web_acl.test,
          on terraform_plugin_test.tf line 2, in resource "aws_wafv2_web_acl" "test":
           2: resource "aws_wafv2_web_acl" "test" {
        
--- FAIL: TestAccWAFV2WebACL_byteMatch (2.08s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      2.140s
FAIL
make: *** [GNUmakefile:52: testacc] Error 1
```
after:
```console
$ make testacc TESTS=TestAccWAFV2WebACL_byteMatch PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_byteMatch'  -timeout 180m
=== RUN   TestAccWAFV2WebACL_byteMatch
=== PAUSE TestAccWAFV2WebACL_byteMatch
=== CONT  TestAccWAFV2WebACL_byteMatch
--- PASS: TestAccWAFV2WebACL_byteMatch (20.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      20.369s
```

I also ran the entire WAFv2 test suite just to be safe and all tests passed except 2 or 3 with this error:

> AccessDeniedException: AWS WAF couldn’t create a service-linked role (SLR) because this account isn’t authorized to perform the following action: iam:CreateServiceLinkedRole.

Which I'm certain is unrelated to my changes and more of an issue with my AWS account/user permissions.