### PR TITLE
add resource aws_sqs_queue_redrive_policy

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2052,8 +2052,9 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_sns_topic_policy":         sns.ResourceTopicPolicy(),
 			"aws_sns_topic_subscription":   sns.ResourceTopicSubscription(),
 
-			"aws_sqs_queue":        sqs.ResourceQueue(),
-			"aws_sqs_queue_policy": sqs.ResourceQueuePolicy(),
+			"aws_sqs_queue":                sqs.ResourceQueue(),
+			"aws_sqs_queue_policy":         sqs.ResourceQueuePolicy(),
+			"aws_sqs_queue_redrive_policy": sqs.ResourceQueueRedrivePolicy(),
 
 			"aws_ssm_activation":                ssm.ResourceActivation(),
 			"aws_ssm_association":               ssm.ResourceAssociation(),

--- a/internal/service/acm/sweep.go
+++ b/internal/service/acm/sweep.go
@@ -72,7 +72,7 @@ func sweepCertificates(region string) error {
 				for _, iub := range output.Certificate.InUseBy {
 					m[aws.StringValue(iub)[:77]] = ""
 				}
-				for k, _ := range m {
+				for k := range m {
 					log.Printf("[INFO]  %s...", k)
 				}
 				continue

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -1,0 +1,147 @@
+package sqs
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"log"
+)
+
+func generateQueueAttributeUpsertFunc(attributeName string) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		conn := meta.(*conns.AWSClient).SQSConn
+
+		attrValue, err := structure.NormalizeJsonString(d.Get(getSchemaKey(attributeName)).(string))
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("%s (%s) is invalid JSON: %w", attributeName, d.Get(getSchemaKey(attributeName)).(string), err))
+		}
+
+		var attributes map[string]string
+
+		switch attributeName {
+		case sqs.QueueAttributeNamePolicy:
+			attributes = map[string]string{
+				sqs.QueueAttributeNamePolicy: attrValue,
+			}
+		case sqs.QueueAttributeNameRedrivePolicy:
+			attributes = map[string]string{
+				sqs.QueueAttributeNameRedrivePolicy: attrValue,
+			}
+		default:
+			return diag.FromErr(fmt.Errorf("%s is an invalid SQS Queue attribute name", attributeName))
+		}
+
+		url := d.Get("queue_url").(string)
+		input := &sqs.SetQueueAttributesInput{
+			Attributes: aws.StringMap(attributes),
+			QueueUrl:   aws.String(url),
+		}
+
+		log.Printf("[DEBUG] Setting SQS Queue Attribute '%s': %s", attributeName, input)
+		_, err = conn.SetQueueAttributesWithContext(ctx, input)
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error setting SQS Queue Attribute '%s' (%s): %w", attributeName, url, err))
+		}
+
+		d.SetId(url)
+
+		err = waitQueueAttributesPropagatedWithContext(ctx, conn, d.Id(), attributes)
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error waiting for SQS Queue Attribute '%s' (%s) to be set: %w", attributeName, d.Id(), err))
+		}
+
+		return generateQueueAttributeReadFunc(attributeName)(ctx, d, meta)
+	}
+}
+func generateQueueAttributeReadFunc(attributeName string) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		conn := meta.(*conns.AWSClient).SQSConn
+
+		outputRaw, err := tfresource.RetryWhenNotFound(queueAttributeReadTimeout, func() (interface{}, error) {
+			return FindQueueAttributeByURL(ctx, conn, d.Id(), attributeName)
+		})
+
+		if !d.IsNewResource() && tfresource.NotFound(err) {
+			log.Printf("[WARN] SQS Queue Policy (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error reading SQS Queue Attribute '%s' (%s): %w", attributeName, d.Id(), err))
+		}
+
+		var attributeToSet string
+		switch attributeName {
+		case sqs.QueueAttributeNamePolicy:
+			attributeToSet, err = verify.PolicyToSet(d.Get(getSchemaKey(attributeName)).(string), outputRaw.(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		case sqs.QueueAttributeNameRedrivePolicy:
+			if BytesEqual([]byte(d.Get(getSchemaKey(attributeName)).(string)), []byte(outputRaw.(string))) {
+				attributeToSet = d.Get(getSchemaKey(attributeName)).(string)
+			} else {
+				attributeToSet = outputRaw.(string)
+			}
+		default:
+			return diag.FromErr(fmt.Errorf("%s is an invalid SQS Queue attribute name", attributeName))
+		}
+
+		d.Set(getSchemaKey(attributeName), attributeToSet)
+
+		d.Set("queue_url", d.Id())
+
+		return nil
+	}
+}
+
+func generateQueueAttributeDeleteFunc(attributeName string) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		conn := meta.(*conns.AWSClient).SQSConn
+
+		log.Printf("[DEBUG] Deleting SQS Queue Attribute '%s': %s", attributeName, d.Id())
+
+		var emptyAttributes map[string]string
+		switch attributeName {
+		case sqs.QueueAttributeNamePolicy:
+			emptyAttributes = queueEmptyPolicyAttributes
+		case sqs.QueueAttributeNameRedrivePolicy:
+			emptyAttributes = queueEmptyRedrivePolicyAttributes
+		default:
+			return diag.FromErr(fmt.Errorf("%s is an invalid SQS Queue attribute name", attributeName))
+		}
+
+		_, err := conn.SetQueueAttributes(&sqs.SetQueueAttributesInput{
+			Attributes: aws.StringMap(emptyAttributes),
+			QueueUrl:   aws.String(d.Id()),
+		})
+
+		if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDoesNotExist) {
+			return nil
+		}
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error deleting SQS Queue Attribute '%s' (%s): %w", attributeName, d.Id(), err))
+		}
+
+		err = waitQueueAttributesPropagatedWithContext(ctx, conn, d.Id(), emptyAttributes)
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error waiting for SQS Queue Attribute '%s' (%s) to delete: %w", attributeName, d.Id(), err))
+		}
+
+		return nil
+	}
+}

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -121,6 +121,7 @@ var (
 		"redrive_policy": {
 			Type:         schema.TypeString,
 			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validation.StringIsJSON,
 			StateFunc: func(v interface{}) string {
 				json, _ := structure.NormalizeJsonString(v)

--- a/internal/service/sqs/queue_policy.go
+++ b/internal/service/sqs/queue_policy.go
@@ -1,17 +1,10 @@
 package sqs
 
 import (
-	"fmt"
-	"log"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -24,16 +17,15 @@ var (
 func ResourceQueuePolicy() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
-		Create: resourceQueuePolicyUpsert,
-		Read:   resourceQueuePolicyRead,
-		Update: resourceQueuePolicyUpsert,
-		Delete: resourceQueuePolicyDelete,
+		CreateContext: generateQueueAttributeUpsertFunc(sqs.QueueAttributeNamePolicy),
+		ReadContext:   generateQueueAttributeReadFunc(sqs.QueueAttributeNamePolicy),
+		UpdateContext: generateQueueAttributeUpsertFunc(sqs.QueueAttributeNamePolicy),
+		DeleteContext: generateQueueAttributeDeleteFunc(sqs.QueueAttributeNamePolicy),
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		MigrateState:  QueuePolicyMigrateState,
 		SchemaVersion: 1,
-
 		Schema: map[string]*schema.Schema{
 			"policy": {
 				Type:             schema.TypeString,
@@ -53,97 +45,4 @@ func ResourceQueuePolicy() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).SQSConn
-
-	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
-	if err != nil {
-		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
-	}
-
-	policyAttributes := map[string]string{
-		sqs.QueueAttributeNamePolicy: policy,
-	}
-
-	url := d.Get("queue_url").(string)
-	input := &sqs.SetQueueAttributesInput{
-		Attributes: aws.StringMap(policyAttributes),
-		QueueUrl:   aws.String(url),
-	}
-
-	log.Printf("[DEBUG] Setting SQS Queue Policy: %s", input)
-	_, err = conn.SetQueueAttributes(input)
-
-	if err != nil {
-		return fmt.Errorf("error setting SQS Queue Policy (%s): %w", url, err)
-	}
-
-	d.SetId(url)
-
-	err = waitQueueAttributesPropagated(conn, d.Id(), policyAttributes)
-
-	if err != nil {
-		return fmt.Errorf("error waiting for SQS Queue Policy (%s) to be set: %w", d.Id(), err)
-	}
-
-	return resourceQueuePolicyRead(d, meta)
-}
-
-func resourceQueuePolicyRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).SQSConn
-
-	outputRaw, err := tfresource.RetryWhenNotFound(queuePolicyReadTimeout, func() (interface{}, error) {
-		return FindQueuePolicyByURL(conn, d.Id())
-	})
-
-	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] SQS Queue Policy (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error reading SQS Queue Policy (%s): %w", d.Id(), err)
-	}
-
-	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), outputRaw.(string))
-
-	if err != nil {
-		return err
-	}
-
-	d.Set("policy", policyToSet)
-
-	d.Set("queue_url", d.Id())
-
-	return nil
-}
-
-func resourceQueuePolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).SQSConn
-
-	log.Printf("[DEBUG] Deleting SQS Queue Policy: %s", d.Id())
-	_, err := conn.SetQueueAttributes(&sqs.SetQueueAttributesInput{
-		Attributes: aws.StringMap(queueEmptyPolicyAttributes),
-		QueueUrl:   aws.String(d.Id()),
-	})
-
-	if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDoesNotExist) {
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error deleting SQS Queue Policy (%s): %w", d.Id(), err)
-	}
-
-	err = waitQueueAttributesPropagated(conn, d.Id(), queueEmptyPolicyAttributes)
-
-	if err != nil {
-		return fmt.Errorf("error waiting for SQS Queue Policy (%s) to delete: %w", d.Id(), err)
-	}
-
-	return nil
 }

