### PR TITLE
Remove erroneous reference to `aws_imagebuilder_distribution_configuration.kms_key_id` argument

### DIFF
--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -48,7 +48,6 @@ The following arguments are required:
 The following arguments are optional:
 
 * `description` - (Optional) Description of the distribution configuration.
-* `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the Key Management Service (KMS) Key used to encrypt the distribution configuration.
 * `tags` - (Optional) Key-value map of resource tags for the distribution configuration. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### distribution


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26401

Output from acceptance testing: N/a, docs

### Description

The documentation for `aws_imagebuilder_distribution_configuration` currently states that there is a top-level argument of `kms_key_id`. This argument does not exist within the resource schema (note that there is a documented and valid `distribution.ami_distribution_configuration.kms_key_id` argument). As the author of the linked issue mentions, there is not a KMS key ID argument in the underlying API, so this seems to be strictly a documentation issue, which this PR aims to fix.

### References

- [Current resource documentation](https://registry.terraform.io/providers/hashicorp/aws/4.27.0/docs/resources/imagebuilder_distribution_configuration#kms_key_id)
- [Resource definition](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/imagebuilder/distribution_configuration.go)
- [AWS API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_CreateDistributionConfiguration.html)