### PR TITLE
r/aws_medialive_multiplex: add CRUD operations

### DIFF
--- a/.changelog/26608.txt
+++ b/.changelog/26608.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+  aws_medialive_multiplex
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1725,6 +1725,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 
 			"aws_medialive_input":                medialive.ResourceInput(),
 			"aws_medialive_input_security_group": medialive.ResourceInputSecurityGroup(),
+			"aws_medialive_multiplex":            medialive.ResourceMultiplex(),
 
 			"aws_media_store_container":        mediastore.ResourceContainer(),
 			"aws_media_store_container_policy": mediastore.ResourceContainerPolicy(),

--- a/internal/service/medialive/medialive_test.go
+++ b/internal/service/medialive/medialive_test.go
@@ -1,0 +1,29 @@
+package medialive_test
+
+import (
+	"testing"
+)
+
+func TestAccMediaLive_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Multiplex": {
+			"basic":      testAccMediaLiveMultiplex_basic,
+			"disappears": testAccMediaLiveMultiplex_disappears,
+			"update":     testAccMediaLiveMultiplex_update,
+			"updateTags": testAccMediaLiveMultiplex_updateTags,
+			"start":      testAccMediaLiveMultiplex_start,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/internal/service/medialive/medialive_test.go
+++ b/internal/service/medialive/medialive_test.go
@@ -7,11 +7,11 @@ import (
 func TestAccMediaLive_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Multiplex": {
-			"basic":      testAccMediaLiveMultiplex_basic,
-			"disappears": testAccMediaLiveMultiplex_disappears,
-			"update":     testAccMediaLiveMultiplex_update,
-			"updateTags": testAccMediaLiveMultiplex_updateTags,
-			"start":      testAccMediaLiveMultiplex_start,
+			"basic":      testAccMultiplex_basic,
+			"disappears": testAccMultiplex_disappears,
+			"update":     testAccMultiplex_update,
+			"updateTags": testAccMultiplex_updateTags,
+			"start":      testAccMultiplex_start,
 		},
 	}
 

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -465,11 +465,8 @@ func startMultiplex(ctx context.Context, conn *medialive.Client, id string, time
 	}
 
 	_, err = waitMultiplexRunning(ctx, conn, id, timeout)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func stopMultiplex(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) error {
@@ -483,9 +480,6 @@ func stopMultiplex(ctx context.Context, conn *medialive.Client, id string, timeo
 	}
 
 	_, err = waitMultiplexStopped(ctx, conn, id, timeout)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -263,7 +263,7 @@ func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta i
 		create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
 	}
 
