### PR TITLE
Migrate the Identity Store service to AWS Go SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
 	github.com/aws/aws-sdk-go v1.44.88
-	github.com/aws/aws-sdk-go-v2 v1.16.12
+	github.com/aws/aws-sdk-go-v2 v1.16.13
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.18.8
 	github.com/aws/aws-sdk-go-v2/service/fis v1.12.13
@@ -55,7 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.4 // indirect
-	github.com/aws/smithy-go v1.13.0 // indirect
+	github.com/aws/smithy-go v1.13.1 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.18.8
 	github.com/aws/aws-sdk-go-v2/service/fis v1.12.13
+	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.22.5
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.5
@@ -48,8 +49,8 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.0 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,11 +34,13 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4/go.mod h1:u/s5/Z+ohUQOPXl0
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13 h1:+uferi8SUDZtMloCDt24Zenyy/i71C/ua5mjUCpbpN0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.13/go.mod h1:y0eXmsNBFIVjUE8ZBjES8myOHlMsXDz7qGT93+MVdjk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.10/go.mod h1:F+EZtuIwjlv35kRJPyBGcsA4f7bnSoz15zOQ2lJq1Z4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19 h1:gC5mudiFrWGhzcdoWj1iCGUfrzCpQG0MQIQf0CXFFQQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19/go.mod h1:llxE6bwUZhuCas0K7qGiu5OgMis3N7kdWtFSxoHmJ7E=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.20 h1:Rk8eqZSdFovt8Id+O+i2qT0c3CY13DPn2SfGOEVlxNs=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.20/go.mod h1:gdZ5gRUaxThXIZyZQ8MTtgYBk2jbHgp05BO3GcD9Cwc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.4/go.mod h1:8glyUqVIM4AmeenIsPo0oVh3+NUwnsQml2OFupfQW+0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13 h1:qezY57na06d6kSE7uuB0N7XEflu914AXx/hg2L8Ykcw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13/go.mod h1:lB12mkZqCSo5PsdBFLNqc2M/OOYgNAy8UtaktyuWvE8=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.14 h1:6Yxuq9yrkoLYab5JXqJnto9tdRuIcYVdR+eiKjsJYWU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.14/go.mod h1:GEV9jaDPIgayiU+uevxwozcvUOjc+P4aHE2BeSjm2vE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 h1:6cZRymlLEIlDTEB0+5+An6Zj1CKt6rSE69tOmFeu1nk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11/go.mod h1:0MR+sS1b/yxsfAPvAESrw8NfwUoxMinDyw6EYR9BS2U=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.18.8 h1:0GNYWmqqR9KfwcYKyUOG9k0V6Mq9jZy2e9pwABsxQmM=
@@ -47,6 +49,8 @@ github.com/aws/aws-sdk-go-v2/service/fis v1.12.13 h1:tDH0KAjglMY+n8Gr+lmDI5icSWD
 github.com/aws/aws-sdk-go-v2/service/fis v1.12.13/go.mod h1:hPItFatx4DLydS1AqZ7N/rWaTi8ASGd3lGQrzfSc0Uk=
 github.com/aws/aws-sdk-go-v2/service/iam v1.18.4 h1:E41guA79mjEbwJdh0zXz1d8+Zt4zxRr+b1ipiVbKXzs=
 github.com/aws/aws-sdk-go-v2/service/iam v1.18.4/go.mod h1:FpNvAfCZyIQ3qeNJUOw4CShKvdizHblXqAvSk0qmyL4=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.0 h1:RkSEzzGoabfnnVXF9Mon9+/KYYVw2hLjK1i47ka/Tyg=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.0/go.mod h1:7dp7wVJ+ldmxHAD1Zo6Q65duUXCtNNoFk10Eu8uSCco=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4 h1:b16QW0XWl0jWjLABFc1A+uh145Oqv+xDcObNk0iQgUk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4/go.mod h1:uKkN7qmSIsNJVyMtxNQoCEYMvFEXbOg9fwCJPdfp2u8=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.33.1 h1:XOTWbVWu4wAVozPAny4v5fyWZtjXS+KZl4OAe04vJbw=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,9 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aws/aws-sdk-go v1.44.88 h1:9jhiZsTx9koQQsM29RTgwI0g4mfyphCdc3bkUcKrdwA=
 github.com/aws/aws-sdk-go v1.44.88/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.3/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
