### PR TITLE
vpc/security_group: Fix complex dependency violations

### DIFF
--- a/.changelog/26553.txt
+++ b/.changelog/26553.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_security_group: Fix complex dependency violations such as using a security group with an EMR cluster
+```

--- a/.changelog/26553.txt
+++ b/.changelog/26553.txt
@@ -1,3 +1,15 @@
 ```release-note:bug
 resource/aws_security_group: Fix complex dependency violations such as using a security group with an EMR cluster
 ```
+
+```release-note:note
+resource/aws_security_group: With AWS's retirement of EC2-Classic, `aws_security_group` has been updated to remove support for EC2-Classic
+```
+
+```release-note:note
+resource/aws_default_security_group: With AWS's retirement of EC2-Classic, `aws_default_security_group` has been updated to remove support for EC2-Classic
+```
+
+```release-note:note
+resource/aws_security_group_rule: With AWS's retirement of EC2-Classic, `aws_security_group_rule` has been updated to remove support for EC2-Classic
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,6 +19,11 @@ ifneq ($(origin SWEEPERS), undefined)
 	SWEEPARGS = -sweep-run='$(SWEEPERS)'
 endif
 
+ifeq ($(PKG_NAME), internal/service/vpc)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
 default: build
 
 build: fmtcheck

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,37 @@ ifneq ($(origin SWEEPERS), undefined)
 	SWEEPARGS = -sweep-run='$(SWEEPERS)'
 endif
 
+ifeq ($(PKG_NAME), internal/service/ebs)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
+ifeq ($(PKG_NAME), internal/service/ipam)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
+ifeq ($(PKG_NAME), internal/service/transitgateway)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
 ifeq ($(PKG_NAME), internal/service/vpc)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
+ifeq ($(PKG_NAME), internal/service/vpnclient)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
+ifeq ($(PKG_NAME), internal/service/vpnsite)
+	PKG_NAME = internal/service/ec2
+	TEST = ./$(PKG_NAME)/...
+endif
+
+ifeq ($(PKG_NAME), internal/service/wavelength)
 	PKG_NAME = internal/service/ec2
 	TEST = ./$(PKG_NAME)/...
 endif

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aws/aws-sdk-go v1.44.88 h1:9jhiZsTx9koQQsM29RTgwI0g4mfyphCdc3bkUcKrdwA=
 github.com/aws/aws-sdk-go v1.44.88/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.3/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
-github.com/aws/aws-sdk-go-v2 v1.16.11/go.mod h1:WTACcleLz6VZTp7fak4EO5b9Q4foxbn+8PIz3PmyKlo=
 github.com/aws/aws-sdk-go-v2 v1.16.12 h1:wbMYa2PlFysFx2GLIQojr6FJV5+OWCM/BwyHXARxETA=
 github.com/aws/aws-sdk-go-v2 v1.16.12/go.mod h1:C+Ym0ag2LIghJbXhfXZ0YEEp49rBWowxKzJLUoob0ts=
 github.com/aws/aws-sdk-go-v2/config v1.15.4 h1:P4mesY1hYUxru4f9SU0XxNKXmzfxsD0FtMIPRBjkH7Q=
