### PR TITLE
Docs: `aws_flow_log` - note requirement of either `log_group_name` or `log_destination`

### DIFF
--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -116,8 +116,8 @@ The following arguments are supported:
 * `eni_id` - (Optional) Elastic Network Interface ID to attach to
 * `iam_role_arn` - (Optional) The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group
 * `log_destination_type` - (Optional) The type of the logging destination. Valid values: `cloud-watch-logs`, `s3`. Default: `cloud-watch-logs`.
-* `log_destination` - (Optional) The ARN of the logging destination.
-* `log_group_name` - (Optional) *Deprecated:* Use `log_destination` instead. The name of the CloudWatch log group.
+* `log_destination` - (Optional) The ARN of the logging destination. Either `log_destination` or `log_group_name` must be set.
+* `log_group_name` - (Optional) *Deprecated:* Use `log_destination` instead. The name of the CloudWatch log group. Either `log_group_name` or `log_destination` must be set.
 * `subnet_id` - (Optional) Subnet ID to attach to
 * `transit_gateway_id` - (Optional) Transit Gateway ID to attach to
 * `transit_gateway_attachment_id` - (Optional) Transit Gateway Attachment ID to attach to


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26664

Output from acceptance testing: N/a, docs.

### Information

The PR clarifies that either `log_group_name` (deprecated) or `log_destination` must be set. This aligns the docs with the [Renaming a Required Attribute](https://www.terraform.io/plugin/sdkv2/best-practices/deprecations#renaming-a-required-attribute) section of the plugin development documentation (step 7), while making the requirement a bit more clear (see closing issue).

### References

- PR where `log_group_name` was deprecated: #5509