### PR TITLE
resource/aws_opsworks_stack: Use Default VPC when no VPC ID passed

### DIFF
--- a/.changelog/26711.txt
+++ b/.changelog/26711.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_opsworks_stack: Defaults to default VPC when not supplied
+```

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -709,7 +709,7 @@ func PreCheckRegionNot(t *testing.T, regions ...string) {
 // PreCheckAlternateRegionIs checks that the alternate test region is the specified region.
 func PreCheckAlternateRegionIs(t *testing.T, region string) {
 	if curr := AlternateRegion(); curr != region {
-		t.Skipf("skipping tests; %s (%s) does not equal %s", conns.EnvVarDefaultRegion, curr, region)
+		t.Skipf("skipping tests; %s (%s) does not equal %s", conns.EnvVarAlternateRegion, curr, region)
 	}
 }
 

--- a/internal/service/acm/sweep.go
+++ b/internal/service/acm/sweep.go
@@ -72,7 +72,7 @@ func sweepCertificates(region string) error {
 				for _, iub := range output.Certificate.InUseBy {
 					m[aws.StringValue(iub)[:77]] = ""
 				}
-				for k, _ := range m {
+				for k := range m {
 					log.Printf("[INFO]  %s...", k)
 				}
 				continue

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -2498,7 +2498,6 @@ resource "aws_security_group" "test" {
 data "aws_vpc" "default" {
   default = true
 }
-
 `, rName)
 }
 
@@ -2512,7 +2511,6 @@ resource "aws_security_group" "test" {
 data "aws_vpc" "default" {
   default = true
 }
-
 `, rName)
 }
 

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -1,7 +1,6 @@
 package opsworks
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -112,10 +111,10 @@ func ResourceStack() *schema.Resource {
 				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
 			},
 			"default_availability_zone": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"default_availability_zone", "vpc_id"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"vpc_id"},
 			},
 			"default_instance_profile_arn": {
 				Type:     schema.TypeString,
@@ -182,11 +181,11 @@ func ResourceStack() *schema.Resource {
 				Default:  true,
 			},
 			"vpc_id": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Computed:     true,
-				Optional:     true,
-				ExactlyOneOf: []string{"default_availability_zone", "vpc_id"},
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"default_availability_zone"},
 			},
 		},
 
@@ -198,10 +197,6 @@ func resourceStackCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).OpsWorksConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
-
-	if _, ok := d.GetOk("vpc_id"); !ok {
-		return errors.New(`with the retirement of EC2-Classic no new OpsWorks Stacks can be created without referencing a VPC`)
-	}
 
 	name := d.Get("name").(string)
 	region := d.Get("region").(string)

--- a/website/docs/r/opsworks_stack.html.markdown
+++ b/website/docs/r/opsworks_stack.html.markdown
@@ -40,32 +40,29 @@ The following arguments are supported:
 * `name` - (Required) The name of the stack.
 * `region` - (Required) The name of the region where the stack will exist.
 * `service_role_arn` - (Required) The ARN of an IAM role that the OpsWorks service will act as.
-* `default_instance_profile_arn` - (Required) The ARN of an IAM Instance Profile that created instances
-  will have by default.
+* `default_instance_profile_arn` - (Required) The ARN of an IAM Instance Profile that created instances will have by default.
 * `agent_version` - (Optional) If set to `"LATEST"`, OpsWorks will automatically install the latest version.
 * `berkshelf_version` - (Optional) If `manage_berkshelf` is enabled, the version of Berkshelf to use.
 * `color` - (Optional) Color to paint next to the stack's resources in the OpsWorks console.
-* `default_availability_zone` - (Optional) Name of the availability zone where instances will be created
-  by default. This is required unless you set `vpc_id`.
 * `configuration_manager_name` - (Optional) Name of the configuration manager to use. Defaults to "Chef".
 * `configuration_manager_version` - (Optional) Version of the configuration manager to use. Defaults to "11.4".
-* `custom_cookbooks_source` - (Optional) When `use_custom_cookbooks` is set, provide this sub-object as
-  described below.
+* `custom_cookbooks_source` - (Optional) When `use_custom_cookbooks` is set, provide this sub-object as described below.
 * `custom_json` - (Optional) User defined JSON passed to "Chef". Use a "here doc" for multiline JSON.
+* `default_availability_zone` - (Optional) Name of the availability zone where instances will be created by default.
+  Cannot be set when `vpc_id` is set.
 * `default_os` - (Optional) Name of OS that will be installed on instances by default.
 * `default_root_device_type` - (Optional) Name of the type of root device instances will have by default.
 * `default_ssh_key_name` - (Optional) Name of the SSH keypair that instances will have by default.
-* `default_subnet_id` - (Optional) Id of the subnet in which instances will be created by default. Mandatory
-  if `vpc_id` is set, and forbidden if it isn't.
-* `hostname_theme` - (Optional) Keyword representing the naming scheme that will be used for instance hostnames
-  within this stack.
+* `default_subnet_id` - (Optional) ID of the subnet in which instances will be created by default.
+  Required if `vpc_id` is set to a VPC other than the default VPC, and forbidden if it isn't.
+* `hostname_theme` - (Optional) Keyword representing the naming scheme that will be used for instance hostnames within this stack.
 * `manage_berkshelf` - (Optional) Boolean value controlling whether Opsworks will run Berkshelf for this stack.
-* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `use_custom_cookbooks` - (Optional) Boolean value controlling whether the custom cookbook settings are
-  enabled.
-* `use_opsworks_security_groups` - (Optional) Boolean value controlling whether the standard OpsWorks
-  security groups apply to created instances.
+* `tags` - (Optional) A map of tags to assign to the resource.
+  If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `use_custom_cookbooks` - (Optional) Boolean value controlling whether the custom cookbook settings are enabled.
+* `use_opsworks_security_groups` - (Optional) Boolean value controlling whether the standard OpsWorks security groups apply to created instances.
 * `vpc_id` - (Optional) ID of the VPC that this stack belongs to.
+  Defaults to the region's default VPC.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the entire stack.
 
 The `custom_cookbooks_source` block supports the following arguments:


### PR DESCRIPTION
When no `vpc_id` is passed to `aws_opsworks_stack`, use the default VPC to match the behaviour of the AWS API.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #26525
Relates #26666
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23625

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc PKG=opsworks TESTS=TestAccOpsWorksStack_

    acctest.go:696: skipping tests; AWS_DEFAULT_REGION (us-west-2) does not equal us-east-1
--- SKIP: TestAccOpsWorksStack_tagsAlternateRegion (1.02s)
--- PASS: TestAccOpsWorksStack_disappears (40.06s)
--- PASS: TestAccOpsWorksStack_noVPC_defaultAZ (40.93s)
--- PASS: TestAccOpsWorksStack_basic (41.47s)
--- PASS: TestAccOpsWorksStack_windows (56.94s)
--- PASS: TestAccOpsWorksStack_noVPC_basic (62.84s)
--- PASS: TestAccOpsWorksStack_tags (73.88s)
--- PASS: TestAccOpsWorksStack_allAttributes (74.94s)
```

```console
$ AWS_DEFAULT_REGION=us-east-1 AWS_ALTERNATE_REGION=us-west-1 make testacc PKG=opsworks TESTS=TestAccOpsWorksStack_tagsAlternateRegion

--- PASS: TestAccOpsWorksStack_tagsAlternateRegion (95.42s)
```
