### PR TITLE
feat(lambda): allow lambda invocation without providing any qualifier

### DIFF
--- a/internal/service/lambda/invocation.go
+++ b/internal/service/lambda/invocation.go
@@ -34,7 +34,6 @@ func ResourceInvocation() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  FunctionVersionLatest,
 			},
 			"result": {
 				Type:     schema.TypeString,

--- a/internal/service/lambda/invocation_data_source.go
+++ b/internal/service/lambda/invocation_data_source.go
@@ -24,7 +24,6 @@ func DataSourceInvocation() *schema.Resource {
 			"qualifier": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  FunctionVersionLatest,
 			},
 
 			"input": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #26391

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccInvocationConfig_basic PKG=lambda

...
```
