### PR TITLE
fix(doc): update aws_prometheus_workspace data source doc with good name

### DIFF
--- a/website/docs/d/prometheus_workspace.html.markdown
+++ b/website/docs/d/prometheus_workspace.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Gets information on an Amazon Managed Prometheus workspace.
 ---
 
-# Data Source: aws_amp_workspace
+# Data Source: aws_prometheus_workspace
 
 Provides an Amazon Managed Prometheus workspace data source.
 
@@ -15,7 +15,7 @@ Provides an Amazon Managed Prometheus workspace data source.
 ### Basic configuration
 
 ```terraform
-data "aws_amp_workspace" "example" {
+data "aws_prometheus_workspace" "example" {
   workspace_id = "ws-41det8a1-2c67-6a1a-9381-9b83d3d78ef7"
 }
 ```


### PR DESCRIPTION
The real datasource name is aws_prometheus_workspace while the documentation ex. use aws_amp_workspace

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
