### PR TITLE
keyspaces Don't sweep system_multiregion_info

### DIFF
--- a/internal/service/keyspaces/sweep.go
+++ b/internal/service/keyspaces/sweep.go
@@ -40,7 +40,7 @@ func sweepKeyspaces(region string) error { // nosemgrep:ci.keyspaces-in-func-nam
 			id := aws.StringValue(v.KeyspaceName)
 
 			switch id {
-			case "system_schema", "system_schema_mcs", "system":
+			case "system_schema", "system_schema_mcs", "system", "system_multiregion_info":
 				// The default keyspaces cannot be deleted.
 				continue
 			}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26529

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

before:

```
 in region (us-west-2): error sweeping Keyspaces Keyspaces (us-west-2): 1 error occurred:
        * error deleting resource: deleting Keyspaces Keyspace (system_multiregion_info): ValidationException: system_multiregion_info keyspace is not user-modifiable.
```

after:
```
2022/09/03 09:30:40 Completed Sweepers for region (us-west-2) in 4.1224265s
2022/09/03 09:30:40 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_keyspaces_keyspace
```