--- a/internal/service/sqs/queue_redrive_policy.go
+++ b/internal/service/sqs/queue_redrive_policy.go
@@ -1,0 +1,43 @@
+package sqs
+
+import (
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var (
+	queueEmptyRedrivePolicyAttributes = map[string]string{
+		sqs.QueueAttributeNameRedrivePolicy: "",
+	}
+)
+
+func ResourceQueueRedrivePolicy() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"redrive_policy": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
+			"queue_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+		SchemaVersion: 0,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		CreateContext: generateQueueAttributeUpsertFunc(sqs.QueueAttributeNameRedrivePolicy),
+		ReadContext:   generateQueueAttributeReadFunc(sqs.QueueAttributeNameRedrivePolicy),
+		UpdateContext: generateQueueAttributeUpsertFunc(sqs.QueueAttributeNameRedrivePolicy),
+		DeleteContext: generateQueueAttributeDeleteFunc(sqs.QueueAttributeNameRedrivePolicy),
+	}
+}

--- a/internal/service/sqs/queue_redrive_policy_test.go
+++ b/internal/service/sqs/queue_redrive_policy_test.go
@@ -1,0 +1,178 @@
+package sqs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfsqs "github.com/hashicorp/terraform-provider-aws/internal/service/sqs"
+)
+
+func TestAccSQSQueueRedrivePolicy_basic(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue_redrive_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sqs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueRedrivePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(queueResourceName, &queueAttributes),
+					testAccCheckQueueExists(fmt.Sprintf("%s-ddl", queueResourceName), &queueAttributes),
+					resource.TestCheckResourceAttrSet(resourceName, "redrive_policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:   testAccQueueRedrivePolicyConfig_basic(rName),
+				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "redrive_policy", queueResourceName, "redrive_policy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSQSQueueRedrivePolicy_disappears(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue_redrive_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sqs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueRedrivePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(queueResourceName, &queueAttributes),
+					testAccCheckQueueExists(fmt.Sprintf("%s-ddl", queueResourceName), &queueAttributes),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsqs.ResourceQueueRedrivePolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSQSQueueRedrivePolicy_Disappears_queue(t *testing.T) {
+	var queueAttributes map[string]string
+	queueResourceName := "aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sqs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueRedrivePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(queueResourceName, &queueAttributes),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsqs.ResourceQueue(), queueResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSQSQueueRedrivePolicy_update(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue_redrive_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sqs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueRedrivePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(queueResourceName, &queueAttributes),
+					resource.TestCheckResourceAttrSet(resourceName, "redrive_policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccQueueRedrivePolicyConfig_updated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "redrive_policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueueRedrivePolicyConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
+}
+
+resource "aws_sqs_queue" "test-ddl" {
+  name = "%[1]s-ddl"
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = [aws_sqs_queue.test.arn]
+  })
+}
+
+resource "aws_sqs_queue_redrive_policy" "test" {
+  queue_url = aws_sqs_queue.test.id
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.test-ddl.arn
+    maxReceiveCount     = 4
+  })
+}
+`, rName)
+}
+
+func testAccQueueRedrivePolicyConfig_updated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
+}
+
+resource "aws_sqs_queue" "test-ddl" {
+  name = "%[1]s-ddl"
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = [aws_sqs_queue.test.arn]
+  })
+}
+
+resource "aws_sqs_queue_redrive_policy" "test" {
+  queue_url = aws_sqs_queue.test.id
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.test-ddl.arn
+    maxReceiveCount     = 2
+  })
+}
+`, rName)
+}