-github.com/aws/aws-sdk-go-v2 v1.16.12 h1:wbMYa2PlFysFx2GLIQojr6FJV5+OWCM/BwyHXARxETA=
 github.com/aws/aws-sdk-go-v2 v1.16.12/go.mod h1:C+Ym0ag2LIghJbXhfXZ0YEEp49rBWowxKzJLUoob0ts=
+github.com/aws/aws-sdk-go-v2 v1.16.13 h1:HgF7OX2q0gSZtcXoo9DMEA8A2Qk/GCxmWyM0RI7Yz2Y=
+github.com/aws/aws-sdk-go-v2 v1.16.13/go.mod h1:xSyvSnzh0KLs5H4HJGeIEsNYemUWdNIl0b/rP6SIsLU=
 github.com/aws/aws-sdk-go-v2/config v1.15.4 h1:P4mesY1hYUxru4f9SU0XxNKXmzfxsD0FtMIPRBjkH7Q=
 github.com/aws/aws-sdk-go-v2/config v1.15.4/go.mod h1:ZijHHh0xd/A+ZY53az0qzC5tT46kt4JVCePf2NX9Lk4=
 github.com/aws/aws-sdk-go-v2/credentials v1.12.0 h1:4R/NqlcRFSkR0wxOhgHi+agGpbEr5qMCjn7VqUIJY+E=
@@ -63,8 +64,9 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.4/go.mod h1:lfSYenAXtavyX2A1LsVig
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.5 h1:hYZofZdt2q8hvpM7XV8/gN49ZEd8wf236G66Oo6QW08=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.21.5/go.mod h1:mmV5KXzUW+R8AMqDFkgX1vJ1th6SiyaghjvqQm3TC8g=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
-github.com/aws/smithy-go v1.13.0 h1:YfyEmSJLo7fAv8FbuDK4R8F9aAmi9DZ88Zb/KJJmUl0=
 github.com/aws/smithy-go v1.13.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.13.1 h1:q09BdpUiaqpothcv393ACfWJJHzlzjB5HaNL1XHKmoQ=
+github.com/aws/smithy-go v1.13.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore"
 	"github.com/aws/aws-sdk-go-v2/service/kendra"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
@@ -142,7 +143,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/healthlake"
 	"github.com/aws/aws-sdk-go/service/honeycode"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/identitystore"
 	"github.com/aws/aws-sdk-go/service/imagebuilder"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/aws/aws-sdk-go/service/inspector2"
@@ -454,7 +454,7 @@ type AWSClient struct {
 	HoneycodeConn                    *honeycode.Honeycode
 	IAMConn                          *iam.IAM
 	IVSConn                          *ivs.IVS
-	IdentityStoreConn                *identitystore.IdentityStore
+	IdentityStoreConn                *identitystore.Client
 	ImageBuilderConn                 *imagebuilder.Imagebuilder
 	InspectorConn                    *inspector.Inspector
 	Inspector2Conn                   *inspector2.Inspector2

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore"
 	"github.com/aws/aws-sdk-go-v2/service/kendra"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
@@ -205,6 +206,12 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	client.FISConn = fis.NewFromConfig(cfg, func(o *fis.Options) {
 		if endpoint := c.Endpoints[names.FIS]; endpoint != "" {
 			o.EndpointResolver = fis.EndpointResolverFromURL(endpoint)
+		}
+	})
+
+	client.IdentityStoreConn = identitystore.NewFromConfig(cfg, func(o *identitystore.Options) {
+		if endpoint := c.Endpoints[names.IdentityStore]; endpoint != "" {
+			o.EndpointResolver = identitystore.EndpointResolverFromURL(endpoint)
 		}
 	})
 

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -133,7 +133,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/healthlake"
 	"github.com/aws/aws-sdk-go/service/honeycode"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/identitystore"
 	"github.com/aws/aws-sdk-go/service/imagebuilder"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/aws/aws-sdk-go/service/inspector2"
@@ -424,7 +423,6 @@ func (c *Config) clientConns(sess *session.Session) *AWSClient {
 		HoneycodeConn:                    honeycode.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Honeycode])})),
 		IAMConn:                          iam.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IAM])})),
 		IVSConn:                          ivs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IVS])})),