@@ -34,11 +33,9 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4/go.mod h1:u/s5/Z+ohUQOPXl0
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13 h1:+uferi8SUDZtMloCDt24Zenyy/i71C/ua5mjUCpbpN0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13/go.mod h1:y0eXmsNBFIVjUE8ZBjES8myOHlMsXDz7qGT93+MVdjk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.10/go.mod h1:F+EZtuIwjlv35kRJPyBGcsA4f7bnSoz15zOQ2lJq1Z4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18/go.mod h1:348MLhzV1GSlZSMusdwQpXKbhD7X2gbI/TxwAPKkYZQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19 h1:gC5mudiFrWGhzcdoWj1iCGUfrzCpQG0MQIQf0CXFFQQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19/go.mod h1:llxE6bwUZhuCas0K7qGiu5OgMis3N7kdWtFSxoHmJ7E=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.4/go.mod h1:8glyUqVIM4AmeenIsPo0oVh3+NUwnsQml2OFupfQW+0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.12/go.mod h1:ckaCVTEdGAxO6KwTGzgskxR1xM+iJW4lxMyDFVda2Fc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13 h1:qezY57na06d6kSE7uuB0N7XEflu914AXx/hg2L8Ykcw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13/go.mod h1:lB12mkZqCSo5PsdBFLNqc2M/OOYgNAy8UtaktyuWvE8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 h1:6cZRymlLEIlDTEB0+5+An6Zj1CKt6rSE69tOmFeu1nk=
@@ -64,7 +61,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.4/go.mod h1:lfSYenAXtavyX2A1LsVig
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.5 h1:hYZofZdt2q8hvpM7XV8/gN49ZEd8wf236G66Oo6QW08=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.5/go.mod h1:mmV5KXzUW+R8AMqDFkgX1vJ1th6SiyaghjvqQm3TC8g=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
-github.com/aws/smithy-go v1.12.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.13.0 h1:YfyEmSJLo7fAv8FbuDK4R8F9aAmi9DZ88Zb/KJJmUl0=
 github.com/aws/smithy-go v1.13.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aws/aws-sdk-go v1.44.88 h1:9jhiZsTx9koQQsM29RTgwI0g4mfyphCdc3bkUcKrdwA=
 github.com/aws/aws-sdk-go v1.44.88/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.3/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
+github.com/aws/aws-sdk-go-v2 v1.16.11/go.mod h1:WTACcleLz6VZTp7fak4EO5b9Q4foxbn+8PIz3PmyKlo=
 github.com/aws/aws-sdk-go-v2 v1.16.12 h1:wbMYa2PlFysFx2GLIQojr6FJV5+OWCM/BwyHXARxETA=
 github.com/aws/aws-sdk-go-v2 v1.16.12/go.mod h1:C+Ym0ag2LIghJbXhfXZ0YEEp49rBWowxKzJLUoob0ts=
 github.com/aws/aws-sdk-go-v2/config v1.15.4 h1:P4mesY1hYUxru4f9SU0XxNKXmzfxsD0FtMIPRBjkH7Q=
