### PR TITLE
Fix Lightsail Database (HA) creation and add timeout support

### DIFF
--- a/.changelog/26488.txt
+++ b/.changelog/26488.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_lightsail_database: The `availability_zone` attribute is now optional/computed to support HA bundle_ids
+```
+
+```release-note:enhancement
+resource/aws_lightsail_database: Add configurable timeouts
+```

--- a/internal/service/lightsail/database.go
+++ b/internal/service/lightsail/database.go
@@ -42,7 +42,8 @@ func ResourceDatabase() *schema.Resource {
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"backup_retention_enabled": {

--- a/internal/service/lightsail/wait.go
+++ b/internal/service/lightsail/wait.go
@@ -35,7 +35,7 @@ const (
 )
 
 // waitOperation waits for an Operation to return Succeeded or Compleated
-func waitOperation(conn *lightsail.Lightsail, oid *string) error {
+func waitOperation(ctx context.Context, conn *lightsail.Lightsail, oid *string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{lightsail.OperationStatusStarted},
 		Target:     []string{lightsail.OperationStatusCompleted, lightsail.OperationStatusSucceeded},
@@ -45,7 +45,7 @@ func waitOperation(conn *lightsail.Lightsail, oid *string) error {
 		MinTimeout: OperationMinTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if _, ok := outputRaw.(*lightsail.GetOperationOutput); ok {
 		return err
@@ -55,7 +55,7 @@ func waitOperation(conn *lightsail.Lightsail, oid *string) error {
 }
 
 // waitDatabaseModified waits for a Modified Database return available
-func waitDatabaseModified(conn *lightsail.Lightsail, db *string) (*lightsail.GetRelationalDatabaseOutput, error) {
+func waitDatabaseModified(ctx context.Context, conn *lightsail.Lightsail, db *string) (*lightsail.GetRelationalDatabaseOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{DatabaseStateModifying},
 		Target:     []string{DatabaseStateAvailable},
@@ -65,7 +65,7 @@ func waitDatabaseModified(conn *lightsail.Lightsail, db *string) (*lightsail.Get
 		MinTimeout: DatabaseMinTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*lightsail.GetRelationalDatabaseOutput); ok {
 		return output, err
@@ -76,7 +76,7 @@ func waitDatabaseModified(conn *lightsail.Lightsail, db *string) (*lightsail.Get
 
 // waitDatabaseBackupRetentionModified waits for a Modified  BackupRetention on Database return available
 
-func waitDatabaseBackupRetentionModified(conn *lightsail.Lightsail, db *string, status *bool) error {
+func waitDatabaseBackupRetentionModified(ctx context.Context, conn *lightsail.Lightsail, db *string, status *bool) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{strconv.FormatBool(!aws.BoolValue(status))},
 		Target:     []string{strconv.FormatBool(aws.BoolValue(status))},
@@ -86,7 +86,7 @@ func waitDatabaseBackupRetentionModified(conn *lightsail.Lightsail, db *string, 
 		MinTimeout: DatabaseMinTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if _, ok := outputRaw.(*lightsail.GetRelationalDatabaseOutput); ok {
 		return err

--- a/website/docs/r/lightsail_database.html.markdown
+++ b/website/docs/r/lightsail_database.html.markdown
@@ -104,7 +104,7 @@ resource "aws_lightsail_database" "test" {
 The following arguments are supported:
 
 * `name` - (Required) The name to use for your new Lightsail database resource. Names be unique within each AWS Region in your Lightsail account.
-* `availability_zone` - (Required) The Availability Zone in which to create your new database. Use the us-east-2a case-sensitive format.
+* `availability_zone` - The Availability Zone in which to create your new database. Use the us-east-2a case-sensitive format.
 * `master_database_name` - (Required) The name of the master database created when the Lightsail database resource is created.
 * `master_password` - (Sensitive) The password for the master user of your new database. The password can include any printable ASCII character except "/", """, or "@".
 * `master_username` - The master user name for your new database.

--- a/website/docs/r/lightsail_database.html.markdown
+++ b/website/docs/r/lightsail_database.html.markdown
@@ -187,6 +187,15 @@ In addition to all arguments above, the following attributes are exported:
 * `support_code` - The support code for the database. Include this code in your email to support when you have questions about a database in Lightsail. This code enables our support team to look up your Lightsail information more easily.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `read` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
 ## Import
 
 Lightsail Databases can be imported using their name, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26137

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccLightsailDatabase_' PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailDatabase_ -timeout 180m
=== RUN   TestAccLightsailDatabase_basic
=== PAUSE TestAccLightsailDatabase_basic
=== RUN   TestAccLightsailDatabase_RelationalDatabaseName
=== PAUSE TestAccLightsailDatabase_RelationalDatabaseName
=== RUN   TestAccLightsailDatabase_MasterDatabaseName
=== PAUSE TestAccLightsailDatabase_MasterDatabaseName
=== RUN   TestAccLightsailDatabase_MasterUsername
=== PAUSE TestAccLightsailDatabase_MasterUsername
=== RUN   TestAccLightsailDatabase_MasterPassword
=== PAUSE TestAccLightsailDatabase_MasterPassword
=== RUN   TestAccLightsailDatabase_PreferredBackupWindow
=== PAUSE TestAccLightsailDatabase_PreferredBackupWindow
=== RUN   TestAccLightsailDatabase_PreferredMaintenanceWindow
=== PAUSE TestAccLightsailDatabase_PreferredMaintenanceWindow
=== RUN   TestAccLightsailDatabase_PubliclyAccessible
=== PAUSE TestAccLightsailDatabase_PubliclyAccessible
=== RUN   TestAccLightsailDatabase_BackupRetentionEnabled
=== PAUSE TestAccLightsailDatabase_BackupRetentionEnabled
=== RUN   TestAccLightsailDatabase_FinalSnapshotName
=== PAUSE TestAccLightsailDatabase_FinalSnapshotName
=== RUN   TestAccLightsailDatabase_Tags
=== PAUSE TestAccLightsailDatabase_Tags
=== RUN   TestAccLightsailDatabase_disappears
=== PAUSE TestAccLightsailDatabase_disappears
=== CONT  TestAccLightsailDatabase_basic
=== CONT  TestAccLightsailDatabase_PreferredMaintenanceWindow
=== CONT  TestAccLightsailDatabase_FinalSnapshotName
=== CONT  TestAccLightsailDatabase_PreferredBackupWindow
=== CONT  TestAccLightsailDatabase_disappears
=== CONT  TestAccLightsailDatabase_MasterPassword
=== CONT  TestAccLightsailDatabase_MasterDatabaseName
=== CONT  TestAccLightsailDatabase_BackupRetentionEnabled
=== CONT  TestAccLightsailDatabase_PubliclyAccessible
=== CONT  TestAccLightsailDatabase_RelationalDatabaseName
=== CONT  TestAccLightsailDatabase_Tags
=== CONT  TestAccLightsailDatabase_MasterUsername
--- PASS: TestAccLightsailDatabase_MasterPassword (5.99s)
--- PASS: TestAccLightsailDatabase_disappears (675.43s)
--- PASS: TestAccLightsailDatabase_Tags (957.12s)
--- PASS: TestAccLightsailDatabase_PreferredMaintenanceWindow (975.88s)
--- PASS: TestAccLightsailDatabase_RelationalDatabaseName (993.72s)
--- PASS: TestAccLightsailDatabase_PubliclyAccessible (1016.18s)
--- PASS: TestAccLightsailDatabase_basic (1022.42s)
--- PASS: TestAccLightsailDatabase_PreferredBackupWindow (1024.94s)
--- PASS: TestAccLightsailDatabase_FinalSnapshotName (1096.77s)
--- PASS: TestAccLightsailDatabase_BackupRetentionEnabled (1144.97s)
--- PASS: TestAccLightsailDatabase_MasterUsername (1998.63s)
--- PASS: TestAccLightsailDatabase_MasterDatabaseName (2079.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	2081.352s
...
```
