### PR TITLE
Fix link to RDS proxy endpoints

### DIFF
--- a/website/docs/r/db_proxy_endpoint.html.markdown
+++ b/website/docs/r/db_proxy_endpoint.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_db_proxy_endpoint
 
-Provides an RDS DB proxy endpoint resource. For additional information, see the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html#rds-proxy-endpoints).
+Provides an RDS DB proxy endpoint resource. For additional information, see the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-endpoints.html).
 
 ## Example Usage
 


### PR DESCRIPTION
The old page still exists but doesn't contain the anchor nor any specific endpoint documentation, thus I figured to switch to the new link.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