@@ -33,9 +34,11 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4/go.mod h1:u/s5/Z+ohUQOPXl0
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13 h1:+uferi8SUDZtMloCDt24Zenyy/i71C/ua5mjUCpbpN0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13/go.mod h1:y0eXmsNBFIVjUE8ZBjES8myOHlMsXDz7qGT93+MVdjk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.10/go.mod h1:F+EZtuIwjlv35kRJPyBGcsA4f7bnSoz15zOQ2lJq1Z4=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18/go.mod h1:348MLhzV1GSlZSMusdwQpXKbhD7X2gbI/TxwAPKkYZQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19 h1:gC5mudiFrWGhzcdoWj1iCGUfrzCpQG0MQIQf0CXFFQQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19/go.mod h1:llxE6bwUZhuCas0K7qGiu5OgMis3N7kdWtFSxoHmJ7E=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.4/go.mod h1:8glyUqVIM4AmeenIsPo0oVh3+NUwnsQml2OFupfQW+0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.12/go.mod h1:ckaCVTEdGAxO6KwTGzgskxR1xM+iJW4lxMyDFVda2Fc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13 h1:qezY57na06d6kSE7uuB0N7XEflu914AXx/hg2L8Ykcw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13/go.mod h1:lB12mkZqCSo5PsdBFLNqc2M/OOYgNAy8UtaktyuWvE8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 h1:6cZRymlLEIlDTEB0+5+An6Zj1CKt6rSE69tOmFeu1nk=
@@ -61,6 +64,7 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.4/go.mod h1:lfSYenAXtavyX2A1LsVig
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.5 h1:hYZofZdt2q8hvpM7XV8/gN49ZEd8wf236G66Oo6QW08=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.5/go.mod h1:mmV5KXzUW+R8AMqDFkgX1vJ1th6SiyaghjvqQm3TC8g=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
+github.com/aws/smithy-go v1.12.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.13.0 h1:YfyEmSJLo7fAv8FbuDK4R8F9aAmi9DZ88Zb/KJJmUl0=
 github.com/aws/smithy-go v1.13.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -64,6 +64,7 @@ const (
 	errCodeInvalidRouteTableIDNotFound                    = "InvalidRouteTableID.NotFound"
 	errCodeInvalidRouteTableIdNotFound                    = "InvalidRouteTableId.NotFound"
 	errCodeInvalidSecurityGroupIDNotFound                 = "InvalidSecurityGroupID.NotFound"
+	errCodeInvalidSecurityGroupRuleIDNotFound             = "InvalidSecurityGroupRuleId.NotFound"
 	errCodeInvalidServiceName                             = "InvalidServiceName"
 	errCodeInvalidSnapshotInUse                           = "InvalidSnapshot.InUse"
 	errCodeInvalidSnapshotNotFound                        = "InvalidSnapshot.NotFound"

--- a/internal/service/ec2/vpc_default_security_group.go
+++ b/internal/service/ec2/vpc_default_security_group.go
@@ -117,7 +117,7 @@ func resourceDefaultSecurityGroupCreate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if err := forceRevokeSecurityGroupRules(d, meta, false); err != nil {
+	if err := forceRevokeSecurityGroupRules(conn, d.Id(), false); err != nil {
 		return err
 	}
 

--- a/internal/service/ec2/vpc_default_security_group.go
+++ b/internal/service/ec2/vpc_default_security_group.go
@@ -117,7 +117,7 @@ func resourceDefaultSecurityGroupCreate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if err := forceRevokeSecurityGroupRules(conn, d.Id()); err != nil {
+	if err := forceRevokeSecurityGroupRules(d, meta, false); err != nil {
 		return err
 	}
 

--- a/internal/service/ec2/vpc_default_security_group_test.go
+++ b/internal/service/ec2/vpc_default_security_group_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccVPCDefaultSecurityGroup_VPC_basic(t *testing.T) {
+func TestAccVPCDefaultSecurityGroup_basic(t *testing.T) {
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_default_security_group.test"
@@ -66,7 +66,7 @@ func TestAccVPCDefaultSecurityGroup_VPC_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCDefaultSecurityGroup_VPC_empty(t *testing.T) {
+func TestAccVPCDefaultSecurityGroup_empty(t *testing.T) {
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_default_security_group.test"
@@ -97,100 +97,9 @@ func TestAccVPCDefaultSecurityGroup_VPC_empty(t *testing.T) {
 	})
 }
 
-func TestAccVPCDefaultSecurityGroup_Classic_serial(t *testing.T) {
-	testCases := map[string]func(t *testing.T){
-		"basic": testAccVPCDefaultSecurityGroup_Classic_basic,
-		"empty": testAccVPCDefaultSecurityGroup_Classic_empty,
-	}
-
-	for name, tc := range testCases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			tc(t)
-		})
-	}
-}
-
-func testAccVPCDefaultSecurityGroup_Classic_basic(t *testing.T) {
-	var group ec2.SecurityGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_default_security_group.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckEC2Classic(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             acctest.CheckDestroyNoop,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVPCDefaultSecurityGroupConfig_classic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSecurityGroupEC2ClassicExists(resourceName, &group),
-					resource.TestCheckResourceAttr(resourceName, "name", "default"),
-					resource.TestCheckResourceAttr(resourceName, "description", "default group"),
-					resource.TestCheckResourceAttr(resourceName, "vpc_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "ingress.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
-						"protocol":      "tcp",
-						"from_port":     "80",
-						"to_port":       "8000",
-						"cidr_blocks.#": "1",
-						"cidr_blocks.0": "10.0.0.0/8",
-					}),
-					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
-					testAccCheckDefaultSecurityGroupARNClassic(resourceName, &group),
-					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-				),
-			},
-			{
-				Config:   testAccVPCDefaultSecurityGroupConfig_classic(rName),
-				PlanOnly: true,
-			},
-			{
-				Config:                  testAccVPCDefaultSecurityGroupConfig_classic(rName),
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
-			},
-		},
-	})
-}
-
-func testAccVPCDefaultSecurityGroup_Classic_empty(t *testing.T) {
-	var group ec2.SecurityGroup
-	resourceName := "aws_default_security_group.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckEC2Classic(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             acctest.CheckDestroyNoop,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVPCDefaultSecurityGroupConfig_classicEmpty(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSecurityGroupEC2ClassicExists(resourceName, &group),
-					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckDefaultSecurityGroupARN(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
-	}
-}
-
-func testAccCheckDefaultSecurityGroupARNClassic(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return acctest.CheckResourceAttrRegionalARNEC2Classic(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
 	}
 }
 
