### PR TITLE
resource/aws_eip: Default to default domain when `vpc` not set

### DIFF
--- a/.changelog/26716.txt
+++ b/.changelog/26716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eip: Defaults to default regional `domain` when `vpc` not set
+```

--- a/internal/service/acm/sweep.go
+++ b/internal/service/acm/sweep.go
@@ -72,7 +72,7 @@ func sweepCertificates(region string) error {
 				for _, iub := range output.Certificate.InUseBy {
 					m[aws.StringValue(iub)[:77]] = ""
 				}
-				for k, _ := range m {
+				for k := range m {
 					log.Printf("[INFO]  %s...", k)
 				}
 				continue

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -131,12 +131,10 @@ func resourceEIPCreate(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	if _, ok := d.GetOk("vpc"); !ok {
-		return errors.New(`with the retirement of EC2-Classic no new non-VPC EC2 EIPs can be created`)
-	}
+	input := &ec2.AllocateAddressInput{}
 
-	input := &ec2.AllocateAddressInput{
-		Domain: aws.String(ec2.DomainTypeVpc),
+	if v := d.Get("vpc"); v != nil && v.(bool) {
+		input.Domain = aws.String(ec2.DomainTypeVpc)
 	}
 
 	if v, ok := d.GetOk("address"); ok {

--- a/internal/service/ec2/ec2_eip_test.go
+++ b/internal/service/ec2/ec2_eip_test.go
@@ -68,6 +68,34 @@ func TestAccEC2EIP_disappears(t *testing.T) {
 	})
 }
 
+func TestAccEC2EIP_noVPC(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPConfig_noVPC,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEIPExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "domain", "vpc"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					testAccCheckEIPPublicDNS(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccEC2EIP_tags(t *testing.T) {
 	var conf ec2.Address
 	resourceName := "aws_eip.test"
@@ -742,6 +770,11 @@ func testAccCheckEIPPublicDNS(resourceName string) resource.TestCheckFunc {
 const testAccEIPConfig_basic = `
 resource "aws_eip" "test" {
   vpc = true
+}
+`
+
+const testAccEIPConfig_noVPC = `
+resource "aws_eip" "test" {
 }
 `
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -103,9 +103,11 @@ The following arguments are supported:
 * `instance` - (Optional) EC2 instance ID.
 * `network_border_group` - (Optional) Location from which the IP address is advertised. Use this parameter to limit the address to this location.
 * `network_interface` - (Optional) Network interface ID to associate with.
-* `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`. This option is only available for VPC EIPs.
+* `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`.
+  This option is only available for VPC EIPs.
 * `tags` - (Optional) Map of tags to assign to the resource. Tags can only be applied to EIPs in a VPC. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc` - (Optional) Boolean if the EIP is in a VPC or not.
+  Defaults to `true` unless the region supports EC2-Classic.
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID, but not both. Including both will **not** return an error from the AWS API, but will have undefined behavior. See the relevant [AssociateAddress API Call][1] for more information.
 
@@ -120,7 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 * `association_id` - ID representing the association of the address with an instance in a VPC.
 * `carrier_ip` - Carrier IP address.
 * `customer_owned_ip` - Customer owned IP.
-* `domain` - Indicates if this EIP is for use in VPC (`vpc`) or EC2 Classic (`standard`).
+* `domain` - Indicates if this EIP is for use in VPC (`vpc`) or EC2-Classic (`standard`).
 * `id` - Contains the EIP allocation ID.
 * `private_dns` - The Private DNS associated with the Elastic IP address (if in VPC).
 * `private_ip` - Contains the private IP address (if in VPC).
@@ -146,7 +148,7 @@ EIPs in a VPC can be imported using their Allocation ID, e.g.,
 $ terraform import aws_eip.bar eipalloc-00a10e96
 ```
 
-EIPs in EC2 Classic can be imported using their Public IP, e.g.,
+EIPs in EC2-Classic can be imported using their Public IP, e.g.,
 
 ```
 $ terraform import aws_eip.bar 52.0.0.0


### PR DESCRIPTION
Default to default domain when `vpc` not set. `standard` in EC2-Classic, `vpc` otherwise

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #26525
Relates #26666
Relates #23625

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ec2 TESTS=TestAccEC2EIP

    ec2_eip_test.go:424: Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set
--- SKIP: TestAccEC2EIP_PublicIPv4Pool_custom (0.00s)
    ec2_eip_test.go:566: Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set
--- SKIP: TestAccEC2EIP_BYOIPAddress_custom (0.00s)
    ec2_eip_test.go:594: Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set
--- SKIP: TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool (0.00s)
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccEC2EIPDataSource_customerOwnedIPv4Pool (1.72s)
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccEC2EIPDataSource_carrierIP (0.07s)
--- PASS: TestAccEC2EIP_disappears (79.49s)
--- PASS: TestAccEC2EIPDataSource_filter (93.29s)
--- PASS: TestAccEC2EIPDataSource_publicIP (95.68s)
--- PASS: TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface (111.14s)
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccEC2EIP_carrierIP (0.26s)
    ec2_classic.go:62: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIPAssociation_classic (3.67s)
--- PASS: TestAccEC2EIP_noVPC (117.52s)
--- PASS: TestAccEC2EIP_basic (117.88s)
--- PASS: TestAccEC2EIP_networkInterface (136.89s)
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccEC2EIP_customerOwnedIPv4Pool (0.55s)
--- PASS: TestAccEC2EIPDataSource_id (95.92s)
--- PASS: TestAccEC2EIPAssociation_basic (197.76s)
    ec2_classic.go:62: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccEC2EIP_Instance_ec2Classic (0.00s)
--- PASS: TestAccEC2EIP_instance (206.65s)
--- PASS: TestAccEC2EIPDataSource_instance (211.27s)
--- PASS: TestAccEC2EIPDataSource_networkInterface (132.06s)
--- PASS: TestAccEC2EIPDataSource_tags (115.42s)
--- PASS: TestAccEC2EIPAssociation_networkInterface (146.10s)
--- PASS: TestAccEC2EIP_networkBorderGroup (150.25s)
--- PASS: TestAccEC2EIP_Instance_notAssociated (290.66s)
--- PASS: TestAccEC2EIPAssociation_spotInstance (198.06s)
--- PASS: TestAccEC2EIPsDataSource_basic (126.28s)
--- PASS: TestAccEC2EIP_tags (302.21s)
--- PASS: TestAccEC2EIP_Instance_reassociate (304.82s)
--- PASS: TestAccEC2EIPAssociation_instance (195.98s)
--- PASS: TestAccEC2EIP_BYOIPAddress_default (113.81s)
--- PASS: TestAccEC2EIP_PublicIPv4Pool_default (109.46s)
--- PASS: TestAccEC2EIPAssociation_disappears (150.53s)
--- PASS: TestAccEC2EIP_Instance_associatedUserPrivateIP (359.90s)
--- PASS: TestAccEC2EIP_association (374.52s)
```
