### PR TITLE
ec2/instance: Dedicated host resource group compatibility

### DIFF
--- a/.changelog/26532.txt
+++ b/.changelog/26532.txt
@@ -3,7 +3,7 @@ data-source/aws_instance: Add `host_resource_group_arn` attribute
 ```
 
 ```release-note:enhancement
-resource/aws_instance: Add `host_resource_group_arn` attribute; improve compatibility with launching instances in a host resource group using an AMI registered with License Manager.
+resource/aws_instance: Add `host_resource_group_arn` attribute; improve compatibility with launching instances in a host resource group using an AMI registered with License Manager. NOTE: Because we cannot easily test this functionality, it is best effort and we ask for community help in testing.
 ```
 
 ```release-note:note

--- a/.changelog/26532.txt
+++ b/.changelog/26532.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+data-source/aws_instance: Add `host_resource_group_arn` attribute
+```
+
+```release-note:enhancement
+resource/aws_instance: Add `host_resource_group_arn` attribute; improve compatibility with launching instances in a host resource group using an AMI registered with License Manager.
+```
+
+```release-note:note
+resource/aws_instance: With the retirement of EC2-Classic, `aws_instance` has been updated to remove support for EC2-Classic
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -28,6 +28,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceInstance() *schema.Resource {
@@ -316,6 +317,12 @@ func ResourceInstance() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"host_resource_group_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"placement_group"},
+			},
 			"iam_instance_profile": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -488,10 +495,11 @@ func ResourceInstance() *schema.Resource {
 				Computed: true,
 			},
 			"placement_group": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"host_resource_group_arn"},
 			},
 			"placement_partition_number": {
 				Type:     schema.TypeInt,
@@ -961,6 +969,11 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("host_id", v)
 		}
 
+		if v := v.HostResourceGroupArn; v != nil {
+			d.Set("placement_group", "")
+			d.Set("host_resource_group_arn", instance.Placement.HostResourceGroupArn)
+		}
+
 		if v := v.PartitionNumber; v != nil {
 			d.Set("placement_partition_number", v)
 		}
@@ -1394,9 +1407,6 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		// HasChange() thinks there is a diff between what is set on the instance and what is set in state. We need to ensure that
 		// if a diff has occurred, it's not because it's a new instance.
 		if d.HasChange("source_dest_check") && !d.IsNewResource() || d.IsNewResource() && !sourceDestCheck {
-			// SourceDestCheck can only be set on VPC instances
-			// AWS will return an error of InvalidParameterCombination if we attempt
-			// to modify the source_dest_check of an instance in EC2 Classic
 			log.Printf("[INFO] Modifying `source_dest_check` on Instance %s", d.Id())
 			_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
 				InstanceId: aws.String(d.Id()),
@@ -1405,12 +1415,7 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				},
 			})
 			if err != nil {
-				// Tolerate InvalidParameterCombination error in Classic, otherwise
-				// return the error
-				if !tfawserr.ErrCodeEquals(err, "InvalidParameterCombination") {
-					return err
-				}
-				log.Printf("[WARN] Attempted to modify SourceDestCheck on non VPC instance: %s", err)
+				return create.Error(names.EC2, create.ErrActionUpdating, "Instance", d.Id(), err)
 			}
 		}
 	}
@@ -2386,13 +2391,13 @@ func readVolumeTags(conn *ec2.EC2, instanceId string) ([]*ec2.Tag, error) {
 	return tagsFromTagDescriptions(resp.Tags), nil
 }
 