@@ -242,28 +151,4 @@ resource "aws_default_security_group" "test" {
   }
 }
 `, rName)
-}
-
-func testAccVPCDefaultSecurityGroupConfig_classic(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigEC2ClassicRegionProvider(), fmt.Sprintf(`
-resource "aws_default_security_group" "test" {
-  ingress {
-    protocol    = "6"
-    from_port   = 80
-    to_port     = 8000
-    cidr_blocks = ["10.0.0.0/8"]
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName))
-}
-
-func testAccVPCDefaultSecurityGroupConfig_classicEmpty() string {
-	return acctest.ConfigCompose(acctest.ConfigEC2ClassicRegionProvider(), `
-resource "aws_default_security_group" "test" {
-  # No attributes set.
-}`)
 }

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -23,6 +23,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceSecurityGroup() *schema.Resource {
@@ -377,7 +378,7 @@ func resourceSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if err != nil {
-			return err
+			return create.Error(names.EC2, create.ErrActionDeleting, "Security Group", d.Id(), err)
 		}
 	}
 
@@ -401,7 +402,7 @@ func resourceSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error
 			}
 
 			if err != nil {
-				return err
+				return create.Error(names.EC2, create.ErrActionDeleting, "Security Group", d.Id(), err)
 			}
 		}
 
@@ -755,13 +756,13 @@ func updateSecurityGroupRules(conn *ec2.EC2, d *schema.ResourceData, ruleType st
 	del, err := ExpandIPPerms(group, SecurityGroupCollapseRules(ruleType, os.Difference(ns).List()))
 
 	if err != nil {
-		return err
+		return fmt.Errorf("updating rules: %w", err)
 	}
 
 	add, err := ExpandIPPerms(group, SecurityGroupCollapseRules(ruleType, ns.Difference(os).List()))
 
 	if err != nil {
-		return err
+		return fmt.Errorf("updating rules: %w", err)
 	}
 
 	// TODO: We need to handle partial state better in the in-between

--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -155,7 +155,7 @@ func resourceSecurityGroupRuleCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("reading Security Group (%s): %w", securityGroupID, err)
 	}
 
-	ipPermission := expandIpPermission(d, sg)
+	ipPermission := expandIPPermission(d, sg)
 	ruleType := d.Get("type").(string)
 	isVPC := aws.StringValue(sg.VpcId) != ""
 	id := SecurityGroupRuleCreateID(securityGroupID, ruleType, ipPermission)
@@ -245,7 +245,7 @@ func resourceSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("reading Security Group (%s): %w", securityGroupID, err)
 	}
 
-	ipPermission := expandIpPermission(d, sg)
+	ipPermission := expandIPPermission(d, sg)
 	isVPC := aws.StringValue(sg.VpcId) != ""
 
 	var rules []*ec2.IpPermission
