### PR TITLE
semgrep 0.112 breaks `helper-schema-ResourceData-Resource-Set-tags`

### DIFF
--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -34,7 +34,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -34,7 +34,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -34,7 +34,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: "returntocorp/semgrep:0.111.1"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

[For example](https://github.com/hashicorp/terraform-provider-aws/runs/8236235605?check_suite_focus=true):

```
Run semgrep $COMMON_PARAMS \

Findings:

  internal/service/accessanalyzer/analyzer.go 
     ci.helper-schema-ResourceData-Resource-Set-tags
        (schema.ResourceData).Set() call with the tags key should be preceded by a call to
        IgnoreConfig or include IgnoreConfig in the value in the case of ASG

        [1](https://github.com/hashicorp/terraform-provider-aws/runs/8236235605?check_suite_focus=true#step:4:1)40┆ tags := KeyValueTags(output.Analyzer.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
        [14](https://github.com/hashicorp/terraform-provider-aws/runs/8236235605?check_suite_focus=true#step:4:15)1┆ 
        142┆ //lintignore:AWSR002
        143┆ if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
        144┆ 	return fmt.Errorf("error setting tags: %w", err)
        145┆ }


  internal/service/acm/certificate.go 
     ci.helper-schema-ResourceData-Resource-Set-tags
        (schema.ResourceData).Set() call with the tags key should be preceded by a call to
        IgnoreConfig or include IgnoreConfig in the value in the case of ASG

        401┆ tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
        402┆ 
        403┆ //lintignore:AWSR002
        404┆ if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
        405┆ 	return fmt.Errorf("error setting tags: %w", err)
        406┆ }
```

Broken after [semgrep@v0.122.0](https://github.com/returntocorp/semgrep/releases/tag/v0.112.0) was released.