### PR TITLE
appstream_fleet: Fix empty domain_join bug

### DIFF
--- a/.changelog/26454.txt
+++ b/.changelog/26454.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_fleet: Fix crash when providing empty `domain_join_info` (_e.g._, `directory_name = ""`)
+```

--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.13.4"
+  version = "0.16.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -39,8 +39,33 @@ jobs:
             | sort -u \
             | xargs -I {} terrafmt diff --check --fmtcompat {}
 
+  validate-init:
+    name: Validate Init
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: .go-version
+      - uses: actions/cache@v3
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - uses: actions/cache@v3
+        name: Cache plugin dir
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
+      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
+      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
+      - run: tflint -c .ci/.tflint.hcl --init
   validate-testsa:
     name: Validate Tests 1 of 2
+    needs: [validate-init]
     runs-on: [custom, linux, medium]
     steps:
       - uses: actions/checkout@v3
@@ -53,19 +78,25 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
-      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
       - uses: actions/cache@v3
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
-          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
-      - run: echo -n "File count $( find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION1 }} | wc -l | xargs )"
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}          
+      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
+      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
+      - run: find ~/ -type d -name .tflint.d
+      - run: tflint -c .ci/.tflint.hcl --init      
+      - run: find ~/ -type d -name .tflint.d
+      - run: ls -hal ~/.tflint.d
+      - run: ls -hal ~/.tflint.d/plugins
+      - run: echo -n "File count $( find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION2 }} | wc -l | xargs )"
       - run: |
           find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION1 }} \
             | .ci/scripts/validate-terraform.sh
   validate-testsb:
     name: Validate Tests 2 of 2
+    needs: [validate-init]
     runs-on: [custom, linux, medium]
     steps:
       - uses: actions/checkout@v3
@@ -78,13 +109,15 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
-      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
       - uses: actions/cache@v3
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
-          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}          
+      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
+      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
+      - run: find ~/ -type d -name .tflint.d
+      - run: tflint -c .ci/.tflint.hcl --init      
       - run: find ~/ -type d -name .tflint.d
       - run: ls -hal ~/.tflint.d
       - run: ls -hal ~/.tflint.d/plugins

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           path: ~/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
-      - run: tflint -c .ci/.tflint.hcl --init
       - run: echo -n "File count $( find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION1 }} | wc -l | xargs )"
       - run: |
           find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION1 }} \
@@ -86,7 +85,8 @@ jobs:
         with:
           path: ~/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
-      - run: tflint -c .ci/.tflint.hcl --init
+      - run: ls -hal ~/.tflint.d
+      - run: ls -hal ~/.tflint.d/plugins
       - run: echo -n "File count $( find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION2 }} | wc -l | xargs )"
       - run: |
           find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION2 }} \

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -80,13 +80,15 @@ jobs:
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - uses: actions/cache@v3
         name: Cache plugin dir
+        continue-on-error: true
+        timeout-minutes: 2
         with:
           path: ~/.tflint.d/plugins
-          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}          
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
       - run: cd .ci/tools && go install github.com/katbyte/terrafmt
       - run: cd .ci/tools && go install github.com/terraform-linters/tflint
       - run: find ~/ -type d -name .tflint.d
-      - run: tflint -c .ci/.tflint.hcl --init      
+      - run: tflint -c .ci/.tflint.hcl --init
       - run: find ~/ -type d -name .tflint.d
       - run: ls -hal ~/.tflint.d
       - run: ls -hal ~/.tflint.d/plugins
@@ -111,13 +113,15 @@ jobs:
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - uses: actions/cache@v3
         name: Cache plugin dir
+        continue-on-error: true
+        timeout-minutes: 2
         with:
           path: ~/.tflint.d/plugins
-          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}          
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
       - run: cd .ci/tools && go install github.com/katbyte/terrafmt
       - run: cd .ci/tools && go install github.com/terraform-linters/tflint
       - run: find ~/ -type d -name .tflint.d
-      - run: tflint -c .ci/.tflint.hcl --init      
+      - run: tflint -c .ci/.tflint.hcl --init
       - run: find ~/ -type d -name .tflint.d
       - run: ls -hal ~/.tflint.d
       - run: ls -hal ~/.tflint.d/plugins

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           path: ~/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
+      - run: find ~/ -type d -name .tflint.d
       - run: ls -hal ~/.tflint.d
       - run: ls -hal ~/.tflint.d/plugins
       - run: echo -n "File count $( find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION2 }} | wc -l | xargs )"

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -561,11 +561,17 @@ func expandDomainJoinInfo(tfList []interface{}) *appstream.DomainJoinInfo {
 
 	apiObject := &appstream.DomainJoinInfo{}
 
-	tfMap := tfList[0].(map[string]interface{})
-	if v, ok := tfMap["directory_name"]; ok {
+	tfMap, ok := tfList[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	if v, ok := tfMap["directory_name"]; ok && v != "" {
 		apiObject.DirectoryName = aws.String(v.(string))
 	}
-	if v, ok := tfMap["organizational_unit_distinguished_name"]; ok {
+
+	if v, ok := tfMap["organizational_unit_distinguished_name"]; ok && v != "" {
 		apiObject.OrganizationalUnitDistinguishedName = aws.String(v.(string))
 	}
 

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -4,20 +4,24 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appstream"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceFleet() *schema.Resource {
@@ -26,9 +30,16 @@ func ResourceFleet() *schema.Resource {
 		ReadWithoutTimeout:   resourceFleetRead,
 		UpdateWithoutTimeout: resourceFleetUpdate,
 		DeleteWithoutTimeout: resourceFleetDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			resourceFleetCustDiff,
+			verify.SetTagsDiff,
+		),
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -91,10 +102,12 @@ func ResourceFleet() *schema.Resource {
 						"directory_name": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"organizational_unit_distinguished_name": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -327,8 +340,12 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.Set("arn", fleet.Arn)
 
-	if err = d.Set("compute_capacity", flattenComputeCapacity(fleet.ComputeCapacityStatus)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Fleet (%s): %w", "compute_capacity", d.Id(), err))
+	if fleet.ComputeCapacityStatus != nil {
+		if err = d.Set("compute_capacity", []interface{}{flattenComputeCapacity(fleet.ComputeCapacityStatus)}); err != nil {
+			return create.DiagSettingError(names.AppStream, "Fleet", d.Id(), "compute_capacity", err)
+		}
+	} else {
+		d.Set("compute_capacity", nil)
 	}
 
 	d.Set("created_time", aws.TimeValue(fleet.CreatedTime).Format(time.RFC3339))
@@ -336,8 +353,12 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("display_name", fleet.DisplayName)
 	d.Set("disconnect_timeout_in_seconds", fleet.DisconnectTimeoutInSeconds)
 
-	if err = d.Set("domain_join_info", flattenDomainInfo(fleet.DomainJoinInfo)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Fleet (%s): %w", "domain_join_info", d.Id(), err))
+	if fleet.DomainJoinInfo != nil {
+		if err = d.Set("domain_join_info", []interface{}{flattenDomainInfo(fleet.DomainJoinInfo)}); err != nil {
+			return create.DiagSettingError(names.AppStream, "Fleet", d.Id(), "domain_join_info", err)
+		}
+	} else {
+		d.Set("domain_join_info", nil)
 	}
 
 	d.Set("idle_disconnect_timeout_in_seconds", fleet.IdleDisconnectTimeoutInSeconds)
@@ -352,8 +373,12 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("state", fleet.State)
 	d.Set("stream_view", fleet.StreamView)
 
-	if err = d.Set("vpc_config", flattenVPCConfig(fleet.VpcConfig)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Fleet (%s): %w", "vpc_config", d.Id(), err))
+	if fleet.VpcConfig != nil {
+		if err = d.Set("vpc_config", []interface{}{flattenVPCConfig(fleet.VpcConfig)}); err != nil {
+			return create.DiagSettingError(names.AppStream, "Fleet", d.Id(), "vpc_config", err)
+		}
+	} else {
+		d.Set("vpc_config", nil)
 	}
 
 	tg, err := conn.ListTagsForResource(&appstream.ListTagsForResourceInput{
@@ -525,6 +550,17 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
+func resourceFleetCustDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	if diff.HasChange("domain_join_info") {
+		o, n := diff.GetChange("domain_join_info")
+
+		if reflect.DeepEqual(expandDomainJoinInfo(o.([]interface{})), expandDomainJoinInfo(n.([]interface{}))) {
+			diff.Clear("domain_join_info")
+		}
+	}
+	return nil
+}
+
 func expandComputeCapacity(tfList []interface{}) *appstream.ComputeCapacity {
 	if len(tfList) == 0 {
 		return nil
@@ -537,21 +573,41 @@ func expandComputeCapacity(tfList []interface{}) *appstream.ComputeCapacity {
 		apiObject.DesiredInstances = aws.Int64(int64(v.(int)))
 	}
 
+	if reflect.DeepEqual(&appstream.ComputeCapacity{}, apiObject) {
+		return nil
+	}
+
 	return apiObject
 }
 
-func flattenComputeCapacity(apiObject *appstream.ComputeCapacityStatus) []interface{} {
+func flattenComputeCapacity(apiObject *appstream.ComputeCapacityStatus) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfList := map[string]interface{}{}
-	tfList["desired_instances"] = aws.Int64Value(apiObject.Desired)
-	tfList["available"] = aws.Int64Value(apiObject.Available)
-	tfList["in_use"] = aws.Int64Value(apiObject.InUse)
-	tfList["running"] = aws.Int64Value(apiObject.Running)
+	tfMap := map[string]interface{}{}
 
-	return []interface{}{tfList}
+	if v := apiObject.Desired; v != nil {
+		tfMap["desired_instances"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.Available; v != nil {
+		tfMap["available"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.InUse; v != nil {
+		tfMap["in_use"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.Running; v != nil {
+		tfMap["running"] = aws.Int64Value(v)
+	}
+
+	if reflect.DeepEqual(map[string]interface{}{}, tfMap) {
+		return nil
+	}
+
+	return tfMap
 }
 
 func expandDomainJoinInfo(tfList []interface{}) *appstream.DomainJoinInfo {
@@ -575,19 +631,33 @@ func expandDomainJoinInfo(tfList []interface{}) *appstream.DomainJoinInfo {
 		apiObject.OrganizationalUnitDistinguishedName = aws.String(v.(string))
 	}
 
+	if reflect.DeepEqual(&appstream.DomainJoinInfo{}, apiObject) {
+		return nil
+	}
+
 	return apiObject
 }
 
-func flattenDomainInfo(apiObject *appstream.DomainJoinInfo) []interface{} {
+func flattenDomainInfo(apiObject *appstream.DomainJoinInfo) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfList := map[string]interface{}{}
-	tfList["directory_name"] = aws.StringValue(apiObject.DirectoryName)
-	tfList["organizational_unit_distinguished_name"] = aws.StringValue(apiObject.OrganizationalUnitDistinguishedName)
+	tfMap := map[string]interface{}{}
 
-	return []interface{}{tfList}
+	if v := apiObject.DirectoryName; v != nil && aws.StringValue(v) != "" {
+		tfMap["directory_name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.OrganizationalUnitDistinguishedName; v != nil && aws.StringValue(v) != "" {
+		tfMap["organizational_unit_distinguished_name"] = aws.StringValue(v)
+	}
+
+	if reflect.DeepEqual(map[string]interface{}{}, tfMap) {
+		return nil
+	}
+
+	return tfMap
 }
 
 func expandVPCConfig(tfList []interface{}) *appstream.VpcConfig {
@@ -601,21 +671,36 @@ func expandVPCConfig(tfList []interface{}) *appstream.VpcConfig {
 	if v, ok := tfMap["security_group_ids"]; ok {
 		apiObject.SecurityGroupIds = flex.ExpandStringList(v.([]interface{}))
 	}
+
 	if v, ok := tfMap["subnet_ids"]; ok {
 		apiObject.SubnetIds = flex.ExpandStringList(v.([]interface{}))
+	}
+
+	if reflect.DeepEqual(&appstream.VpcConfig{}, apiObject) {
+		return nil
 	}
 
 	return apiObject
 }
 
-func flattenVPCConfig(apiObject *appstream.VpcConfig) []interface{} {
+func flattenVPCConfig(apiObject *appstream.VpcConfig) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfList := map[string]interface{}{}
-	tfList["security_group_ids"] = aws.StringValueSlice(apiObject.SecurityGroupIds)
-	tfList["subnet_ids"] = aws.StringValueSlice(apiObject.SubnetIds)
+	tfMap := map[string]interface{}{}
 
-	return []interface{}{tfList}
+	if v := apiObject.SecurityGroupIds; v != nil {
+		tfMap["security_group_ids"] = aws.StringValueSlice(v)
+	}
+
+	if v := apiObject.SubnetIds; v != nil {
+		tfMap["subnet_ids"] = aws.StringValueSlice(v)
+	}
+
+	if reflect.DeepEqual(map[string]interface{}{}, tfMap) {
+		return nil
+	}
+
+	return tfMap
 }

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -555,7 +555,7 @@ func resourceFleetCustDiff(_ context.Context, diff *schema.ResourceDiff, meta in
 		o, n := diff.GetChange("domain_join_info")
 
 		if reflect.DeepEqual(expandDomainJoinInfo(o.([]interface{})), expandDomainJoinInfo(n.([]interface{}))) {
-			diff.Clear("domain_join_info")
+			return diff.Clear("domain_join_info")
 		}
 	}
 	return nil

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -253,6 +253,52 @@ func TestAccAppStreamFleet_withTags(t *testing.T) {
 	})
 }
 
+func TestAccAppStreamFleet_emptyDomainJoin(t *testing.T) {
+	var fleetOutput appstream.Fleet
+	resourceName := "aws_appstream_fleet.test"
+	instanceType := "stream.standard.small"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckHasIAMRole(t, "AmazonAppStreamServiceAccess")
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t, appstream.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_emptyDomainJoin(rName, instanceType, `""`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(resourceName, &fleetOutput),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", instanceType),
+					resource.TestCheckResourceAttr(resourceName, "state", appstream.FleetStateRunning),
+					resource.TestCheckResourceAttr(resourceName, "stream_view", appstream.StreamViewApp),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_emptyDomainJoin(rName, instanceType, "null"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(resourceName, &fleetOutput),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", instanceType),
+					resource.TestCheckResourceAttr(resourceName, "state", appstream.FleetStateRunning),
+					resource.TestCheckResourceAttr(resourceName, "stream_view", appstream.StreamViewApp),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckFleetExists(resourceName string, appStreamFleet *appstream.Fleet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -437,4 +483,24 @@ resource "aws_appstream_fleet" "test" {
   }
 }
 `, name, description, fleetType, instanceType, displayName))