-// Determine whether we're referring to security groups with
-// IDs or names. We use a heuristic to figure this out. By default,
-// we use IDs if we're in a VPC, and names otherwise (EC2-Classic).
-// However, the default VPC accepts either, so store them both here and let the
-// config determine which one to use in Plan and Apply.
+// Determine whether we're referring to security groups with IDs or names. We
+// use a heuristic to figure this out. The default VPC can have security groups
+// with IDs or names, so store them both here and let the config determine
+// which one to use in Plan and Apply.
 func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.EC2) error {
-	// An instance with a subnet is in a VPC; an instance without a subnet is in EC2-Classic.
+	// An instance with a subnet is in a VPC, and possibly the default VPC.
+	// An instance without a subnet is in the default VPC.
 	hasSubnet := aws.StringValue(instance.SubnetId) != ""
 	useID, useName := hasSubnet, !hasSubnet
 
@@ -2499,7 +2504,7 @@ func getInstancePasswordData(instanceID string, conn *ec2.EC2) (string, error) {
 	return passwordData, nil
 }
 
-type awsInstanceOpts struct {
+type instanceOpts struct {
 	BlockDeviceMappings               []*ec2.BlockDeviceMapping
 	CapacityReservationSpecification  *ec2.CapacityReservationSpecification
 	CpuOptions                        *ec2.CpuOptionsRequest
@@ -2531,10 +2536,10 @@ type awsInstanceOpts struct {
 	UserData64                        *string
 }
 
-func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*awsInstanceOpts, error) {
+func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*instanceOpts, error) {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	opts := &awsInstanceOpts{
+	opts := &instanceOpts{
 		DisableAPIStop:        aws.Bool(d.Get("disable_api_stop").(bool)),
 		DisableAPITermination: aws.Bool(d.Get("disable_api_termination").(bool)),
 		EBSOptimized:          aws.Bool(d.Get("ebs_optimized").(bool)),
@@ -2635,16 +2640,20 @@ func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*awsInstanceOp
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
 	}
 
-	if v := d.Get("placement_group").(string); instanceInterruptionBehavior == "" || instanceInterruptionBehavior == ec2.InstanceInterruptionBehaviorTerminate {
-		opts.Placement.GroupName = aws.String(v)
-		opts.SpotPlacement.GroupName = aws.String(v)
+	if v, ok := d.GetOk("placement_group"); ok && v.(string) != "" && (instanceInterruptionBehavior == "" || instanceInterruptionBehavior == ec2.InstanceInterruptionBehaviorTerminate) {
+		opts.Placement.GroupName = aws.String(v.(string))
+		opts.SpotPlacement.GroupName = aws.String(v.(string))
 	}
 
-	if v := d.Get("tenancy").(string); v != "" {
-		opts.Placement.Tenancy = aws.String(v)
+	if v, ok := d.GetOk("tenancy"); ok && v.(string) != "" {
+		opts.Placement.Tenancy = aws.String(v.(string))
 	}
-	if v := d.Get("host_id").(string); v != "" {
-		opts.Placement.HostId = aws.String(v)
+	if v, ok := d.GetOk("host_id"); ok && v.(string) != "" {
+		opts.Placement.HostId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("host_resource_group_arn"); ok && v.(string) != "" {
+		opts.Placement.HostResourceGroupArn = aws.String(v.(string))
 	}
 
 	if v := d.Get("cpu_core_count").(int); v > 0 {

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -970,7 +970,6 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if v := v.HostResourceGroupArn; v != nil {
-			d.Set("placement_group", "")
 			d.Set("host_resource_group_arn", instance.Placement.HostResourceGroupArn)
 		}
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2640,19 +2640,19 @@ func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*instanceOpts,
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
 	}
 
-	if v, ok := d.GetOk("placement_group"); ok && v.(string) != "" && (instanceInterruptionBehavior == "" || instanceInterruptionBehavior == ec2.InstanceInterruptionBehaviorTerminate) {
+	if v, ok := d.GetOk("placement_group"); ok && (instanceInterruptionBehavior == "" || instanceInterruptionBehavior == ec2.InstanceInterruptionBehaviorTerminate) {
 		opts.Placement.GroupName = aws.String(v.(string))
 		opts.SpotPlacement.GroupName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("tenancy"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("tenancy"); ok {
 		opts.Placement.Tenancy = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("host_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("host_id"); ok {
 		opts.Placement.HostId = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("host_resource_group_arn"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("host_resource_group_arn"); ok {
 		opts.Placement.HostResourceGroupArn = aws.String(v.(string))
 	}
 

--- a/internal/service/ec2/ec2_instance_data_source.go
+++ b/internal/service/ec2/ec2_instance_data_source.go
@@ -170,6 +170,10 @@ func DataSourceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"host_resource_group_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"iam_instance_profile": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -466,6 +470,9 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 	}
 	if instance.Placement.HostId != nil {
 		d.Set("host_id", instance.Placement.HostId)
+	}
+	if instance.Placement.HostResourceGroupArn != nil {
+		d.Set("host_resource_group_arn", instance.Placement.HostResourceGroupArn)
 	}
 
 	d.Set("ami", instance.ImageId)

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -5706,15 +5706,14 @@ resource "aws_instance" "test" {
 func testAccInstanceConfig_dedicated(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		testAccInstanceVPCConfig(rName, false, 1),
 		// Prevent frequent errors like
 		//	"InsufficientInstanceCapacity: We currently do not have sufficient m1.small capacity in the Availability Zone you requested (us-west-2a)."
-		testAccInstanceVPCConfig(rName, false, 1),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[1]", "t3.small", "t3.micro", "m1.small", "a1.medium"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-
-  # tflint-ignore: aws_instance_previous_type
-  instance_type               = "m1.small"
+  ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id                   = aws_subnet.test.id
   associate_public_ip_address = true
   tenancy                     = "dedicated"

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -177,10 +177,10 @@ func TestAccEC2Instance_basic(t *testing.T) {
 	resourceName := "aws_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC with default subnets or EC2-Classic.
+		// No subnet_id specified requires default VPC with default subnets.
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			testAccPreCheckClassicOrHasDefaultVPCDefaultSubnets(t)
+			testAccPreCheckHasDefaultVPCDefaultSubnets(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -195,11 +195,10 @@ func TestAccEC2Instance_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Required for EC2-Classic.
-				ImportStateVerifyIgnore: []string{"source_dest_check", "user_data_replace_on_change"},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 		},
 	})
@@ -210,10 +209,10 @@ func TestAccEC2Instance_disappears(t *testing.T) {
 	resourceName := "aws_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC with default subnets or EC2-Classic.
+		// No subnet_id specified requires default VPC with default subnets.
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			testAccPreCheckClassicOrHasDefaultVPCDefaultSubnets(t)
+			testAccPreCheckHasDefaultVPCDefaultSubnets(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -236,10 +235,10 @@ func TestAccEC2Instance_tags(t *testing.T) {
 	resourceName := "aws_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC with default subnets or EC2-Classic.
+		// No subnet_id specified requires default VPC with default subnets.
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			testAccPreCheckClassicOrHasDefaultVPCDefaultSubnets(t)
+			testAccPreCheckHasDefaultVPCDefaultSubnets(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -329,37 +328,6 @@ func TestAccEC2Instance_inDefaultVPCBySgID(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
-			},
-		},
-	})
-}
-
-func TestAccEC2Instance_inEC2Classic(t *testing.T) {
-	resourceName := "aws_instance.test"
-	var v ec2.Instance
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckEC2Classic(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceConfig_classic(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceClassicExists(resourceName, &v),
-				),
-			},
-			{
-				Config:            testAccInstanceConfig_classic(),
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"network_interface",
-					"source_dest_check",
-					"user_data_replace_on_change",
-				},
 			},
 		},
 	})
@@ -4752,10 +4720,6 @@ func testAccCheckInstanceExists(n string, v *ec2.Instance) resource.TestCheckFun
 	return testAccCheckInstanceExistsWithProvider(n, v, func() *schema.Provider { return acctest.Provider })
 }
 
-func testAccCheckInstanceClassicExists(n string, v *ec2.Instance) resource.TestCheckFunc {
-	return testAccCheckInstanceExistsWithProvider(n, v, func() *schema.Provider { return acctest.ProviderEC2Classic })
-}
-
 func testAccCheckInstanceExistsWithProvider(n string, v *ec2.Instance, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -4885,15 +4849,14 @@ func driftTags(instance *ec2.Instance) resource.TestCheckFunc {
 	}
 }
 
-// testAccPreCheckClassicOrHasDefaultVPCDefaultSubnets checks that the test region has either
-// - The EC2-Classic platform available, or
+// testAccPreCheckHasDefaultVPCDefaultSubnets checks that the test region has
 // - A default VPC with default subnets.
 // This check is useful to ensure that an instance can be launched without specifying a subnet.
-func testAccPreCheckClassicOrHasDefaultVPCDefaultSubnets(t *testing.T) {
+func testAccPreCheckHasDefaultVPCDefaultSubnets(t *testing.T) {
 	client := acctest.Provider.Meta().(*conns.AWSClient)
 
-	if !conns.HasEC2Classic(client.SupportedPlatforms) && !(hasDefaultVPC(t) && defaultSubnetCount(t) > 0) {
-		t.Skipf("skipping tests; %s does not have EC2-Classic or a default VPC with default subnets", client.Region)
+	if !(hasDefaultVPC(t) && defaultSubnetCount(t) > 0) {
+		t.Skipf("skipping tests; %s does not have a default VPC with default subnets", client.Region)
 	}
 }
 
@@ -5109,7 +5072,6 @@ resource "aws_subnet" "test" {
 func testAccInstanceConfig_basic() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
-		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html#ec2-classic-instance-types
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
 		`
 resource "aws_instance" "test" {
@@ -5201,19 +5163,6 @@ resource "aws_instance" "test" {
   }
 }
 `, rName))
-}
-
-func testAccInstanceConfig_classic() string { // nosempgrep:ec2-in-func-name
-	return acctest.ConfigCompose(
-		acctest.ConfigEC2ClassicRegionProvider(),
-		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
-		acctest.AvailableEC2InstanceTypeForRegion("t1.micro", "m3.medium", "m3.large", "c3.large", "r3.large"),
-		`
-resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-}
-`)
 }
 
 func testAccInstanceConfig_atLeastOneOtherEBSVolume(rName string) string {

--- a/internal/service/ec2/ec2_instances_data_source_test.go
+++ b/internal/service/ec2/ec2_instances_data_source_test.go
@@ -21,8 +21,8 @@ func TestAccEC2InstancesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccInstancesDataSourceConfig_ids(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_instances.test", "private_ips.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_instances.test", "private_ips.#", "2"),
 					// Public IP values are flakey for new EC2 instances due to eventual consistency
 					resource.TestCheckResourceAttrSet("data.aws_instances.test", "public_ips.#"),
 				),
@@ -113,7 +113,7 @@ func testAccInstancesDataSourceConfig_ids(rName string) string {
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  count         = 3
+  count         = 2
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -8,8 +8,7 @@ description: |-
 
 # Data Source: aws_instance
 
-Use this data source to get the ID of an Amazon EC2 Instance for use in other
-resources.
+Use this data source to get the ID of an Amazon EC2 Instance for use in other resources.
 
 ## Example Usage
 
@@ -33,7 +32,7 @@ data "aws_instance" "foo" {
 
 * `instance_id` - (Optional) Specify the exact Instance ID with which to populate the data source.
 
-* `instance_tags` - (Optional) A map of tags, each pair of which must
+* `instance_tags` - (Optional) Map of tags, each pair of which must
 exactly match a pair on the desired Instance.
 
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
@@ -58,81 +57,76 @@ are exported:
 ~> **NOTE:** Some values are not always set and may not be available for
 interpolation.
 
-* `ami` - The ID of the AMI used to launch the instance.
-* `arn` - The ARN of the instance.
+* `ami` - ID of the AMI used to launch the instance.
+* `arn` - ARN of the instance.
 * `associate_public_ip_address` - Whether or not the Instance is associated with a public IP address or not (Boolean).
-* `availability_zone` - The availability zone of the Instance.
+* `availability_zone` - Availability zone of the Instance.
+* `credit_specification` - Credit specification of the Instance.
 * `disable_api_stop` - Whether or not EC2 Instance Stop Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html#Using_StopProtection) is enabled (Boolean).
 * `disable_api_termination` - Whether or not [EC2 Instance Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination) is enabled (Boolean).
-* `ebs_block_device` - The EBS block device mappings of the Instance.
+* `ebs_block_device` - EBS block device mappings of the Instance.
     * `delete_on_termination` - If the EBS volume will be deleted on termination.
-    * `device_name` - The physical name of the device.
+    * `device_name` - Physical name of the device.
     * `encrypted` - If the EBS volume is encrypted.
     * `iops` - `0` If the EBS volume is not a provisioned IOPS image, otherwise the supported IOPS count.
     * `kms_key_arn` - Amazon Resource Name (ARN) of KMS Key, if EBS volume is encrypted.
-    * `snapshot_id` - The ID of the snapshot.
-    * `throughput` - The throughput of the volume, in MiB/s.
-    * `volume_size` - The size of the volume, in GiB.
-    * `volume_type` - The volume type.
+    * `snapshot_id` - ID of the snapshot.
+    * `throughput` - Throughput of the volume, in MiB/s.
+    * `volume_size` - Size of the volume, in GiB.
+    * `volume_type` - Volume type.
 * `ebs_optimized` - Whether the Instance is EBS optimized or not (Boolean).
-* `ephemeral_block_device` - The ephemeral block device mappings of the Instance.
-    * `device_name` - The physical name of the device.
+* `enclave_options` - Enclave options of the instance.
+    * `enabled` - Whether Nitro Enclaves are enabled.
+* `ephemeral_block_device` - Ephemeral block device mappings of the Instance.
+    * `device_name` - Physical name of the device.
     * `no_device` - Whether the specified device included in the device mapping was suppressed or not (Boolean).
-    * `virtual_name` - The virtual device name.
-* `iam_instance_profile` - The name of the instance profile associated with the Instance.
-* `ipv6_addresses` - The IPv6 addresses associated to the Instance, if applicable. **NOTE**: Unlike the IPv4 address, this doesn't change if you attach an EIP to the instance.
-* `instance_state` - The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`. See [Instance Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html) for more information.
-* `instance_type` - The type of the Instance.
-* `key_name` - The key name of the Instance.
+    * `virtual_name` - Virtual device name.
+* `host_id` - ID of the dedicated host the instance will be assigned to.
+* `host_resource_group_arn` - ARN of the host resource group the instance is associated with.
+* `iam_instance_profile` - Name of the instance profile associated with the Instance.
+* `instance_state` - State of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`. See [Instance Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html) for more information.
+* `instance_type` - Type of the Instance.
+* `ipv6_addresses` - IPv6 addresses associated to the Instance, if applicable. **NOTE**: Unlike the IPv4 address, this doesn't change if you attach an EIP to the instance.
+* `key_name` - Key name of the Instance.
+* `maintenance_options` - Maintenance and recovery options for the instance.
+    * `auto_recovery` - Automatic recovery behavior of the instance.
+* `metadata_options` - Metadata options of the Instance.
+    * `http_endpoint` - State of the metadata service: `enabled`, `disabled`.
+    * `http_tokens` - If session tokens are required: `optional`, `required`.
+    * `http_put_response_hop_limit` - Desired HTTP PUT response hop limit for instance metadata requests.
+    * `instance_metadata_tags` - If access to instance tags is allowed from the metadata service: `enabled`, `disabled`.
 * `monitoring` - Whether detailed monitoring is enabled or disabled for the Instance (Boolean).
-* `network_interface_id` - The ID of the network interface that was created with the Instance.
-* `password_data` - Base-64 encoded encrypted password data for the instance.
-  Useful for getting the administrator password for instances running Microsoft Windows.
-  This attribute is only exported if `get_password_data` is true.
-  See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
-* `placement_group` - The placement group of the Instance.
-* `placement_partition_number` - The number of the partition the instance is in.
-* `private_dns` - The private DNS name assigned to the Instance. Can only be
-  used inside the Amazon EC2, and only available if you've enabled DNS hostnames
-  for your VPC.
-* `private_dns_name_options` - The options for the instance hostname.
+* `network_interface_id` - ID of the network interface that was created with the Instance.
+* `outpost_arn` - ARN of the Outpost.
+* `password_data` - Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
+* `placement_group` - Placement group of the Instance.
+* `placement_partition_number` - Number of the partition the instance is in.
+* `private_dns` - Private DNS name assigned to the Instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC.
+* `private_dns_name_options` - Options for the instance hostname.
     * `enable_resource_name_dns_aaaa_record` - Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.
     * `enable_resource_name_dns_a_record` - Indicates whether to respond to DNS queries for instance hostnames with DNS A records.
-    * `hostname_type` - The type of hostname for EC2 instances.
-* `private_ip` - The private IP address assigned to the Instance.
-* `secondary_private_ips` - The secondary private IPv4 addresses assigned to the instance's primary network interface (eth0) in a VPC.
-* `public_dns` - The public DNS name assigned to the Instance. For EC2-VPC, this
-  is only available if you've enabled DNS hostnames for your VPC.
-* `public_ip` - The public IP address assigned to the Instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
-* `root_block_device` - The root block device mappings of the Instance
-    * `device_name` - The physical name of the device.
+    * `hostname_type` - Type of hostname for EC2 instances.
+* `private_ip` - Private IP address assigned to the Instance.
+* `public_dns` - Public DNS name assigned to the Instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
+* `public_ip` - Public IP address assigned to the Instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
+* `root_block_device` - Root block device mappings of the Instance
+    * `device_name` - Physical name of the device.
     * `delete_on_termination` - If the root block device will be deleted on termination.
     * `encrypted` - If the EBS volume is encrypted.
     * `iops` - `0` If the volume is not a provisioned IOPS image, otherwise the supported IOPS count.
-    * `kms_key_arn` - Amazon Resource Name (ARN) of KMS Key, if EBS volume is encrypted.
-    * `throughput` - The throughput of the volume, in MiB/s.
-    * `volume_size` - The size of the volume, in GiB.
-    * `volume_type` - The type of the volume.
-* `security_groups` - The associated security groups.
+    * `kms_key_arn` - ARN of KMS Key, if EBS volume is encrypted.
+    * `throughput` - Throughput of the volume, in MiB/s.
+    * `volume_size` - Size of the volume, in GiB.
+    * `volume_type` - Type of the volume.
+* `secondary_private_ips` - Secondary private IPv4 addresses assigned to the instance's primary network interface (eth0) in a VPC.
+* `security_groups` - Associated security groups.
 * `source_dest_check` - Whether the network interface performs source/destination checking (Boolean).
-* `subnet_id` - The VPC subnet ID.
-* `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.
+* `subnet_id` - VPC subnet ID.
+* `tags` - Map of tags assigned to the Instance.
+* `tenancy` - Tenancy of the instance: `dedicated`, `default`, `host`.
 * `user_data` - SHA-1 hash of User Data supplied to the Instance.
 * `user_data_base64` - Base64 encoded contents of User Data supplied to the Instance. Valid UTF-8 contents can be decoded with the [`base64decode` function](https://www.terraform.io/docs/configuration/functions/base64decode.html). This attribute is only exported if `get_user_data` is true.
-* `tags` - A map of tags assigned to the Instance.
-* `tenancy` - The tenancy of the instance: `dedicated`, `default`, `host`.
-* `host_id` - The Id of the dedicated host the instance will be assigned to.
-* `vpc_security_group_ids` - The associated security groups in a non-default VPC.
-* `credit_specification` - The credit specification of the Instance.
-* `metadata_options` - The metadata options of the Instance.
-    * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
-    * `http_tokens` - If session tokens are required: `optional`, `required`.
-    * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
-    * `instance_metadata_tags` - If access to instance tags is allowed from the metadata service: `enabled`, `disabled`.
-* `enclave_options` - The enclave options of the instance.
-    * `enabled` - Whether Nitro Enclaves are enabled.
-* `maintenance_options` - The maintenance and recovery options for the instance.
-    * `auto_recovery` - The automatic recovery behavior of the instance.
+* `vpc_security_group_ids` - Associated security groups in a non-default VPC.
 
 ## Timeouts
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -12,7 +12,7 @@ Provides an EC2 instance resource. This allows instances to be created, updated,
 
 ## Example Usage
 
-### Basic Example Using AMI Lookup
+### Basic example using AMI lookup
 
 ```terraform
 data "aws_ami" "ubuntu" {
@@ -41,7 +41,7 @@ resource "aws_instance" "web" {
 }
 ```
 
-### Network and Credit Specification Example
+### Network and credit specification example
 
 ```terraform
 resource "aws_vpc" "my_vpc" {
@@ -86,6 +86,21 @@ resource "aws_instance" "foo" {
 }
 ```
 
+### Host resource group or Licence Manager registered AMI example
+
+A host resource group is a collection of Dedicated Hosts that you can manage as a single entity. As you launch instances, License Manager allocates the hosts and launches instances on them based on the settings that you configured. You can add existing Dedicated Hosts to a host resource group and take advantage of automated host management through License Manager.
+
+-> **NOTE:** A dedicated host is automatically associated with a License Manager host resource group if **Allocate hosts automatically** is enabled. Otherwise, use the `host_resource_group_arn` argument to explicitly associate the instance with the host resource group.
+
+```
+resource "aws_instance" "this" {
+  ami                       = "ami-0dcc1e21636832c5d"
+  instance_type             = "m5.large"
+  host_resource_group_arn   = "arn:aws:resource-groups:us-west-2:012345678901:group/win-testhost"
+  tenancy                   = "host"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -110,40 +125,41 @@ The following arguments are supported:
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
 * `hibernation` - (Optional) If true, the launched EC2 instance will support hibernation.
 * `host_id` - (Optional) ID of a dedicated host that the instance will be assigned to. Use when an instance is to be launched on a specific dedicated host.
+* `host_resource_group_arn` - (Optional) ARN of the host resource group in which to launch the instances. If you specify an ARN, omit the `tenancy` parameter or set it to `host`.
 * `iam_instance_profile` - (Optional) IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. Ensure your credentials have the correct permission to assign the instance profile according to the [EC2 documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-permissions), notably `iam:PassRole`.
 * `instance_initiated_shutdown_behavior` - (Optional) Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
-* `instance_type` - (Optional) The instance type to use for the instance. Updates to this field will trigger a stop/start of the EC2 instance.
-* `ipv6_address_count`- (Optional) A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet.
+* `instance_type` - (Optional) Instance type to use for the instance. Updates to this field will trigger a stop/start of the EC2 instance.
+* `ipv6_address_count`- (Optional) Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet.
 * `ipv6_addresses` - (Optional) Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface
 * `key_name` - (Optional) Key name of the Key Pair to use for the instance; which can be managed using [the `aws_key_pair` resource](key_pair.html).
 * `launch_template` - (Optional) Specifies a Launch Template to configure the instance. Parameters configured on this resource will override the corresponding parameters in the Launch Template.
   See [Launch Template Specification](#launch-template-specification) below for more details.
-* `maintenance_options` - (Optional) The maintenance and recovery options for the instance. See [Maintenance Options](#maintenance-options) below for more details.
+* `maintenance_options` - (Optional) Maintenance and recovery options for the instance. See [Maintenance Options](#maintenance-options) below for more details.
 * `metadata_options` - (Optional) Customize the metadata options of the instance. See [Metadata Options](#metadata-options) below for more details.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)
 * `network_interface` - (Optional) Customize network interfaces to be attached at instance boot time. See [Network Interfaces](#network-interfaces) below for more details.
 * `placement_group` - (Optional) Placement Group to start the instance in.
-* `placement_partition_number` - (Optional) The number of the partition the instance is in. Valid only if [the `aws_placement_group` resource's](placement_group.html) `strategy` argument is set to `"partition"`.
-* `private_dns_name_options` - (Optional) The options for the instance hostname. The default values are inherited from the subnet. See [Private DNS Name Options](#private-dns-name-options) below for more details.
+* `placement_partition_number` - (Optional) Number of the partition the instance is in. Valid only if [the `aws_placement_group` resource's](placement_group.html) `strategy` argument is set to `"partition"`.
+* `private_dns_name_options` - (Optional) Options for the instance hostname. The default values are inherited from the subnet. See [Private DNS Name Options](#private-dns-name-options) below for more details.
 * `private_ip` - (Optional) Private IP address to associate with the instance in a VPC.
 * `root_block_device` - (Optional) Configuration block to customize details about the root block device of the instance. See [Block Devices](#ebs-ephemeral-and-root-block-devices) below for details. When accessing this as an attribute reference, it is a list containing one object.
-* `secondary_private_ips` - (Optional) A list of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e., referenced in a `network_interface` block. Refer to the [Elastic network interfaces documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) to see the maximum number of private IP addresses allowed per instance type.
-* `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names to associate with.
+* `secondary_private_ips` - (Optional) List of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e., referenced in a `network_interface` block. Refer to the [Elastic network interfaces documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) to see the maximum number of private IP addresses allowed per instance type.
+* `security_groups` - (Optional, EC2-Classic and default VPC only) List of security group names to associate with.
 
 -> **NOTE:** If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 
 * `source_dest_check` - (Optional) Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs. Defaults true.
 * `subnet_id` - (Optional) VPC Subnet ID to launch in.
-* `tags` - (Optional) A map of tags to assign to the resource. Note that these tags apply to the instance and not block storage devices. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `tenancy` - (Optional) Tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
+* `tags` - (Optional) Map of tags to assign to the resource. Note that these tags apply to the instance and not block storage devices. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tenancy` - (Optional) Tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of `dedicated` runs on single-tenant hardware. The `host` tenancy is not supported for the import-instance command. Valid values are `default`, `dedicated`, and `host`.
 * `user_data` - (Optional) User data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see `user_data_base64` instead. Updates to this field will trigger a stop/start of the EC2 instance by default. If the `user_data_replace_on_change` is set then updates to this field will trigger a destroy and recreate.
 * `user_data_base64` - (Optional) Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. Updates to this field will trigger a stop/start of the EC2 instance by default. If the `user_data_replace_on_change` is set then updates to this field will trigger a destroy and recreate.
 * `user_data_replace_on_change` - (Optional) When used in combination with `user_data` or `user_data_base64` will trigger a destroy and recreate when set to `true`. Defaults to `false` if not set.
-* `volume_tags` - (Optional) A map of tags to assign, at instance-creation time, to root and EBS volumes.
+* `volume_tags` - (Optional) Map of tags to assign, at instance-creation time, to root and EBS volumes.
 
 ~> **NOTE:** Do not use `volume_tags` if you plan to manage block device tags outside the `aws_instance` configuration, such as using `tags` in an [`aws_ebs_volume`](/docs/providers/aws/r/ebs_volume.html) resource attached via [`aws_volume_attachment`](/docs/providers/aws/r/volume_attachment.html). Doing so will result in resource cycling and inconsistent behavior.
 
-* `vpc_security_group_ids` - (Optional, VPC only) A list of security group IDs to associate with.
+* `vpc_security_group_ids` - (Optional, VPC only) List of security group IDs to associate with.
 
 ### Capacity Reservation Specification
 
@@ -166,8 +182,8 @@ Describes a target Capacity Reservation.
 
 This `capacity_reservation_target` block supports the following:
 
-* `capacity_reservation_id` - (Optional) The ID of the Capacity Reservation in which to run the instance.
-* `capacity_reservation_resource_group_arn` - (Optional) The ARN of the Capacity Reservation resource group in which to run the instance.
+* `capacity_reservation_id` - (Optional) ID of the Capacity Reservation in which to run the instance.
+* `capacity_reservation_resource_group_arn` - (Optional) ARN of the Capacity Reservation resource group in which to run the instance.
 
 ### Credit Specification
 
@@ -185,7 +201,7 @@ The `root_block_device` block supports the following:
 * `encrypted` - (Optional) Whether to enable volume encryption. Defaults to `false`. Must be configured to perform drift detection.
 * `iops` - (Optional) Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). Only valid for volume_type of `io1`, `io2` or `gp3`.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use when encrypting the volume. Must be configured to perform drift detection.
-* `tags` - (Optional) A map of tags to assign to the device.
+* `tags` - (Optional) Map of tags to assign to the device.
 * `throughput` - (Optional) Throughput to provision for a volume in mebibytes per second (MiB/s). This is only valid for `volume_type` of `gp3`.
 * `volume_size` - (Optional) Size of the volume in gibibytes (GiB).
 * `volume_type` - (Optional) Type of volume. Valid values include `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1`, or `st1`. Defaults to `gp2`.
@@ -200,7 +216,7 @@ Each `ebs_block_device` block supports the following:
 * `iops` - (Optional) Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). Only valid for volume_type of `io1`, `io2` or `gp3`.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use when encrypting the volume. Must be configured to perform drift detection.
 * `snapshot_id` - (Optional) Snapshot ID to mount.
-* `tags` - (Optional) A map of tags to assign to the device.
+* `tags` - (Optional) Map of tags to assign to the device.
 * `throughput` - (Optional) Throughput to provision for a volume in mebibytes per second (MiB/s). This is only valid for `volume_type` of `gp3`.
 * `volume_size` - (Optional) Size of the volume in gibibytes (GiB).
 * `volume_type` - (Optional) Type of volume. Valid values include `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1`, or `st1`. Defaults to `gp2`.
@@ -209,7 +225,7 @@ Each `ebs_block_device` block supports the following:
 
 Each `ephemeral_block_device` block supports the following:
 
-* `device_name` - The name of the block device to mount on the instance.
+* `device_name` - Name of the block device to mount on the instance.
 * `no_device` - (Optional) Suppresses the specified device included in the AMI's block device mapping.
 * `virtual_name` - (Optional) [Instance Store Device Name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) (e.g., `ephemeral0`).
 
@@ -231,7 +247,7 @@ For more information, see the documentation on [Nitro Enclaves](https://docs.aws
 
 The `maintenance_options` block supports the following:
 
-* `auto_recovery` - (Optional) The automatic recovery behavior of the Instance. Can be `"default"` or `"disabled"`. See [Recover your instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-recover.html) for more details.
+* `auto_recovery` - (Optional) Automatic recovery behavior of the Instance. Can be `"default"` or `"disabled"`. See [Recover your instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-recover.html) for more details.
 
 ### Metadata Options
 
@@ -265,7 +281,7 @@ The `private_dns_name_options` block supports the following:
 
 * `enable_resource_name_dns_aaaa_record` - Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.
 * `enable_resource_name_dns_a_record` - Indicates whether to respond to DNS queries for instance hostnames with DNS A records.
-* `hostname_type` - The type of hostname for Amazon EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 native subnets, an instance DNS name must be based on the instance ID. For dual-stack subnets, you can specify whether DNS names use the instance IPv4 address or the instance ID. Valid values: `ip-name` and `resource-name`.
+* `hostname_type` - Type of hostname for Amazon EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 native subnets, an instance DNS name must be based on the instance ID. For dual-stack subnets, you can specify whether DNS names use the instance IPv4 address or the instance ID. Valid values: `ip-name` and `resource-name`.
 
 ### Launch Template Specification
 
@@ -276,24 +292,24 @@ Any other instance parameters that you specify will override the same parameters
 
 The `launch_template` block supports the following:
 
-* `id` - The ID of the launch template. Conflicts with `name`.
-* `name` - The name of the launch template. Conflicts with `id`.
+* `id` - ID of the launch template. Conflicts with `name`.
+* `name` - Name of the launch template. Conflicts with `id`.
 * `version` - Template version. Can be a specific version number, `$Latest` or `$Default`. The default value is `$Default`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the instance.
+* `arn` - ARN of the instance.
 * `capacity_reservation_specification` - Capacity reservation specification of the instance.
-* `instance_state` - The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`. See [Instance Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html) for more information.
-* `outpost_arn` - The ARN of the Outpost the instance is assigned to.
+* `instance_state` - State of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`. See [Instance Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html) for more information.
+* `outpost_arn` - ARN of the Outpost the instance is assigned to.
 * `password_data` - Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true. Note that this encrypted value will be stored in the state file, as with all exported attributes. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
-* `primary_network_interface_id` - The ID of the instance's primary network interface.
-* `private_dns` - The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC.
-* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
-* `public_ip` - The public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `primary_network_interface_id` - ID of the instance's primary network interface.
+* `private_dns` - Private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC.
+* `public_dns` - Public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
+* `public_ip` - Public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 For `ebs_block_device`, in addition to the arguments above, the following attribute is exported:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16995.
Closes #17282.
Supersedes https://github.com/hashicorp/terraform-provider-aws/pull/17282. 

**NOTE:** We cannot easily test this solution. We have determined that it does not seem to cause any regressions and should work. However, this is best-effort functionality. We would love to hear from you if you use this functionality and it does or doesn't work.

The crux of the problem noted by op in #16995 resulted from `ec2.RunInstanceInput.Placement.GroupName` always being set in API calls, even if to an empty string, if instance interruption behavior was not set or set to terminate, regardless whether `placement_group` was configured. `ec2.RunInstanceInput.Placement.GroupName` cannot be set if launching in a (dedicated) host resource group. Even though the `host_resource_group_arn` argument is added in this PR, the association could previously be done implicitly based on the AMI ID and the host resource group being set to "Allocate hosts automatically."

Now, `placement_group` and `host_resource_group_arn` cannot both be set and `ec2.RunInstanceInput.Placement.GroupName` is not defined if `placement_group` is not configured.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccEC2Instance_ PKG=ec2       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_'  -timeout 180m
--- PASS: TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable (139.08s)
--- PASS: TestAccEC2Instance_LaunchTemplate_overrideTemplate (142.13s)
--- PASS: TestAccEC2Instance_LaunchTemplate_spotAndStop (145.67s)
--- PASS: TestAccEC2Instance_basic (159.10s)
--- PASS: TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard (185.58s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (187.68s)
--- PASS: TestAccEC2Instance_LaunchTemplate_setSpecificVersion (204.65s)
--- PASS: TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion (207.14s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable (208.01s)
--- PASS: TestAccEC2Instance_LaunchTemplate_swapIDAndName (208.39s)
--- PASS: TestAccEC2Instance_CreditSpecification_standardCPUCredits (208.55s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination (211.56s)
--- PASS: TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits (215.94s)
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (220.58s)
--- PASS: TestAccEC2Instance_LaunchTemplate_updateTemplateVersion (232.31s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyTarget (243.06s)
--- PASS: TestAccEC2Instance_GetPasswordData_trueToFalse (245.37s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (261.30s)
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (119.98s)
--- PASS: TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices (262.24s)
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (130.49s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePrivate (152.86s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePublic (140.12s)
--- PASS: TestAccEC2Instance_rootBlockDeviceMismatch (300.90s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_open (117.93s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_none (129.95s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPrivate (152.35s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPublic (154.13s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPublic (152.96s)
--- PASS: TestAccEC2Instance_metadataOptions (158.64s)
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (171.00s)
--- PASS: TestAccEC2Instance_UserData_emptyStringToUnspecified (174.76s)
--- PASS: TestAccEC2Instance_UserData_unspecifiedToEmptyString (184.94s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPrivate (147.55s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64 (229.64s)
--- PASS: TestAccEC2Instance_hibernation (243.53s)
--- PASS: TestAccEC2Instance_enclaveOptions (263.34s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off (248.29s)
--- PASS: TestAccEC2Instance_UserData (144.27s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize (186.45s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs (164.06s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On (255.71s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination (151.18s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate (208.73s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On_Base64 (281.33s)
--- PASS: TestAccEC2Instance_UserData_stringToEncodedString (263.27s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyAll (192.82s)
--- PASS: TestAccEC2Instance_UserData_update (266.26s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs (117.67s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3 (199.86s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate (247.79s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2 (211.15s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits (143.32s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1 (179.42s)
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (135.81s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyType (185.69s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits (162.42s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifySize (179.11s)
--- PASS: TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable (131.22s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g (114.56s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited (143.96s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3a (109.24s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits (237.73s)
--- PASS: TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint (274.19s)
--- PASS: TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck (152.39s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint (280.01s)
--- PASS: TestAccEC2Instance_networkCardIndex (139.69s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs (245.41s)
--- PASS: TestAccEC2Instance_gp3RootBlockDevice (99.12s)
--- PASS: TestAccEC2Instance_primaryNetworkInterface (120.64s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3 (135.79s)
--- PASS: TestAccEC2Instance_CreditSpecification_updateCPUCredits (236.15s)
--- PASS: TestAccEC2Instance_keyPairCheck (119.31s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2 (146.83s)
--- PASS: TestAccEC2Instance_gp2WithIopsValue (16.46s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (158.74s)
--- PASS: TestAccEC2Instance_Empty_privateIP (140.00s)
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserDataBase64 (337.74s)
--- PASS: TestAccEC2Instance_associatePublicIPAndPrivateIP (142.79s)
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (2.02s)
--- PASS: TestAccEC2Instance_PrivateDNSNameOptions_configured (179.74s)
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccEC2Instance_outpost (0.61s)
--- PASS: TestAccEC2Instance_changeInstanceType (225.93s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (141.13s)
--- PASS: TestAccEC2Instance_privateIP (154.13s)
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (239.09s)
--- PASS: TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs (142.62s)
--- PASS: TestAccEC2Instance_disableAPITerminationFinalTrue (129.54s)
--- PASS: TestAccEC2Instance_PrivateDNSNameOptions_computed (203.84s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (19.20s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (194.12s)
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserData (280.37s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (20.51s)
--- PASS: TestAccEC2Instance_addSecurityGroupNetworkInterface (453.36s)
--- PASS: TestAccEC2Instance_networkInstanceSecurityGroups (152.43s)
--- PASS: TestAccEC2Instance_addSecondaryInterface (451.97s)
--- PASS: TestAccEC2Instance_placementGroup (100.75s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (237.89s)
--- PASS: TestAccEC2Instance_disableAPITerminationFinalFalse (186.81s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_withAttachedVolume (263.99s)
--- PASS: TestAccEC2Instance_dedicatedInstance (122.64s)
--- PASS: TestAccEC2Instance_placementPartitionNumber (119.30s)
--- PASS: TestAccEC2Instance_blockDevices (109.04s)
--- PASS: TestAccEC2Instance_rootInstanceStore (120.09s)
--- PASS: TestAccEC2Instance_autoRecovery (177.58s)
--- PASS: TestAccEC2Instance_noAMIEphemeralDevices (133.10s)
--- PASS: TestAccEC2Instance_instanceProfileChange (318.10s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_kmsKeyARN (118.28s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (156.39s)
--- PASS: TestAccEC2Instance_disableAPIStop (197.36s)
--- PASS: TestAccEC2Instance_gp2IopsDevice (103.28s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgID (144.32s)
--- PASS: TestAccEC2Instance_userDataBase64 (132.47s)
--- PASS: TestAccEC2Instance_sourceDestCheck (225.37s)
--- PASS: TestAccEC2Instance_RootBlockDevice_kmsKeyARN (128.45s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgName (135.37s)
--- PASS: TestAccEC2Instance_tags (197.66s)
--- PASS: TestAccEC2Instance_atLeastOneOtherEBSVolume (229.72s)
--- PASS: TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups (155.67s)
--- PASS: TestAccEC2Instance_userDataBase64_updateWithBashFile (239.47s)
--- PASS: TestAccEC2Instance_userDataBase64_updateWithZipFile (221.96s)
--- PASS: TestAccEC2Instance_userDataBase64_update (261.46s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed (263.74s)
--- PASS: TestAccEC2Instance_disappears (330.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1372.987s
% make testacc TESTS=TestAccEC2InstanceDataSource_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceDataSource_'  -timeout 180m
--- PASS: TestAccEC2InstanceDataSource_enclaveOptions (106.93s)
--- PASS: TestAccEC2InstanceDataSource_placementGroup (108.88s)
--- PASS: TestAccEC2InstanceDataSource_RootBlockDevice_kmsKeyID (112.87s)
--- PASS: TestAccEC2InstanceDataSource_gp3ThroughputDevice (130.04s)
--- PASS: TestAccEC2InstanceDataSource_blockDevices (132.61s)
--- PASS: TestAccEC2InstanceDataSource_blockDeviceTags (134.91s)
--- PASS: TestAccEC2InstanceDataSource_timeout (138.63s)
--- PASS: TestAccEC2InstanceDataSource_basic (145.44s)
--- PASS: TestAccEC2InstanceDataSource_keyPair (148.82s)
--- PASS: TestAccEC2InstanceDataSource_rootInstanceStore (150.13s)
--- PASS: TestAccEC2InstanceDataSource_vpc (155.16s)
--- PASS: TestAccEC2InstanceDataSource_creditSpecification (155.91s)
--- PASS: TestAccEC2InstanceDataSource_secondaryPrivateIPs (156.60s)
--- PASS: TestAccEC2InstanceDataSource_metadataOptions (160.41s)
--- PASS: TestAccEC2InstanceDataSource_EBSBlockDevice_kmsKeyID (161.87s)
--- PASS: TestAccEC2InstanceDataSource_privateIP (165.21s)
--- PASS: TestAccEC2InstanceDataSource_ipv6Addresses (176.36s)
--- PASS: TestAccEC2InstanceDataSource_disableAPIStopTermination (191.34s)
--- PASS: TestAccEC2InstanceDataSource_autoRecovery (205.62s)
--- PASS: TestAccEC2InstanceDataSource_GetPasswordData_falseToTrue (212.72s)
--- PASS: TestAccEC2InstanceDataSource_securityGroups (112.23s)
--- PASS: TestAccEC2InstanceDataSource_gp2IopsDevice (86.87s)
--- PASS: TestAccEC2InstanceDataSource_vpcSecurityGroups (149.33s)
--- PASS: TestAccEC2InstanceDataSource_tags (125.85s)
--- PASS: TestAccEC2InstanceDataSource_azUserData (146.76s)
--- PASS: TestAccEC2InstanceDataSource_GetPasswordData_trueToFalse (199.72s)
--- PASS: TestAccEC2InstanceDataSource_GetUserData_noUserData (194.06s)
--- PASS: TestAccEC2InstanceDataSource_getUserData (204.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	338.961s
% make testacc TESTS=TestAccEC2InstancesDataSource_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstancesDataSource_'  -timeout 180m
--- PASS: TestAccEC2InstancesDataSource_empty (30.27s)
--- PASS: TestAccEC2InstancesDataSource_instanceStateNames (107.62s)
--- PASS: TestAccEC2InstancesDataSource_timeout (118.17s)
--- PASS: TestAccEC2InstancesDataSource_tags (158.67s)
--- PASS: TestAccEC2InstancesDataSource_basic (129.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	709.139s
```
