### PR TITLE
Restore use of `latest` semgrep container image in CI

### DIFF
--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -38,7 +38,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@v0.111.1
+      image: returntocorp/semgrep@0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -38,7 +38,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:0.111.1"
+      image: returntocorp/semgrep@v0.111.1
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -38,7 +38,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@0.111.1
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/26691.
Relates https://github.com/returntocorp/semgrep/issues/6059.