--- a/internal/service/sqs/status.go
+++ b/internal/service/sqs/status.go
@@ -42,7 +42,7 @@ func statusQueueAttributeState(conn *sqs.SQS, url string, expected map[string]st
 						continue
 					}
 
-					return queuePolicyStateNotEqual
+					return queueAttributeStateNotEqual
 				}
 
 				switch k {
@@ -50,24 +50,24 @@ func statusQueueAttributeState(conn *sqs.SQS, url string, expected map[string]st
 					equivalent, err := awspolicy.PoliciesAreEquivalent(g, e)
 
 					if err != nil {
-						return queuePolicyStateNotEqual
+						return queueAttributeStateNotEqual
 					}
 
 					if !equivalent {
-						return queuePolicyStateNotEqual
+						return queueAttributeStateNotEqual
 					}
 				case sqs.QueueAttributeNameRedriveAllowPolicy, sqs.QueueAttributeNameRedrivePolicy:
 					if !StringsEquivalent(g, e) {
-						return queuePolicyStateNotEqual
+						return queueAttributeStateNotEqual
 					}
 				default:
 					if g != e {
-						return queuePolicyStateNotEqual
+						return queueAttributeStateNotEqual
 					}
 				}
 			}
 
-			return queuePolicyStateEqual
+			return queueAttributeStateEqual
 		}
 
 		got, err := FindQueueAttributesByURL(conn, url)

