### PR TITLE
F/aws s3 bucket object lock configuration

### DIFF
--- a/.changelog/26520.txt
+++ b/.changelog/26520.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_object_lock_configuration: Update `rule` attribute to be optional
+```

--- a/.changelog/26520.txt
+++ b/.changelog/26520.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_s3_bucket_object_lock_configuration: Update `rule` attribute to be optional
+resource/aws_s3_bucket_object_lock_configuration: Update `rule` argument to be Optional
 ```

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -49,7 +49,7 @@ func ResourceBucketObjectLockConfiguration() *schema.Resource {
 			},
 			"rule": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 * `bucket` - (Required, Forces new resource) The name of the bucket.
 * `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
 * `object_lock_enabled` - (Optional, Forces new resource) Indicates whether this bucket has an Object Lock configuration enabled. Defaults to `Enabled`. Valid values: `Enabled`.
-* `rule` - (Required) Configuration block for specifying the Object Lock rule for the specified object [detailed below](#rule).
+* `rule` - (Optional) Configuration block for specifying the Object Lock rule for the specified object [detailed below](#rule).
 * `token` - (Optional) A token to allow Object Lock to be enabled for an existing bucket. You must contact AWS support for the bucket's "Object Lock token".
 The token is generated in the back-end when [versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html) is enabled on a bucket. For more details on versioning, see the [`aws_s3_bucket_versioning` resource](s3_bucket_versioning.html.markdown).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25070

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccS3BucketObjectLockConfiguration_ PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketObjectLockConfiguration_'  -timeout 180m
=== RUN   TestAccS3BucketObjectLockConfiguration_basic
=== PAUSE TestAccS3BucketObjectLockConfiguration_basic
=== RUN   TestAccS3BucketObjectLockConfiguration_disappears
=== PAUSE TestAccS3BucketObjectLockConfiguration_disappears
=== RUN   TestAccS3BucketObjectLockConfiguration_update
=== PAUSE TestAccS3BucketObjectLockConfiguration_update
=== RUN   TestAccS3BucketObjectLockConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketObjectLockConfiguration_migrate_noChange
=== RUN   TestAccS3BucketObjectLockConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketObjectLockConfiguration_migrate_withChange
=== CONT  TestAccS3BucketObjectLockConfiguration_basic
=== CONT  TestAccS3BucketObjectLockConfiguration_migrate_noChange
=== CONT  TestAccS3BucketObjectLockConfiguration_migrate_withChange
=== CONT  TestAccS3BucketObjectLockConfiguration_update
=== CONT  TestAccS3BucketObjectLockConfiguration_disappears
--- PASS: TestAccS3BucketObjectLockConfiguration_disappears (39.25s)
--- PASS: TestAccS3BucketObjectLockConfiguration_basic (43.75s)
--- PASS: TestAccS3BucketObjectLockConfiguration_migrate_noChange (62.07s)
--- PASS: TestAccS3BucketObjectLockConfiguration_migrate_withChange (62.99s)
--- PASS: TestAccS3BucketObjectLockConfiguration_update (66.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	69.976s
...
```
