### PR TITLE
Reload Lambda Function environment variables if `kms_key_arn` has changed

### DIFF
--- a/.changelog/26696.txt
+++ b/.changelog/26696.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Update the environment variables if the `kms_key_arn` has changed
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1099,7 +1099,7 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("runtime") {
 		configReq.Runtime = aws.String(d.Get("runtime").(string))
 	}
-	if d.HasChange("environment") {
+	if d.HasChange("environment") || d.HasChange("kms_key_arn") {
 		if v, ok := d.GetOk("environment"); ok {
 			environments := v.([]interface{})
 			environment, ok := environments[0].(map[string]interface{})

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1099,7 +1099,7 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("runtime") {
 		configReq.Runtime = aws.String(d.Get("runtime").(string))
 	}
-	if d.HasChange("environment") || d.HasChange("kms_key_arn") {
+	if d.HasChanges("environment", "kms_key_arn") {
 		if v, ok := d.GetOk("environment"); ok {
 			environments := v.([]interface{})
 			environment, ok := environments[0].(map[string]interface{})

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -864,7 +864,7 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 		// List is sorted from oldest to latest
 		// so this may get costly over time :'(
 		var lastVersion, lastQualifiedArn string
-		err = listVersionsByFunctionPages(conn, &lambda.ListVersionsByFunctionInput{
+		err = conn.ListVersionsByFunctionPages(&lambda.ListVersionsByFunctionInput{
 			FunctionName: function.FunctionName,
 			MaxItems:     aws.Int64(10000),
 		}, func(p *lambda.ListVersionsByFunctionOutput, lastPage bool) bool {
@@ -922,24 +922,6 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("code_signing_config_arn", codeSigningConfigArn)
 
-	return nil
-}
-
-func listVersionsByFunctionPages(c *lambda.Lambda, input *lambda.ListVersionsByFunctionInput,
-	fn func(p *lambda.ListVersionsByFunctionOutput, lastPage bool) bool) error {
-	for {
-		page, err := c.ListVersionsByFunction(input)
-		if err != nil {
-			return err
-		}
-		lastPage := page.NextMarker == nil
-
-		shouldContinue := fn(page, lastPage)
-		if !shouldContinue || lastPage {
-			break
-		}
-		input.Marker = page.NextMarker
-	}
 	return nil
 }
 

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1099,6 +1099,7 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("runtime") {
 		configReq.Runtime = aws.String(d.Get("runtime").(string))
 	}
+
 	if d.HasChanges("environment", "kms_key_arn") {
 		if v, ok := d.GetOk("environment"); ok {
 			environments := v.([]interface{})

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -230,7 +230,7 @@ func dataSourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		var latestVersion string
 		log.Printf("[DEBUG] Getting List of Lambda Versions : %s", versionsInput)
-		errVersions := listVersionsByFunctionPages(conn, versionsInput, func(p *lambda.ListVersionsByFunctionOutput, lastPage bool) bool {
+		errVersions := conn.ListVersionsByFunctionPages(versionsInput, func(p *lambda.ListVersionsByFunctionOutput, lastPage bool) bool {
 			if lastPage {
 				last := p.Versions[len(p.Versions)-1]
 				latestVersion = aws.StringValue(last.Version)

--- a/internal/service/lambda/generate.go
+++ b/internal/service/lambda/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ListTagsInIDElem=Resource -ServiceTagsMap -TagInIDElem=Resource -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -TagInIDElem=Resource -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package lambda

--- a/internal/service/lambda/tags_gen.go
+++ b/internal/service/lambda/tags_gen.go
@@ -11,27 +11,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-// ListTags lists lambda service tags.
-// The identifier is typically the Amazon Resource Name (ARN), although
-// it may also be a different identifier depending on the service.
-func ListTags(conn lambdaiface.LambdaAPI, identifier string) (tftags.KeyValueTags, error) {
-	return ListTagsWithContext(context.Background(), conn, identifier)
-}
-
-func ListTagsWithContext(ctx context.Context, conn lambdaiface.LambdaAPI, identifier string) (tftags.KeyValueTags, error) {
-	input := &lambda.ListTagsInput{
-		Resource: aws.String(identifier),
-	}
-
-	output, err := conn.ListTagsWithContext(ctx, input)
-
-	if err != nil {
-		return tftags.New(nil), err
-	}
-
-	return KeyValueTags(output.Tags), nil
-}
-
 // map[string]*string handling
 
 // Tags returns lambda service tags.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26692

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
