### PR TITLE
fix: Tag changes do not cause updates to firehose destinations

### DIFF
--- a/.changelog/26451.txt
+++ b/.changelog/26451.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_kinesis_firehose_delivery_stream: Updating tags no longer causes an uncessary update
+resource/aws_kinesis_firehose_delivery_stream: Updating `tags` no longer causes an unnecessary update
 ```

--- a/.changelog/26451.txt
+++ b/.changelog/26451.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kinesis_firehose_delivery_stream: Updating tags no longer causes an uncessary update
+```

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -2721,92 +2721,95 @@ func resourceDeliveryStreamUpdate(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*conns.AWSClient).FirehoseConn
 
 	sn := d.Get("name").(string)
-	updateInput := &firehose.UpdateDestinationInput{
-		DeliveryStreamName:             aws.String(sn),
-		CurrentDeliveryStreamVersionId: aws.String(d.Get("version_id").(string)),
-		DestinationId:                  aws.String(d.Get("destination_id").(string)),
-	}
 
-	if d.Get("destination").(string) == destinationTypeExtendedS3 {
-		extendedS3Config := updateExtendedS3Config(d)
-		updateInput.ExtendedS3DestinationUpdate = extendedS3Config
-	} else {
-		s3Config := updateS3Config(d)
-
-		if d.Get("destination").(string) == destinationTypeS3 {
-			updateInput.S3DestinationUpdate = s3Config
-		} else if d.Get("destination").(string) == destinationTypeElasticsearch {
-			esUpdate, err := updateElasticsearchConfig(d, s3Config)
-			if err != nil {
-				return err
-			}
-			updateInput.ElasticsearchDestinationUpdate = esUpdate
-		} else if d.Get("destination").(string) == destinationTypeRedshift {
-			// Redshift does not currently support ErrorOutputPrefix,
-			// which is set to the empty string within "updateS3Config",
-			// thus we must remove it here to avoid an InvalidArgumentException.
-			if s3Config != nil {
-				s3Config.ErrorOutputPrefix = nil
-			}
-			rc, err := updateRedshiftConfig(d, s3Config)
-			if err != nil {
-				return err
-			}
-			updateInput.RedshiftDestinationUpdate = rc
-		} else if d.Get("destination").(string) == destinationTypeSplunk {
-			rc, err := updateSplunkConfig(d, s3Config)
-			if err != nil {
-				return err
-			}
-			updateInput.SplunkDestinationUpdate = rc
-		} else if d.Get("destination").(string) == destinationTypeHTTPEndpoint {
-			rc, err := updateHTTPEndpointConfig(d, s3Config)
-			if err != nil {
-				return err
-			}
-			updateInput.HttpEndpointDestinationUpdate = rc
+	if d.HasChangesExcept("tags", "tags_all") {
+		updateInput := &firehose.UpdateDestinationInput{
+			DeliveryStreamName:             aws.String(sn),
+			CurrentDeliveryStreamVersionId: aws.String(d.Get("version_id").(string)),
+			DestinationId:                  aws.String(d.Get("destination_id").(string)),
 		}
-	}
 
-	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
-		_, err := conn.UpdateDestination(updateInput)
+		if d.Get("destination").(string) == destinationTypeExtendedS3 {
+			extendedS3Config := updateExtendedS3Config(d)
+			updateInput.ExtendedS3DestinationUpdate = extendedS3Config
+		} else {
+			s3Config := updateS3Config(d)
+
+			if d.Get("destination").(string) == destinationTypeS3 {
+				updateInput.S3DestinationUpdate = s3Config
+			} else if d.Get("destination").(string) == destinationTypeElasticsearch {
+				esUpdate, err := updateElasticsearchConfig(d, s3Config)
+				if err != nil {
+					return err
+				}
+				updateInput.ElasticsearchDestinationUpdate = esUpdate
+			} else if d.Get("destination").(string) == destinationTypeRedshift {
+				// Redshift does not currently support ErrorOutputPrefix,
+				// which is set to the empty string within "updateS3Config",
+				// thus we must remove it here to avoid an InvalidArgumentException.
+				if s3Config != nil {
+					s3Config.ErrorOutputPrefix = nil
+				}
+				rc, err := updateRedshiftConfig(d, s3Config)
+				if err != nil {
+					return err
+				}
+				updateInput.RedshiftDestinationUpdate = rc
+			} else if d.Get("destination").(string) == destinationTypeSplunk {
+				rc, err := updateSplunkConfig(d, s3Config)
+				if err != nil {
+					return err
+				}
+				updateInput.SplunkDestinationUpdate = rc
+			} else if d.Get("destination").(string) == destinationTypeHTTPEndpoint {
+				rc, err := updateHTTPEndpointConfig(d, s3Config)
+				if err != nil {
+					return err
+				}
+				updateInput.HttpEndpointDestinationUpdate = rc
+			}
+		}
+
+		err := resource.Retry(propagationTimeout, func() *resource.RetryError {
+			_, err := conn.UpdateDestination(updateInput)
+			if err != nil {
+				// Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions.
+				if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Access was denied") {
+					return resource.RetryableError(err)
+				}
+
+				if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
+					return resource.RetryableError(err)
+				}
+
+				if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
+					return resource.RetryableError(err)
+				}
+
+				// InvalidArgumentException: Verify that the IAM role has access to the Elasticsearch domain.
+				if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
+					return resource.RetryableError(err)
+				}
+
+				if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Firehose is unable to assume role") {
+					return resource.RetryableError(err)
+				}
+
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		})
+
+		if tfresource.TimedOut(err) {
+			_, err = conn.UpdateDestination(updateInput)
+		}
+
 		if err != nil {
-			// Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions.
-			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Access was denied") {
-				return resource.RetryableError(err)
-			}
-
-			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
-				return resource.RetryableError(err)
-			}
-
-			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
-				return resource.RetryableError(err)
-			}
-
-			// InvalidArgumentException: Verify that the IAM role has access to the Elasticsearch domain.
-			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
-				return resource.RetryableError(err)
-			}
-
-			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Firehose is unable to assume role") {
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			return fmt.Errorf(
+				"Error Updating Kinesis Firehose Delivery Stream: \"%s\"\n%s",
+				sn, err)
 		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		_, err = conn.UpdateDestination(updateInput)
-	}
-
-	if err != nil {
-		return fmt.Errorf(
-			"Error Updating Kinesis Firehose Delivery Stream: \"%s\"\n%s",
-			sn, err)
 	}
 
 	if d.HasChange("tags_all") {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #25396

Output from acceptance testing:

```
$ AWS_DEFAULT_REGION=eu-west-1 AWS_SDK_LOAD_CONFIG=1 AWS_PROFILE=dev make testacc TESTS=TestAccFirehoseDeliveryStream_tagUpdates PKG=firehose
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/firehose/... -v -count 1 -parallel 20 -run='TestAccFirehoseDeliveryStream_tagUpdates'  -timeout 180m
=== RUN   TestAccFirehoseDeliveryStream_tagUpdates
=== PAUSE TestAccFirehoseDeliveryStream_tagUpdates
=== CONT  TestAccFirehoseDeliveryStream_tagUpdates
--- PASS: TestAccFirehoseDeliveryStream_tagUpdates (375.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	377.636s
```

I don't really know how to test that this fixes the underlying issue, as the redshift password is not returned in API requests (and as such it's not possible to check that it hasn't been changed, AFAIK). But from comments on the ticket this appears to be the correct solution. Any advice here greatly appreciated.
