### PR TITLE
Add validation to on aws_iam_policy_document source_policy_documents

### DIFF
--- a/.changelog/26640.txt
+++ b/.changelog/26640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ data-source/aws_iam_policy_document: Prevent crash when `source_policy_documents` contains empty or invalid JSON documents
+```

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -56,7 +56,7 @@ func DataSourcePolicyDocument() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.All(validation.StringIsNotEmpty, validation.StringIsJSON),
+					ValidateFunc: validation.StringIsJSON,
 				},
 			},
 			"statement": {
@@ -139,6 +139,10 @@ func dataSourcePolicyDocumentRead(d *schema.ResourceData, meta interface{}) erro
 
 		// merge sourceDocs in order specified
 		for sourceJSONIndex, sourceJSON := range v.([]interface{}) {
+			if sourceJSON == nil {
+				continue
+			}
+
 			sourceDoc := &IAMPolicyDoc{}
 			if err := json.Unmarshal([]byte(sourceJSON.(string)), sourceDoc); err != nil {
 				return err

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -54,7 +54,10 @@ func DataSourcePolicyDocument() *schema.Resource {
 			"source_policy_documents": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.All(validation.StringIsNotEmpty, validation.StringIsJSON),
+				},
 			},
 			"statement": {
 				Type:     schema.TypeList,

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -223,6 +223,24 @@ func TestAccIAMPolicyDocumentDataSource_duplicateSid(t *testing.T) {
 	})
 }
 
+func TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJson(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPolicyDocumentDataSourceConfig_invalidJson,
+				ExpectError: regexp.MustCompile(`"source_policy_documents.0" contains an invalid JSON: unexpected end of JSON input`),
+			},
+			{
+				Config:      testAccPolicyDocumentDataSourceConfig_emptyString,
+				ExpectError: regexp.MustCompile(`expected "source_policy_documents.0" to not be an empty string, got`),
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/10777
 func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice(t *testing.T) {
 	dataSourceName := "data.aws_iam_policy_document.test"
@@ -1274,6 +1292,18 @@ data "aws_iam_policy_document" "test" {
       type = "AWS"
     }
   }
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_emptyString = `
+data "aws_iam_policy_document" "test" {
+	source_policy_documents = [""]
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_invalidJson = `
+data "aws_iam_policy_document" "test" {
+	source_policy_documents = ["{"]
 }
 `
 

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -223,19 +223,23 @@ func TestAccIAMPolicyDocumentDataSource_duplicateSid(t *testing.T) {
 	})
 }
 
-func TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJson(t *testing.T) {
+func TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccPolicyDocumentDataSourceConfig_invalidJson,
+				Config:      testAccPolicyDocumentDataSourceConfig_invalidJSON,
 				ExpectError: regexp.MustCompile(`"source_policy_documents.0" contains an invalid JSON: unexpected end of JSON input`),
 			},
 			{
-				Config:      testAccPolicyDocumentDataSourceConfig_emptyString,
-				ExpectError: regexp.MustCompile(`expected "source_policy_documents.0" to not be an empty string, got`),
+				Config: testAccPolicyDocumentDataSourceConfig_emptyString,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json",
+						testAccPolicyDocumentExpectedJSONNoStatement,
+					),
+				),
 			},
 		},
 	})
@@ -1297,15 +1301,19 @@ data "aws_iam_policy_document" "test" {
 
 var testAccPolicyDocumentDataSourceConfig_emptyString = `
 data "aws_iam_policy_document" "test" {
-	source_policy_documents = [""]
+  source_policy_documents = [""]
 }
 `
 
-var testAccPolicyDocumentDataSourceConfig_invalidJson = `
+var testAccPolicyDocumentDataSourceConfig_invalidJSON = `
 data "aws_iam_policy_document" "test" {
-	source_policy_documents = ["{"]
+  source_policy_documents = ["{"]
 }
 `
+
+var testAccPolicyDocumentExpectedJSONNoStatement = `{
+  "Version": "2012-10-17"
+}`
 
 func testAccPolicyDocumentExpectedJSONStatementPrincipalIdentifiersMultiplePrincipals() string {
 	return fmt.Sprintf(`{

--- a/internal/service/iam/policy_model.go
+++ b/internal/service/iam/policy_model.go
@@ -13,7 +13,7 @@ const (
 type IAMPolicyDoc struct {
 	Version    string                `json:",omitempty"`
 	Id         string                `json:",omitempty"`
-	Statements []*IAMPolicyStatement `json:"Statement"`
+	Statements []*IAMPolicyStatement `json:"Statement,omitempty"`
 }
 
 type IAMPolicyStatement struct {


### PR DESCRIPTION
Adds empty string and JSON validation to `aws_iam_policy_document.source_policy_documents`
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26071.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23910.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ ACCTEST_PARALLELISM=10 make testacc TESTS=TestAccIAMPolicyDocumentDataSource PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 10 -run='TestAccIAMPolicyDocumentDataSource'  -timeout 180m
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== RUN   TestAccIAMPolicyDocumentDataSource_source
=== PAUSE TestAccIAMPolicyDocumentDataSource_source
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceList
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceList
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_override
=== PAUSE TestAccIAMPolicyDocumentDataSource_override
=== RUN   TestAccIAMPolicyDocumentDataSource_overrideList
=== PAUSE TestAccIAMPolicyDocumentDataSource_overrideList
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== RUN   TestAccIAMPolicyDocumentDataSource_duplicateSid
=== PAUSE TestAccIAMPolicyDocumentDataSource_duplicateSid
=== RUN   TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJson
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJson
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== RUN   TestAccIAMPolicyDocumentDataSource_version20081017
=== PAUSE TestAccIAMPolicyDocumentDataSource_version20081017
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMPolicyDocumentDataSource_override
=== CONT  TestAccIAMPolicyDocumentDataSource_source
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceList
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== CONT  TestAccIAMPolicyDocumentDataSource_version20081017
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
    acctest.go:719: skipping tests; current partition (aws) does not equal aws-us-gov
--- SKIP: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov (1.69s)
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceListConflicting (6.16s)
=== CONT  TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== CONT  TestAccIAMPolicyDocumentDataSource_duplicateSid
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (20.43s)
--- PASS: TestAccIAMPolicyDocumentDataSource_override (20.45s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJson
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementOverride
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice (20.51s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementMerge (20.51s)
=== CONT  TestAccIAMPolicyDocumentDataSource_overrideList
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (20.56s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceList (20.62s)
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals (18.94s)
--- PASS: TestAccIAMPolicyDocumentDataSource_singleConditionValue (15.79s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJson (1.65s)
--- PASS: TestAccIAMPolicyDocumentDataSource_version20081017 (28.95s)
--- PASS: TestAccIAMPolicyDocumentDataSource_source (31.61s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementOverride (12.24s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideList (12.29s)
--- PASS: TestAccIAMPolicyDocumentDataSource_duplicateSid (14.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	37.017s

...
```
