### PR TITLE
F aws eks addon add timeouts

### DIFF
--- a/.changelog/26629.txt
+++ b/.changelog/26629.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_addon: Support configurable timeouts for addon create, update, and delete
+```

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -11,19 +11,15 @@ import (
 )
 
 const (
-	addonCreatedTimeout = 20 * time.Minute
-	addonUpdatedTimeout = 20 * time.Minute
-	addonDeletedTimeout = 40 * time.Minute
-
 	clusterDeleteRetryTimeout = 60 * time.Minute
 )
 
-func waitAddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
+func waitAddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string, timeout time.Duration) (*eks.Addon, error) {
 	stateConf := resource.StateChangeConf{
 		Pending: []string{eks.AddonStatusCreating, eks.AddonStatusDegraded},
 		Target:  []string{eks.AddonStatusActive},
 		Refresh: statusAddon(ctx, conn, clusterName, addonName),
-		Timeout: addonCreatedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -39,12 +35,12 @@ func waitAddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName
 	return nil, err
 }
 
-func waitAddonDeleted(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
+func waitAddonDeleted(ctx context.Context, conn *eks.EKS, clusterName, addonName string, timeout time.Duration) (*eks.Addon, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.AddonStatusActive, eks.AddonStatusDeleting},
 		Target:  []string{},
 		Refresh: statusAddon(ctx, conn, clusterName, addonName),
-		Timeout: addonDeletedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -60,12 +56,12 @@ func waitAddonDeleted(ctx context.Context, conn *eks.EKS, clusterName, addonName
 	return nil, err
 }
 
-func waitAddonUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, addonName, id string) (*eks.Update, error) {
+func waitAddonUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, addonName, id string, timeout time.Duration) (*eks.Update, error) {
 	stateConf := resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},
 		Target:  []string{eks.UpdateStatusSuccessful},
 		Refresh: statusAddonUpdate(ctx, conn, clusterName, addonName, id),
-		Timeout: addonUpdatedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -110,6 +110,14 @@ In addition to all arguments above, the following attributes are exported:
 * `modified_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the EKS add-on was updated.
 * `tags_all` - (Optional) Key-value map of resource tags, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `20m`)
+* `update` - (Default `20m`)
+* `delete` - (Default `40m`)
+
 ## Import
 
 EKS add-on can be imported using the `cluster_name` and `addon_name` separated by a colon (`:`), e.g.,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #26474 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I did not exercise acceptance tests on this change because the related aws_eks_cluster does not exercise Timeout settings in its acceptance tests.
