### PR TITLE
d/aws_location_tracker_associations: new data source

### DIFF
--- a/.changelog/26472.txt
+++ b/.changelog/26472.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_location_tracker_associations
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -737,12 +737,13 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_lex_intent":    lexmodels.DataSourceIntent(),
 			"aws_lex_slot_type": lexmodels.DataSourceSlotType(),
 
-			"aws_location_geofence_collection": location.DataSourceGeofenceCollection(),
-			"aws_location_map":                 location.DataSourceMap(),
-			"aws_location_place_index":         location.DataSourcePlaceIndex(),
-			"aws_location_route_calculator":    location.DataSourceRouteCalculator(),
-			"aws_location_tracker":             location.DataSourceTracker(),
-			"aws_location_tracker_association": location.DataSourceTrackerAssociation(),
+			"aws_location_geofence_collection":  location.DataSourceGeofenceCollection(),
+			"aws_location_map":                  location.DataSourceMap(),
+			"aws_location_place_index":          location.DataSourcePlaceIndex(),
+			"aws_location_route_calculator":     location.DataSourceRouteCalculator(),
+			"aws_location_tracker":              location.DataSourceTracker(),
+			"aws_location_tracker_association":  location.DataSourceTrackerAssociation(),
+			"aws_location_tracker_associations": location.DataSourceTrackerAssociations(),
 
 			// "aws_arn":                     meta.DataSourceARN(), // Now implemented using Terraform Plugin Framework.
 			"aws_billing_service_account": meta.DataSourceBillingServiceAccount(),

--- a/internal/service/location/tracker_associations_data_source.go
+++ b/internal/service/location/tracker_associations_data_source.go
@@ -1,0 +1,74 @@
+package location
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceTrackerAssociations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTrackerAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"consumer_arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tracker_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+		},
+	}
+}
+
+const (
+	DSNameTrackerAssociations = "Tracker Associations Data Source"
+)
+
+func dataSourceTrackerAssociationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LocationConn
+
+	name := d.Get("tracker_name").(string)
+
+	in := &locationservice.ListTrackerConsumersInput{
+		TrackerName: aws.String(name),
+	}
+
+	var arns []string
+
+	err := conn.ListTrackerConsumersPagesWithContext(ctx, in, func(page *locationservice.ListTrackerConsumersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, arn := range page.ConsumerArns {
+			if arn == nil {
+				continue
+			}
+
+			arns = append(arns, aws.StringValue(arn))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return create.DiagError(names.Location, create.ErrActionReading, DSNameTrackerAssociations, name, err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("consumer_arns", arns)
+
+	return nil
+}

--- a/internal/service/location/tracker_associations_data_source_test.go
+++ b/internal/service/location/tracker_associations_data_source_test.go
@@ -1,0 +1,53 @@
+package location_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/locationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLocationTrackerAssociationsDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_location_tracker_associations.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, locationservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrackerAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrackerAssociationsDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "consumer_arns.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "consumer_arns.0", "aws_location_tracker_association.test", "consumer_arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTrackerAssociationsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_geofence_collection" "test" {
+  collection_name = %[1]q
+}
+
+resource "aws_location_tracker" "test" {
+  tracker_name = %[1]q
+}
+
+resource "aws_location_tracker_association" "test" {
+  consumer_arn = aws_location_geofence_collection.test.collection_arn
+  tracker_name = aws_location_tracker.test.tracker_name
+}
+
+data "aws_location_tracker_associations" "test" {
+  tracker_name = aws_location_tracker_association.test.tracker_name
+}
+`, rName)
+}

--- a/website/docs/d/location_tracker_associations.html.markdown
+++ b/website/docs/d/location_tracker_associations.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_tracker_associations"
+description: |-
+    Retrieve information about Location Service Tracker Associations.
+---
+
+# Data Source: aws_location_tracker_associations
+
+Retrieve information about Location Service Tracker Associations.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_location_tracker_associations" "example" {
+  tracker_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `tracker_name` - (Required) The name of the tracker resource associated with a geofence collection.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `consumer_arns` - The list of geofence collection ARNs associated to the tracker resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19629.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationTrackerAssociationsDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationTrackerAssociationsDataSource_'  -timeout 180m
=== RUN   TestAccLocationTrackerAssociationsDataSource_basic
=== PAUSE TestAccLocationTrackerAssociationsDataSource_basic
=== CONT  TestAccLocationTrackerAssociationsDataSource_basic
--- PASS: TestAccLocationTrackerAssociationsDataSource_basic (27.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/location	29.291s
```
