### PR TITLE
linter: Adds rules from Semgrep Registry

### DIFF
--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -29,6 +29,7 @@ jobs:
             --config .ci/.semgrep.yml \
             --config 'r/dgryski.semgrep-go.badnilguard' \
             --config 'r/dgryski.semgrep-go.errnilcheck' \
+            --config 'r/dgryski.semgrep-go.marshaljson' \
             --config 'r/dgryski.semgrep-go.nilerr' \
             --config 'r/dgryski.semgrep-go.oddifsequence' \
             --config 'r/dgryski.semgrep-go.oserrors'

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -25,11 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          |
           semgrep $COMMON_PARAMS \
             --config .ci/.semgrep.yml \
             --config 'r/dgryski.semgrep-go.badnilguard' \
             --config 'r/dgryski.semgrep-go.errnilcheck' \
-            --config 'r/dgryski.semgrep-go.nilerr'
+            --config 'r/dgryski.semgrep-go.nilerr' \
+            --config 'r/dgryski.semgrep-go.oserrors'
 
   naming_cae:
     name: Naming Scan Caps/AWS/EC2

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - run: |
           semgrep $COMMON_PARAMS \
             --config .ci/.semgrep.yml \
+            --config 'r/dgryski.semgrep-go.badnilguard' \
             --config 'r/dgryski.semgrep-go.errnilcheck' \
             --config 'r/dgryski.semgrep-go.nilerr'
 

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -25,12 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-          |
           semgrep $COMMON_PARAMS \
             --config .ci/.semgrep.yml \
             --config 'r/dgryski.semgrep-go.badnilguard' \
             --config 'r/dgryski.semgrep-go.errnilcheck' \
             --config 'r/dgryski.semgrep-go.nilerr' \
+            --config 'r/dgryski.semgrep-go.oddifsequence' \
             --config 'r/dgryski.semgrep-go.oserrors'
 
   naming_cae:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -248,6 +248,7 @@ semall:
 		--config .ci/.semgrep-service-name3.yml \
 		--config 'r/dgryski.semgrep-go.badnilguard' \
 		--config 'r/dgryski.semgrep-go.errnilcheck' \
+    	--config 'r/dgryski.semgrep-go.marshaljson' \
 		--config 'r/dgryski.semgrep-go.nilerr' \
         --config 'r/dgryski.semgrep-go.oddifsequence' \
 		--config 'r/dgryski.semgrep-go.oserrors'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -249,6 +249,7 @@ semall:
 		--config 'r/dgryski.semgrep-go.badnilguard' \
 		--config 'r/dgryski.semgrep-go.errnilcheck' \
 		--config 'r/dgryski.semgrep-go.nilerr' \
+        --config 'r/dgryski.semgrep-go.oddifsequence' \
 		--config 'r/dgryski.semgrep-go.oserrors'
 
 skaff:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -248,7 +248,8 @@ semall:
 		--config .ci/.semgrep-service-name3.yml \
 		--config 'r/dgryski.semgrep-go.badnilguard' \
 		--config 'r/dgryski.semgrep-go.errnilcheck' \
-		--config 'r/dgryski.semgrep-go.nilerr'
+		--config 'r/dgryski.semgrep-go.nilerr' \
+		--config 'r/dgryski.semgrep-go.oserrors'
 
 skaff:
 	cd skaff && go install github.com/hashicorp/terraform-provider-aws/skaff

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -246,6 +246,7 @@ semall:
 		--config .ci/.semgrep-service-name1.yml \
 		--config .ci/.semgrep-service-name2.yml \
 		--config .ci/.semgrep-service-name3.yml \
+		--config 'r/dgryski.semgrep-go.badnilguard' \
 		--config 'r/dgryski.semgrep-go.errnilcheck' \
 		--config 'r/dgryski.semgrep-go.nilerr'
 

