### PR TITLE
Correct `aws_ce_anomaly_monitor` arguments in `aws_ce_anomaly_subscription` docs

### DIFF
--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -16,9 +16,9 @@ Provides a CE Anomaly Subscription.
 
 ```terraform
 resource "aws_ce_anomaly_monitor" "test" {
-  name      = "AWSServiceMonitor"
-  type      = "DIMENSIONAL"
-  dimension = "SERVICE"
+  name              = "AWSServiceMonitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
 }
 
 resource "aws_ce_anomaly_subscription" "test" {
@@ -110,9 +110,9 @@ resource "aws_sns_topic_policy" "default" {
 }
 
 resource "aws_ce_anomaly_monitor" "anomaly_monitor" {
-  name      = "AWSServiceMonitor"
-  type      = "DIMENSIONAL"
-  dimension = "SERVICE"
+  name              = "AWSServiceMonitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
 }
 
 resource "aws_ce_anomaly_subscription" "realtime_subscription" {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26505

Output from acceptance testing: n/a, docs

### Information

As called out in the linked issue, the arguments for `aws_ce_anomaly_monitor` were incorrect. This PR corrects them.

### References

- Related PR: #25301
- [`aws_ce_anomaly_monitor` docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ce_anomaly_monitor)