--- a/internal/service/sqs/strings.go
+++ b/internal/service/sqs/strings.go
@@ -1,0 +1,14 @@
+package sqs
+
+import "github.com/aws/aws-sdk-go/service/sqs"
+
+func getSchemaKey(attributeName string) string {
+	switch attributeName {
+	case sqs.QueueAttributeNamePolicy:
+		return "policy"
+	case sqs.QueueAttributeNameRedrivePolicy:
+		return "redrive_policy"
+	default:
+		return ""
+	}
+}

--- a/website/docs/r/sqs_queue_redrive_policy.html.markdown
+++ b/website/docs/r/sqs_queue_redrive_policy.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "SQS (Simple Queue)"
+layout: "aws"
+page_title: "AWS: aws_sqs_queue_redrive_policy"
+description: |-
+Provides a SQS Queue Redrive Policy resource.
+---
+
+# Resource: aws_sqs_queue_redrive_policy
+
+Allows you to set a redrive policy of an SQS Queue
+while referencing ARN of the dead letter queue inside the redrive policy.
+
+This is useful when you want to set a dedicated
+dead letter queue for a standard or FIFO queue, but need
+the dead letter queue to exist before setting the redrive policy.
+
+## Example Usage
+
+```terraform
+resource "aws_sqs_queue" "q" {
+  name = "examplequeue"
+}
+
+resource "aws_sqs_queue" "ddl" {
+  name = "examplequeue-ddl"
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = [aws_sqs_queue.q.arn]
+  })
+}
+
+resource "aws_sqs_queue_redrive_policy" "q" {
+  queue_url = aws_sqs_queue.q.id
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.ddl.arn
+    maxReceiveCount     = 4
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `queue_url` - (Required) The URL of the SQS Queue to which to attach the policy
+* `redrive_policy` - (Required) The JSON redrive policy for the SQS queue. Accepts two key/val pairs: `deadLetterTargetArn` and `maxReceiveCount`. Learn more in the [Amazon SQS dead-letter queues documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html).
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+SQS Queue Redrive Policies can be imported using the queue URL, e.g.,
+
+```
+$ terraform import aws_sqs_queue_redrive_policy.test https://queue.amazonaws.com/0123456789012/myqueue
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22577

