### PR TITLE
New Resource: aws_medialive_multiplex_program

### DIFF
--- a/.changelog/26694.txt
+++ b/.changelog/26694.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+   aws_medialive_multiplex_program
+```

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.11.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-mux v0.7.0
@@ -83,7 +84,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
-	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
@@ -92,7 +93,7 @@ require (
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-framework v0.11.1 h1:rq8f+TLDO4tJu+n9mMYlDrcRoIdrg0gTUvV2Jr0Ya24=
 github.com/hashicorp/terraform-plugin-framework v0.11.1/go.mod h1:GENReHOz6GEt8Jk3UN94vk8BdC6irEHFgN3Z9HPhPUU=
+github.com/hashicorp/terraform-plugin-framework-validators v0.5.0 h1:eD79idhnJOBajkUMEbm0c8dOyOb/F49STbUEVojT6F4=
+github.com/hashicorp/terraform-plugin-framework-validators v0.5.0/go.mod h1:NfGgclDM3FZqvNVppPKE2aHI1JAyT002ypPRya7ch3I=
 github.com/hashicorp/terraform-plugin-go v0.14.0 h1:ttnSlS8bz3ZPYbMb84DpcPhY4F5DsQtcAS7cHo8uvP4=
 github.com/hashicorp/terraform-plugin-go v0.14.0/go.mod h1:2nNCBeRLaenyQEi78xrGrs9hMbulveqG/zDMQSvVJTE=
 github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
@@ -278,8 +280,9 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
-github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
+github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
@@ -379,8 +382,8 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
-google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/meta"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -306,6 +307,8 @@ func (p *fwprovider) Configure(ctx context.Context, request provider.ConfigureRe
 func (p *fwprovider) GetResources(ctx context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	resources := make(map[string]provider.ResourceType)
+
+	resources["aws_medialive_multiplex_program"] = medialive.NewResourceMultiplexProgramType(ctx, p.Primary.Meta())
 
 	return resources, diags
 }

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -308,7 +308,7 @@ func (p *fwprovider) GetResources(ctx context.Context) (map[string]provider.Reso
 	var diags diag.Diagnostics
 	resources := make(map[string]provider.ResourceType)
 
-	resources["aws_medialive_multiplex_program"] = medialive.NewResourceMultiplexProgramType(ctx, p.Primary.Meta())
+	resources["aws_medialive_multiplex_program"] = medialive.NewResourceMultiplexProgramType(ctx, p.Primary)
 
 	return resources, diags
 }

--- a/internal/service/medialive/medialive_test.go
+++ b/internal/service/medialive/medialive_test.go
@@ -13,6 +13,10 @@ func TestAccMediaLive_serial(t *testing.T) {
 			"updateTags": testAccMultiplex_updateTags,
 			"start":      testAccMultiplex_start,
 		},
+		"MultiplexProgram": {
+			"basic":      testAccMultiplexProgram_basic,
+			"disappears": testAccMultiplexProgram_disappears,
+		},
 	}
 
 	for group, m := range testCases {

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -3,6 +3,7 @@ package medialive
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
@@ -15,7 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	resourceHelper "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func NewResourceMultiplexProgramType(_ context.Context, meta interface{ Meta() interface{} }) provider.ResourceType {
@@ -31,6 +34,13 @@ type resourceMultiplexProgramType struct {
 func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	schema := tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Type:     types.StringType,
+				Computed: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
 			"multiplex_id": {
 				Type:     types.StringType,
 				Required: true,
@@ -41,6 +51,9 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 			"program_name": {
 				Type:     types.StringType,
 				Required: true,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.RequiresReplace(),
+				},
 			},
 		},
 		Blocks: map[string]tfsdk.Block{
@@ -54,7 +67,7 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 					},
 					"preferred_channel_pipeline": {
 						Type:     types.StringType,
-						Optional: true,
+						Required: true,
 						Validators: []tfsdk.AttributeValidator{
 							stringvalidator.OneOf(preferredChannelPipelineToSlice(mltypes.PreferredChannelPipeline("").Values())...),
 						},
@@ -75,33 +88,33 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 							},
 						},
 					},
-				},
-			},
-			"video_settings": {
-				NestingMode: tfsdk.BlockNestingModeList,
-				MaxItems:    1,
-				Attributes: map[string]tfsdk.Attribute{
-					"constant_bitrate": {
-						Type:     types.NumberType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"statmux_settings": {
+					"video_settings": {
 						NestingMode: tfsdk.BlockNestingModeList,
 						MaxItems:    1,
 						Attributes: map[string]tfsdk.Attribute{
-							"maximum_bitrate": {
+							"constant_bitrate": {
 								Type:     types.NumberType,
 								Optional: true,
 							},
-							"minimum_bitrate": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"priority": {
-								Type:     types.NumberType,
-								Optional: true,
+						},
+						Blocks: map[string]tfsdk.Block{
+							"statemux_settings": {
+								NestingMode: tfsdk.BlockNestingModeList,
+								MaxItems:    1,
+								Attributes: map[string]tfsdk.Attribute{
+									"maximum_bitrate": {
+										Type:     types.NumberType,
+										Optional: true,
+									},
+									"minimum_bitrate": {
+										Type:     types.NumberType,
+										Optional: true,
+									},
+									"priority": {
+										Type:     types.NumberType,
+										Optional: true,
+									},
+								},
 							},
 						},
 					},
@@ -112,6 +125,10 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 
 	return schema, nil
 }
+
+const (
+	ResNameMultiplexProgram = "Multiplex Program"
+)
 
 func (t *resourceMultiplexProgramType) NewResource(ctx context.Context, provider provider.Provider) (resource.Resource, diag.Diagnostics) {
 	return &multiplexProgram{
@@ -139,38 +156,26 @@ func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateReques
 		RequestId:   aws.String(resourceHelper.UniqueId()),
 	}
 
-	in.MultiplexProgramSettings = &mltypes.MultiplexProgramSettings{
-		ProgramNumber:            plan.MultiplexProgramSettings[0].ProgramNumber,
-		PreferredChannelPipeline: mltypes.PreferredChannelPipeline(plan.MultiplexProgramSettings[0].PreferredChannelPipeline.Value),
-	}
-
-	if len(plan.MultiplexProgramSettings[0].ServiceDescriptor) > 0 {
-		in.MultiplexProgramSettings.ServiceDescriptor.ServiceName = aws.String(plan.MultiplexProgramSettings[0].ServiceDescriptor[0].ServiceName.Value)
-	}
+	in.MultiplexProgramSettings = expandMultiplexProgramSettings(plan.MultiplexProgramSettings)
 
 	out, err := conn.CreateMultiplexProgram(ctx, in)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating MediaLive Multiplex Program",
+			create.ProblemStandardMessage(names.MediaLive, create.ErrActionCreating, ResNameMultiplexProgram, plan.ProgramName.String(), nil),
 			err.Error(),
 		)
 		return
 	}
 
-	result := resourceMultiplexProgramData{
-		ProgramName: types.String{Value: aws.ToString(out.MultiplexProgram.ProgramName)},
-		MultiplexID: types.String{Value: plan.MultiplexID.Value},
-		MultiplexProgramSettings: []multiplexProgramSettings{
-			{
-				ProgramNumber:            out.MultiplexProgram.MultiplexProgramSettings.ProgramNumber,
-				PreferredChannelPipeline: types.String{Value: string(out.MultiplexProgram.MultiplexProgramSettings.PreferredChannelPipeline)},
-			},
-		},
-	}
+	var result resourceMultiplexProgramData
 
-	diags = resp.State.Set(ctx, result)
-	resp.Diagnostics.Append(diags...)
+	result.ID.Value = fmt.Sprintf("%s/%s", plan.ProgramName.Value, plan.MultiplexID.Value)
+	result.ProgramName.Value = aws.ToString(out.MultiplexProgram.ProgramName)
+	result.MultiplexID.Value = plan.MultiplexID.Value
+	result.MultiplexProgramSettings = flattenMultiplexProgramSettings(out.MultiplexProgram.MultiplexProgramSettings)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -192,30 +197,78 @@ func (m *multiplexProgram) Read(ctx context.Context, req resource.ReadRequest, r
 
 	out, err := FindMultipleProgramByID(ctx, conn, multiplexId, programName)
 
+	if tfresource.NotFound(err) {
+		diag.NewWarningDiagnostic(
+			"AWS Resource Not Found During Refresh",
+			fmt.Sprintf("Automatically removing from Terraform State instead of returning the error, which may trigger resource recreation. Original Error: %s", err.Error()),
+		)
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading MediaLive Multiplex Program",
+			create.ProblemStandardMessage(names.MediaLive, create.ErrActionReading, ResNameMultiplexProgram, state.ProgramName.String(), nil),
 			err.Error(),
 		)
 		return
 	}
 
-	state.ProgramName = types.String{Value: aws.ToString(out.ProgramName)}
-	state.MultiplexProgramSettings = []multiplexProgramSettings{
-		{
-			ProgramNumber:            out.MultiplexProgramSettings.ProgramNumber,
-			PreferredChannelPipeline: types.String{Value: string(out.MultiplexProgramSettings.PreferredChannelPipeline)},
-		},
-	}
+	state.ID.Value = fmt.Sprintf("%s/%s", state.ProgramName.Value, state.MultiplexID.Value)
+	state.MultiplexProgramSettings = flattenMultiplexProgramSettings(out.MultiplexProgramSettings)
 
-	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
 }
 
 func (m *multiplexProgram) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := m.meta.Meta().(*conns.AWSClient).MediaLiveConn
+
+	var plan resourceMultiplexProgramData
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state resourceMultiplexProgramData
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &medialive.UpdateMultiplexProgramInput{
+		MultiplexId:              aws.String(state.MultiplexID.Value),
+		ProgramName:              aws.String(state.ProgramName.Value),
+		MultiplexProgramSettings: expandMultiplexProgramSettings(plan.MultiplexProgramSettings),
+	}
+
+	out, err := conn.UpdateMultiplexProgram(ctx, in)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.MediaLive, create.ErrActionUpdating, ResNameMultiplexProgram, state.ProgramName.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+
+	//var result resourceMultiplexProgramData
+
+	state.ProgramName.Value = aws.ToString(out.MultiplexProgram.ProgramName)
+	//state.MultiplexID.Value = state.MultiplexID.Value
+	state.MultiplexProgramSettings = flattenMultiplexProgramSettings(out.MultiplexProgram.MultiplexProgramSettings)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 func (m *multiplexProgram) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -238,7 +291,7 @@ func (m *multiplexProgram) Delete(ctx context.Context, req resource.DeleteReques
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error deleting MediaLive Multiplex Program",
+			create.ProblemStandardMessage(names.MediaLive, create.ErrActionDeleting, ResNameMultiplexProgram, state.ProgramName.String(), nil),
 			err.Error(),
 		)
 		return
@@ -272,6 +325,80 @@ func FindMultipleProgramByID(ctx context.Context, conn *medialive.Client, multip
 	return out, nil
 }
 
+func expandMultiplexProgramSettings(mps []multiplexProgramSettings) *mltypes.MultiplexProgramSettings {
+	if len(mps) == 0 {
+		return nil
+	}
+
+	data := mps[0]
+
+	l := &mltypes.MultiplexProgramSettings{
+		ProgramNumber:            data.ProgramNumber,
+		PreferredChannelPipeline: mltypes.PreferredChannelPipeline(data.PreferredChannelPipeline.Value),
+	}
+
+	if len(data.ServiceDescriptor) > 0 {
+		l.ServiceDescriptor = &mltypes.MultiplexProgramServiceDescriptor{
+			ProviderName: aws.String(data.ServiceDescriptor[0].ProviderName.Value),
+			ServiceName:  aws.String(data.ServiceDescriptor[0].ServiceName.Value),
+		}
+	}
+
+	if len(data.VideoSettings) > 0 {
+		l.VideoSettings = &mltypes.MultiplexVideoSettings{
+			ConstantBitrate: data.VideoSettings[0].ConstantBitrate,
+		}
+
+		if len(data.VideoSettings[0].StatemuxSettings) > 0 {
+			l.VideoSettings.StatmuxSettings = &mltypes.MultiplexStatmuxVideoSettings{
+				MinimumBitrate: data.VideoSettings[0].StatemuxSettings[0].MinimumBitrate,
+				MaximumBitrate: data.VideoSettings[0].StatemuxSettings[0].MaximumBitrate,
+				Priority:       data.VideoSettings[0].StatemuxSettings[0].Priority,
+			}
+		}
+	}
+
+	return l
+}
+
+func flattenMultiplexProgramSettings(mps *mltypes.MultiplexProgramSettings) []multiplexProgramSettings {
+	if mps == nil {
+		return nil
+	}
+
+	m := multiplexProgramSettings{
+		ProgramNumber:            mps.ProgramNumber,
+		PreferredChannelPipeline: types.String{Value: string(mps.PreferredChannelPipeline)},
+	}
+
+	if mps.ServiceDescriptor != nil {
+		m.ServiceDescriptor = []serviceDescriptor{
+			{
+				ProviderName: types.String{Value: aws.ToString(mps.ServiceDescriptor.ProviderName)},
+				ServiceName:  types.String{Value: aws.ToString(mps.ServiceDescriptor.ServiceName)},
+			},
+		}
+	}
+
+	if mps.VideoSettings != nil {
+		var vs videoSettings
+		vs.ConstantBitrate = mps.VideoSettings.ConstantBitrate
+		if mps.VideoSettings.StatmuxSettings != nil {
+			vs.StatemuxSettings = []statemuxSettings{
+				{
+					MinimumBitrate: mps.VideoSettings.StatmuxSettings.MinimumBitrate,
+					MaximumBitrate: mps.VideoSettings.StatmuxSettings.MaximumBitrate,
+					Priority:       mps.VideoSettings.StatmuxSettings.Priority,
+				},
+			}
+		}
+
+		m.VideoSettings = []videoSettings{vs}
+	}
+
+	return []multiplexProgramSettings{m}
+}
+
 func preferredChannelPipelineToSlice(p []mltypes.PreferredChannelPipeline) []string {
 	s := make([]string, 0)
 
@@ -282,16 +409,17 @@ func preferredChannelPipelineToSlice(p []mltypes.PreferredChannelPipeline) []str
 }
 
 type resourceMultiplexProgramData struct {
+	ID                       types.String               `tfsdk:"id"`
 	MultiplexID              types.String               `tfsdk:"multiplex_id"`
 	MultiplexProgramSettings []multiplexProgramSettings `tfsdk:"multiplex_program_settings"`
 	ProgramName              types.String               `tfsdk:"program_name"`
-	VideoSettings            []videoSettings            `tfsdk:"video_settings"`
 }
 
 type multiplexProgramSettings struct {
 	ProgramNumber            int32               `tfsdk:"program_number"`
 	PreferredChannelPipeline types.String        `tfsdk:"preferred_channel_pipeline"`
 	ServiceDescriptor        []serviceDescriptor `tfsdk:"service_descriptor"`
+	VideoSettings            []videoSettings     `tfsdk:"video_settings"`
 }
 
 type serviceDescriptor struct {
@@ -301,7 +429,7 @@ type serviceDescriptor struct {
 
 type videoSettings struct {
 	ConstantBitrate  int32              `tfsdk:"constant_bitrate"`
-	statemuxSettings []statemuxSettings `tfsdk:"statemux_settings"`
+	StatemuxSettings []statemuxSettings `tfsdk:"statemux_settings"`
 }
 
 type statemuxSettings struct {

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -61,6 +61,7 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 		Blocks: map[string]tfsdk.Block{
 			"multiplex_program_settings": {
 				NestingMode: tfsdk.BlockNestingModeList,
+				MinItems:    1,
 				MaxItems:    1,
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					resource.RequiresReplace(),
@@ -107,11 +108,11 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 								NestingMode: tfsdk.BlockNestingModeList,
 								MaxItems:    1,
 								Attributes: map[string]tfsdk.Attribute{
-									"maximum_bitrate": {
+									"minimum_bitrate": {
 										Type:     types.NumberType,
 										Optional: true,
 									},
-									"minimum_bitrate": {
+									"maximum_bitrate": {
 										Type:     types.NumberType,
 										Optional: true,
 									},

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -1,0 +1,190 @@
+package medialive
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/medialive"
+	mltypes "github.com/aws/aws-sdk-go-v2/service/medialive/types"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	resourceHelper "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func NewResourceMultiplexProgramType(_ context.Context, meta interface{}) provider.ResourceType {
+	return &resourceMultiplexProgramType{
+		meta: meta,
+	}
+}
+
+type resourceMultiplexProgramType struct {
+	meta interface{}
+}
+
+func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	schema := tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"multiplex_id": {
+				Type:     types.StringType,
+				Required: true,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.RequiresReplace(),
+				},
+			},
+			"program_name": {
+				Type:     types.StringType,
+				Required: true,
+			},
+		},
+		Blocks: map[string]tfsdk.Block{
+			"multiplex_program_settings": {
+				NestingMode: tfsdk.BlockNestingModeList,
+				MaxItems:    1,
+				Attributes: map[string]tfsdk.Attribute{
+					"program_number": {
+						Type:     types.NumberType,
+						Required: true,
+					},
+					"preferred_channel_pipeline": {
+						Type:     types.StringType,
+						Optional: true,
+						//Validators: []tfsdk.AttributeValidator{
+						//	stringvalidator.OneOf(preferredChannelPipelineToSlice(mltypes.PreferredChannelPipeline("").Values())...),
+						//},
+					},
+				},
+				Blocks: map[string]tfsdk.Block{
+					"service_descriptor": {
+						NestingMode: tfsdk.BlockNestingModeList,
+						MaxItems:    1,
+						Attributes: map[string]tfsdk.Attribute{
+							"provider_name": {
+								Type:     types.StringType,
+								Required: true,
+							},
+							"service_name": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			"video_settings": {
+				NestingMode: tfsdk.BlockNestingModeList,
+				MaxItems:    1,
+				Attributes: map[string]tfsdk.Attribute{
+					"constant_bitrate": {
+						Type:     types.NumberType,
+						Optional: true,
+					},
+				},
+				Blocks: map[string]tfsdk.Block{
+					"statmux_settings": {
+						NestingMode: tfsdk.BlockNestingModeList,
+						MaxItems:    1,
+						Attributes: map[string]tfsdk.Attribute{
+							"maximum_bitrate": {
+								Type:     types.NumberType,
+								Optional: true,
+							},
+							"minimum_bitrate": {
+								Type:     types.NumberType,
+								Optional: true,
+							},
+							"priority": {
+								Type:     types.NumberType,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return schema, nil
+}
+
+func (t *resourceMultiplexProgramType) NewResource(ctx context.Context, provider provider.Provider) (resource.Resource, diag.Diagnostics) {
+	return &multiplexProgram{
+		meta: t.meta,
+	}, nil
+}
+
+type multiplexProgram struct {
+	meta interface{}
+}
+
+func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	log.Printf("[INFO] meta: %v", m.meta)
+	conn := m.meta.(conns.AWSClient).MediaLiveConn
+
+	var plan resourceMultiplexProgramData
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &medialive.CreateMultiplexProgramInput{
+		MultiplexId: aws.String(plan.MultiplexID.Value),
+		RequestId:   aws.String(resourceHelper.UniqueId()),
+	}
+
+	out, err := conn.CreateMultiplexProgram(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating MediaLive Multiplex Program",
+			err.Error(),
+		)
+		return
+	}
+
+	result := resourceMultiplexProgramData{
+		ID:          types.String{Value: aws.ToString(out.MultiplexProgram.ProgramName)},
+		ProgramName: types.String{Value: aws.ToString(out.MultiplexProgram.ProgramName)},
+	}
+
+	diags = resp.State.Set(ctx, result)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (m *multiplexProgram) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+}
+
+func (m *multiplexProgram) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (m *multiplexProgram) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func preferredChannelPipelineToSlice(p []mltypes.PreferredChannelPipeline) []string {
+	s := make([]string, 0)
+
+	for _, v := range p {
+		s = append(s, string(v))
+	}
+	return s
+}
+
+type resourceMultiplexProgramData struct {
+	ID                       types.String `tfsdk:"id"`
+	MultiplexID              types.String `tfsdk:"multiplex_id"`
+	MultiplexProgramSettings *multiplexProgramSettings
+	ProgramName              types.String `tfsdk:"program_name"`
+}
+
+type multiplexProgramSettings struct {
+	ProgramNumber            types.Number `tfsdk:"program_number"`
+	PreferredChannelPipeline types.String `tfsdk:"preferred_channel_pipeline"`
+}

--- a/internal/service/medialive/multiplex_program_test.go
+++ b/internal/service/medialive/multiplex_program_test.go
@@ -192,8 +192,6 @@ resource "aws_medialive_multiplex" "test" {
     maximum_video_buffer_delay_milliseconds = 1000
   }
 
-  #   start_multiplex = true
-
   tags = {
     Name = %[1]q
   }

--- a/internal/service/medialive/multiplex_program_test.go
+++ b/internal/service/medialive/multiplex_program_test.go
@@ -1,0 +1,221 @@
+package medialive_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/medialive"
+	"github.com/aws/aws-sdk-go/aws"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfmedialive "github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccMultiplexProgram_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiplexprogram medialive.DescribeMultiplexProgramOutput
+	rName := fmt.Sprintf("tf_acc_%s", sdkacctest.RandString(8))
+	resourceName := "aws_medialive_multiplex_program.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiplexProgramDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiplexProgramConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiplexProgramExists(resourceName, &multiplexprogram),
+					resource.TestCheckResourceAttr(resourceName, "program_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "multiplex_id"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.program_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.preferred_channel_pipeline", "CURRENTLY_ACTIVE"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"multiplex_id"},
+			},
+		},
+	})
+}
+
+func testAccMultiplexProgram_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiplexprogram medialive.DescribeMultiplexProgramOutput
+	rName := fmt.Sprintf("tf_acc_%s", sdkacctest.RandString(8))
+	resourceName := "aws_medialive_multiplex_program.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiplexProgramDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiplexProgramConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiplexProgramExists(resourceName, &multiplexprogram),
+					testAccCheckMultiplexProgramDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMultiplexProgramDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID missing: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+		ctx := context.Background()
+		programName, multiplexId, err := tfmedialive.ParseMultiplexProgramID(rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplexProgram, rs.Primary.ID, err)
+		}
+
+		_, err = conn.DeleteMultiplexProgram(ctx, &medialive.DeleteMultiplexProgramInput{
+			MultiplexId: aws.String(multiplexId),
+			ProgramName: aws.String(programName),
+		})
+
+		if err != nil {
+			return create.Error(names.MediaLive, "checking disappears", tfmedialive.ResNameMultiplexProgram, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+func testAccCheckMultiplexProgramDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_medialive_multiplex_program" {
+			continue
+		}
+
+		attributes := rs.Primary.Attributes
+
+		_, err := tfmedialive.FindMultipleProgramByID(ctx, conn, attributes["multiplex_id"], attributes["program_name"])
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingDestroyed, tfmedialive.ResNameMultiplexProgram, rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMultiplexProgramExists(name string, multiplexprogram *medialive.DescribeMultiplexProgramOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplexProgram, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplexProgram, name, errors.New("not set"))
+		}
+
+		programName, multiplexId, err := tfmedialive.ParseMultiplexProgramID(rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplexProgram, rs.Primary.ID, err)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
+		ctx := context.Background()
+		resp, err := tfmedialive.FindMultipleProgramByID(ctx, conn, multiplexId, programName)
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplexProgram, rs.Primary.ID, err)
+		}
+
+		*multiplexprogram = *resp
+
+		return nil
+	}
+}
+
+func testAccMultiplexProgramBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "test" {
+  state = "available"
+}
+
+resource "aws_medialive_multiplex" "test" {
+  name               = %[1]q
+  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+
+  multiplex_settings {
+    transport_stream_bitrate                = 1000000
+    transport_stream_id                     = 1
+    transport_stream_reserved_bitrate       = 1
+    maximum_video_buffer_delay_milliseconds = 1000
+  }
+
+  #   start_multiplex = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+func testAccMultiplexProgramConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccMultiplexProgramBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_medialive_multiplex_program" "test" {
+  program_name = %[1]q
+  multiplex_id = aws_medialive_multiplex.test.id
+
+  multiplex_program_settings {
+    program_number             = 1
+    preferred_channel_pipeline = "CURRENTLY_ACTIVE"
+
+    video_settings {
+      constant_bitrate = 100000
+    }
+  }
+}
+`, rName))
+}

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "MediaLive"
+subcategory: "Elemental MediaLive"
 layout: "aws"
 page_title: "AWS: aws_medialive_multiplex_program"
 description: |-
