### PR TITLE
Fixing S3 Regional Domain Name bug

### DIFF
--- a/.changelog/15102.txt
+++ b/.changelog/15102.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/s3_bucket: Fix default region output for the Regional Endpoint Domain Name URL
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1490,8 +1490,8 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 func BucketRegionalDomainName(bucket string, region string) (string, error) {
 	// Return a default AWS Commercial domain name if no region is provided
 	// Otherwise EndpointFor() will return BUCKET.s3..amazonaws.com
-	if region == "" {
-		return fmt.Sprintf("%s.s3.amazonaws.com", bucket), nil //lintignore:AWSR001
+	if region == "" || region == endpoints.UsEast1RegionID {
+		return fmt.Sprintf("%s.s3.%s.amazonaws.com", bucket, endpoints.UsEast1RegionID), nil //lintignore:AWSR001
 	}
 	endpoint, err := endpoints.DefaultResolver().EndpointFor(endpoints.S3ServiceID, region)
 	if err != nil {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2483,7 +2483,7 @@ func TestBucketRegionalDomainName(t *testing.T) {
 		{
 			Region:           "",
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.amazonaws.com",
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com", endpoints.UsEast1RegionID),
 		},
 		{
 			Region:           "custom",
@@ -2493,7 +2493,7 @@ func TestBucketRegionalDomainName(t *testing.T) {
 		{
 			Region:           endpoints.UsEast1RegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.amazonaws.com",
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com", endpoints.UsEast1RegionID),
 		},
 		{
 			Region:           endpoints.UsWest2RegionID,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request



<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Close Issue #15102 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestBucketRegionalDomainName PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestBucketRegionalDomainName'  -timeout 180m
=== RUN   TestBucketRegionalDomainName
--- PASS: TestBucketRegionalDomainName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 0.063s
```