### PR TITLE
feat: add target_capacity_unit_type to ec2_fleet and ec2_spot_fleet_request resources

### DIFF
--- a/.changelog/26493.txt
+++ b/.changelog/26493.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ec2_fleet: Add `target_capacity_unit_type` attribute to the `target_capacity_specification` configuration block
+```
+
+```release-note:enhancement
+resource/aws_spot_fleet_request: Add `target_capacity_unit_type` argument
+```

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -530,15 +530,15 @@ func ResourceFleet() *schema.Resource {
 								return oldInt == totalTargetCapacityO.(int)
 							},
 						},
-						"total_target_capacity": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
 						"target_capacity_unit_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice(ec2.TargetCapacityUnitType_Values(), false),
+						},
+						"total_target_capacity": {
+							Type:     schema.TypeInt,
+							Required: true,
 						},
 					},
 				},

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -534,6 +534,12 @@ func ResourceFleet() *schema.Resource {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
+						"target_capacity_unit_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(ec2.TargetCapacityUnitType_Values(), false),
+						},
 					},
 				},
 			},
@@ -992,6 +998,10 @@ func expandTargetCapacitySpecificationRequest(tfMap map[string]interface{}) *ec2
 		apiObject.TotalTargetCapacity = aws.Int64(int64(v))
 	}
 
+	if v, ok := tfMap["target_capacity_unit_type"].(string); ok && v != "" {
+		apiObject.TargetCapacityUnitType = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -1202,6 +1212,10 @@ func flattenTargetCapacitySpecification(apiObject *ec2.TargetCapacitySpecificati
 
 	if v := apiObject.TotalTargetCapacity; v != nil {
 		tfMap["total_target_capacity"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.TargetCapacityUnitType; v != nil {
+		tfMap["target_capacity_unit_type"] = aws.StringValue(v)
 	}
 
 	return tfMap

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -777,6 +777,12 @@ func ResourceSpotFleetRequest() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			"target_capacity_unit_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ec2.TargetCapacityUnitType_Values(), false),
+			},
 			"target_group_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -934,6 +940,10 @@ func resourceSpotFleetRequestCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	if v, ok := d.GetOk("target_capacity_unit_type"); ok {
+		spotFleetConfig.SetTargetCapacityUnitType(v.(string))
+	}
+
 	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-RequestSpotFleetInput
 	input := &ec2.RequestSpotFleetInput{
 		SpotFleetRequestConfig: spotFleetConfig,
@@ -1016,6 +1026,10 @@ func resourceSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) erro
 
 	if config.TargetCapacity != nil {
 		d.Set("target_capacity", config.TargetCapacity)
+	}
+
+	if config.TargetCapacityUnitType != nil {
+		d.Set("target_capacity_unit_type", config.TargetCapacityUnitType)
 	}
 
 	if config.TerminateInstancesWithExpiration != nil {

--- a/internal/service/ec2/ec2_spot_fleet_request_test.go
+++ b/internal/service/ec2/ec2_spot_fleet_request_test.go
@@ -1828,7 +1828,7 @@ func testAccCheckSpotFleetRequest_IAMInstanceProfileARN(sfr *ec2.SpotFleetReques
 	}
 }
 
-func testAccSpotFleetRequestBaseConfig(rName, publicKey string) string {
+func testAccSpotFleetRequestConfig_base(rName, publicKey string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -1909,7 +1909,7 @@ resource "aws_iam_policy_attachment" "test" {
 }
 
 func testAccSpotFleetRequestConfig_basic(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -1935,7 +1935,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_tags1(rName, publicKey, validUntil, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -1965,7 +1965,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_tags2(rName, publicKey, validUntil, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -1996,7 +1996,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_associatePublicIPAddress(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2022,7 +2022,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_targetCapacity(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2047,7 +2047,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchTemplate(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -2085,7 +2085,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchTemplateMultiple(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 data "aws_ec2_instance_type_offering" "test" {
   filter {
     name   = "instance-type"
@@ -2154,7 +2154,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchTemplateInstanceTypeOverrides(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -2203,7 +2203,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchTemplateInstanceRequirementsOverrides(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -2259,7 +2259,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_excessCapacityTermination(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2285,7 +2285,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_type(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2310,7 +2310,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_iamInstanceProfileARN(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_iam_role" "test-role1" {
   name = "tf-test-role1-%[1]s"
 
@@ -2381,7 +2381,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_changeBidPrice(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2406,7 +2406,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_azs(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2443,7 +2443,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_subnet(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -2508,7 +2508,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_elbs(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -2576,7 +2576,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_targetGroups(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -2655,7 +2655,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_multipleInstanceTypesinSameAZ(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2692,7 +2692,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_multipleInstanceTypesinSameSubnet(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -2743,7 +2743,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_overridingPrice(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2781,7 +2781,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_noPrice(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   target_capacity                     = 2
@@ -2817,7 +2817,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_multipleInstancePools(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.7"
@@ -2866,7 +2866,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_diversifiedAllocation(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.7"
@@ -2915,7 +2915,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_weightedCapacity(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.7"
@@ -2954,7 +2954,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_ebs(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -2990,7 +2990,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceKMSKeyID(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
@@ -3036,7 +3036,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceKMSKeyID(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
@@ -3075,7 +3075,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceGP3(rName, publicKey string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -3112,7 +3112,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceGP3(rName, publicKey string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -3144,7 +3144,7 @@ resource "aws_spot_fleet_request" "test" {
 func testAccSpotFleetRequestConfig_launchSpecificationInstanceStoreAMI(rName, publicKey, validUntil string) string {
 	return acctest.ConfigCompose(
 		testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore(),
-		testAccSpotFleetRequestBaseConfig(rName, publicKey),
+		testAccSpotFleetRequestConfig_base(rName, publicKey),
 		fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test-role.arn
@@ -3169,7 +3169,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_tags(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -3195,7 +3195,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_tenancyGroup(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %[1]q
   strategy = "cluster"
@@ -3226,7 +3226,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_zeroCapacity(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -3252,7 +3252,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_capacityRebalance(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
   spot_price                          = "0.05"
@@ -3283,7 +3283,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_onDemandTargetCapacity(rName, publicKey, validUntil string, targetCapacity int) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -3322,7 +3322,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_onDemandMaxTotalPrice(rName, publicKey, validUntil, price string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -3361,7 +3361,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_onDemandAllocationStrategy(rName, publicKey, validUntil, strategy string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -3400,7 +3400,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_noTerminateInstancesExpiration(rName, publicKey, validUntil string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                  = aws_iam_role.test.arn
   spot_price                      = "0.05"
@@ -3426,7 +3426,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccSpotFleetRequestConfig_targetCapacityUnitType(rName, publicKey, validUntil, targetCapacityUnitType string) string {
-	return acctest.ConfigCompose(testAccSpotFleetRequestBaseConfig(rName, publicKey), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -2,13 +2,11 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -463,30 +461,7 @@ func StatusSpotFleetActivityStatus(conn *ec2.EC2, id string) resource.StateRefre
 			return nil, "", err
 		}
 
-		activityStatus := aws.StringValue(output.ActivityStatus)
-		var errs *multierror.Error
-
-		if activityStatus == ec2.ActivityStatusError {
-			startTime := aws.TimeValue(output.CreateTime)
-
-			for _, eventType := range []string{ec2.EventTypeInformation, ec2.EventTypeError} {
-				input := &ec2.DescribeSpotFleetRequestHistoryInput{
-					EventType:          aws.String(eventType),
-					SpotFleetRequestId: aws.String(id),
-					StartTime:          aws.Time(startTime),
-				}
-
-				output, err := FindSpotFleetRequestHistoryRecords(conn, input)
-
-				if err != nil {
-					for _, v := range output {
-						errs = multierror.Append(errs, fmt.Errorf("%s", v))
-					}
-				}
-			}
-		}
-
-		return output, activityStatus, errs.ErrorOrNil()
+		return output, aws.StringValue(output.ActivityStatus), nil
 	}
 }
 

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -2421,6 +2422,25 @@ func WaitSpotFleetRequestFulfilled(conn *ec2.EC2, id string, timeout time.Durati
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*ec2.SpotFleetRequestConfig); ok {
+		if activityStatus := aws.StringValue(output.ActivityStatus); activityStatus == ec2.ActivityStatusError {
+			var errs *multierror.Error
+
+			input := &ec2.DescribeSpotFleetRequestHistoryInput{
+				SpotFleetRequestId: aws.String(id),
+				StartTime:          aws.Time(time.UnixMilli(0)),
+			}
+
+			if output, err := FindSpotFleetRequestHistoryRecords(conn, input); err == nil {
+				for _, v := range output {
+					if eventType := aws.StringValue(v.EventType); eventType == ec2.EventTypeError || eventType == ec2.EventTypeInformation {
+						errs = multierror.Append(errs, errors.New(v.String()))
+					}
+				}
+			}
+
+			tfresource.SetLastError(err, errs.ErrorOrNil())
+		}
+
 		return output, err
 	}
 

--- a/website/docs/r/ec2_fleet.html.markdown
+++ b/website/docs/r/ec2_fleet.html.markdown
@@ -218,6 +218,7 @@ This configuration block supports the following:
 * `total_target_capacity` - (Required) The number of units to request, filled using `default_target_capacity_type`.
 * `on_demand_target_capacity` - (Optional) The number of On-Demand units to request.
 * `spot_target_capacity` - (Optional) The number of Spot units to request.
+* `target_capacity_unit_type` - (Optional) The unit for the target capacity. This can only be done with `instance_requirements` defined
 
 ## Attributes Reference
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -217,6 +217,7 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
+* `target_capacity_unit_type` - (Optional) The unit for the target capacity. This can only be done with `instance_requirements` defined
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.
@@ -370,7 +371,7 @@ This configuration block supports the following:
     * `max` - (Optional) Maximum.
 * `on_demand_max_price_percentage_over_lowest_price` - (Optional) The price protection threshold for On-Demand Instances. This is the maximum you’ll pay for an On-Demand Instance, expressed as a percentage higher than the cheapest M, C, or R instance type with your specified attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will exclude instance types whose price is higher than your threshold. The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To turn off price protection, specify a high value, such as 999999. Default is 20.
 
-    If you set DesiredCapacityType to vcpu or memory-mib, the price protection threshold is applied based on the per vCPU or per memory price instead of the per instance price.  
+    If you set DesiredCapacityType to vcpu or memory-mib, the price protection threshold is applied based on the per vCPU or per memory price instead of the per instance price.
 * `require_hibernate_support` - (Optional) Indicate whether instance types must support On-Demand Instance Hibernation, either `true` or `false`. Default is `false`.
 * `spot_max_price_percentage_over_lowest_price` - (Optional) The price protection threshold for Spot Instances. This is the maximum you’ll pay for a Spot Instance, expressed as a percentage higher than the cheapest M, C, or R instance type with your specified attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will exclude instance types whose price is higher than your threshold. The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To turn off price protection, specify a high value, such as 999999. Default is 100.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

feat: add target_capacity_unit_type to ec2_fleet and ec2_spot_fleet_request resources
Closes #25777


Output from acceptance testing:

```zsh
terraform-provider-aws on  f-aws_ec2_fleet-aws_spot_fleet_request-add-target_capacity_unit_type [!] via 🐹 v1.18.4 took 2s
[I] ➜ make testacc TESTS=TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType'
-timeout 180m
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType (435.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        438.463s
```

```zsh
terraform-provider-aws on  f-aws_ec2_fleet-aws_spot_fleet_request-add-target_capacity_unit_type [!] via 🐹 v1.18.4 took 3s
[I] ➜ make testacc TESTS=TestAccEC2SpotFleetRequest_targetCapacityUnitType PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2SpotFleetRequest_targetCapacityUnitType'  -timeout 180m
=== RUN   TestAccEC2SpotFleetRequest_targetCapacityUnitType
=== PAUSE TestAccEC2SpotFleetRequest_targetCapacityUnitType
=== CONT  TestAccEC2SpotFleetRequest_targetCapacityUnitType
--- PASS: TestAccEC2SpotFleetRequest_targetCapacityUnitType (203.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        206.555s
```

