### PR TITLE
resource/aws_instance: Handle regions where instance metadata tags are unsupported

### DIFF
--- a/.changelog/26631.txt
+++ b/.changelog/26631.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: No longer fails when setting `metadata_options.instance_metadata_tags`
+```


### PR DESCRIPTION
Some AWS regions, such as `me-central-1` do not currently support Instance Metadata Tags. The default value supplied by the provider was causing the provider to fail in some cases.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26561

Output from acceptance testing:

Previously:

```
$ AWS_REGION=me-central-1 make testacc PKG=ec2 TESTS=TestAccEC2Instance_metadataOptions

        Error: updating EC2 Instance (i-abc123) metadata options: UnsupportedOperation: Specifying InstanceMetadataTags is not yet supported in this region.
```

Now (changing expected `instance_metadata_tags` to `""`)

```
--- PASS: TestAccEC2Instance_metadataOptions (291.19s)
```

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25227.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/25778.