### PR TITLE
d/aws_location_tracker_association: remove unnecessary ForceNew

### DIFF
--- a/internal/service/location/tracker_association_data_source.go
+++ b/internal/service/location/tracker_association_data_source.go
@@ -21,13 +21,11 @@ func DataSourceTrackerAssociation() *schema.Resource {
 			"consumer_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
 			"tracker_name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=location TESTS="TestAccLocationTrackerAssociationDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/location/... -v -count 1 -parallel 20 -run='TestAccLocationTrackerAssociationDataSource_'  -timeout 180m
=== RUN   TestAccLocationTrackerAssociationDataSource_basic
=== PAUSE TestAccLocationTrackerAssociationDataSource_basic
=== CONT  TestAccLocationTrackerAssociationDataSource_basic
--- PASS: TestAccLocationTrackerAssociationDataSource_basic (28.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/location   29.746s
```
