### PR TITLE
Correct `scaling_config` and `update_config` values in `aws_eks_node_group` docs

### DIFF
--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -21,12 +21,12 @@ resource "aws_eks_node_group" "example" {
 
   scaling_config {
     desired_size = 1
-    max_size     = 1
+    max_size     = 2
     min_size     = 1
   }
 
   update_config {
-    max_unavailable = 2
+    max_unavailable = 1
   }
 
   # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26535

Output from acceptance testing: N/a, docs

### Information

The way the example was previous set up, the `update_config.max_unavailable` value was greater than the `scaling_config.max_size` value, leading to the following error:

```shell
Error: error creating EKS Node Group (<example>): InvalidParameterException: max-unavailable must be within the range 1 and max size of the node group
```

This PR makes the `max_size` argument greater than the `max_unavailable` to correct this error.