### PR TITLE
resource/aws_security_group: Use default VPC when no VPC ID passed

### DIFF
--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -3,7 +3,6 @@ package ec2
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -181,10 +180,6 @@ func resourceSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	if _, ok := d.GetOk("vpc_id"); !ok {
-		return errors.New(`with the retirement of EC2-Classic no new Security Groups can be created without referencing a VPC`)
-	}
-
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &ec2.CreateSecurityGroupInput{
 		GroupName: aws.String(name),
@@ -202,7 +197,6 @@ func resourceSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error
 		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSecurityGroup)
 	}
 
-	log.Printf("[DEBUG] Creating Security Group: %s", input)
 	output, err := conn.CreateSecurityGroup(input)
 
 	if err != nil {
@@ -220,6 +214,7 @@ func resourceSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error
 
 	// AWS defaults all Security Groups to have an ALLOW ALL egress rule.
 	// Here we revoke that rule, so users don't unknowingly have/use it.
+	// This will only be false for Security Groups in EC2-Classic
 	if aws.StringValue(group.VpcId) != "" {
 		input := &ec2.RevokeSecurityGroupEgressInput{
 			GroupId: aws.String(d.Id()),
@@ -348,6 +343,7 @@ func resourceSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("updating Security Group (%s) %s rules: %w", d.Id(), securityGroupRuleTypeIngress, err)
 	}
 
+	// This will only be false for Security Groups in EC2-Classic
 	if d.Get("vpc_id") != nil {
 		err = updateSecurityGroupRules(conn, d, securityGroupRuleTypeEgress, group)
 

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -502,7 +502,7 @@ func TestAccVPCSecurityGroup_basic(t *testing.T) {
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "revoke_rules_on_delete", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 				),
 			},
 			{
@@ -1339,7 +1339,7 @@ func TestAccVPCSecurityGroup_vpc(t *testing.T) {
 						"cidr_blocks.#": "1",
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 				),
 			},
 			{
@@ -1375,7 +1375,7 @@ func TestAccVPCSecurityGroup_vpcNegOneIngress(t *testing.T) {
 						"cidr_blocks.#": "1",
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 				),
 			},
 			{
@@ -1411,7 +1411,7 @@ func TestAccVPCSecurityGroup_vpcProtoNumIngress(t *testing.T) {
 						"cidr_blocks.#": "1",
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 				),
 			},
 			{
@@ -2198,7 +2198,7 @@ func TestAccVPCSecurityGroup_emrDependencyViolation(t *testing.T) {
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "revoke_rules_on_delete", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 				),
 				ExpectError: regexp.MustCompile("unexpected state"),
 			},

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -538,6 +538,42 @@ func TestAccVPCSecurityGroup_disappears(t *testing.T) {
 	})
 }
 
+func TestAccVPCSecurityGroup_noVPC(t *testing.T) {
+	var group ec2.SecurityGroup
+	resourceName := "aws_security_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCSecurityGroupConfig_noVPC(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecurityGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "data.aws_vpc.default", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
+			},
+			{
+				Config:   testAccVPCSecurityGroupConfig_defaultVPC(rName),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccVPCSecurityGroupConfig_noVPC(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccVPCSecurityGroup_nameGenerated(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.test"
@@ -2451,6 +2487,33 @@ resource "aws_security_group" "test" {
   vpc_id      = aws_vpc.test.id
 }
 `, rName, namePrefix)
+}
+
+func testAccVPCSecurityGroupConfig_noVPC(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+`, rName)
+}
+
+func testAccVPCSecurityGroupConfig_defaultVPC(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = data.aws_vpc.default.id
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+`, rName)
 }
 
 func testAccVPCSecurityGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -118,7 +118,7 @@ resource "aws_security_group" "sg_with_changeable_name" {
 
 The following arguments are supported:
 
-* `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. __NOTE__: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
+* `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
 * `egress` - (Optional, VPC only) Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 * `ingress` - (Optional) Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
@@ -126,6 +126,7 @@ The following arguments are supported:
 * `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_id` - (Optional, Forces new resource) VPC ID.
+  Defaults to the region's default VPC.
 
 ### ingress
 


### PR DESCRIPTION
When no `vpc_id` is passed to `aws_security_group`, use the default VPC to match the behaviour of the AWS API.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #26525
Relates #26666

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ec2 TESTS=TestAccVPCSecurityGroup_

--- PASS: TestAccVPCSecurityGroup_invalidCIDRBlock (9.83s)
--- PASS: TestAccVPCSecurityGroup_namePrefix (88.38s)
--- PASS: TestAccVPCSecurityGroup_ipv6 (90.89s)
--- PASS: TestAccVPCSecurityGroup_self (93.06s)
--- PASS: TestAccVPCSecurityGroup_basic (93.14s)
--- PASS: TestAccVPCSecurityGroup_allowAll (93.43s)
--- PASS: TestAccVPCSecurityGroup_defaultEgressVPC (93.89s)
--- PASS: TestAccVPCSecurityGroup_vpc (95.51s)
--- PASS: TestAccVPCSecurityGroup_sourceSecurityGroup (97.19s)
--- PASS: TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules (100.59s)
--- PASS: TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC (103.11s)
--- PASS: TestAccVPCSecurityGroup_cidrAndGroups (105.65s)
--- PASS: TestAccVPCSecurityGroup_multiIngress (105.65s)
--- PASS: TestAccVPCSecurityGroup_egressWithPrefixList (114.39s)
--- PASS: TestAccVPCSecurityGroup_ruleGathering (117.20s)
--- PASS: TestAccVPCSecurityGroup_change (136.03s)
--- PASS: TestAccVPCSecurityGroup_namePrefixTerraform (68.74s)
--- PASS: TestAccVPCSecurityGroup_vpcProtoNumIngress (67.09s)
--- PASS: TestAccVPCSecurityGroup_vpcNegOneIngress (66.90s)
--- PASS: TestAccVPCSecurityGroup_failWithDiffMismatch (58.01s)
--- PASS: TestAccVPCSecurityGroup_driftComplex (72.95s)
--- PASS: TestAccVPCSecurityGroup_ingressMode (170.21s)
--- PASS: TestAccVPCSecurityGroup_egressMode (172.46s)
--- PASS: TestAccVPCSecurityGroup_tags (170.21s)
--- PASS: TestAccVPCSecurityGroup_ipRangesWithSameRules (62.89s)
--- PASS: TestAccVPCSecurityGroup_ipv4AndIPv6Egress (69.32s)
--- PASS: TestAccVPCSecurityGroup_nameTerraformPrefix (56.87s)
--- PASS: TestAccVPCSecurityGroup_rulesDropOnError (103.10s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend (104.97s)
--- PASS: TestAccVPCSecurityGroup_disappears (39.89s)
--- PASS: TestAccVPCSecurityGroup_noVPC (45.66s)
--- PASS: TestAccVPCSecurityGroup_nameGenerated (49.06s)
--- PASS: TestAccVPCSecurityGroup_ruleDescription (126.07s)
--- PASS: TestAccVPCSecurityGroup_ingressWithPrefixList (58.58s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededAppend (129.34s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededAllNew (126.46s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededPrepend (125.52s)
--- PASS: TestAccVPCSecurityGroup_forceRevokeRulesTrue (403.84s)
--- PASS: TestAccVPCSecurityGroup_emrDependencyViolation (845.93s)
--- PASS: TestAccVPCSecurityGroup_forceRevokeRulesFalse (1149.34s)
```
