### PR TITLE
resource/aws_ec2_fleet: Create sweeper

### DIFF
--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -618,12 +618,10 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 	// Instead of an error here, allow the Read function to trigger recreation.
 	targetStates := []string{ec2.FleetStateCodeActive}
 	if fleetType == ec2.FleetTypeRequest {
-		targetStates = append(targetStates, ec2.FleetStateCodeDeleted)
-		targetStates = append(targetStates, ec2.FleetStateCodeDeletedRunning)
-		targetStates = append(targetStates, ec2.FleetStateCodeDeletedTerminating)
+		targetStates = append(targetStates, ec2.FleetStateCodeDeleted, ec2.FleetStateCodeDeletedRunning, ec2.FleetStateCodeDeletedTerminating)
 	}
 
-	if _, err := WaitFleet(conn, d.Id(), []string{ec2.FleetStateCodeSubmitted}, targetStates, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if _, err := WaitFleet(conn, d.Id(), []string{ec2.FleetStateCodeSubmitted}, targetStates, d.Timeout(schema.TimeoutCreate), 0); err != nil {
 		return fmt.Errorf("waiting for EC2 Fleet (%s) create: %w", d.Id(), err)
 	}
 
@@ -722,7 +720,7 @@ func resourceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("modifying EC2 Fleet (%s): %w", d.Id(), err)
 		}
 
-		if _, err := WaitFleet(conn, d.Id(), []string{ec2.FleetStateCodeModifying}, []string{ec2.FleetStateCodeActive}, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := WaitFleet(conn, d.Id(), []string{ec2.FleetStateCodeModifying}, []string{ec2.FleetStateCodeActive}, d.Timeout(schema.TimeoutUpdate), 0); err != nil {
 			return fmt.Errorf("waiting for EC2 Fleet (%s) update: %w", d.Id(), err)
 		}
 	}
@@ -759,15 +757,17 @@ func resourceFleetDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("deleting EC2 Fleet (%s): %w", d.Id(), err)
 	}
 
+	delay := 0 * time.Second
 	pendingStates := []string{ec2.FleetStateCodeActive}
 	targetStates := []string{ec2.FleetStateCodeDeleted}
 	if d.Get("terminate_instances").(bool) {
 		pendingStates = append(pendingStates, ec2.FleetStateCodeDeletedTerminating)
+		delay = 5 * time.Minute
 	} else {
 		targetStates = append(targetStates, ec2.FleetStateCodeDeletedRunning)
 	}
 
-	if _, err := WaitFleet(conn, d.Id(), pendingStates, targetStates, d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, err := WaitFleet(conn, d.Id(), pendingStates, targetStates, d.Timeout(schema.TimeoutDelete), delay); err != nil {
 		return fmt.Errorf("waiting for EC2 Fleet (%s) delete: %w", d.Id(), err)
 	}
 

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -371,12 +371,14 @@ func WaitClientVPNRouteDeleted(conn *ec2.EC2, endpointID, targetSubnetID, destin
 	return nil, err
 }
 
-func WaitFleet(conn *ec2.EC2, id string, pending, target []string, timeout time.Duration) (*ec2.FleetData, error) {
+func WaitFleet(conn *ec2.EC2, id string, pending, target []string, timeout, delay time.Duration) (*ec2.FleetData, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: pending,
-		Target:  target,
-		Refresh: StatusFleetState(conn, id),
-		Timeout: timeout,
+		Pending:    pending,
+		Target:     target,
+		Refresh:    StatusFleetState(conn, id),
+		Timeout:    timeout,
+		Delay:      delay,
+		MinTimeout: 1 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForState()


### PR DESCRIPTION
Creates sweeper for `aws_ec2_fleet`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26630

```console
$ make sweep SWEEPERS=aws_ec2_fleet

[DEBUG] Running Sweepers for region (us-west-2):
[DEBUG] Running Sweeper (aws_ec2_fleet) in region (us-west-2)
[DEBUG] Completed Sweeper (aws_ec2_fleet) in region (us-west-2) in 4.525787176s
Completed Sweepers for region (us-west-2) in 4.526096262s
Sweeper Tests for region (us-west-2) ran successfully:
	- aws_ec2_fleet
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ec2 TESTS=TestAccEC2Fleet_

--- PASS: TestAccEC2Fleet_SpotOptions_capacityRebalance (109.46s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDemand (110.28s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot (110.31s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (110.85s)
--- PASS: TestAccEC2Fleet_basic (110.87s)
--- PASS: TestAccEC2Fleet_capacityRebalanceInvalidType (10.94s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType (141.80s)
--- PASS: TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior (159.46s)
--- PASS: TestAccEC2Fleet_terminateInstancesWithExpiration (160.08s)
--- PASS: TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount (160.45s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_priority (177.69s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple (186.10s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceType (189.90s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_subnetID (190.49s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorageTypes (193.71s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_requireHibernateSupport (194.78s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_instanceGenerations (195.46s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTypes (195.60s)
--- PASS: TestAccEC2Fleet_SpotOptions_allocationStrategy (105.98s)
--- PASS: TestAccEC2Fleet_OnDemandOptions_allocationStrategy (106.38s)
--- PASS: TestAccEC2Fleet_replaceUnhealthyInstances (97.34s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorage (240.95s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_networkInterfaceCount (243.48s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU (245.08s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice (53.65s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone (110.64s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorNames (112.92s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorManufacturers (119.45s)
--- PASS: TestAccEC2Fleet_type (55.09s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID (107.93s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateName (109.48s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount (115.65s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version (110.65s)
--- PASS: TestAccEC2Fleet_tags (95.36s)
--- PASS: TestAccEC2Fleet_disappears (41.85s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_totalLocalStorageGB (173.87s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple (103.31s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB (168.96s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_excludedInstanceTypes (101.69s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorCount (162.34s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_cpuManufacturers (103.03s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_burstablePerformance (155.80s)
--- PASS: TestAccEC2Fleet_excessCapacityTerminationPolicy (102.88s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity (102.91s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps (167.66s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_bareMetal (154.56s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType (432.97s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity (472.80s)
--- PASS: TestAccEC2Fleet_templateMultipleNetworkInterfaces (557.76s)
```