-	if out.State != types.MultiplexStateRunning {
+	if out.State == types.MultiplexStateRunning {
 		if err := stopMultiplex(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 			return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
 		}

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -49,6 +49,8 @@ func ResourceMultiplex() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
+				MinItems: 2,
+				MaxItems: 2,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"multiplex_settings": {
@@ -184,6 +186,9 @@ func resourceMultiplexUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			MultiplexId: aws.String(d.Id()),
 		}
 
+		if d.HasChange("name") {
+			in.Name = aws.String(d.Get("name").(string))
+		}
 		if d.HasChange("multiplex_settings") {
 			in.MultiplexSettings = expandMultiplexSettings(d.Get("multiplex_settings").([]interface{}))
 		}
@@ -348,21 +353,21 @@ func expandMultiplexSettings(tfList []interface{}) *types.MultiplexSettings {
 		return nil
 	}
 
-	var s types.MultiplexSettings
-
 	m := tfList[0].(map[string]interface{})
 
-	if val, ok := m["transport_stream_bitrate"]; ok {
-		s.TransportStreamBitrate = val.(int32)
+	s := types.MultiplexSettings{}
+
+	if v, ok := m["transport_stream_bitrate"]; ok {
+		s.TransportStreamBitrate = int32(v.(int))
 	}
-	if val, ok := m["transport_stream_id"]; ok {
-		s.TransportStreamBitrate = val.(int32)
+	if v, ok := m["transport_stream_id"]; ok {
+		s.TransportStreamId = int32(v.(int))
 	}
 	if val, ok := m["maximum_video_buffer_delay_milliseconds"]; ok {
-		s.TransportStreamBitrate = val.(int32)
+		s.MaximumVideoBufferDelayMilliseconds = int32(val.(int))
 	}
 	if val, ok := m["transport_stream_reserved_bitrate"]; ok {
-		s.TransportStreamBitrate = val.(int32)
+		s.TransportStreamReservedBitrate = int32(val.(int))
 	}
 
 	return &s

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -1,0 +1,369 @@
+package medialive
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/medialive"
+	"github.com/aws/aws-sdk-go-v2/service/medialive/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceMultiplex() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceMultiplexCreate,
+		ReadWithoutTimeout:   resourceMultiplexRead,
+		UpdateWithoutTimeout: resourceMultiplexUpdate,
+		DeleteWithoutTimeout: resourceMultiplexDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"multiplex_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"transport_stream_bitrate": {
+							Type:             schema.TypeInt,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1000000, 100000000)),
+						},
+						"transport_stream_reserved_bitrate": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"transport_stream_id": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"maximum_video_buffer_delay_milliseconds": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameMultiplex = "Multiplex"
+)
+
+func resourceMultiplexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MediaLiveConn
+
+	in := &medialive.CreateMultiplexInput{
+		RequestId:         aws.String(resource.UniqueId()),
+		Name:              aws.String(d.Get("name").(string)),
+		AvailabilityZones: flex.ExpandStringValueList(d.Get("availability_zones").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("multiplex_settings"); ok && len(v.([]interface{})) > 0 {
+		in.MultiplexSettings = expandMultiplexSettings(v.([]interface{}))
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateMultiplex(ctx, in)
+	if err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Get("name").(string), err)
+	}
+
+	if out == nil || out.Multiplex == nil {
+		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.ToString(out.Multiplex.Id))
+
+	if _, err := waitMultiplexCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionWaitingForCreation, ResNameMultiplex, d.Id(), err)
+	}
+
+	return resourceMultiplexRead(ctx, d, meta)
+}
+
+func resourceMultiplexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MediaLiveConn
+
+	out, err := FindMultiplexByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] MediaLive Multiplex (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionReading, ResNameMultiplex, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("availability_zones", out.AvailabilityZones)
+	d.Set("name", out.Name)
+
+	if err := d.Set("multiplex_settings", flattenMultiplexSettings(out.MultiplexSettings)); err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameMultiplex, d.Id(), err)
+	}
+
+	tags, err := ListTags(ctx, conn, aws.ToString(out.Arn))
+	if err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionReading, ResNameMultiplex, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameMultiplex, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameMultiplex, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceMultiplexUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MediaLiveConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		in := &medialive.UpdateMultiplexInput{
+			MultiplexId: aws.String(d.Id()),
+		}
+
+		if d.HasChange("multiplex_settings") {
+			in.MultiplexSettings = expandMultiplexSettings(d.Get("multiplex_settings").([]interface{}))
+		}
+
+		log.Printf("[DEBUG] Updating MediaLive Multiplex (%s): %#v", d.Id(), in)
+		out, err := conn.UpdateMultiplex(ctx, in)
+		if err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
+		}
+
+		if _, err := waitMultiplexUpdated(ctx, conn, aws.ToString(out.Multiplex.Id), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionWaitingForUpdate, ResNameMultiplex, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
+		}
+	}
+
+	return resourceMultiplexRead(ctx, d, meta)
+}
+
+func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MediaLiveConn
+
+	log.Printf("[INFO] Deleting MediaLive Multiplex %s", d.Id())
+
+	_, err := conn.DeleteMultiplex(ctx, &medialive.DeleteMultiplexInput{
+		MultiplexId: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+
+		return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
+	}
+
+	if _, err := waitMultiplexDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return create.DiagError(names.MediaLive, create.ErrActionWaitingForDeletion, ResNameMultiplex, d.Id(), err)
+	}
+
+	return nil
+}
+
+func waitMultiplexCreated(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeMultiplexOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   enum.Slice(types.MultiplexStateCreating),
+		Target:                    enum.Slice(types.MultiplexStateIdle),
+		Refresh:                   statusMultiplex(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+		Delay:                     30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*medialive.DescribeMultiplexOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitMultiplexUpdated(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeMultiplexOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    enum.Slice(types.MultiplexStateIdle),
+		Refresh:                   statusMultiplex(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+		Delay:                     30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*medialive.DescribeMultiplexOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitMultiplexDeleted(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeMultiplexOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: enum.Slice(types.MultiplexStateDeleting),
+		Target:  enum.Slice(types.MultiplexStateDeleted),
+		Refresh: statusMultiplex(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*medialive.DescribeMultiplexOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func statusMultiplex(ctx context.Context, conn *medialive.Client, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := FindMultiplexByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, string(out.State), nil
+	}
+}
+
+func FindMultiplexByID(ctx context.Context, conn *medialive.Client, id string) (*medialive.DescribeMultiplexOutput, error) {
+	in := &medialive.DescribeMultiplexInput{
+		MultiplexId: aws.String(id),
+	}
+	out, err := conn.DescribeMultiplex(ctx, in)
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func flattenMultiplexSettings(apiObject *types.MultiplexSettings) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"transport_stream_bitrate":                apiObject.TransportStreamBitrate,
+		"transport_stream_id":                     apiObject.TransportStreamId,
+		"maximum_video_buffer_delay_milliseconds": apiObject.MaximumVideoBufferDelayMilliseconds,
+		"transport_stream_reserved_bitrate":       apiObject.TransportStreamReservedBitrate,
+	}
+
+	return []interface{}{m}
+}
+
+func expandMultiplexSettings(tfList []interface{}) *types.MultiplexSettings {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var s types.MultiplexSettings
+
+	m := tfList[0].(map[string]interface{})
+
+	if val, ok := m["transport_stream_bitrate"]; ok {
+		s.TransportStreamBitrate = val.(int32)
+	}
+	if val, ok := m["transport_stream_id"]; ok {
+		s.TransportStreamBitrate = val.(int32)
+	}
+	if val, ok := m["maximum_video_buffer_delay_milliseconds"]; ok {
+		s.TransportStreamBitrate = val.(int32)
+	}
+	if val, ok := m["transport_stream_reserved_bitrate"]; ok {
+		s.TransportStreamBitrate = val.(int32)
+	}
+
+	return &s
+}

--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -288,17 +288,17 @@ func testAccMultiplexesPreCheck(t *testing.T) {
 	}
 }
 
-func testAccMultiplexBaseConfig(rName string) string {
-	return fmt.Sprintf(`
+func testAccMultiplexBaseConfig() string {
+	return `
 data "aws_availability_zones" "test" {
   state = "available"
 }
-`)
+`
 }
 
 func testAccMultiplexConfig_basic(rName string, start bool) string {
 	return acctest.ConfigCompose(
-		testAccMultiplexBaseConfig(rName),
+		testAccMultiplexBaseConfig(),
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
@@ -322,7 +322,7 @@ resource "aws_medialive_multiplex" "test" {
 
 func testAccMultiplexConfig_update(rName string, start bool) string {
 	return acctest.ConfigCompose(
-		testAccMultiplexBaseConfig(rName),
+		testAccMultiplexBaseConfig(),
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
@@ -346,7 +346,7 @@ resource "aws_medialive_multiplex" "test" {
 
 func testAccMultiplexConfig_tags1(rName, key1, value1 string) string {
 	return acctest.ConfigCompose(
-		testAccMultiplexBaseConfig(rName),
+		testAccMultiplexBaseConfig(),
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
@@ -368,7 +368,7 @@ resource "aws_medialive_multiplex" "test" {
 
 func testAccMultiplexConfig_tags2(rName, key1, value1, key2, value2 string) string {
 	return acctest.ConfigCompose(
-		testAccMultiplexBaseConfig(rName),
+		testAccMultiplexBaseConfig(),
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q

--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccMediaLiveMultiplex_basic(t *testing.T) {
+func testAccMediaLiveMultiplex_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -27,7 +27,7 @@ func TestAccMediaLiveMultiplex_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_medialive_multiplex.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
@@ -59,7 +59,7 @@ func TestAccMediaLiveMultiplex_basic(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveMultiplex_start(t *testing.T) {
+func testAccMediaLiveMultiplex_start(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -68,7 +68,7 @@ func TestAccMediaLiveMultiplex_start(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_medialive_multiplex.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
@@ -98,7 +98,7 @@ func TestAccMediaLiveMultiplex_start(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveMultiplex_update(t *testing.T) {
+func testAccMediaLiveMultiplex_update(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -107,7 +107,7 @@ func TestAccMediaLiveMultiplex_update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_medialive_multiplex.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
@@ -145,7 +145,7 @@ func TestAccMediaLiveMultiplex_update(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveMultiplex_updateTags(t *testing.T) {
+func testAccMediaLiveMultiplex_updateTags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -154,7 +154,7 @@ func TestAccMediaLiveMultiplex_updateTags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_medialive_multiplex.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
@@ -193,7 +193,7 @@ func TestAccMediaLiveMultiplex_updateTags(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveMultiplex_disappears(t *testing.T) {
+func testAccMediaLiveMultiplex_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -202,7 +202,7 @@ func TestAccMediaLiveMultiplex_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_medialive_multiplex.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)

--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -1,252 +1,176 @@
 package medialive_test
 
-//import (
-//	"context"
-//	"fmt"
-//	"regexp"
-//	"strings"
-//	"testing"
-//
-//	"github.com/aws/aws-sdk-go-v2/aws"
-//	"github.com/aws/aws-sdk-go-v2/service/medialive"
-//	"github.com/aws/aws-sdk-go-v2/service/medialive/types"
-//	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-//	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-//	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-//	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-//	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-//	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-//	"github.com/hashicorp/terraform-provider-aws/internal/create"
-//	tfmedialive "github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
-//	"github.com/hashicorp/terraform-provider-aws/names"
-//)
-//
-//func TestMultiplexExampleUnitTest(t *testing.T) {
-//	testCases := []struct {
-//		TestName string
-//		Input    string
-//		Expected string
-//		Error    bool
-//	}{
-//		{
-//			TestName: "empty",
-//			Input:    "",
-//			Expected: "",
-//			Error:    true,
-//		},
-//		{
-//			TestName: "descriptive name",
-//			Input:    "some input",
-//			Expected: "some output",
-//			Error:    false,
-//		},
-//		{
-//			TestName: "another descriptive name",
-//			Input:    "more input",
-//			Expected: "more output",
-//			Error:    false,
-//		},
-//	}
-//
-//	for _, testCase := range testCases {
-//		t.Run(testCase.TestName, func(t *testing.T) {
-//			got, err := tfmedialive.FunctionFromResource(testCase.Input)
-//
-//			if err != nil && !testCase.Error {
-//				t.Errorf("got error (%s), expected no error", err)
-//			}
-//
-//			if err == nil && testCase.Error {
-//				t.Errorf("got (%s) and no error, expected error", got)
-//			}
-//
-//			if got != testCase.Expected {
-//				t.Errorf("got %s, expected %s", got, testCase.Expected)
-//			}
-//		})
-//	}
-//}
-//
-//func TestAccMediaLiveMultiplex_basic(t *testing.T) {
-//	if testing.Short() {
-//		t.Skip("skipping long-running test in short mode")
-//	}
-//
-//	var multiplex medialive.DescribeMultiplexResponse
-//	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-//	resourceName := "aws_medialive_multiplex.test"
-//
-//	resource.ParallelTest(t, resource.TestCase{
-//		PreCheck: func() {
-//			acctest.PreCheck(t)
-//			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
-//			testAccPreCheck(t)
-//		},
-//		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
-//		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-//		CheckDestroy:             testAccCheckMultiplexDestroy,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccMultiplexConfig_basic(rName),
-//				Check: resource.ComposeTestCheckFunc(
-//					testAccCheckMultiplexExists(resourceName, &multiplex),
-//					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-//					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
-//					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
-//						"console_access": "false",
-//						"groups.#":       "0",
-//						"username":       "Test",
-//						"password":       "TestTest1234",
-//					}),
-//					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "medialive", regexp.MustCompile(`multiplex:+.`)),
-//				),
-//			},
-//			{
-//				ResourceName:            resourceName,
-//				ImportState:             true,
-//				ImportStateVerify:       true,
-//				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
-//			},
-//		},
-//	})
-//}
-//
-//func TestAccMediaLiveMultiplex_disappears(t *testing.T) {
-//	if testing.Short() {
-//		t.Skip("skipping long-running test in short mode")
-//	}
-//
-//	var multiplex medialive.DescribeMultiplexResponse
-//	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-//	resourceName := "aws_medialive_multiplex.test"
-//
-//	resource.ParallelTest(t, resource.TestCase{
-//		PreCheck: func() {
-//			acctest.PreCheck(t)
-//			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
-//			testAccPreCheck(t)
-//		},
-//		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
-//		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-//		CheckDestroy:             testAccCheckMultiplexDestroy,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccMultiplexConfig_basic(rName, testAccMultiplexVersionNewer),
-//				Check: resource.ComposeTestCheckFunc(
-//					testAccCheckMultiplexExists(resourceName, &multiplex),
-//					acctest.CheckResourceDisappears(acctest.Provider, tfmedialive.ResourceMultiplex(), resourceName),
-//				),
-//				ExpectNonEmptyPlan: true,
-//			},
-//		},
-//	})
-//}
-//
-//func testAccCheckMultiplexDestroy(s *terraform.State) error {
-//	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
-//	ctx := context.Background()
-//
-//	for _, rs := range s.RootModule().Resources {
-//		if rs.Type != "aws_medialive_multiplex" {
-//			continue
-//		}
-//
-//		input := &medialive.DescribeMultiplexInput{
-//			MultiplexId: aws.String(rs.Primary.ID),
-//		}
-//		_, err := conn.DescribeMultiplex(ctx, &medialive.DescribeMultiplexInput{
-//			MultiplexId: aws.String(rs.Primary.ID),
-//		})
-//		if err != nil {
-//			var nfe *types.ResourceNotFoundException
-//			if errors.As(err, &nfe) {
-//				return nil
-//			}
-//			return err
-//		}
-//
-//		return create.Error(names.MediaLive, create.ErrActionCheckingDestroyed, tfmedialive.ResNameMultiplex, rs.Primary.ID, errors.New("not destroyed"))
-//	}
-//
-//	return nil
-//}
-//
-//func testAccCheckMultiplexExists(name string, multiplex *medialive.DescribeMultiplexResponse) resource.TestCheckFunc {
-//	return func(s *terraform.State) error {
-//		rs, ok := s.RootModule().Resources[name]
-//		if !ok {
-//			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, name, errors.New("not found"))
-//		}
-//
-//		if rs.Primary.ID == "" {
-//			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, name, errors.New("not set"))
-//		}
-//
-//		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
-//		ctx := context.Background()
-//		resp, err := conn.DescribeMultiplex(ctx, &medialive.DescribeMultiplexInput{
-//			MultiplexId: aws.String(rs.Primary.ID),
-//		})
-//
-//		if err != nil {
-//			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, rs.Primary.ID, err)
-//		}
-//
-//		*multiplex = *resp
-//
-//		return nil
-//	}
-//}
-//
-//func testAccPreCheck(t *testing.T) {
-//	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
-//	ctx := context.Background()
-//
-//	input := &medialive.ListMultiplexsInput{}
-//	_, err := conn.ListMultiplexs(ctx, input)
-//
-//	if acctest.PreCheckSkipError(err) {
-//		t.Skipf("skipping acceptance testing: %s", err)
-//	}
-//
-//	if err != nil {
-//		t.Fatalf("unexpected PreCheck error: %s", err)
-//	}
-//}
-//
-//func testAccCheckMultiplexNotRecreated(before, after *medialive.DescribeMultiplexResponse) resource.TestCheckFunc {
-//	return func(s *terraform.State) error {
-//		if before, after := aws.StringValue(before.MultiplexId), aws.StringValue(after.MultiplexId); before != after {
-//			return create.Error(names.MediaLive, create.ErrActionCheckingNotRecreated, tfmedialive.ResNameMultiplex, aws.StringValue(before.MultiplexId), errors.New("recreated"))
-//		}
-//
-//		return nil
-//	}
-//}
-//
-//func testAccMultiplexConfig_basic(rName, version string) string {
-//	return fmt.Sprintf(`
-//resource "aws_security_group" "test" {
-//  name = %[1]q
-//}
-//
-//resource "aws_medialive_multiplex" "test" {
-//  multiplex_name             = %[1]q
-//  engine_type             = "ActiveMediaLive"
-//  engine_version          = %[2]q
-//  host_instance_type      = "medialive.t2.micro"
-//  security_groups         = [aws_security_group.test.id]
-//  authentication_strategy = "simple"
-//  storage_type            = "efs"
-//
-//  logs {
-//    general = true
-//  }
-//
-//  user {
-//    username = "Test"
-//    password = "TestTest1234"
-//  }
-//}
-//`, rName, version)
-//}
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/medialive"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfmedialive "github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccMediaLiveMultiplex_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiplex medialive.DescribeMultiplexOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_medialive_multiplex.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+			testAccMultiplexesPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiplexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiplexConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiplexExists(resourceName, &multiplex),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_bitrate", "1000000"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_multiplex"},
+			},
+		},
+	})
+}
+
+func TestAccMediaLiveMultiplex_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiplex medialive.DescribeMultiplexOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_medialive_multiplex.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+			testAccMultiplexesPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiplexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiplexConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiplexExists(resourceName, &multiplex),
+					acctest.CheckResourceDisappears(acctest.Provider, tfmedialive.ResourceMultiplex(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMultiplexDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_medialive_multiplex" {
+			continue
+		}
+
+		_, err := tfmedialive.FindInputSecurityGroupByID(ctx, conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingDestroyed, tfmedialive.ResNameMultiplex, rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMultiplexExists(name string, multiplex *medialive.DescribeMultiplexOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+		ctx := context.Background()
+		resp, err := tfmedialive.FindMultiplexByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, rs.Primary.ID, err)
+		}
+
+		*multiplex = *resp
+
+		return nil
+	}
+}
+
+func testAccMultiplexesPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+	ctx := context.Background()
+
+	input := &medialive.ListMultiplexesInput{}
+	_, err := conn.ListMultiplexes(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccMultiplexConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "test" {
+  state = "available"
+}
+
+resource "aws_medialive_multiplex" "test" {
+  name               = %[1]q
+  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+
+  multiplex_settings {
+    transport_stream_bitrate = 1000000
+    transport_stream_id      = 1
+    transport_stream_reserved_bitrate       = 1
+    maximum_video_buffer_delay_milliseconds = 1000
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}

--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -1,0 +1,252 @@
+package medialive_test
+
+//import (
+//	"context"
+//	"fmt"
+//	"regexp"
+//	"strings"
+//	"testing"
+//
+//	"github.com/aws/aws-sdk-go-v2/aws"
+//	"github.com/aws/aws-sdk-go-v2/service/medialive"
+//	"github.com/aws/aws-sdk-go-v2/service/medialive/types"
+//	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+//	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+//	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+//	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+//	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+//	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+//	"github.com/hashicorp/terraform-provider-aws/internal/create"
+//	tfmedialive "github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
+//	"github.com/hashicorp/terraform-provider-aws/names"
+//)
+//
+//func TestMultiplexExampleUnitTest(t *testing.T) {
+//	testCases := []struct {
+//		TestName string
+//		Input    string
+//		Expected string
+//		Error    bool
+//	}{
+//		{
+//			TestName: "empty",
+//			Input:    "",
+//			Expected: "",
+//			Error:    true,
+//		},
+//		{
+//			TestName: "descriptive name",
+//			Input:    "some input",
+//			Expected: "some output",
+//			Error:    false,
+//		},
+//		{
+//			TestName: "another descriptive name",
+//			Input:    "more input",
+//			Expected: "more output",
+//			Error:    false,
+//		},
+//	}
+//
+//	for _, testCase := range testCases {
+//		t.Run(testCase.TestName, func(t *testing.T) {
+//			got, err := tfmedialive.FunctionFromResource(testCase.Input)
+//
+//			if err != nil && !testCase.Error {
+//				t.Errorf("got error (%s), expected no error", err)
+//			}
+//
+//			if err == nil && testCase.Error {
+//				t.Errorf("got (%s) and no error, expected error", got)
+//			}
+//
+//			if got != testCase.Expected {
+//				t.Errorf("got %s, expected %s", got, testCase.Expected)
+//			}
+//		})
+//	}
+//}
+//
+//func TestAccMediaLiveMultiplex_basic(t *testing.T) {
+//	if testing.Short() {
+//		t.Skip("skipping long-running test in short mode")
+//	}
+//
+//	var multiplex medialive.DescribeMultiplexResponse
+//	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+//	resourceName := "aws_medialive_multiplex.test"
+//
+//	resource.ParallelTest(t, resource.TestCase{
+//		PreCheck: func() {
+//			acctest.PreCheck(t)
+//			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+//			testAccPreCheck(t)
+//		},
+//		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+//		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+//		CheckDestroy:             testAccCheckMultiplexDestroy,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccMultiplexConfig_basic(rName),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckMultiplexExists(resourceName, &multiplex),
+//					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+//					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+//					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+//						"console_access": "false",
+//						"groups.#":       "0",
+//						"username":       "Test",
+//						"password":       "TestTest1234",
+//					}),
+//					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "medialive", regexp.MustCompile(`multiplex:+.`)),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceName,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+//			},
+//		},
+//	})
+//}
+//
+//func TestAccMediaLiveMultiplex_disappears(t *testing.T) {
+//	if testing.Short() {
+//		t.Skip("skipping long-running test in short mode")
+//	}
+//
+//	var multiplex medialive.DescribeMultiplexResponse
+//	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+//	resourceName := "aws_medialive_multiplex.test"
+//
+//	resource.ParallelTest(t, resource.TestCase{
+//		PreCheck: func() {
+//			acctest.PreCheck(t)
+//			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+//			testAccPreCheck(t)
+//		},
+//		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+//		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+//		CheckDestroy:             testAccCheckMultiplexDestroy,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccMultiplexConfig_basic(rName, testAccMultiplexVersionNewer),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckMultiplexExists(resourceName, &multiplex),
+//					acctest.CheckResourceDisappears(acctest.Provider, tfmedialive.ResourceMultiplex(), resourceName),
+//				),
+//				ExpectNonEmptyPlan: true,
+//			},
+//		},
+//	})
+//}
+//
+//func testAccCheckMultiplexDestroy(s *terraform.State) error {
+//	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+//	ctx := context.Background()
+//
+//	for _, rs := range s.RootModule().Resources {
+//		if rs.Type != "aws_medialive_multiplex" {
+//			continue
+//		}
+//
+//		input := &medialive.DescribeMultiplexInput{
+//			MultiplexId: aws.String(rs.Primary.ID),
+//		}
+//		_, err := conn.DescribeMultiplex(ctx, &medialive.DescribeMultiplexInput{
+//			MultiplexId: aws.String(rs.Primary.ID),
+//		})
+//		if err != nil {
+//			var nfe *types.ResourceNotFoundException
+//			if errors.As(err, &nfe) {
+//				return nil
+//			}
+//			return err
+//		}
+//
+//		return create.Error(names.MediaLive, create.ErrActionCheckingDestroyed, tfmedialive.ResNameMultiplex, rs.Primary.ID, errors.New("not destroyed"))
+//	}
+//
+//	return nil
+//}
+//
+//func testAccCheckMultiplexExists(name string, multiplex *medialive.DescribeMultiplexResponse) resource.TestCheckFunc {
+//	return func(s *terraform.State) error {
+//		rs, ok := s.RootModule().Resources[name]
+//		if !ok {
+//			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, name, errors.New("not found"))
+//		}
+//
+//		if rs.Primary.ID == "" {
+//			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, name, errors.New("not set"))
+//		}
+//
+//		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+//		ctx := context.Background()
+//		resp, err := conn.DescribeMultiplex(ctx, &medialive.DescribeMultiplexInput{
+//			MultiplexId: aws.String(rs.Primary.ID),
+//		})
+//
+//		if err != nil {
+//			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplex, rs.Primary.ID, err)
+//		}
+//
+//		*multiplex = *resp
+//
+//		return nil
+//	}
+//}
+//
+//func testAccPreCheck(t *testing.T) {
+//	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+//	ctx := context.Background()
+//
+//	input := &medialive.ListMultiplexsInput{}
+//	_, err := conn.ListMultiplexs(ctx, input)
+//
+//	if acctest.PreCheckSkipError(err) {
+//		t.Skipf("skipping acceptance testing: %s", err)
+//	}
+//
+//	if err != nil {
+//		t.Fatalf("unexpected PreCheck error: %s", err)
+//	}
+//}
+//
+//func testAccCheckMultiplexNotRecreated(before, after *medialive.DescribeMultiplexResponse) resource.TestCheckFunc {
+//	return func(s *terraform.State) error {
+//		if before, after := aws.StringValue(before.MultiplexId), aws.StringValue(after.MultiplexId); before != after {
+//			return create.Error(names.MediaLive, create.ErrActionCheckingNotRecreated, tfmedialive.ResNameMultiplex, aws.StringValue(before.MultiplexId), errors.New("recreated"))
+//		}
+//
+//		return nil
+//	}
+//}
+//
+//func testAccMultiplexConfig_basic(rName, version string) string {
+//	return fmt.Sprintf(`
+//resource "aws_security_group" "test" {
+//  name = %[1]q
+//}
+//
+//resource "aws_medialive_multiplex" "test" {
+//  multiplex_name             = %[1]q
+//  engine_type             = "ActiveMediaLive"
+//  engine_version          = %[2]q
+//  host_instance_type      = "medialive.t2.micro"
+//  security_groups         = [aws_security_group.test.id]
+//  authentication_strategy = "simple"
+//  storage_type            = "efs"
+//
+//  logs {
+//    general = true
+//  }
+//
+//  user {
+//    username = "Test"
+//    password = "TestTest1234"
+//  }
+//}
+//`, rName, version)
+//}

--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func testAccMediaLiveMultiplex_basic(t *testing.T) {
+func testAccMultiplex_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -59,7 +59,7 @@ func testAccMediaLiveMultiplex_basic(t *testing.T) {
 	})
 }
 
-func testAccMediaLiveMultiplex_start(t *testing.T) {
+func testAccMultiplex_start(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -98,7 +98,7 @@ func testAccMediaLiveMultiplex_start(t *testing.T) {
 	})
 }
 
-func testAccMediaLiveMultiplex_update(t *testing.T) {
+func testAccMultiplex_update(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -145,7 +145,7 @@ func testAccMediaLiveMultiplex_update(t *testing.T) {
 	})
 }
 
-func testAccMediaLiveMultiplex_updateTags(t *testing.T) {
+func testAccMultiplex_updateTags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -193,7 +193,7 @@ func testAccMediaLiveMultiplex_updateTags(t *testing.T) {
 	})
 }
 
-func testAccMediaLiveMultiplex_disappears(t *testing.T) {
+func testAccMultiplex_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}

--- a/internal/service/medialive/sweep.go
+++ b/internal/service/medialive/sweep.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 )
 
 func init() {

--- a/internal/service/medialive/sweep.go
+++ b/internal/service/medialive/sweep.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 )
 
 func init() {
@@ -28,6 +27,11 @@ func init() {
 	resource.AddTestSweepers("aws_medialive_input_security_group", &resource.Sweeper{
 		Name: "aws_medialive_input_security_group",
 		F:    sweepInputSecurityGroups,
+	})
+
+	resource.AddTestSweepers("aws_medialive_multiplex", &resource.Sweeper{
+		Name: "aws_medialive_multiplex",
+		F:    sweepMultiplexes,
 	})
 }
 
@@ -125,6 +129,56 @@ func sweepInputSecurityGroups(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping MediaLive Input Security Groups sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepMultiplexes(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		fmt.Errorf("error getting client: %s", err)
+	}
+
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).MediaLiveConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	in := &medialive.ListMultiplexesInput{}
+	var errs *multierror.Error
+
+	pages := medialive.NewListMultiplexesPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Println("[WARN] Skipping MediaLive Multiplexes sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error retrieving MediaLive Multiplexes: %w", err)
+		}
+
+		for _, multiplex := range page.Multiplexes {
+			id := aws.ToString(multiplex.Id)
+			log.Printf("[INFO] Deleting MediaLive Multiplex: %s", id)
+
+			r := ResourceMultiplex()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping MediaLive Multiplexes for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping MediaLive Multiplexes sweep for %s: %s", region, errs)
 		return nil
 	}
 

--- a/website/docs/r/medialive_multiplex.html.markdown
+++ b/website/docs/r/medialive_multiplex.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "MediaLive"
+subcategory: "Elemental MediaLive"
 layout: "aws"
 page_title: "AWS: aws_medialive_multiplex"
 description: |-

--- a/website/docs/r/medialive_multiplex.html.markdown
+++ b/website/docs/r/medialive_multiplex.html.markdown
@@ -15,7 +15,26 @@ Terraform resource for managing an AWS MediaLive Multiplex.
 ### Basic Usage
 
 ```terraform
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_medialive_multiplex" "example" {
+  name               = "example-multiplex-changed"
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+
+  multiplex_settings {
+    transport_stream_bitrate                = 1000000
+    transport_stream_id                     = 1
+    transport_stream_reserved_bitrate       = 1
+    maximum_video_buffer_delay_milliseconds = 1000
+  }
+
+  start_multiplex = true
+
+  tags = {
+    tag1 = "value1"
+  }
 }
 ```
 
@@ -23,11 +42,21 @@ resource "aws_medialive_multiplex" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description.
+* `availability_zones` - (Required) A list of availability zones. You must specify exactly two.
+* `multiplex_settings`- (Required) Multiplex settings. See [Multiplex Settings](#multiplex-settings) for more details.
+* `name` - (Required) name of Multiplex.
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Concise argument description.
+* `start_multiplex` - (Optional) Whether to start the Multiplex. Defaults to `false`.
+* `tags` - (Optional) A map of tags to assign to the Multiplex. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Multiplex Settings
+
+* `transport_stream_bitrate` - (Required) Transport stream bit rate.
+* `transport_stream_id` - (Required) Unique ID for each multiplex.
+* `transport_stream_reserved_bitrate` - (Optional) Transport stream reserved bit rate.
+* `maximum_video_buffer_delay_milliseconds` - (Optional) Maximum video buffer delay.
 
 ## Attributes Reference
 
@@ -40,14 +69,14 @@ In addition to all arguments above, the following attributes are exported:
 
 [Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 
-MediaLive Multiplex can be imported using the `example_id_arg`, e.g.,
+MediaLive Multiplex can be imported using the `id`, e.g.,
 
 ```
-$ terraform import aws_medialive_multiplex.example rft-8012925589
+$ terraform import aws_medialive_multiplex.example 12345678
 ```

--- a/website/docs/r/medialive_multiplex.html.markdown
+++ b/website/docs/r/medialive_multiplex.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "MediaLive"
+layout: "aws"
+page_title: "AWS: aws_medialive_multiplex"
+description: |-
+  Terraform resource for managing an AWS MediaLive Multiplex.
+---
+
+# Resource: aws_medialive_multiplex
+
+Terraform resource for managing an AWS MediaLive Multiplex.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_medialive_multiplex" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Multiplex.
+* `example_attribute` - Concise description.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+MediaLive Multiplex can be imported using the `example_id_arg`, e.g.,
+
+```
+$ terraform import aws_medialive_multiplex.example rft-8012925589
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4936

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestAccMediaLiveMultiplex_ PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveMultiplex_'  -timeout 180m
=== RUN   TestAccMediaLiveMultiplex_basic
=== PAUSE TestAccMediaLiveMultiplex_basic
=== RUN   TestAccMediaLiveMultiplex_start
=== PAUSE TestAccMediaLiveMultiplex_start
=== RUN   TestAccMediaLiveMultiplex_update
=== PAUSE TestAccMediaLiveMultiplex_update
=== RUN   TestAccMediaLiveMultiplex_updateTags
=== PAUSE TestAccMediaLiveMultiplex_updateTags
=== RUN   TestAccMediaLiveMultiplex_disappears
=== PAUSE TestAccMediaLiveMultiplex_disappears
=== CONT  TestAccMediaLiveMultiplex_basic
=== CONT  TestAccMediaLiveMultiplex_update
=== CONT  TestAccMediaLiveMultiplex_start
=== CONT  TestAccMediaLiveMultiplex_updateTags
=== CONT  TestAccMediaLiveMultiplex_disappears
--- PASS: TestAccMediaLiveMultiplex_basic (57.43s)
--- PASS: TestAccMediaLiveMultiplex_update (96.74s)
--- PASS: TestAccMediaLiveMultiplex_updateTags (161.13s)
--- PASS: TestAccMediaLiveMultiplex_disappears (208.85s)
--- PASS: TestAccMediaLiveMultiplex_start (268.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	271.104s
...
```