--- a/internal/generate/servicesemgrep/main.go
+++ b/internal/generate/servicesemgrep/main.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"regexp"
@@ -115,7 +117,7 @@ func main() {
 			rp = l[names.ColSplitPackageRealPackage]
 		}
 
-		if _, err := os.Stat(fmt.Sprintf("../../service/%s", rp)); err != nil || os.IsNotExist(err) {
+		if _, err := os.Stat(fmt.Sprintf("../../service/%s", rp)); err != nil || errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 

--- a/internal/generate/sweepimp/main.go
+++ b/internal/generate/sweepimp/main.go
@@ -6,8 +6,10 @@ package main
 import (
 	"bytes"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"go/format"
+	"io/fs"
 	"log"
 	"os"
 	"sort"
@@ -68,11 +70,11 @@ func main() {
 			p = l[names.ColProviderPackageActual]
 		}
 
-		if _, err := os.Stat(fmt.Sprintf("../../service/%s", p)); err != nil || os.IsNotExist(err) {
+		if _, err := os.Stat(fmt.Sprintf("../../service/%s", p)); err != nil || errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 
-		if _, err := os.Stat(fmt.Sprintf("../../service/%s/sweep.go", p)); err != nil || os.IsNotExist(err) {
+		if _, err := os.Stat(fmt.Sprintf("../../service/%s/sweep.go", p)); err != nil || errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 

--- a/internal/service/apigateway/base_path_mapping.go
+++ b/internal/service/apigateway/base_path_mapping.go
@@ -133,9 +133,7 @@ func resourceBasePathMappingUpdate(d *schema.ResourceData, meta interface{}) err
 	_, err := conn.UpdateBasePathMapping(&input)
 
 	if err != nil {
-		if err != nil {
-			return fmt.Errorf("Updating API Gateway base path mapping failed: %s", err)
-		}
+		return fmt.Errorf("Updating API Gateway base path mapping failed: %w", err)
 	}
 
 	if d.HasChange("base_path") {

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -159,7 +159,7 @@ func testAccCheckDirectoryConfigExists(resourceName string, appStreamDirectoryCo
 			return err
 		}
 
-		if resp == nil && len(resp.DirectoryConfigs) == 0 {
+		if resp == nil || len(resp.DirectoryConfigs) == 0 {
 			return fmt.Errorf("AppStream Directory Config %q does not exist", rs.Primary.ID)
 		}
 

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -313,7 +313,7 @@ func testAccCheckFleetExists(resourceName string, appStreamFleet *appstream.Flee
 			return err
 		}
 
-		if resp == nil && len(resp.Fleets) == 0 {
+		if resp == nil || len(resp.Fleets) == 0 {
 			return fmt.Errorf("appstream fleet %q does not exist", rs.Primary.ID)
 		}
 

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -167,7 +167,7 @@ func testAccCheckStackExists(resourceName string, appStreamStack *appstream.Stac
 			return fmt.Errorf("problem checking for AppStream Stack existence: %w", err)
 		}
 
-		if resp == nil && len(resp.Stacks) == 0 {
+		if resp == nil || len(resp.Stacks) == 0 {
 			return fmt.Errorf("appstream stack %q does not exist", rs.Primary.ID)
 		}
 

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -67,10 +67,6 @@ func resourceInvitationAccepterRead(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error listing Detective InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
-	if err != nil {
-		return diag.Errorf("error reading Detective InvitationAccepter (%s): %s", d.Id(), err)
-	}
-
 	d.Set("graph_arn", graphArn)
 	return nil
 }

--- a/internal/service/glue/find.go
+++ b/internal/service/glue/find.go
@@ -153,7 +153,7 @@ func FindPartitionByValues(conn *glue.Glue, id string) (*glue.Partition, error) 
 		return nil, err
 	}
 
-	if output == nil && output.Partition == nil {
+	if output == nil || output.Partition == nil {
 		return nil, nil
 	}
 

--- a/internal/service/networkfirewall/logging_configuration_test.go
+++ b/internal/service/networkfirewall/logging_configuration_test.go
@@ -635,7 +635,7 @@ func testAccCheckLoggingConfigurationExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		if output == nil && output.LoggingConfiguration == nil {
+		if output == nil || output.LoggingConfiguration == nil {
 			return fmt.Errorf("NetworkFirewall Logging Configuration for firewall (%s) not found", rs.Primary.ID)
 		}
 

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -68,7 +68,7 @@ type CoreNetworkEdgeLocation struct {
 	InsideCidrBlocks interface{} `json:"inside-cidr-blocks,omitempty"`
 }
 
-func (c *CoreNetworkPolicySegmentAction) MarshalJSON() ([]byte, error) {
+func (c CoreNetworkPolicySegmentAction) MarshalJSON() ([]byte, error) {
 	type Alias CoreNetworkPolicySegmentAction
 
 	var share interface{}

--- a/internal/service/redshift/event_subscription.go
+++ b/internal/service/redshift/event_subscription.go
@@ -163,10 +163,6 @@ func resourceEventSubscriptionRead(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("retrieving Redshift Event Subscription %s: %w", d.Id(), err)
-	}
-
-	if err != nil {
 		return fmt.Errorf("reading Redshift Event Subscription (%s): %w", d.Id(), err)
 	}
 

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -1,7 +1,9 @@
 package names
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"testing"
 )
@@ -216,7 +218,7 @@ func TestServicesForDirectories(t *testing.T) {
 				t.Errorf("error reading working directory: %s", err)
 			}
 
-			if _, err := os.Stat(fmt.Sprintf("%s/../internal/service/%s", wd, testCase)); os.IsNotExist(err) {
+			if _, err := os.Stat(fmt.Sprintf("%s/../internal/service/%s", wd, testCase)); errors.Is(err, fs.ErrNotExist) {
 				for _, service := range nonExisting {
 					if service == testCase {
 						t.Skipf("skipping %s because not yet implemented", testCase)

--- a/skaff/datasource/datasource.go
+++ b/skaff/datasource/datasource.go
@@ -3,7 +3,9 @@ package datasource
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +102,7 @@ func Create(dsName, snakeName string, comments, force, v2 bool) error {
 }
 
 func writeTemplate(templateName, filename, tmpl string, force bool, td TemplateData) error {
-	if _, err := os.Stat(filename); !os.IsNotExist(err) && !force {
+	if _, err := os.Stat(filename); !errors.Is(err, fs.ErrNotExist) && !force {
 		return fmt.Errorf("file (%s) already exists and force is not set", filename)
 	}
 

--- a/skaff/resource/resource.go
+++ b/skaff/resource/resource.go
@@ -3,7 +3,9 @@ package resource
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -120,7 +122,7 @@ func Create(resName, snakeName string, comments, force, v2 bool) error {
 }
 
 func writeTemplate(templateName, filename, tmpl string, force bool, td TemplateData) error {
-	if _, err := os.Stat(filename); !os.IsNotExist(err) && !force {
+	if _, err := os.Stat(filename); !errors.Is(err, fs.ErrNotExist) && !force {
 		return fmt.Errorf("file (%s) already exists and force is not set", filename)
 	}
 


### PR DESCRIPTION
Adds the Semgrep rules

* [`dgryski.semgrep-go.badnilguard`](https://semgrep.dev/r?q=dgryski.semgrep-go.badnilguard)
* [`dgryski.semgrep-go.marshaljson`](https://semgrep.dev/r?q=dgryski.semgrep-go.marshaljson)
* [`dgryski.semgrep-go.oddifsequence`](https://semgrep.dev/r?q=dgryski.semgrep-go.oddifsequence)
* [`dgryski.semgrep-go.oserrors`](https://semgrep.dev/r?q=dgryski.semgrep-go.oserrors)