@@ -297,7 +297,7 @@ func resourceSecurityGroupRuleUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("reading Security Group (%s): %w", securityGroupID, err)
 		}
 
-		ipPermission := expandIpPermission(d, sg)
+		ipPermission := expandIPPermission(d, sg)
 		ruleType := d.Get("type").(string)
 		isVPC := aws.StringValue(sg.VpcId) != ""
 
@@ -345,7 +345,7 @@ func resourceSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("reading Security Group (%s): %w", securityGroupID, err)
 	}
 
-	ipPermission := expandIpPermission(d, sg)
+	ipPermission := expandIPPermission(d, sg)
 	ruleType := d.Get("type").(string)
 	isVPC := aws.StringValue(sg.VpcId) != ""
 
@@ -688,7 +688,7 @@ func SecurityGroupRuleCreateID(securityGroupID, ruleType string, ip *ec2.IpPermi
 	return fmt.Sprintf("sgrule-%d", create.StringHashcode(buf.String()))
 }
 
-func expandIpPermission(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IpPermission { // nosemgrep:ci.caps5-in-func-name
+func expandIPPermission(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IpPermission { // nosemgrep:ci.caps5-in-func-name
 	apiObject := &ec2.IpPermission{
 		IpProtocol: aws.String(ProtocolForValue(d.Get("protocol").(string))),
 	}

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -302,46 +302,6 @@ func TestAccVPCSecurityGroupRule_Ingress_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccVPCSecurityGroupRule_Ingress_classic(t *testing.T) {
-	var group ec2.SecurityGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_security_group_rule.test"
-	sgResourceName := "aws_security_group.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckEC2Classic(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSecurityGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVPCSecurityGroupRuleConfig_ingressClassic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSecurityGroupEC2ClassicExists(sgResourceName, &group),
-					resource.TestCheckResourceAttr(resourceName, "cidr_blocks.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cidr_blocks.0", "10.0.0.0/8"),
-					resource.TestCheckNoResourceAttr(resourceName, "description"),
-					resource.TestCheckResourceAttr(resourceName, "from_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_blocks.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "prefix_list_ids.#", "0"),
-					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", sgResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "self", "false"),
-					resource.TestCheckNoResourceAttr(resourceName, "source_security_group_id"),
-					resource.TestCheckResourceAttr(resourceName, "to_port", "8000"),
-					resource.TestCheckResourceAttr(resourceName, "type", "ingress"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccSecurityGroupRuleImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccVPCSecurityGroupRule_egress(t *testing.T) {
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1675,28 +1635,6 @@ resource "aws_security_group_rule" "test" {
   self              = true
 }
 `, rName)
-}
-
-func testAccVPCSecurityGroupRuleConfig_ingressClassic(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigEC2ClassicRegionProvider(), fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  name = %[1]q
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_security_group_rule" "test" {
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 80
-  to_port     = 8000
-  cidr_blocks = ["10.0.0.0/8"]
-
-  security_group_id = aws_security_group.test.id
-}
-`, rName))
 }
 
 func testAccVPCSecurityGroupRuleConfig_egress(rName string) string {

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -2,8 +2,6 @@ package ec2_test
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -2439,28 +2437,6 @@ func testAccCheckSecurityGroupRuleLimit(n string, v *int) resource.TestCheckFunc
 
 		return nil
 	}
-}
-
-// testAccSecurityGroupRulesPerGroupLimitFromEnv returns security group rules per group limit
-// Currently this information is not available from any EC2 or Trusted Advisor API
-// Prefers the EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT environment variable or defaults to 50
-func testAccSecurityGroupRulesPerGroupLimitFromEnv() int {
-	const defaultLimit = 50
-	const envVar = "EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT"
-
-	envLimitStr := os.Getenv(envVar)
-	if envLimitStr == "" {
-		return defaultLimit
-	}
-	envLimitInt, err := strconv.Atoi(envLimitStr)
-	if err != nil {
-		log.Printf("[WARN] Error converting %q environment variable value %q to integer: %s", envVar, envLimitStr, err)
-		return defaultLimit
-	}
-	if envLimitInt <= 50 {
-		return defaultLimit
-	}
-	return envLimitInt
 }
 
 func testAccCheckSecurityGroupRuleCount(group *ec2.SecurityGroup, expectedIngressCount, expectedEgressCount int) resource.TestCheckFunc {

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -1966,7 +1965,6 @@ func TestAccVPCSecurityGroup_failWithDiffMismatch(t *testing.T) {
 }
 
 var ruleLimit int
-var quotaMutex = &sync.Mutex{}
 
 // testAccSecurityGroup_ruleLimit sets the global "ruleLimit" and is only called once
 // but does not run in parallel slowing down tests. The mutex limits it to one slow down
@@ -1992,11 +1990,9 @@ func testAccSecurityGroup_ruleLimit(t *testing.T) {
 }
 
 func TestAccVPCSecurityGroup_RuleLimit_exceededAppend(t *testing.T) {
-	quotaMutex.Lock()
 	if ruleLimit == 0 {
 		testAccSecurityGroup_ruleLimit(t)
 	}
-	quotaMutex.Unlock()
 
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2043,11 +2039,9 @@ func TestAccVPCSecurityGroup_RuleLimit_exceededAppend(t *testing.T) {
 }
 
 func TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend(t *testing.T) {
-	quotaMutex.Lock()
 	if ruleLimit == 0 {
 		testAccSecurityGroup_ruleLimit(t)
 	}
-	quotaMutex.Unlock()
 
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2108,11 +2102,9 @@ func TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend(t *testing.T) {
 }
 
 func TestAccVPCSecurityGroup_RuleLimit_exceededPrepend(t *testing.T) {
-	quotaMutex.Lock()
 	if ruleLimit == 0 {
 		testAccSecurityGroup_ruleLimit(t)
 	}
-	quotaMutex.Unlock()
 
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2157,11 +2149,9 @@ func TestAccVPCSecurityGroup_RuleLimit_exceededPrepend(t *testing.T) {
 }
 
 func TestAccVPCSecurityGroup_RuleLimit_exceededAllNew(t *testing.T) {
-	quotaMutex.Lock()
 	if ruleLimit == 0 {
 		testAccSecurityGroup_ruleLimit(t)
 	}
-	quotaMutex.Unlock()
 
 	var group ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -2723,6 +2723,10 @@ resource "aws_security_group" "primary" {
   tags = {
     Name = %[1]q
   }
+
+  timeouts {
+    delete = "2m"
+  }
 }
 
 resource "aws_security_group" "secondary" {
@@ -2731,6 +2735,10 @@ resource "aws_security_group" "secondary" {
 
   tags = {
     Name = %[1]q
+  }
+
+  timeouts {
+    delete = "2m"
   }
 }
 `, rName)

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -12,9 +12,7 @@ Provides a resource to manage a default security group. This resource can manage
 
 ~> **NOTE:** This is an advanced resource with special caveats. Please read this document in its entirety before using this resource. The `aws_default_security_group` resource behaves differently from normal resources. Terraform does not _create_ this resource but instead attempts to "adopt" it into management.
 
-For EC2 Classic accounts, each region comes with a default security group. Additionally, each VPC created in AWS comes with a default security group that can be managed but not destroyed.
-
-When Terraform first adopts the default security group, it **immediately removes all ingress and egress rules in the Security Group**. It then creates any rules specified in the configuration. This way only the rules specified in the configuration are created.
+When Terraform first begins managing the default security group, it **immediately removes all ingress and egress rules in the Security Group**. It then creates any rules specified in the configuration. This way only the rules specified in the configuration are created.
 
 This resource treats its inline rules as absolute; only the rules defined inline are created, and any additions/removals external to this resource will result in diff shown. For these reasons, this resource is incompatible with the `aws_security_group_rule` resource.
 
@@ -94,7 +92,7 @@ Both `egress` and `ingress` objects have the same arguments.
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints)
 * `protocol` - (Required) Protocol. If you select a protocol of "-1" (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to `0`. If not `icmp`, `tcp`, `udp`, or `-1` use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
 * `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
 * `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -143,7 +143,7 @@ The following arguments are optional:
 * `description` - (Optional) Description of this ingress rule.
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
 * `prefix_list_ids` - (Optional) List of Prefix List IDs.
-* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
 * `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
 
 ### egress
@@ -162,7 +162,7 @@ The following arguments are optional:
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
 * `prefix_list_ids` - (Optional) List of Prefix List IDs.
 * `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0.  The supported values are defined in the `IpProtocol` argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
-* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
 * `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1671
Closes #8285
Closes #8769
Relates #10329 
Closes #12394
Relates #12396
Closes #12420
Closes #13228
Closes #16165
Relates #18559
Closes #19932
Closes #20035
Closes #20405
Closes #20743
Closes #20925
Relates #23488 
Closes #26090

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccVPCSecurityGroup_ PKG=ec2         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroup_'  -timeout 180m
--- PASS: TestAccVPCSecurityGroup_invalidCIDRBlock (9.79s)
--- PASS: TestAccVPCSecurityGroup_drift (93.59s)
--- PASS: TestAccVPCSecurityGroup_cidrAndGroups (104.10s)
--- PASS: TestAccVPCSecurityGroup_failWithDiffMismatch (105.54s)
--- PASS: TestAccVPCSecurityGroup_basic (111.49s)
--- PASS: TestAccVPCSecurityGroup_vpcNegOneIngress (111.68s)
--- PASS: TestAccVPCSecurityGroup_self (102.55s)
--- PASS: TestAccVPCSecurityGroup_vpc (112.34s)
--- PASS: TestAccVPCSecurityGroup_ipRangesWithSameRules (112.54s)
--- PASS: TestAccVPCSecurityGroup_driftComplex (114.84s)
--- PASS: TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC (115.03s)
--- PASS: TestAccVPCSecurityGroup_ipv4AndIPv6Egress (121.28s)
--- PASS: TestAccVPCSecurityGroup_egressWithPrefixList (127.12s)
--- PASS: TestAccVPCSecurityGroup_ingressWithPrefixList (129.94s)
--- PASS: TestAccVPCSecurityGroup_rulesDropOnError (171.17s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend (187.09s)
--- PASS: TestAccVPCSecurityGroup_ipv6 (103.98s)
--- PASS: TestAccVPCSecurityGroup_defaultEgressVPC (96.23s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededAppend (244.95s)
--- PASS: TestAccVPCSecurityGroup_namePrefixTerraform (106.25s)
--- PASS: TestAccVPCSecurityGroup_sourceSecurityGroup (115.38s)
--- PASS: TestAccVPCSecurityGroup_allowAll (115.61s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededAllNew (230.75s)
--- PASS: TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules (118.60s)
--- PASS: TestAccVPCSecurityGroup_ruleGathering (125.96s)
--- PASS: TestAccVPCSecurityGroup_multiIngress (110.93s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededPrepend (240.74s)
--- PASS: TestAccVPCSecurityGroup_vpcProtoNumIngress (87.60s)
--- PASS: TestAccVPCSecurityGroup_change (157.58s)
--- PASS: TestAccVPCSecurityGroup_nameTerraformPrefix (83.18s)
--- PASS: TestAccVPCSecurityGroup_disappears (59.65s)
--- PASS: TestAccVPCSecurityGroup_namePrefix (79.78s)
--- PASS: TestAccVPCSecurityGroup_nameGenerated (75.91s)
--- PASS: TestAccVPCSecurityGroup_ingressMode (186.22s)
--- PASS: TestAccVPCSecurityGroup_egressMode (173.33s)
--- PASS: TestAccVPCSecurityGroup_tags (182.14s)
--- PASS: TestAccVPCSecurityGroup_ruleDescription (128.42s)
--- PASS: TestAccVPCSecurityGroup_forceRevokeRulesTrue (487.29s)
--- PASS: TestAccVPCSecurityGroup_emrDependencyViolation (819.83s)
--- PASS: TestAccVPCSecurityGroup_forceRevokeRulesFalse (1213.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1243.196s
% make testacc TESTS=TestAccVPCDefaultSecurityGroup_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCDefaultSecurityGroup_'  -timeout 180m
--- PASS: TestAccVPCDefaultSecurityGroup_empty (45.12s)
--- PASS: TestAccVPCDefaultSecurityGroup_basic (63.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	64.994s
% make testacc TESTS=TestAccVPCSecurityGroupRule_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroupRule_'  -timeout 180m
--- PASS: TestAccVPCSecurityGroupRule_expectInvalidTypeError (8.14s)
--- PASS: TestAccVPCSecurityGroupRule_prefixListEmptyString (8.45s)
--- PASS: TestAccVPCSecurityGroupRule_expectInvalidCIDR (10.47s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_icmpv6 (113.47s)
--- PASS: TestAccVPCSecurityGroupRule_selfReference (122.56s)
--- PASS: TestAccVPCSecurityGroupRule_egress (123.42s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_protocol (124.46s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_vpc (124.96s)
--- PASS: TestAccVPCSecurityGroupRule_issue5310 (124.97s)
--- PASS: TestAccVPCSecurityGroupRule_egressDescription (118.29s)
--- PASS: TestAccVPCSecurityGroupRule_selfSource (130.95s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_ipv6 (131.29s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_prefixListAndSource (137.94s)
--- PASS: TestAccVPCSecurityGroupRule_prefixListEgress (139.94s)
--- PASS: TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash (142.10s)
--- PASS: TestAccVPCSecurityGroupRule_PartialMatching_source (143.64s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_peeredVPC (138.29s)
--- PASS: TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts (173.84s)
--- PASS: TestAccVPCSecurityGroupRule_EgressDescription_updates (177.10s)
--- PASS: TestAccVPCSecurityGroupRule_IngressDescription_updates (176.52s)
--- PASS: TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id (81.66s)
--- PASS: TestAccVPCSecurityGroupRule_ingressDescription (81.45s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_ipv4AndIPv6 (88.87s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_prefixListAndSelf (99.13s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_multipleIPv6 (83.11s)
--- PASS: TestAccVPCSecurityGroupRule_Ingress_multiplePrefixLists (93.01s)
--- PASS: TestAccVPCSecurityGroupRule_PartialMatching_basic (100.79s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (232.63s)
--- PASS: TestAccVPCSecurityGroupRule_Description_allPorts (113.62s)
--- PASS: TestAccVPCSecurityGroupRule_multiDescription (245.23s)
--- PASS: TestAccVPCSecurityGroupRule_race (264.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	265.527s
% make testacc TESTS=TestAccVPCSecurityGroupDataSource_ PKG=vpc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroupDataSource_'  -timeout 180m
--- PASS: TestAccVPCSecurityGroupDataSource_basic (41.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	43.270s
% make testacc TESTS=TestAccVPCSecurityGroupsDataSource_ PKG=vpc   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroupsDataSource_'  -timeout 180m
--- PASS: TestAccVPCSecurityGroupsDataSource_empty (27.66s)
--- PASS: TestAccVPCSecurityGroupsDataSource_filter (42.80s)
--- PASS: TestAccVPCSecurityGroupsDataSource_tag (43.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	45.272s
```
