### PR TITLE
skaff: Use snake name in data source website docs

### DIFF
--- a/skaff/datasource/websitedoc.tmpl
+++ b/skaff/datasource/websitedoc.tmpl
@@ -1,12 +1,12 @@
 ---
 subcategory: "{{ .Service }}"
 layout: "aws"
-page_title: "AWS: aws_{{ .ServicePackage }}_{{ .DataSourceLower }}"
+page_title: "AWS: aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}"
 description: |-
   Terraform data source for managing an AWS {{ .Service }} {{ .DataSource }}.
 ---
 
-# Data Source: aws_{{ .ServicePackage }}_{{ .DataSourceLower }}
+# Data Source: aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}
 
 Terraform data source for managing an AWS {{ .Service }} {{ .DataSource }}.
 
@@ -15,7 +15,7 @@ Terraform data source for managing an AWS {{ .Service }} {{ .DataSource }}.
 ### Basic Usage
 
 ```terraform
-data "aws_{{ .ServicePackage }}_{{ .DataSourceLower }}" "example" {
+data "aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}" "example" {
 }
 ```
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Applying changes from #25949 to data source website template.

Before & after:
```
$ diff old.html.markdown new.html.markdown 
4c4
< page_title: "AWS: aws_location_trackerassociation"
---
> page_title: "AWS: aws_location_tracker_association"
9c9
< # Data Source: aws_location_trackerassociation
---
> # Data Source: aws_location_tracker_association
18c18
< data "aws_location_trackerassociation" "example" {
---
> data "aws_location_tracker_association" "example" {
```