-		IdentityStoreConn:                identitystore.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.IdentityStore])})),
 		ImageBuilderConn:                 imagebuilder.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ImageBuilder])})),
 		InspectorConn:                    inspector.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Inspector])})),
 		Inspector2Conn:                   inspector2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Inspector2])})),

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -1,19 +1,23 @@
 package identitystore
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/identitystore"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func DataSourceGroup() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceGroupRead,
+		ReadContext: dataSourceGroupRead,
 
 		Schema: map[string]*schema.Schema{
 			"display_name": {
@@ -60,70 +64,74 @@ func DataSourceGroup() *schema.Resource {
 	}
 }
 
-func dataSourceGroupRead(d *schema.ResourceData, meta interface{}) error {
+const (
+	DSNameGroup = "Group Data Source"
+)
+
+func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).IdentityStoreConn
 
+	identityStoreId := d.Get("identity_store_id").(string)
+
+	// Filters has been marked as deprecated in favour of GetGroupId, which
+	// allows only a single filter. Keep using it to maintain backwards
+	// compatibility of the data source.
+
 	input := &identitystore.ListGroupsInput{
-		IdentityStoreId: aws.String(d.Get("identity_store_id").(string)),
+		IdentityStoreId: aws.String(identityStoreId),
 		Filters:         expandFilters(d.Get("filter").(*schema.Set).List()),
 	}
 
-	var results []*identitystore.Group
+	var results []types.Group
 
-	err := conn.ListGroupsPages(input, func(page *identitystore.ListGroupsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	paginator := identitystore.NewListGroupsPaginator(conn, input)
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+
+		if err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreId, err)
 		}
 
 		for _, group := range page.Groups {
-			if group == nil {
-				continue
-			}
-
-			if v, ok := d.GetOk("group_id"); ok && v.(string) != aws.StringValue(group.GroupId) {
+			if v, ok := d.GetOk("group_id"); ok && v.(string) != aws.ToString(group.GroupId) {
 				continue
 			}
 
 			results = append(results, group)
 		}
-
-		return !lastPage
-	})
-
-	if err != nil {
-		return fmt.Errorf("error listing Identity Store Groups: %w", err)
 	}
 
 	if len(results) == 0 {
-		return fmt.Errorf("no Identity Store Group found matching criteria\n%v; try different search", input.Filters)
+		return diag.Errorf("no Identity Store Group found matching criteria\n%v; try different search", input.Filters)
 	}
 
 	if len(results) > 1 {
-		return fmt.Errorf("multiple Identity Store Groups found matching criteria\n%v; try different search", input.Filters)
+		return diag.Errorf("multiple Identity Store Groups found matching criteria\n%v; try different search", input.Filters)
 	}
 
 	group := results[0]
 
-	d.SetId(aws.StringValue(group.GroupId))
+	d.SetId(aws.ToString(group.GroupId))
 	d.Set("display_name", group.DisplayName)
 	d.Set("group_id", group.GroupId)
 
 	return nil
 }
 