@@ -15,7 +15,40 @@ Terraform resource for managing an AWS MediaLive MultiplexProgram.
 ### Basic Usage
 
 ```terraform
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_medialive_multiplex" "example" {
+  name               = "example-multiplex-changed"
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+
+  multiplex_settings {
+    transport_stream_bitrate                = 1000000
+    transport_stream_id                     = 1
+    transport_stream_reserved_bitrate       = 1
+    maximum_video_buffer_delay_milliseconds = 1000
+  }
+
+  start_multiplex = true
+
+  tags = {
+    tag1 = "value1"
+  }
+}
+
 resource "aws_medialive_multiplex_program" "example" {
+  program_name = "example_program"
+  multiplex_id = aws_medialive_multiplex.example.id
+
+ multiplex_program_settings {
+    program_number             = 1
+    preferred_channel_pipeline = "CURRENTLY_ACTIVE"
+
+    video_settings {
+      constant_bitrate = 100000
+    }
+  }
 }
 ```
 
@@ -23,17 +56,41 @@ resource "aws_medialive_multiplex_program" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description.
+* `multiplex_id` - (Required) Multiplex ID.
+* `program_name` - (Required) Unique program name.
+* `multiplex_program_settings` - (Required) MultiplexProgram settings. See [Multiplex Program Settings](#multiple-program-settings) for more details.
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Concise argument description.
+### Multiple Program Settings
+
+* `program_number` - (Required) Unique program number.
+* `preferred_channel_pipeline` - (Required) Enum for preferred channel pipeline. Options are `CURRENTLY_ACTIVE`, `PIPELINE_0`, or `PIPELINE_1`.
+* `service_descriptor` - (Optional) Service Descriptor. See [Service Descriptor](#service-descriptor) for more details.
+* `video_settings` - (Optional) Video settings. See [Video Settings](#video-settings) for more details.
+
+### Service Descriptor
+
+* `provider_name` - (Required) Unique provider name.
+* `service_name` - (Required) Unique service name.
+
+### Video Settings
+
+`constant_bitrate` - (Optional) Constant bitrate value.
+`statemux_settings` - (Optional) Statemux settings. See [Statemux Settings](#statemux-settings) for more details.
+
+
+### Statemux Settings
+
+* `minimum_bitrate` - (Optional) Minimum bitrate.
+* `maximum_bitrate` - (Optional) Maximum bitrate.
+* `priority` - (Optional) Priority value.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the MultiplexProgram.
+* `id` - ID of the MultiplexProgram.
 * `example_attribute` - Concise description.
 
 ## Timeouts
@@ -46,8 +103,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-MediaLive MultiplexProgram can be imported using the `example_id_arg`, e.g.,
+MediaLive MultiplexProgram can be imported using the `id`, or a combination of "`program_name`/`multiplex_id`" e.g.,
 
 ```
-$ terraform import aws_medialive_multiplex_program.example rft-8012925589
+$ terraform import aws_medialive_multiplex_program.example example_program/1234567
 ```

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "MediaLive"
+layout: "aws"
+page_title: "AWS: aws_medialive_multiplex_program"
+description: |-
+  Terraform resource for managing an AWS MediaLive MultiplexProgram.
+---
+
+# Resource: aws_medialive_multiplex_program
+
+Terraform resource for managing an AWS MediaLive MultiplexProgram.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_medialive_multiplex_program" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the MultiplexProgram.
+* `example_attribute` - Concise description.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+MediaLive MultiplexProgram can be imported using the `example_id_arg`, e.g.,
+
+```
+$ terraform import aws_medialive_multiplex_program.example rft-8012925589
+```

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -41,7 +41,7 @@ resource "aws_medialive_multiplex_program" "example" {
   program_name = "example_program"
   multiplex_id = aws_medialive_multiplex.example.id
 
- multiplex_program_settings {
+  multiplex_program_settings {
     program_number             = 1
     preferred_channel_pipeline = "CURRENTLY_ACTIVE"
 
@@ -92,14 +92,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the MultiplexProgram.
 * `example_attribute` - Concise description.
-
-## Timeouts
-
-[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
-
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4936

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestAccMediaLive_serial/MultiplexProgram PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLive_serial/MultiplexProgram'  -timeout 180m
=== RUN   TestAccMediaLive_serial
=== RUN   TestAccMediaLive_serial/MultiplexProgram
=== RUN   TestAccMediaLive_serial/MultiplexProgram/basic
=== RUN   TestAccMediaLive_serial/MultiplexProgram/disappears
--- PASS: TestAccMediaLive_serial (121.92s)
    --- PASS: TestAccMediaLive_serial/MultiplexProgram (121.92s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/basic (62.11s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/disappears (59.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	124.376s
...
```
