### PR TITLE
d/ec2_managed_prefix_list_entry - updated example

### DIFF
--- a/website/docs/r/ec2_managed_prefix_list_entry.html.markdown
+++ b/website/docs/r/ec2_managed_prefix_list_entry.html.markdown
@@ -35,7 +35,7 @@ resource "aws_ec2_managed_prefix_list" "example" {
 resource "aws_ec2_managed_prefix_list_entry" "entry_1" {
   cidr           = aws_vpc.example.cidr_block
   description    = "Primary"
-  prefix_list_id = aws_ec2_managed_prefix_list.entry.id
+  prefix_list_id = aws_ec2_managed_prefix_list.example.id
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Summary: 
Made a small update to the documentation for the `ec2_managed_prefix_list_entry` resource.  The issue was originally reported on the forums here: https://discuss.hashicorp.com/t/example-page-for-aws-managed-prefix-list-and-entry-has-an-error/43650.

Output from acceptance testing:

Acceptance tests not ran since this was a documentation update.