### PR TITLE
sweepers/aws_kendra_index

### DIFF
--- a/internal/service/kendra/sweep.go
+++ b/internal/service/kendra/sweep.go
@@ -1,0 +1,74 @@
+//go:build sweep
+// +build sweep
+
+package kendra
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kendra"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_kendra_index", &resource.Sweeper{
+		Name: "aws_kendra_index",
+		F:    sweepIndex,
+	})
+}
+
+func sweepIndex(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %w", err)
+	}
+
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).KendraConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	in := &kendra.ListIndicesInput{}
+	var errs *multierror.Error
+
+	pages := kendra.NewListIndicesPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Println("[WARN] Skipping Kendra Indices sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error retrieving Kendra Indices: %w", err)
+		}
+
+		for _, index := range page.IndexConfigurationSummaryItems {
+			id := aws.ToString(index.Id)
+			log.Printf("[INFO] Deleting Kendra Index: %s", id)
+
+			r := ResourceIndex()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Kendra Indices for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Kendra Indices sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -81,6 +81,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/iot"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/kafka"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/kendra"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/kinesis"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13367

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPARGS=-sweep-run=aws_kendra SWEEP=us-west-2
2022/08/26 00:55:39 [DEBUG] Completed Sweeper (aws_kendra_index) in region (us-west-2) in 1m37.362750881s
2022/08/26 00:55:39 Completed Sweepers for region (us-west-2) in 1m37.362800935s
2022/08/26 00:55:39 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_kendra_index
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      97.381s
...
```