This PR adds the resource `aws_sqs_queue_redrive_policy`, which allows you to create a redrive policy after an existing sqs queue. Read more in #22577 on why this is needed.

The internals of this resource are nearly identical to the `aws_sqs_queue_policy` resource, with a few small exceptions. For this reason, I created a function generator that the CRUD functions utilize, reusing most of the function definitions from the `aws_sqs_queue_policy` CRUD methods, with a few exceptions. The function generators are in `attribute_funcs` file within the sqs package. For this reason, I have also listed the output of the `aws_sqs_queue_policy` resource tests below.

Additional note, by creating this as a shared function and using the latest context-based methods, this also updates the `aws_sqs_queue_policy` resource to use the context CRUD methods.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSQSQueueRedrivePolicy_ PKG=sqs

=== RUN   TestAccSQSQueueRedrivePolicy_basic
=== PAUSE TestAccSQSQueueRedrivePolicy_basic
=== RUN   TestAccSQSQueueRedrivePolicy_disappears
=== PAUSE TestAccSQSQueueRedrivePolicy_disappears
=== RUN   TestAccSQSQueueRedrivePolicy_Disappears_queue
=== PAUSE TestAccSQSQueueRedrivePolicy_Disappears_queue
=== RUN   TestAccSQSQueueRedrivePolicy_update
=== PAUSE TestAccSQSQueueRedrivePolicy_update
=== CONT  TestAccSQSQueueRedrivePolicy_basic
=== CONT  TestAccSQSQueueRedrivePolicy_Disappears_queue
=== CONT  TestAccSQSQueueRedrivePolicy_disappears
=== CONT  TestAccSQSQueueRedrivePolicy_update
--- PASS: TestAccSQSQueueRedrivePolicy_basic (132.95s)
--- PASS: TestAccSQSQueueRedrivePolicy_Disappears_queue (136.76s)
--- PASS: TestAccSQSQueueRedrivePolicy_disappears (142.35s)
--- PASS: TestAccSQSQueueRedrivePolicy_update (161.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	163.709s
...
```

```
$ make testacc TESTS=TestAccSQSQueuePolicy_ PKG=sqs

=== RUN   TestAccSQSQueuePolicy_basic
=== PAUSE TestAccSQSQueuePolicy_basic
=== RUN   TestAccSQSQueuePolicy_disappears
=== PAUSE TestAccSQSQueuePolicy_disappears
=== RUN   TestAccSQSQueuePolicy_Disappears_queue
=== PAUSE TestAccSQSQueuePolicy_Disappears_queue
=== RUN   TestAccSQSQueuePolicy_update
=== PAUSE TestAccSQSQueuePolicy_update
=== CONT  TestAccSQSQueuePolicy_basic
=== CONT  TestAccSQSQueuePolicy_Disappears_queue
=== CONT  TestAccSQSQueuePolicy_update
=== CONT  TestAccSQSQueuePolicy_disappears
--- PASS: TestAccSQSQueuePolicy_basic (103.59s)
--- PASS: TestAccSQSQueuePolicy_Disappears_queue (105.82s)
--- PASS: TestAccSQSQueuePolicy_disappears (113.81s)
--- PASS: TestAccSQSQueuePolicy_update (132.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	135.581s
...
```