### PR TITLE
Clarify valid values for `aws_elb.access_logs.interval`

### DIFF
--- a/website/docs/r/elb.html.markdown
+++ b/website/docs/r/elb.html.markdown
@@ -98,7 +98,7 @@ Access Logs (`access_logs`) support the following:
 
 * `bucket` - (Required) The S3 bucket name to store the logs in.
 * `bucket_prefix` - (Optional) The S3 bucket prefix. Logs are stored in the root if not configured.
-* `interval` - (Optional) The publishing interval in minutes. Default: 60 minutes.
+* `interval` - (Optional) The publishing interval in minutes. Valid values: `5` and `60`. Default: `60`
 * `enabled` - (Optional) Boolean to enable / disable `access_logs`. Default is `true`
 
 Listeners (`listener`) support the following:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26458

Output from acceptance testing: n/a, docs

### Information

As mentioned in the linked issue, the documentation mentioned the default value for `aws_elb.access_logs.interval`, but did not mention that there are only 2 valid values. This edit aims to make it clear that the only options are `5` and `60`.

### Related links

- [AWS Documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html)