-func expandFilters(l []interface{}) []*identitystore.Filter {
+func expandFilters(l []interface{}) []types.Filter {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	filters := make([]*identitystore.Filter, 0, len(l))
+	filters := make([]types.Filter, 0, len(l))
 	for _, v := range l {
 		tfMap, ok := v.(map[string]interface{})
 		if !ok {
 			continue
 		}
 
-		filter := &identitystore.Filter{}
+		filter := types.Filter{}
 
 		if v, ok := tfMap["attribute_path"].(string); ok && v != "" {
 			filter.AttributePath = aws.String(v)

--- a/names/names.go
+++ b/names/names.go
@@ -24,6 +24,7 @@ import (
 // This "should" be defined by the AWS Go SDK v2, but currently isn't.
 const (
 	ComprehendEndpointID     = "comprehend"
+	IdentityStoreEndpointID  = "identitystore"
 	KendraEndpointID         = "kendra"
 	MediaLiveEndpointID      = "medialive"
 	RolesAnywhereEndpointID  = "rolesanywhere"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -326,7 +326,7 @@ ssm-contacts,ssmcontacts,ssmcontacts,ssmcontacts,,ssmcontacts,,,SSMContacts,SSMC
 ssm-incidents,ssmincidents,ssmincidents,ssmincidents,,ssmincidents,,,SSMIncidents,SSMIncidents,,1,,aws_ssmincidents_,,ssmincidents_,SSM Incident Manager Incidents,AWS,,,,,
 sso,sso,sso,sso,,sso,,,SSO,SSO,,1,,aws_sso_,,sso_,SSO (Single Sign-On),AWS,,,,,
 sso-admin,ssoadmin,ssoadmin,ssoadmin,,ssoadmin,,,SSOAdmin,SSOAdmin,,1,,aws_ssoadmin_,,ssoadmin_,SSO Admin,AWS,,,,,
-identitystore,identitystore,identitystore,identitystore,,identitystore,,,IdentityStore,IdentityStore,,1,,aws_identitystore_,,identitystore_,SSO Identity Store,AWS,,,,,
+identitystore,identitystore,identitystore,identitystore,,identitystore,,,IdentityStore,IdentityStore,x,2,,aws_identitystore_,,identitystore_,SSO Identity Store,AWS,,,,,
 sso-oidc,ssooidc,ssooidc,ssooidc,,ssooidc,,,SSOOIDC,SSOOIDC,,1,,aws_ssooidc_,,ssooidc_,SSO OIDC,AWS,,,,,
 storagegateway,storagegateway,storagegateway,storagegateway,,storagegateway,,,StorageGateway,StorageGateway,,1,,aws_storagegateway_,,storagegateway_,Storage Gateway,AWS,,,,,
 sts,sts,sts,sts,,sts,,,STS,STS,x,1,aws_caller_identity,aws_sts_,,caller_identity,STS (Security Token),AWS,,,AWS_STS_ENDPOINT,TF_AWS_STS_ENDPOINT,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/26598

AWS Go SDK v2 is required to update user and group attributes. (https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_AttributeOperation.html)

The `Filter` attribute of the `ListUsers` and `ListGroups` API-s has been deprecated in favour of `GetUserId` and `GetGroupId`, which would also lead to the deprecation of the `filters` argument to the data sources (where only one type of query is supported anyway). However, I think it'd be simpler to introduce this deprecation after the resources have been implemented, as there's an overlap of finders.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccIdentityStore PKG=identitystore
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 20 -run='TestAccIdentityStore'  -timeout 180m
=== RUN   TestAccIdentityStoreGroupDataSource_displayName
=== PAUSE TestAccIdentityStoreGroupDataSource_displayName
=== RUN   TestAccIdentityStoreGroupDataSource_groupID
=== PAUSE TestAccIdentityStoreGroupDataSource_groupID
=== RUN   TestAccIdentityStoreGroupDataSource_nonExistent
=== PAUSE TestAccIdentityStoreGroupDataSource_nonExistent
=== RUN   TestAccIdentityStoreUserDataSource_userName
=== PAUSE TestAccIdentityStoreUserDataSource_userName
=== RUN   TestAccIdentityStoreUserDataSource_userID
=== PAUSE TestAccIdentityStoreUserDataSource_userID
=== RUN   TestAccIdentityStoreUserDataSource_nonExistent
=== PAUSE TestAccIdentityStoreUserDataSource_nonExistent
=== CONT  TestAccIdentityStoreGroupDataSource_displayName
=== CONT  TestAccIdentityStoreUserDataSource_userName
=== CONT  TestAccIdentityStoreGroupDataSource_nonExistent
=== CONT  TestAccIdentityStoreGroupDataSource_groupID
=== CONT  TestAccIdentityStoreUserDataSource_nonExistent
=== CONT  TestAccIdentityStoreUserDataSource_userID
--- PASS: TestAccIdentityStoreGroupDataSource_nonExistent (2.57s)
--- PASS: TestAccIdentityStoreUserDataSource_nonExistent (2.59s)
--- PASS: TestAccIdentityStoreUserDataSource_userName (8.24s)
--- PASS: TestAccIdentityStoreGroupDataSource_displayName (8.33s)
--- PASS: TestAccIdentityStoreGroupDataSource_groupID (8.37s)
--- PASS: TestAccIdentityStoreUserDataSource_userID (8.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/identitystore   10.129s
```
