### PR TITLE
d/aws_location_tracker_association: new data source

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -740,6 +740,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_location_place_index":         location.DataSourcePlaceIndex(),
 			"aws_location_route_calculator":    location.DataSourceRouteCalculator(),
 			"aws_location_tracker":             location.DataSourceTracker(),
+			"aws_location_tracker_association": location.DataSourceTrackerAssociation(),
 
 			// "aws_arn":                     meta.DataSourceARN(), // Now implemented using Terraform Plugin Framework.
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -142,7 +142,9 @@ func FindTrackerAssociationByTrackerNameAndConsumerARN(ctx context.Context, conn
 	}
 
 	found := false
-	fn := func(page *locationservice.ListTrackerConsumersOutput, lastPage bool) bool {
+
+	err := conn.ListTrackerConsumersPagesWithContext(ctx, in, func(page *locationservice.ListTrackerConsumersOutput, lastPage bool) bool {
+
 		if page == nil {
 			return !lastPage
 		}
@@ -155,9 +157,7 @@ func FindTrackerAssociationByTrackerNameAndConsumerARN(ctx context.Context, conn
 		}
 
 		return !lastPage
-	}
-
-	err := conn.ListTrackerConsumersPagesWithContext(ctx, in, fn)
+	})
 
 	if err != nil {
 		return err

--- a/internal/service/location/tracker_association_data_source.go
+++ b/internal/service/location/tracker_association_data_source.go
@@ -1,0 +1,57 @@
+package location
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceTrackerAssociation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTrackerAssociationRead,
+
+		Schema: map[string]*schema.Schema{
+			"consumer_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"tracker_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+		},
+	}
+}
+
+const (
+	DSNameTrackerAssociation = "Tracker Association Data Source"
+)
+
+func dataSourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	consumerArn := d.Get("consumer_arn").(string)
+	trackerName := d.Get("tracker_name").(string)
+	id := fmt.Sprintf("%s|%s", trackerName, consumerArn)
+
+	err := FindTrackerAssociationByTrackerNameAndConsumerARN(ctx, conn, trackerName, consumerArn)
+
+	if err != nil {
+		return create.DiagError(names.Location, create.ErrActionReading, DSNameTrackerAssociation, id, err)
+	}
+
+	d.SetId(id)
+
+	return nil
+}

--- a/internal/service/location/tracker_association_data_source_test.go
+++ b/internal/service/location/tracker_association_data_source_test.go
@@ -1,0 +1,56 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationTrackerAssociationDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_tracker_association.test"
+	resourceName := "aws_location_tracker_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrackerAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerAssociationDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrackerAssociationExists(dataSourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "consumer_arn", "aws_location_geofence_collection.test", "collection_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "tracker_name", "aws_location_tracker.test", "tracker_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTrackerAssociationDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+  collection_name = %[1]q
+}
+
+resource "aws_location_tracker" "test" {
+  tracker_name = %[1]q
+}
+
+resource "aws_location_tracker_association" "test" {
+  consumer_arn = aws_location_geofence_collection.test.collection_arn
+  tracker_name = aws_location_tracker.test.tracker_name
+}
+
+data "aws_location_tracker_association" "test" {
+  consumer_arn = aws_location_tracker_association.test.consumer_arn
+  tracker_name = aws_location_tracker_association.test.tracker_name
+}
+`, rName)
+}

--- a/website/docs/d/location_tracker_association.html.markdown
+++ b/website/docs/d/location_tracker_association.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_tracker_association"
+description: |-
+    Retrieve information about a Location Service Tracker Association.
+---
+
+# Data Source: aws_location_tracker_association
+
+Retrieve information about a Location Service Tracker Association.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_location_tracker_association" "example" {
+  consumer_arn = "arn:aws:geo:region:account-id:geofence-collection/ExampleGeofenceCollectionConsumer"
+  tracker_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `consumer_arn` - (Required) The Amazon Resource Name (ARN) of the geofence collection associated to tracker resource.
+* `tracker_name` - (Required) The name of the tracker resource associated with a geofence collection.
+
+## Attributes Reference
+
+No additional attributes are exported.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19629.

Output from acceptance testing:

```
$ make testacc PKG=location TESTS="TestAccLocationTrackerAssociation_|TestAccLocationTrackerAssociationDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationTrackerAssociation_|TestAccLocationTrackerAssociationDataSource_'  -timeout 180m
=== RUN   TestAccLocationTrackerAssociationDataSource_basic
=== PAUSE TestAccLocationTrackerAssociationDataSource_basic
=== RUN   TestAccLocationTrackerAssociation_basic
=== PAUSE TestAccLocationTrackerAssociation_basic
=== RUN   TestAccLocationTrackerAssociation_disappears
=== PAUSE TestAccLocationTrackerAssociation_disappears
=== CONT  TestAccLocationTrackerAssociationDataSource_basic
=== CONT  TestAccLocationTrackerAssociation_disappears
=== CONT  TestAccLocationTrackerAssociation_basic
--- PASS: TestAccLocationTrackerAssociation_disappears (31.08s)
--- PASS: TestAccLocationTrackerAssociationDataSource_basic (34.37s)
--- PASS: TestAccLocationTrackerAssociation_basic (36.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/location	38.430s
```