+}
+
+func testAccFleetConfig_emptyDomainJoin(name, instanceType, empty string) string {
+	// "Amazon-AppStream2-Sample-Image-02-04-2019" is not available in GovCloud
+	return fmt.Sprintf(`
+resource "aws_appstream_fleet" "test" {
+  name          = %[1]q
+  image_name    = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  instance_type = %[2]q
+
+  compute_capacity {
+    desired_instances = 1
+  }
+
+  domain_join_info {
+    directory_name                         = %[3]s
+    organizational_unit_distinguished_name = %[3]s
+  }
+}
+`, name, instanceType, empty)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #24798

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccAppStreamFleet PKG=appstream
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamFleet'  -timeout 180m
=== RUN   TestAccAppStreamFleetStackAssociation_basic
=== PAUSE TestAccAppStreamFleetStackAssociation_basic
=== RUN   TestAccAppStreamFleetStackAssociation_disappears
=== PAUSE TestAccAppStreamFleetStackAssociation_disappears
=== RUN   TestAccAppStreamFleet_basic
=== PAUSE TestAccAppStreamFleet_basic
=== RUN   TestAccAppStreamFleet_disappears
=== PAUSE TestAccAppStreamFleet_disappears
=== RUN   TestAccAppStreamFleet_completeWithStop
=== PAUSE TestAccAppStreamFleet_completeWithStop
=== RUN   TestAccAppStreamFleet_completeWithoutStop
=== PAUSE TestAccAppStreamFleet_completeWithoutStop
=== RUN   TestAccAppStreamFleet_withTags
=== PAUSE TestAccAppStreamFleet_withTags
=== RUN   TestAccAppStreamFleet_emptyDomainJoin
=== PAUSE TestAccAppStreamFleet_emptyDomainJoin
=== CONT  TestAccAppStreamFleetStackAssociation_basic
=== CONT  TestAccAppStreamFleet_completeWithStop
=== CONT  TestAccAppStreamFleet_withTags
=== CONT  TestAccAppStreamFleet_completeWithoutStop
=== CONT  TestAccAppStreamFleet_basic
=== CONT  TestAccAppStreamFleet_emptyDomainJoin
=== CONT  TestAccAppStreamFleet_disappears
=== CONT  TestAccAppStreamFleetStackAssociation_disappears
--- PASS: TestAccAppStreamFleetStackAssociation_disappears (889.77s)
--- PASS: TestAccAppStreamFleet_disappears (891.87s)
--- PASS: TestAccAppStreamFleetStackAssociation_basic (936.04s)
--- PASS: TestAccAppStreamFleet_emptyDomainJoin (944.70s)
--- PASS: TestAccAppStreamFleet_basic (978.95s)
--- PASS: TestAccAppStreamFleet_completeWithoutStop (987.97s)
--- PASS: TestAccAppStreamFleet_withTags (1095.04s)
--- PASS: TestAccAppStreamFleet_completeWithStop (1774.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	1775.730s
```
