### PR TITLE
Bugfix: Use DescribeManagedPrefixListsPagesWithContext to get prefix list

### DIFF
--- a/.changelog/26683.txt
+++ b/.changelog/26683.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ec2_managed_prefix_list: Fixes bug where an error is returned for regions with more than 100 managed prefix lists
+```

--- a/internal/service/ec2/consts.go
+++ b/internal/service/ec2/consts.go
@@ -86,6 +86,18 @@ const (
 )
 
 const (
+	managedPrefixListAddressFamilyIPv4 = "IPv4"
+	managedPrefixListAddressFamilyIPv6 = "IPv6"
+)
+
+func managedPrefixListAddressFamily_Values() []string {
+	return []string{
+		managedPrefixListAddressFamilyIPv4,
+		managedPrefixListAddressFamilyIPv6,
+	}
+}
+
+const (
 	vpnTunnelOptionsDPDTimeoutActionClear   = "clear"
 	vpnTunnelOptionsDPDTimeoutActionNone    = "none"
 	vpnTunnelOptionsDPDTimeoutActionRestart = "restart"

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -91,6 +91,7 @@ const (
 	errCodeInvalidVPNGatewayAttachmentNotFound            = "InvalidVpnGatewayAttachment.NotFound"
 	errCodeInvalidVPNGatewayIDNotFound                    = "InvalidVpnGatewayID.NotFound"
 	errCodeNatGatewayNotFound                             = "NatGatewayNotFound"
+	errCodePrefixListVersionMismatch                      = "PrefixListVersionMismatch"
 	errCodeResourceNotReady                               = "ResourceNotReady"
 	errCodeSnapshotCreationPerVolumeRateExceeded          = "SnapshotCreationPerVolumeRateExceeded"
 	errCodeUnsupportedOperation                           = "UnsupportedOperation"

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -64,7 +64,7 @@ const (
 	errCodeInvalidRouteTableIDNotFound                    = "InvalidRouteTableID.NotFound"
 	errCodeInvalidRouteTableIdNotFound                    = "InvalidRouteTableId.NotFound"
 	errCodeInvalidSecurityGroupIDNotFound                 = "InvalidSecurityGroupID.NotFound"
-	errCodeInvalidSecurityGroupRuleIDNotFound             = "InvalidSecurityGroupRuleId.NotFound"
+	errCodeInvalidSecurityGroupRuleIdNotFound             = "InvalidSecurityGroupRuleId.NotFound"
 	errCodeInvalidServiceName                             = "InvalidServiceName"
 	errCodeInvalidSnapshotInUse                           = "InvalidSnapshot.InUse"
 	errCodeInvalidSnapshotNotFound                        = "InvalidSnapshot.NotFound"

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4980,8 +4980,8 @@ func FindLaunchTemplateVersionByTwoPartKey(conn *ec2.EC2, launchTemplateID, vers
 	return output, nil
 }
 
-func FindManagedPrefixList(conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsInput) (*ec2.ManagedPrefixList, error) {
-	output, err := FindManagedPrefixLists(conn, input)
+func FindManagedPrefixList(ctx context.Context, conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsInput) (*ec2.ManagedPrefixList, error) {
+	output, err := FindManagedPrefixLists(ctx, conn, input)
 
 	if err != nil {
 		return nil, err
@@ -4998,10 +4998,10 @@ func FindManagedPrefixList(conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsI
 	return output[0], nil
 }
 
-func FindManagedPrefixLists(conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsInput) ([]*ec2.ManagedPrefixList, error) {
+func FindManagedPrefixLists(ctx context.Context, conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsInput) ([]*ec2.ManagedPrefixList, error) {
 	var output []*ec2.ManagedPrefixList
 
-	err := conn.DescribeManagedPrefixListsPages(input, func(page *ec2.DescribeManagedPrefixListsOutput, lastPage bool) bool {
+	err := conn.DescribeManagedPrefixListsPagesWithContext(ctx, input, func(page *ec2.DescribeManagedPrefixListsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
@@ -5029,12 +5029,12 @@ func FindManagedPrefixLists(conn *ec2.EC2, input *ec2.DescribeManagedPrefixLists
 	return output, nil
 }
 
-func FindManagedPrefixListByID(conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
+func FindManagedPrefixListByID(ctx context.Context, conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
 	input := &ec2.DescribeManagedPrefixListsInput{
 		PrefixListIds: aws.StringSlice([]string{id}),
 	}
 
-	output, err := FindManagedPrefixList(conn, input)
+	output, err := FindManagedPrefixList(ctx, conn, input)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -5057,10 +5057,10 @@ func FindManagedPrefixListByID(ctx context.Context, conn *ec2.EC2, id string) (*
 	return output, nil
 }
 
-func FindManagedPrefixListEntries(conn *ec2.EC2, input *ec2.GetManagedPrefixListEntriesInput) ([]*ec2.PrefixListEntry, error) {
+func FindManagedPrefixListEntries(ctx context.Context, conn *ec2.EC2, input *ec2.GetManagedPrefixListEntriesInput) ([]*ec2.PrefixListEntry, error) {
 	var output []*ec2.PrefixListEntry
 
-	err := conn.GetManagedPrefixListEntriesPages(input, func(page *ec2.GetManagedPrefixListEntriesOutput, lastPage bool) bool {
+	err := conn.GetManagedPrefixListEntriesPagesWithContext(ctx, input, func(page *ec2.GetManagedPrefixListEntriesOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
@@ -5088,16 +5088,16 @@ func FindManagedPrefixListEntries(conn *ec2.EC2, input *ec2.GetManagedPrefixList
 	return output, nil
 }
 
-func FindManagedPrefixListEntriesByID(conn *ec2.EC2, id string) ([]*ec2.PrefixListEntry, error) {
+func FindManagedPrefixListEntriesByID(ctx context.Context, conn *ec2.EC2, id string) ([]*ec2.PrefixListEntry, error) {
 	input := &ec2.GetManagedPrefixListEntriesInput{
 		PrefixListId: aws.String(id),
 	}
 
-	return FindManagedPrefixListEntries(conn, input)
+	return FindManagedPrefixListEntries(ctx, conn, input)
 }
 
-func FindManagedPrefixListEntryByIDAndCIDR(conn *ec2.EC2, id, cidr string) (*ec2.PrefixListEntry, error) {
-	prefixListEntries, err := FindManagedPrefixListEntriesByID(conn, id)
+func FindManagedPrefixListEntryByIDAndCIDR(ctx context.Context, conn *ec2.EC2, id, cidr string) (*ec2.PrefixListEntry, error) {
+	prefixListEntries, err := FindManagedPrefixListEntriesByID(ctx, conn, id)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4980,62 +4980,36 @@ func FindLaunchTemplateVersionByTwoPartKey(conn *ec2.EC2, launchTemplateID, vers
 	return output, nil
 }
 
-func FindManagedPrefixListByID(conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
-	input := &ec2.DescribeManagedPrefixListsInput{
-		PrefixListIds: aws.StringSlice([]string{id}),
-	}
-
-	output, err := conn.DescribeManagedPrefixLists(input)
-
-	if tfawserr.ErrCodeEquals(err, errCodeInvalidPrefixListIDNotFound) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
+func FindManagedPrefixList(conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsInput) (*ec2.ManagedPrefixList, error) {
+	output, err := FindManagedPrefixLists(conn, input)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || len(output.PrefixLists) == 0 || output.PrefixLists[0] == nil {
+	if len(output) == 0 || output[0] == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if count := len(output.PrefixLists); count > 1 {
+	if count := len(output); count > 1 {
 		return nil, tfresource.NewTooManyResultsError(count, input)
 	}
 
-	prefixList := output.PrefixLists[0]
-
-	if state := aws.StringValue(prefixList.State); state == ec2.PrefixListStateDeleteComplete {
-		return nil, &resource.NotFoundError{
-			Message:     state,
-			LastRequest: input,
-		}
-	}
-
-	return prefixList, nil
+	return output[0], nil
 }
 
-func FindManagedPrefixListEntriesByID(conn *ec2.EC2, id string) ([]*ec2.PrefixListEntry, error) {
-	input := &ec2.GetManagedPrefixListEntriesInput{
-		PrefixListId: aws.String(id),
-	}
+func FindManagedPrefixLists(conn *ec2.EC2, input *ec2.DescribeManagedPrefixListsInput) ([]*ec2.ManagedPrefixList, error) {
+	var output []*ec2.ManagedPrefixList
 
-	var prefixListEntries []*ec2.PrefixListEntry
-
-	err := conn.GetManagedPrefixListEntriesPages(input, func(page *ec2.GetManagedPrefixListEntriesOutput, lastPage bool) bool {
+	err := conn.DescribeManagedPrefixListsPages(input, func(page *ec2.DescribeManagedPrefixListsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, entry := range page.Entries {
-			if entry == nil {
-				continue
+		for _, v := range page.PrefixLists {
+			if v != nil {
+				output = append(output, v)
 			}
-
-			prefixListEntries = append(prefixListEntries, entry)
 		}
 
 		return !lastPage
@@ -5052,7 +5026,74 @@ func FindManagedPrefixListEntriesByID(conn *ec2.EC2, id string) ([]*ec2.PrefixLi
 		return nil, err
 	}
 
-	return prefixListEntries, nil
+	return output, nil
+}
+
+func FindManagedPrefixListByID(conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
+	input := &ec2.DescribeManagedPrefixListsInput{
+		PrefixListIds: aws.StringSlice([]string{id}),
+	}
+
+	output, err := FindManagedPrefixList(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if state := aws.StringValue(output.State); state == ec2.PrefixListStateDeleteComplete {
+		return nil, &resource.NotFoundError{
+			Message:     state,
+			LastRequest: input,
+		}
+	}
+
+	// Eventual consistency check.
+	if aws.StringValue(output.PrefixListId) != id {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
+func FindManagedPrefixListEntries(conn *ec2.EC2, input *ec2.GetManagedPrefixListEntriesInput) ([]*ec2.PrefixListEntry, error) {
+	var output []*ec2.PrefixListEntry
+
+	err := conn.GetManagedPrefixListEntriesPages(input, func(page *ec2.GetManagedPrefixListEntriesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Entries {
+			if v != nil {
+				output = append(output, v)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidPrefixListIDNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func FindManagedPrefixListEntriesByID(conn *ec2.EC2, id string) ([]*ec2.PrefixListEntry, error) {
+	input := &ec2.GetManagedPrefixListEntriesInput{
+		PrefixListId: aws.String(id),
+	}
+
+	return FindManagedPrefixListEntries(conn, input)
 }
 
 func FindManagedPrefixListEntryByIDAndCIDR(conn *ec2.EC2, id, cidr string) (*ec2.PrefixListEntry, error) {
@@ -5062,9 +5103,9 @@ func FindManagedPrefixListEntryByIDAndCIDR(conn *ec2.EC2, id, cidr string) (*ec2
 		return nil, err
 	}
 
-	for _, entry := range prefixListEntries {
-		if aws.StringValue(entry.Cidr) == cidr {
-			return entry, nil
+	for _, v := range prefixListEntries {
+		if aws.StringValue(v.Cidr) == cidr {
+			return v, nil
 		}
 	}
 

--- a/internal/service/ec2/id.go
+++ b/internal/service/ec2/id.go
@@ -7,24 +7,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 )
 
-const managedPrefixListEntryIDSeparator = ","
-
-func ManagedPrefixListEntryCreateID(prefixListID, cidrBlock string) string {
-	parts := []string{prefixListID, cidrBlock}
-	id := strings.Join(parts, managedPrefixListEntryIDSeparator)
-	return id
-}
-
-func ManagedPrefixListEntryParseID(id string) (string, string, error) {
-	parts := strings.Split(id, managedPrefixListEntryIDSeparator)
-	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
-		return parts[0], parts[1], nil
-	}
-
-	return "", "",
-		fmt.Errorf("unexpected format for ID (%q), expected prefix-list-id"+managedPrefixListEntryIDSeparator+"cidr-block", id)
-}
-
 // RouteCreateID returns a route resource ID.
 func RouteCreateID(routeTableID, destination string) string {
 	return fmt.Sprintf("r-%s%d", routeTableID, create.StringHashcode(destination))

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1101,9 +1101,9 @@ func StatusInternetGatewayAttachmentState(conn *ec2.EC2, internetGatewayID, vpcI
 	}
 }
 
-func StatusManagedPrefixListState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+func StatusManagedPrefixListState(ctx context.Context, conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindManagedPrefixListByID(conn, id)
+		output, err := FindManagedPrefixListByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -2,12 +2,12 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -19,10 +19,10 @@ import (
 
 func ResourceManagedPrefixList() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceManagedPrefixListCreate,
-		Read:   resourceManagedPrefixListRead,
-		Update: resourceManagedPrefixListUpdate,
-		Delete: resourceManagedPrefixListDelete,
+		CreateWithoutTimeout: resourceManagedPrefixListCreate,
+		ReadWithoutTimeout:   resourceManagedPrefixListRead,
+		UpdateWithoutTimeout: resourceManagedPrefixListUpdate,
+		DeleteWithoutTimeout: resourceManagedPrefixListDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -91,7 +91,7 @@ func ResourceManagedPrefixList() *schema.Resource {
 	}
 }
 
-func resourceManagedPrefixListCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceManagedPrefixListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -119,27 +119,27 @@ func resourceManagedPrefixListCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Managed Prefix List: %s", input)
-	output, err := conn.CreateManagedPrefixList(input)
+	output, err := conn.CreateManagedPrefixListWithContext(ctx, input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EC2 Managed Prefix List: %w", err)
+		return diag.Errorf("creating EC2 Managed Prefix List: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.PrefixList.PrefixListId))
 
-	if _, err := WaitManagedPrefixListCreated(context.TODO(), conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) create: %w", d.Id(), err)
+	if _, err := WaitManagedPrefixListCreated(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for EC2 Managed Prefix List (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceManagedPrefixListRead(d, meta)
+	return resourceManagedPrefixListRead(ctx, d, meta)
 }
 
-func resourceManagedPrefixListRead(d *schema.ResourceData, meta interface{}) error {
+func resourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	pl, err := FindManagedPrefixListByID(context.TODO(), conn, d.Id())
+	pl, err := FindManagedPrefixListByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EC2 Managed Prefix List %s not found, removing from state", d.Id())
@@ -148,43 +148,40 @@ func resourceManagedPrefixListRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Managed Prefix List (%s): %w", d.Id(), err)
+		return diag.Errorf("reading EC2 Managed Prefix List (%s): %s", d.Id(), err)
 	}
 
-	prefixListEntries, err := FindManagedPrefixListEntriesByID(context.TODO(), conn, d.Id())
+	prefixListEntries, err := FindManagedPrefixListEntriesByID(ctx, conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Managed Prefix List (%s) Entries: %w", d.Id(), err)
+		return diag.Errorf("reading EC2 Managed Prefix List (%s) Entries: %s", d.Id(), err)
 	}
 
 	d.Set("address_family", pl.AddressFamily)
 	d.Set("arn", pl.PrefixListArn)
-
 	if err := d.Set("entry", flattenPrefixListEntries(prefixListEntries)); err != nil {
-		return fmt.Errorf("error setting entry: %w", err)
+		return diag.Errorf("setting entry: %s", err)
 	}
-
 	d.Set("max_entries", pl.MaxEntries)
 	d.Set("name", pl.PrefixListName)
 	d.Set("owner_id", pl.OwnerId)
+	d.Set("version", pl.Version)
 
 	tags := KeyValueTags(pl.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return diag.Errorf("setting tags_all: %s", err)
 	}
-
-	d.Set("version", pl.Version)
 
 	return nil
 }
 
-func resourceManagedPrefixListUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceManagedPrefixListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -241,24 +238,20 @@ func resourceManagedPrefixListUpdate(d *schema.ResourceData, meta interface{}) e
 			}
 
 			if len(descriptionOnlyRemovals) > 0 {
-				_, err := conn.ModifyManagedPrefixList(&ec2.ModifyManagedPrefixListInput{
+				_, err := conn.ModifyManagedPrefixListWithContext(ctx, &ec2.ModifyManagedPrefixListInput{
 					CurrentVersion: input.CurrentVersion,
 					PrefixListId:   aws.String(d.Id()),
 					RemoveEntries:  descriptionOnlyRemovals,
 				})
 
 				if err != nil {
-					return fmt.Errorf("error updating EC2 Managed Prefix List (%s): %w", d.Id(), err)
+					return diag.Errorf("updating EC2 Managed Prefix List (%s): %s", d.Id(), err)
 				}
 
-				managedPrefixList, err := WaitManagedPrefixListModified(context.TODO(), conn, d.Id())
+				managedPrefixList, err := WaitManagedPrefixListModified(ctx, conn, d.Id())
 
 				if err != nil {
-					return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) update: %w", d.Id(), err)
-				}
-
-				if managedPrefixList == nil {
-					return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) update: empty response", d.Id())
+					return diag.Errorf("waiting for EC2 Managed Prefix List (%s) update: %s", d.Id(), err)
 				}
 
 				input.CurrentVersion = managedPrefixList.Version
@@ -278,34 +271,35 @@ func resourceManagedPrefixListUpdate(d *schema.ResourceData, meta interface{}) e
 			wait = true
 		}
 
-		_, err := conn.ModifyManagedPrefixList(input)
+		_, err := conn.ModifyManagedPrefixListWithContext(ctx, input)
 
 		if err != nil {
-			return fmt.Errorf("error updating EC2 Managed Prefix List (%s): %w", d.Id(), err)
+			return diag.Errorf("updating EC2 Managed Prefix List (%s): %s", d.Id(), err)
 		}
 
 		if wait {
-			if _, err := WaitManagedPrefixListModified(context.TODO(), conn, d.Id()); err != nil {
-				return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) update: %w", d.Id(), err)
+			if _, err := WaitManagedPrefixListModified(ctx, conn, d.Id()); err != nil {
+				return diag.Errorf("waiting for EC2 Managed Prefix List (%s) update: %s", d.Id(), err)
 			}
 		}
 	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating EC2 Managed Prefix List (%s) tags: %w", d.Id(), err)
+
+		if err := UpdateTagsWithContext(ctx, conn, d.Id(), o, n); err != nil {
+			return diag.Errorf("updating EC2 Managed Prefix List (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceManagedPrefixListRead(d, meta)
+	return resourceManagedPrefixListRead(ctx, d, meta)
 }
 
-func resourceManagedPrefixListDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceManagedPrefixListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	log.Printf("[INFO] Deleting EC2 Managed Prefix List: %s", d.Id())
-	_, err := conn.DeleteManagedPrefixList(&ec2.DeleteManagedPrefixListInput{
+	_, err := conn.DeleteManagedPrefixListWithContext(ctx, &ec2.DeleteManagedPrefixListInput{
 		PrefixListId: aws.String(d.Id()),
 	})
 
@@ -314,11 +308,11 @@ func resourceManagedPrefixListDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting EC2 Managed Prefix List (%s): %w", d.Id(), err)
+		return diag.Errorf("deleting EC2 Managed Prefix List (%s): %s", d.Id(), err)
 	}
 
-	if _, err := WaitManagedPrefixListDeleted(context.TODO(), conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) delete: %w", d.Id(), err)
+	if _, err := WaitManagedPrefixListDeleted(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for EC2 Managed Prefix List (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -127,7 +127,7 @@ func resourceManagedPrefixListCreate(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(aws.StringValue(output.PrefixList.PrefixListId))
 
-	if _, err := WaitManagedPrefixListCreated(conn, d.Id()); err != nil {
+	if _, err := WaitManagedPrefixListCreated(context.TODO(), conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) create: %w", d.Id(), err)
 	}
 
@@ -139,7 +139,7 @@ func resourceManagedPrefixListRead(d *schema.ResourceData, meta interface{}) err
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	pl, err := FindManagedPrefixListByID(conn, d.Id())
+	pl, err := FindManagedPrefixListByID(context.TODO(), conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EC2 Managed Prefix List %s not found, removing from state", d.Id())
@@ -251,7 +251,7 @@ func resourceManagedPrefixListUpdate(d *schema.ResourceData, meta interface{}) e
 					return fmt.Errorf("error updating EC2 Managed Prefix List (%s): %w", d.Id(), err)
 				}
 
-				managedPrefixList, err := WaitManagedPrefixListModified(conn, d.Id())
+				managedPrefixList, err := WaitManagedPrefixListModified(context.TODO(), conn, d.Id())
 
 				if err != nil {
 					return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) update: %w", d.Id(), err)
@@ -285,7 +285,7 @@ func resourceManagedPrefixListUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if wait {
-			if _, err := WaitManagedPrefixListModified(conn, d.Id()); err != nil {
+			if _, err := WaitManagedPrefixListModified(context.TODO(), conn, d.Id()); err != nil {
 				return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) update: %w", d.Id(), err)
 			}
 		}
@@ -317,7 +317,7 @@ func resourceManagedPrefixListDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error deleting EC2 Managed Prefix List (%s): %w", d.Id(), err)
 	}
 
-	if _, err := WaitManagedPrefixListDeleted(conn, d.Id()); err != nil {
+	if _, err := WaitManagedPrefixListDeleted(context.TODO(), conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for EC2 Managed Prefix List (%s) delete: %w", d.Id(), err)
 	}
 

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -37,12 +37,10 @@ func ResourceManagedPrefixList() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"address_family": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice(
-					[]string{"IPv4", "IPv6"},
-					false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(managedPrefixListAddressFamily_Values(), false),
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -151,7 +151,7 @@ func resourceManagedPrefixListRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error reading EC2 Managed Prefix List (%s): %w", d.Id(), err)
 	}
 
-	prefixListEntries, err := FindManagedPrefixListEntriesByID(conn, d.Id())
+	prefixListEntries, err := FindManagedPrefixListEntriesByID(context.TODO(), conn, d.Id())
 
 	if err != nil {
 		return fmt.Errorf("error reading EC2 Managed Prefix List (%s) Entries: %w", d.Id(), err)

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source.go
@@ -10,11 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func DataSourceManagedPrefixList() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceManagedPrefixListRead,
+		ReadWithoutTimeout: dataSourceManagedPrefixListRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(20 * time.Minute),
@@ -45,7 +46,7 @@ func DataSourceManagedPrefixList() *schema.Resource {
 					},
 				},
 			},
-			"filter": DataSourceFiltersSchema(),
+			"filter": CustomFiltersSchema(),
 			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -77,83 +78,51 @@ func dataSourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData
 	conn := meta.(*conns.AWSClient).EC2Conn
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	input := ec2.DescribeManagedPrefixListsInput{}
-
-	if filters, ok := d.GetOk("filter"); ok {
-		input.Filters = BuildFiltersDataSource(filters.(*schema.Set))
+	input := &ec2.DescribeManagedPrefixListsInput{
+		Filters: BuildAttributeFilterList(map[string]string{
+			"prefix-list-name": d.Get("name").(string),
+		}),
 	}
 
-	if prefixListId, ok := d.GetOk("id"); ok {
-		input.PrefixListIds = aws.StringSlice([]string{prefixListId.(string)})
+	if v, ok := d.GetOk("id"); ok {
+		input.PrefixListIds = aws.StringSlice([]string{v.(string)})
 	}
 
-	if prefixListName, ok := d.GetOk("name"); ok {
-		input.Filters = append(input.Filters, &ec2.Filter{
-			Name:   aws.String("prefix-list-name"),
-			Values: aws.StringSlice([]string{prefixListName.(string)}),
-		})
+	input.Filters = append(input.Filters, BuildCustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+
+	if len(input.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		input.Filters = nil
 	}
 
-	var prefixLists []*ec2.ManagedPrefixList
-
-	err := conn.DescribeManagedPrefixListsPagesWithContext(
-		ctx,
-		&input,
-		func(output *ec2.DescribeManagedPrefixListsOutput, lastPage bool) bool {
-			prefixLists = append(prefixLists, output.PrefixLists...)
-			return !lastPage
-		})
+	pl, err := FindManagedPrefixList(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error describing EC2 Managed Prefix Lists: %s", err)
+		return diag.FromErr(tfresource.SingularDataSourceFindError("EC2 Managed Prefix List", err))
 	}
-
-	if len(prefixLists) < 1 || prefixLists[0] == nil {
-		return diag.Errorf("no managed prefix lists matched the given criteria")
-	}
-
-	if len(prefixLists) > 1 {
-		return diag.Errorf("more than 1 prefix list matched the given criteria")
-	}
-
-	pl := prefixLists[0]
 
 	d.SetId(aws.StringValue(pl.PrefixListId))
-	d.Set("name", pl.PrefixListName)
-	d.Set("owner_id", pl.OwnerId)
+
+	prefixListEntries, err := FindManagedPrefixListEntriesByID(ctx, conn, d.Id())
+
+	if err != nil {
+		return diag.Errorf("reading EC2 Managed Prefix List (%s) Entries: %s", d.Id(), err)
+	}
+
 	d.Set("address_family", pl.AddressFamily)
 	d.Set("arn", pl.PrefixListArn)
+	if err := d.Set("entries", flattenPrefixListEntries(prefixListEntries)); err != nil {
+		return diag.Errorf("setting entries: %s", err)
+	}
 	d.Set("max_entries", pl.MaxEntries)
+	d.Set("name", pl.PrefixListName)
+	d.Set("owner_id", pl.OwnerId)
 	d.Set("version", pl.Version)
 
 	if err := d.Set("tags", KeyValueTags(pl.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags attribute: %s", err)
-	}
-
-	var entries []interface{}
-
-	err = conn.GetManagedPrefixListEntriesPages(
-		&ec2.GetManagedPrefixListEntriesInput{
-			PrefixListId: pl.PrefixListId,
-		},
-		func(output *ec2.GetManagedPrefixListEntriesOutput, lastPage bool) bool {
-			for _, entry := range output.Entries {
-				entries = append(entries, map[string]interface{}{
-					"cidr":        aws.StringValue(entry.Cidr),
-					"description": aws.StringValue(entry.Description),
-				})
-			}
-
-			return !lastPage
-		},
-	)
-
-	if err != nil {
-		return diag.Errorf("error listing EC2 Managed Prefix List (%s) entries: %s", d.Id(), err)
-	}
-
-	if err := d.Set("entries", entries); err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source.go
@@ -100,10 +100,7 @@ func dataSourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData
 		ctx,
 		&input,
 		func(output *ec2.DescribeManagedPrefixListsOutput, lastPage bool) bool {
-			for _, prefixList := range output.PrefixLists {
-				prefixLists = append(prefixLists, prefixList)
-			}
-
+			prefixLists = append(prefixLists, output.PrefixLists...)
 			return !lastPage
 		})
 

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
@@ -159,7 +159,7 @@ func TestAccVPCManagedPrefixListDataSource_matchesTooMany(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccVPCManagedPrefixListDataSourceConfig_matchesTooMany,
-				ExpectError: regexp.MustCompile(`more than 1 prefix list matched the given criteria`),
+				ExpectError: regexp.MustCompile(`multiple EC2 Managed Prefix Lists matched`),
 			},
 		},
 	})

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -101,7 +101,7 @@ func resourceManagedPrefixListEntryRead(d *schema.ResourceData, meta interface{}
 	}
 
 	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ManagedPrefixListEntryCreateTimeout, func() (interface{}, error) {
-		return FindManagedPrefixListEntryByIDAndCIDR(conn, plID, cidr)
+		return FindManagedPrefixListEntryByIDAndCIDR(context.TODO(), conn, plID, cidr)
 	}, d.IsNewResource())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -62,7 +63,7 @@ func resourceManagedPrefixListEntryCreate(d *schema.ResourceData, meta interface
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)
 
-		pl, err := FindManagedPrefixListByID(conn, plID)
+		pl, err := FindManagedPrefixListByID(context.TODO(), conn, plID)
 
 		if err != nil {
 			return nil, fmt.Errorf("error reading VPC Managed Prefix List (%s): %w", plID, err)
@@ -83,7 +84,7 @@ func resourceManagedPrefixListEntryCreate(d *schema.ResourceData, meta interface
 
 	d.SetId(id)
 
-	if _, err := WaitManagedPrefixListModified(conn, plID); err != nil {
+	if _, err := WaitManagedPrefixListModified(context.TODO(), conn, plID); err != nil {
 		return fmt.Errorf("error waiting for VPC Managed Prefix List Entry (%s) create: %w", d.Id(), err)
 	}
 
@@ -135,7 +136,7 @@ func resourceManagedPrefixListEntryDelete(d *schema.ResourceData, meta interface
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)
 
-		pl, err := FindManagedPrefixListByID(conn, plID)
+		pl, err := FindManagedPrefixListByID(context.TODO(), conn, plID)
 
 		if err != nil {
 			return nil, fmt.Errorf("error reading VPC Managed Prefix List (%s): %w", plID, err)
@@ -154,7 +155,7 @@ func resourceManagedPrefixListEntryDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error deleting VPC Managed Prefix List Entry (%s): %w", d.Id(), err)
 	}
 
-	_, err = WaitManagedPrefixListModified(conn, plID)
+	_, err = WaitManagedPrefixListModified(context.TODO(), conn, plID)
 
 	if err != nil {
 		return fmt.Errorf("error waiting for VPC Managed Prefix List Entry (%s) delete: %w", d.Id(), err)

--- a/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
@@ -206,7 +206,7 @@ func testAccCheckManagedPrefixListEntryDestroy(s *terraform.State) error {
 			continue
 		}
 
-		plID, cidr, err := tfec2.ManagedPrefixListEntryParseID(rs.Primary.ID)
+		plID, cidr, err := tfec2.ManagedPrefixListEntryParseResourceID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -241,7 +241,7 @@ func testAccCheckManagedPrefixListEntryExists(n string, v *ec2.PrefixListEntry) 
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 
-		plID, cidr, err := tfec2.ManagedPrefixListEntryParseID(rs.Primary.ID)
+		plID, cidr, err := tfec2.ManagedPrefixListEntryParseResourceID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -269,7 +269,7 @@ func testAccManagedPrefixListEntryImportStateIdFunc(resourceName string) resourc
 		plID := rs.Primary.Attributes["prefix_list_id"]
 		cidr := rs.Primary.Attributes["cidr"]
 
-		return tfec2.ManagedPrefixListEntryCreateID(plID, cidr), nil
+		return tfec2.ManagedPrefixListEntryCreateResourceID(plID, cidr), nil
 	}
 }
 

--- a/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry_test.go
@@ -1,6 +1,7 @@
 package ec2_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -211,7 +212,7 @@ func testAccCheckManagedPrefixListEntryDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = tfec2.FindManagedPrefixListEntryByIDAndCIDR(conn, plID, cidr)
+		_, err = tfec2.FindManagedPrefixListEntryByIDAndCIDR(context.Background(), conn, plID, cidr)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -246,7 +247,7 @@ func testAccCheckManagedPrefixListEntryExists(n string, v *ec2.PrefixListEntry) 
 			return err
 		}
 
-		output, err := tfec2.FindManagedPrefixListEntryByIDAndCIDR(conn, plID, cidr)
+		output, err := tfec2.FindManagedPrefixListEntryByIDAndCIDR(context.Background(), conn, plID, cidr)
 
 		if err != nil {
 			return err

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -1,6 +1,7 @@
 package ec2_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -310,7 +311,7 @@ func testAccCheckManagedPrefixListDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfec2.FindManagedPrefixListByID(conn, rs.Primary.ID)
+		_, err := tfec2.FindManagedPrefixListByID(context.Background(), conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -339,7 +340,7 @@ func testAccManagedPrefixListExists(resourceName string) resource.TestCheckFunc 
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 
-		_, err := tfec2.FindManagedPrefixListByID(conn, rs.Primary.ID)
+		_, err := tfec2.FindManagedPrefixListByID(context.Background(), conn, rs.Primary.ID)
 
 		return err
 	}

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -476,7 +476,7 @@ func forceRevokeSecurityGroupRules(conn *ec2.EC2, id string, searchAll bool) err
 			_, err = conn.RevokeSecurityGroupEgress(input)
 		}
 
-		if tfawserr.ErrCodeEquals(err, errCodeInvalidSecurityGroupRuleIDNotFound) {
+		if tfawserr.ErrCodeEquals(err, errCodeInvalidSecurityGroupRuleIdNotFound) {
 			continue
 		}
 

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2281,15 +2281,15 @@ const (
 	ManagedPrefixListTimeout = 15 * time.Minute
 )
 
-func WaitManagedPrefixListCreated(conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
+func WaitManagedPrefixListCreated(ctx context.Context, conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.PrefixListStateCreateInProgress},
 		Target:  []string{ec2.PrefixListStateCreateComplete},
 		Timeout: ManagedPrefixListTimeout,
-		Refresh: StatusManagedPrefixListState(conn, id),
+		Refresh: StatusManagedPrefixListState(ctx, conn, id),
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*ec2.ManagedPrefixList); ok {
 		if state := aws.StringValue(output.State); state == ec2.PrefixListStateCreateFailed {
@@ -2302,15 +2302,15 @@ func WaitManagedPrefixListCreated(conn *ec2.EC2, id string) (*ec2.ManagedPrefixL
 	return nil, err
 }
 
-func WaitManagedPrefixListModified(conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
+func WaitManagedPrefixListModified(ctx context.Context, conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.PrefixListStateModifyInProgress},
 		Target:  []string{ec2.PrefixListStateModifyComplete},
 		Timeout: ManagedPrefixListTimeout,
-		Refresh: StatusManagedPrefixListState(conn, id),
+		Refresh: StatusManagedPrefixListState(ctx, conn, id),
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*ec2.ManagedPrefixList); ok {
 		if state := aws.StringValue(output.State); state == ec2.PrefixListStateModifyFailed {
@@ -2323,15 +2323,15 @@ func WaitManagedPrefixListModified(conn *ec2.EC2, id string) (*ec2.ManagedPrefix
 	return nil, err
 }
 
-func WaitManagedPrefixListDeleted(conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
+func WaitManagedPrefixListDeleted(ctx context.Context, conn *ec2.EC2, id string) (*ec2.ManagedPrefixList, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.PrefixListStateDeleteInProgress},
 		Target:  []string{},
 		Timeout: ManagedPrefixListTimeout,
-		Refresh: StatusManagedPrefixListState(conn, id),
+		Refresh: StatusManagedPrefixListState(ctx, conn, id),
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*ec2.ManagedPrefixList); ok {
 		if state := aws.StringValue(output.State); state == ec2.PrefixListStateDeleteFailed {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #26004

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCManagedPrefixListDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCManagedPrefixListDataSource'  -timeout 180m
=== RUN   TestAccVPCManagedPrefixListDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListDataSource_basic
=== RUN   TestAccVPCManagedPrefixListDataSource_filter
=== PAUSE TestAccVPCManagedPrefixListDataSource_filter
=== RUN   TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== PAUSE TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== CONT  TestAccVPCManagedPrefixListDataSource_basic
=== CONT  TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== CONT  TestAccVPCManagedPrefixListDataSource_filter
--- PASS: TestAccVPCManagedPrefixListDataSource_matchesTooMany (6.14s)
--- PASS: TestAccVPCManagedPrefixListDataSource_filter (22.10s)
--- PASS: TestAccVPCManagedPrefixListDataSource_basic (23.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        25.352s
...
```
