### PR TITLE
Handle bool value in condition when importing json policy

### DIFF
--- a/.changelog/26657.txt
+++ b/.changelog/26657.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
- data-source/aws_iam_policy_document: Correctly handle unquoted Boolean value in `Condition`
+ data-source/aws_iam_policy_document: Correctly handle unquoted Boolean values in `Condition`
 ```

--- a/.changelog/26657.txt
+++ b/.changelog/26657.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ data-source/aws_iam_policy_document: Correctly handle unquoted Boolean value in `Condition`
+```

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -1241,6 +1241,8 @@ data "aws_iam_policy_document" "test" {
 `
 
 const testAccPolicyDocumentConfig_conditionWithBoolValue = `
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "test" {
   source_policy_documents = [<<EOF
 {
@@ -1253,7 +1255,7 @@ data "aws_iam_policy_document" "test" {
                 "ec2:CreateTags",
                 "ec2:DeleteTags"
             ],
-            "Resource": "arn:aws:ec2:*:*:vpc/*",
+            "Resource": "arn:${data.aws_partition.current.partition}:ec2:*:*:vpc/*",
             "Condition": {
                 "Null": {
                     "aws:ResourceTag/SpecialTag": false
@@ -1262,7 +1264,7 @@ data "aws_iam_policy_document" "test" {
                     "aws:ResourceAccount": [
                         "123456"
                     ],
-                    "aws:PrincipalArn": "arn:aws:iam::*:role/AWSAFTExecution"
+                    "aws:PrincipalArn": "arn:${data.aws_partition.current.partition}:iam::*:role/AWSAFTExecution"
                 }
             }
         }

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -60,7 +60,7 @@ func TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue(t *testing.T) {
 				Config: testAccPolicyDocumentConfig_conditionWithBoolValue,
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrEquivalentJSON("data.aws_iam_policy_document.test", "json",
-						testAccPolicyDocumentConfig_conditionWithBoolValue_expectedJson,
+						testAccPolicyDocumentConditionWithBoolValueExpectedJSON(),
 					),
 				),
 			},
@@ -1275,8 +1275,8 @@ EOF
 }
 `
 
-const testAccPolicyDocumentConfig_conditionWithBoolValue_expectedJson = `
-{
+func testAccPolicyDocumentConditionWithBoolValueExpectedJSON() string {
+	return fmt.Sprintf(`{
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -1286,7 +1286,7 @@ const testAccPolicyDocumentConfig_conditionWithBoolValue_expectedJson = `
                 "ec2:CreateTags",
                 "ec2:DeleteTags"
             ],
-            "Resource": "arn:aws:ec2:*:*:vpc/*",
+            "Resource": "arn:%[1]s:ec2:*:*:vpc/*",
             "Condition": {
                 "Null": {
                     "aws:ResourceTag/SpecialTag": "false"
@@ -1296,14 +1296,14 @@ const testAccPolicyDocumentConfig_conditionWithBoolValue_expectedJson = `
                         "123456"
                     ],
                     "aws:PrincipalArn": [
-						"arn:aws:iam::*:role/AWSAFTExecution"
+						"arn:%[1]s:iam::*:role/AWSAFTExecution"
 					]
                 }
             }
         }
     ]
+  }`, acctest.Partition())
 }
-`
 
 func testAccPolicyDocumentExpectedJSONStatementPrincipalIdentifiersStringAndSlice() string {
 	return fmt.Sprintf(`{

--- a/internal/service/iam/policy_model.go
+++ b/internal/service/iam/policy_model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 )
 
 const (
@@ -199,6 +200,8 @@ func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
 			switch var_values := var_values.(type) {
 			case string:
 				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: []string{var_values}})
+			case bool:
+				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: strconv.FormatBool(var_values)})
 			case []interface{}:
 				values := []string{}
 				for _, v := range var_values {


### PR DESCRIPTION
Handle situation where we import a policy with a bool value in a condition.

[Quoting](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html#policies-grammar-json) AWS 
>Values are enclosed in quotation marks. Quotation marks are optional for numeric and Boolean values

This merge addresses the issue raised in 26485. However we may still see a scenario where we do not handle an unquoted numeric or a list of unquoted bool or numeric. I can look at addressing these problems in a separate merge or is it worth handling these issues in this merge?

Thanks

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26485

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
ACCTEST_PARALLELISM=10 make testacc TESTS=TestAccIAMPolicyDocumentDataSource PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 10 -run='TestAccIAMPolicyDocumentDataSource'  -timeout 180m
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== RUN   TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== RUN   TestAccIAMPolicyDocumentDataSource_source
=== PAUSE TestAccIAMPolicyDocumentDataSource_source
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceList
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceList
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_override
=== PAUSE TestAccIAMPolicyDocumentDataSource_override
=== RUN   TestAccIAMPolicyDocumentDataSource_overrideList
=== PAUSE TestAccIAMPolicyDocumentDataSource_overrideList
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== RUN   TestAccIAMPolicyDocumentDataSource_duplicateSid
=== PAUSE TestAccIAMPolicyDocumentDataSource_duplicateSid
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== RUN   TestAccIAMPolicyDocumentDataSource_version20081017
=== PAUSE TestAccIAMPolicyDocumentDataSource_version20081017
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_overrideList
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== CONT  TestAccIAMPolicyDocumentDataSource_duplicateSid
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== CONT  TestAccIAMPolicyDocumentDataSource_version20081017
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceList
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
    acctest.go:719: skipping tests; current partition (aws) does not equal aws-us-gov
--- SKIP: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov (1.38s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals (26.11s)
=== CONT  TestAccIAMPolicyDocumentDataSource_override
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceList (26.90s)
=== CONT  TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (25.85s)
=== CONT  TestAccIAMPolicyDocumentDataSource_source
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice (27.41s)
=== CONT  TestAccIAMPolicyDocumentDataSource_singleConditionValue
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementMerge (27.68s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceListConflicting
--- PASS: TestAccIAMPolicyDocumentDataSource_duplicateSid (28.31s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (28.32s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideList (28.32s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementOverride (28.32s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceListConflicting (3.92s)
--- PASS: TestAccIAMPolicyDocumentDataSource_version20081017 (37.54s)
--- PASS: TestAccIAMPolicyDocumentDataSource_override (15.54s)
--- PASS: TestAccIAMPolicyDocumentDataSource_singleConditionValue (16.22s)
--- PASS: TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue (16.73s)
--- PASS: TestAccIAMPolicyDocumentDataSource_source (27.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	57.949s

...
```
