### PR TITLE
Add support for python_version 3.9 in aws_glue_job

### DIFF
--- a/.changelog/26407.txt
+++ b/.changelog/26407.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_job: Add support for `3.9` as valid `python_version` value
+```

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -53,7 +53,7 @@ func ResourceJob() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.StringInSlice([]string{"2", "3"}, true),
+							ValidateFunc: validation.StringInSlice([]string{"2", "3", "3.9"}, true),
 						},
 					},
 				},

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -687,6 +687,16 @@ func TestAccGlueJob_pythonShell(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "command.0.name", "pythonshell"),
 				),
 			},
+			{
+				Config: testAccJobConfig_pythonShellVersion(rName, "3.9"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.python_version", "3.9"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.name", "pythonshell"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, or `gluestreaming` for Streaming Job Type. `max_capacity` needs to be set if `pythonshell` is chosen.
 * `script_location` - (Required) Specifies the S3 path to a script that executes a job.
-* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2 or 3.
+* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2, 3 or 3.9. Version 3 refers to Python 3.6.
 
 ### execution_property Argument Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26350 

Output from acceptance testing:

```
$ make testacc TESTS=TestAccGlueJob_pythonShell PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueJob_pythonShell'  -timeout 180m
=== RUN   TestAccGlueJob_pythonShell
=== PAUSE TestAccGlueJob_pythonShell
=== CONT  TestAccGlueJob_pythonShell
--- PASS: TestAccGlueJob_pythonShell (134.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       134.575s
```

### References

https://aws.amazon.com/blogs/big-data/aws-glue-python-shell-now-supports-python-3-9-with-a-flexible-pre-loaded-environment-and-support-to-install-additional-libraries/
https://docs.aws.amazon.com/glue/latest/dg/add-job-python.html
