### PR TITLE
Handle Redis DMS target endpoint correctly

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -125,6 +125,16 @@ The following arguments are optional:
 * `extract_doc_id` - (Optional) Document ID. Use this setting when `nesting_level` is set to `none`. Default is `false`.
 * `nesting_level` - (Optional) Specifies either document or table mode. Default is `none`. Valid values are `one` (table mode) and `none` (document mode).
 
+### redis_settings
+
+-> Additional information can be found in the [Using Redis as a target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Redis.html).
+
+* `auth_password` - (Optional) The password provided with the auth-role and auth-token options of the AuthType setting for a Redis target endpoint.
+* `auth_type` - (Optional) The type of authentication to perform when connecting to a Redis target. Options include `none`, `auth-token`, and `auth-role`. The `auth-token` option requires an `auth_password` value to be provided. The `auth-role` option requires `auth_user_name` and `auth_password` values to be provided.
+* `auth_user_name` - (Optional) The username provided with the `auth-role` option of the AuthType setting for a Redis target endpoint.
+* `ssl_ca_certificate_arn` - (Optional) The Amazon Resource Name (ARN) for the certificate authority (CA) that DMS uses to connect to your Redis target endpoint.
+* `ssl_security_protocol`- (Optional) The plaintext option doesn't provide Transport Layer Security (TLS) encryption for traffic between endpoint and database.
+
 ### redshift_settings
 
 -> Additional information can be found in the [Using Amazon Redshift as a Target for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Redshift.html).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26266

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDMSEndpoint_Redis_' PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20  -run=TestAccDMSEndpoint_Redis_ -timeout 180m
=== RUN   TestAccDMSEndpoint_Redis_basic
=== PAUSE TestAccDMSEndpoint_Redis_basic
=== RUN   TestAccDMSEndpoint_Redis_update
=== PAUSE TestAccDMSEndpoint_Redis_update
=== CONT  TestAccDMSEndpoint_Redis_basic
=== CONT  TestAccDMSEndpoint_Redis_update
--- PASS: TestAccDMSEndpoint_Redis_basic (103.42s)
--- PASS: TestAccDMSEndpoint_Redis_update (118.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	120.368s
```
