### PR TITLE
New resource: Grafana Workspace Api Key

### DIFF
--- a/.changelog/26383.txt
+++ b/.changelog/26383.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_grafana_workspace_api_key
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1550,7 +1550,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_grafana_license_association":          grafana.ResourceLicenseAssociation(),
 			"aws_grafana_role_association":             grafana.ResourceRoleAssociation(),
 			"aws_grafana_workspace":                    grafana.ResourceWorkspace(),
-			"aws_grafana_workspace_api_key":            grafana.ResourceWorkspaceApiKey(),
+			"aws_grafana_workspace_api_key":            grafana.ResourceWorkspaceAPIKey(),
 			"aws_grafana_workspace_saml_configuration": grafana.ResourceWorkspaceSAMLConfiguration(),
 
 			"aws_guardduty_detector":                   guardduty.ResourceDetector(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1550,6 +1550,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_grafana_license_association":          grafana.ResourceLicenseAssociation(),
 			"aws_grafana_role_association":             grafana.ResourceRoleAssociation(),
 			"aws_grafana_workspace":                    grafana.ResourceWorkspace(),
+			"aws_grafana_workspace_api_key":            grafana.ResourceWorkspaceApiKey(),
 			"aws_grafana_workspace_saml_configuration": grafana.ResourceWorkspaceSAMLConfiguration(),
 
 			"aws_guardduty_detector":                   guardduty.ResourceDetector(),

--- a/internal/service/grafana/workspace_api_key.go
+++ b/internal/service/grafana/workspace_api_key.go
@@ -1,0 +1,97 @@
+package grafana
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/managedgrafana"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func ResourceWorkspaceApiKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWorkspaceApiKeyCreate,
+		Read:   resourceWorkspaceApiKeyRead,
+		Delete: resourceWorkspaceApiKeyDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key_role": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(managedgrafana.Role_Values(), false),
+			},
+			"seconds_to_live": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceWorkspaceApiKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).GrafanaConn
+
+	input := &managedgrafana.CreateWorkspaceApiKeyInput{
+		KeyName:       aws.String(d.Get("key_name").(string)),
+		KeyRole:       aws.String(d.Get("key_role").(string)),
+		SecondsToLive: aws.Int64(int64(d.Get("seconds_to_live").(int))),
+		WorkspaceId:   aws.String(d.Get("workspace_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating Grafana Workspace API Key: %s", input)
+	output, err := conn.CreateWorkspaceApiKey(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating Grafana Workspace API Key: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.KeyName))
+
+	return resourceWorkspaceApiKeyRead(d, meta)
+}
+
+func resourceWorkspaceApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+	d.Set("key_name", d.Get("key_name").(string))
+	d.Set("key_role", d.Get("key_role").(string))
+	d.Set("seconds_to_live", d.Get("seconds_to_live").(int))
+	d.Set("workspace_id", d.Get("workspace_id").(string))
+
+	return nil
+}
+
+func resourceWorkspaceApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).GrafanaConn
+
+	log.Printf("[DEBUG] Deleting Grafana Workspace API Key: %s", d.Id())
+	_, err := conn.DeleteWorkspaceApiKey(&managedgrafana.DeleteWorkspaceApiKeyInput{
+		KeyName:     aws.String(d.Get("key_name").(string)),
+		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error deleting Grafana Workspace API Key (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/grafana/workspace_api_key.go
+++ b/internal/service/grafana/workspace_api_key.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/managedgrafana"
@@ -20,11 +19,6 @@ func ResourceWorkspaceApiKey() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/grafana/workspace_api_key.go
+++ b/internal/service/grafana/workspace_api_key.go
@@ -25,19 +25,23 @@ func ResourceWorkspaceApiKey() *schema.Resource {
 			"key_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"key_role": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(managedgrafana.Role_Values(), false),
+				ForceNew:     true,
 			},
 			"seconds_to_live": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			"workspace_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/internal/service/grafana/workspace_api_key.go
+++ b/internal/service/grafana/workspace_api_key.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-func ResourceWorkspaceApiKey() *schema.Resource {
+func ResourceWorkspaceAPIKey() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceWorkspaceApiKeyCreate,
-		Read:   resourceWorkspaceApiKeyRead,
-		Delete: resourceWorkspaceApiKeyDelete,
+		Create: resourceWorkspaceAPIKeyCreate,
+		Read:   resourceWorkspaceAPIKeyRead,
+		Delete: resourceWorkspaceAPIKeyDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -47,7 +47,7 @@ func ResourceWorkspaceApiKey() *schema.Resource {
 	}
 }
 
-func resourceWorkspaceApiKeyCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceWorkspaceAPIKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GrafanaConn
 
 	input := &managedgrafana.CreateWorkspaceApiKeyInput{
@@ -66,10 +66,10 @@ func resourceWorkspaceApiKeyCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(aws.StringValue(output.KeyName))
 
-	return resourceWorkspaceApiKeyRead(d, meta)
+	return resourceWorkspaceAPIKeyRead(d, meta)
 }
 
-func resourceWorkspaceApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+func resourceWorkspaceAPIKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_name", d.Get("key_name").(string))
 	d.Set("key_role", d.Get("key_role").(string))
 	d.Set("seconds_to_live", d.Get("seconds_to_live").(int))
@@ -78,7 +78,7 @@ func resourceWorkspaceApiKeyRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceWorkspaceApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceWorkspaceAPIKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GrafanaConn
 
 	log.Printf("[DEBUG] Deleting Grafana Workspace Api Key: %s", d.Id())

--- a/internal/service/grafana/workspace_api_key.go
+++ b/internal/service/grafana/workspace_api_key.go
@@ -57,11 +57,11 @@ func resourceWorkspaceApiKeyCreate(d *schema.ResourceData, meta interface{}) err
 		WorkspaceId:   aws.String(d.Get("workspace_id").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating Grafana Workspace API Key: %s", input)
+	log.Printf("[DEBUG] Creating Grafana Workspace Api Key: %s", input)
 	output, err := conn.CreateWorkspaceApiKey(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating Grafana Workspace API Key: %w", err)
+		return fmt.Errorf("error creating Grafana Workspace Api Key: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.KeyName))
@@ -81,14 +81,14 @@ func resourceWorkspaceApiKeyRead(d *schema.ResourceData, meta interface{}) error
 func resourceWorkspaceApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GrafanaConn
 
-	log.Printf("[DEBUG] Deleting Grafana Workspace API Key: %s", d.Id())
+	log.Printf("[DEBUG] Deleting Grafana Workspace Api Key: %s", d.Id())
 	_, err := conn.DeleteWorkspaceApiKey(&managedgrafana.DeleteWorkspaceApiKeyInput{
 		KeyName:     aws.String(d.Get("key_name").(string)),
 		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
 	})
 
 	if err != nil {
-		return fmt.Errorf("error deleting Grafana Workspace API Key (%s): %w", d.Id(), err)
+		return fmt.Errorf("error deleting Grafana Workspace Api Key (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccWorkspaceApiKey_basic(t *testing.T) {
+func testAccWorkspaceApiKey_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace_api_key.test"
 	workspaceResourceName := "aws_grafana_workspace.test"

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func testAccWorkspaceApiKey_basic(t *testing.T) {
+func testAccWorkspaceApiKeyConfig_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace_api_key.test"
 	workspaceResourceName := "aws_grafana_workspace.test"

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func testAccWorkspaceApiKeyConfig_basic(t *testing.T) {
+func testAccWorkspaceApiKey_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace_api_key.test"
 	workspaceResourceName := "aws_grafana_workspace.test"

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -25,7 +25,7 @@ func TestAccWorkspaceApiKey_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "key_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "key_role", "Editor"),
+					resource.TestCheckResourceAttr(resourceName, "key_role", "EDITOR"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_to_live", "3600"),
 				),
 			},
@@ -38,7 +38,7 @@ func testAccWorkspaceApiKey_providerBasic(rName string) string {
 resource "aws_grafana_workspace_api_key" "test" {
 	workspace_id    = aws_grafana_workspace.test.id
 	key_name        = "example-key"
-	key_role        = "Editor"
+	key_role        = "EDITOR"
 	seconds_to_live = 3600
 }`)
 }

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -1,6 +1,7 @@
 package grafana_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/managedgrafana"
@@ -34,11 +35,11 @@ func TestAccWorkspaceApiKey_basic(t *testing.T) {
 }
 
 func testAccWorkspaceApiKey_providerBasic(rName string) string {
-	return acctest.ConfigCompose(testAccWorkspaceSAMLConfigurationConfig_providerBasic(rName), `
+	return acctest.ConfigCompose(testAccWorkspaceSAMLConfigurationConfig_providerBasic(rName), fmt.Sprintf(`
 resource "aws_grafana_workspace_api_key" "test" {
-	workspace_id    = aws_grafana_workspace.test.id
-	key_name        = "example-key"
-	key_role        = "EDITOR"
-	seconds_to_live = 3600
-}`)
+  workspace_id    = aws_grafana_workspace.test.id
+  key_name        = %[1]q
+  key_role        = "EDITOR"
+  seconds_to_live = 3600
+}`, rName))
 }

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -34,7 +34,7 @@ func testAccWorkspaceApiKey_basic(t *testing.T) {
 	})
 }
 
-func testAccWorkspaceApiKey_providerBasic(rName string) string {
+func testAccWorkspaceApiKeyConfig_providerBasic(rName string) string {
 	return acctest.ConfigCompose(testAccWorkspaceSAMLConfigurationConfig_providerBasic(rName), fmt.Sprintf(`
 resource "aws_grafana_workspace_api_key" "test" {
   workspace_id    = aws_grafana_workspace.test.id

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -1,0 +1,44 @@
+package grafana_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/managedgrafana"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccWorkspaceApiKey_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_grafana_workspace_api_key.test"
+	workspaceResourceName := "aws_grafana_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(managedgrafana.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, managedgrafana.EndpointsID),
+		CheckDestroy:             nil,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceApiKey_providerBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "key_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "key_role", "Editor"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_to_live", "3600"),
+				),
+			},
+		},
+	})
+}
+
+func testAccWorkspaceApiKey_providerBasic(rName string) string {
+	return acctest.ConfigCompose(testAccWorkspaceSAMLConfigurationConfig_providerBasic(rName), `
+resource "aws_grafana_workspace_api_key" "test" {
+	workspace_id    = aws_grafana_workspace.test.id
+	key_name        = "example-key"
+	key_role        = "Editor"
+	seconds_to_live = 3600
+}`)
+}

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -22,7 +22,7 @@ func testAccWorkspaceApiKey_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceApiKey_providerBasic(rName),
+				Config: testAccWorkspaceApiKeyConfig_providerBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "key_name", rName),

--- a/internal/service/grafana/workspace_api_key_test.go
+++ b/internal/service/grafana/workspace_api_key_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func testAccWorkspaceApiKey_basic(t *testing.T) {
+func testAccWorkspaceAPIKey_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace_api_key.test"
 	workspaceResourceName := "aws_grafana_workspace.test"
@@ -22,7 +22,7 @@ func testAccWorkspaceApiKey_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceApiKeyConfig_providerBasic(rName),
+				Config: testAccWorkspaceAPIKeyConfig_providerBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "key_name", rName),
@@ -34,7 +34,7 @@ func testAccWorkspaceApiKey_basic(t *testing.T) {
 	})
 }
 
-func testAccWorkspaceApiKeyConfig_providerBasic(rName string) string {
+func testAccWorkspaceAPIKeyConfig_providerBasic(rName string) string {
 	return acctest.ConfigCompose(testAccWorkspaceSAMLConfigurationConfig_providerBasic(rName), fmt.Sprintf(`
 resource "aws_grafana_workspace_api_key" "test" {
   workspace_id    = aws_grafana_workspace.test.id

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -27,6 +27,9 @@ func TestAccGrafana_serial(t *testing.T) {
 			"notificationDestinations": testAccWorkspace_notificationDestinations,
 			"tags":                     testAccWorkspace_tags,
 		},
+		"WorkspaceApiKey": {
+			"basic": testAccWorkspaceApiKey_basic,
+		},
 		"DataSource": {
 			"basic": testAccWorkspaceDataSource_basic,
 		},

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -28,7 +28,7 @@ func TestAccGrafana_serial(t *testing.T) {
 			"tags":                     testAccWorkspace_tags,
 		},
 		"WorkspaceApiKey": {
-			"basic": testAccWorkspaceApiKey_basic,
+			"basic": testAccWorkspaceAPIKey_basic,
 		},
 		"DataSource": {
 			"basic": testAccWorkspaceDataSource_basic,

--- a/website/docs/r/grafana_workspace_api_key.html.markdown
+++ b/website/docs/r/grafana_workspace_api_key.html.markdown
@@ -34,7 +34,7 @@ The following arguments are required:
 
 ## Attributes Reference
 
-All the above arguments are also exported as attributes.
+No additional attributes are exported.
 
 ## Import
 

--- a/website/docs/r/grafana_workspace_api_key.html.markdown
+++ b/website/docs/r/grafana_workspace_api_key.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Managed Grafana"
+layout: "aws"
+page_title: "AWS: aws_grafana_workspace_api_key"
+description: |-
+  Provides an Amazon Managed Grafana Workspace Api Key resource.
+---
+
+# Resource: aws_grafana_workspace_api_key
+
+Provides an Amazon Managed Grafana Workspace Api Key resource.
+
+## Example Usage
+
+### Basic configuration
+
+```terraform
+resource "aws_grafana_workspace_api_Key" "example" {
+  workspace_id    = aws_grafana_workspace.example.id
+  key_name        = "example-editor-key"
+  key_role        = "EDITOR"
+  seconds_to_live = 3600
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+- `workspace_id` - (Required) The ID of the workspace that the key is valid for.
+- `key_name` - (Required) Specifies the name of the key. Keynames must be unique to the workspace.
+- `key_role` - (Required) Specifies the permission level of the key. Valid values are `VIEWER`, `EDITOR`, or `ADMIN`.
+- `seconds_to_live` - (Required) Specifies the time in seconds until the key expires. Keys can be valid for up to 30 days.
+
+## Attributes Reference
+
+All the above arguments are also exported as attributes.
+
+## Import
+
+Grafana Workspace Api Key can be imported using the Workspace Api Key's `key_name`, e.g.,
+
+```
+$ terraform import aws_grafana_workspace_api_key.example example-editor-key
+```

--- a/website/docs/r/grafana_workspace_api_key.html.markdown
+++ b/website/docs/r/grafana_workspace_api_key.html.markdown
@@ -15,7 +15,7 @@ Provides an Amazon Managed Grafana Workspace Api Key resource.
 ### Basic configuration
 
 ```terraform
-resource "aws_grafana_workspace_api_Key" "example" {
+resource "aws_grafana_workspace_api_key" "example" {
   workspace_id    = aws_grafana_workspace.example.id
   key_name        = "example-editor-key"
   key_role        = "EDITOR"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26374

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
bruno $ make testacc TESTS=TestAccWorkspaceApiKey_basic PKG=grafana
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/grafana/... -v -count 1 -parallel 20 -run='TestAccWorkspaceApiKey_basic'  -timeout 180m
=== RUN   TestAccWorkspaceApiKey_basic
--- PASS: TestAccWorkspaceApiKey_basic (147.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/grafana    147.980s
```
