### PR TITLE
Adds user_attribute_update_settings support to aws_cognito_user_pool

### DIFF
--- a/.changelog/26450.txt
+++ b/.changelog/26450.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool: Add `user_attribute_update_settings` configuration block
+```

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -88,6 +88,7 @@ The following arguments are optional:
 * `user_pool_add_ons` - (Optional) Configuration block for user pool add-ons to enable user pool advanced security mode features. [Detailed below](#user_pool_add_ons).
 * `username_attributes` - (Optional) Whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes`.
 * `username_configuration` - (Optional) Configuration block for username configuration. [Detailed below](#username_configuration).
+* `user_attribute_update_settings` - (Optional) Configuration block for updates to user attributes. [Details below](#user_attribute_update_settings). Requires `auto_verified_attributes` to be configured.
 * `verification_message_template` - (Optional) Configuration block for verification message templates. [Detailed below](#verification_message_template).
 
 ### account_recovery_setting
@@ -209,6 +210,10 @@ resource "aws_cognito_user_pool" "example" {
 The following arguments are required in the `software_token_mfa_configuration` configuration block:
 
 * `enabled` - (Required) Boolean whether to enable software token Multi-Factor (MFA) tokens, such as Time-based One-Time Password (TOTP). To disable software token MFA When `sms_configuration` is not present, the `mfa_configuration` argument must be set to `OFF` and the `software_token_mfa_configuration` configuration block must be fully removed.
+
+### user_attribute_update_settings
+
+* `attributes_require_verification_before_update` - (Required) Attributes to be verified before update. Valid values: `email`, `phone_number`.
 
 ### user_pool_add_ons
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25228

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccCognitoIDPUserPool_' PKG=cognitoidp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20  -run=TestAccCognitoIDPUserPool_ -timeout 180m
=== RUN   TestAccCognitoIDPUserPool_basic
=== PAUSE TestAccCognitoIDPUserPool_basic
=== RUN   TestAccCognitoIDPUserPool_recovery
=== PAUSE TestAccCognitoIDPUserPool_recovery
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUser
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUser
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== PAUSE TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== RUN   TestAccCognitoIDPUserPool_withDevice
=== PAUSE TestAccCognitoIDPUserPool_withDevice
=== RUN   TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_MFA_sms
=== PAUSE TestAccCognitoIDPUserPool_MFA_sms
=== RUN   TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== RUN   TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== RUN   TestAccCognitoIDPUserPool_sms
=== PAUSE TestAccCognitoIDPUserPool_sms
=== RUN   TestAccCognitoIDPUserPool_SMS_externalID
=== PAUSE TestAccCognitoIDPUserPool_SMS_externalID
=== RUN   TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== RUN   TestAccCognitoIDPUserPool_smsVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_withEmail
=== PAUSE TestAccCognitoIDPUserPool_withEmail
=== RUN   TestAccCognitoIDPUserPool_withEmailSource
    user_pool_test.go:753: 'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.
--- SKIP: TestAccCognitoIDPUserPool_withEmailSource (0.00s)
=== RUN   TestAccCognitoIDPUserPool_withTags
=== PAUSE TestAccCognitoIDPUserPool_withTags
=== RUN   TestAccCognitoIDPUserPool_withAliasAttributes
=== PAUSE TestAccCognitoIDPUserPool_withAliasAttributes
=== RUN   TestAccCognitoIDPUserPool_withUsernameAttributes
=== PAUSE TestAccCognitoIDPUserPool_withUsernameAttributes
=== RUN   TestAccCognitoIDPUserPool_withPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withUsername
=== PAUSE TestAccCognitoIDPUserPool_withUsername
=== RUN   TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== PAUSE TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== RUN   TestAccCognitoIDPUserPool_withLambda
=== PAUSE TestAccCognitoIDPUserPool_withLambda
=== RUN   TestAccCognitoIDPUserPool_WithLambda_email
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_email
=== RUN   TestAccCognitoIDPUserPool_WithLambda_sms
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_sms
=== RUN   TestAccCognitoIDPUserPool_schemaAttributes
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributes
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesModified
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesModified
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== RUN   TestAccCognitoIDPUserPool_update
=== PAUSE TestAccCognitoIDPUserPool_update
=== RUN   TestAccCognitoIDPUserPool_disappears
=== PAUSE TestAccCognitoIDPUserPool_disappears
=== CONT  TestAccCognitoIDPUserPool_basic
=== CONT  TestAccCognitoIDPUserPool_withEmail
=== CONT  TestAccCognitoIDPUserPool_withDevice
=== CONT  TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_sms
=== CONT  TestAccCognitoIDPUserPool_smsVerificationMessage
=== CONT  TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== CONT  TestAccCognitoIDPUserPool_SMS_externalID
=== CONT  TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== CONT  TestAccCognitoIDPUserPool_WithLambda_sms
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_WithLambda_email
=== CONT  TestAccCognitoIDPUserPool_MFA_sms
=== CONT  TestAccCognitoIDPUserPool_disappears
=== CONT  TestAccCognitoIDPUserPool_update
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesModified
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== CONT  TestAccCognitoIDPUserPool_schemaAttributes
--- PASS: TestAccCognitoIDPUserPool_disappears (21.26s)
=== CONT  TestAccCognitoIDPUserPool_withPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_withEmail (25.08s)
=== CONT  TestAccCognitoIDPUserPool_withLambda
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (27.50s)
Adds user_attribute_update_settings support to aws_cognito_user_pool resource
=== CONT  TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
--- PASS: TestAccCognitoIDPUserPool_basic (29.48s)
=== CONT  TestAccCognitoIDPUserPool_withUsername
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (31.92s)
=== CONT  TestAccCognitoIDPUserPool_withAliasAttributes
--- PASS: TestAccCognitoIDPUserPool_withDevice (41.98s)
=== CONT  TestAccCognitoIDPUserPool_withUsernameAttributes
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (43.36s)
=== CONT  TestAccCognitoIDPUserPool_withEmailVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (44.99s)
=== CONT  TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_withTags
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (45.13s)
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (49.07s)
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityMode
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (64.75s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (65.85s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUser
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (66.99s)
=== CONT  TestAccCognitoIDPUserPool_recovery
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (46.43s)
--- PASS: TestAccCognitoIDPUserPool_withUsername (47.36s)
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (51.73s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (85.25s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (85.85s)
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (86.97s)
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (47.44s)
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (46.66s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (92.24s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (27.54s)
--- PASS: TestAccCognitoIDPUserPool_sms (94.82s)
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (94.89s)
--- PASS: TestAccCognitoIDPUserPool_update (95.79s)
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (69.88s)
--- PASS: TestAccCognitoIDPUserPool_withTags (56.54s)
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (54.18s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (37.44s)
--- PASS: TestAccCognitoIDPUserPool_withLambda (83.70s)
--- PASS: TestAccCognitoIDPUserPool_recovery (44.43s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (70.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	117.372s
...
```
