### PR TITLE
Correct spelling of argument in example of `aws_accessanalyzer_archive_rule`

### DIFF
--- a/website/docs/r/accessanalyzer_archive_rule.html.markdown
+++ b/website/docs/r/accessanalyzer_archive_rule.html.markdown
@@ -16,7 +16,7 @@ Terraform resource for managing an AWS AccessAnalyzer Archive Rule.
 
 ```terraform
 resource "aws_accessanalyzer_archive_rule" "example" {
-  analyser_name = "example-analyzer"
+  analyzer_name = "example-analyzer"
   rule_name     = "example-rule"
 
   filter {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26463

Output from acceptance testing: N/a, docs

### Information

This PR fixes a misspelling of the `analyzer_name` argument in the example on the `aws_accessanalyzer_archive_rule` resource.