### PR TITLE
resource/aws_dynamodb_table: Handles Tables in `ARCHIVED` status

### DIFF
--- a/.changelog/26744.txt
+++ b/.changelog/26744.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: No longer returns error for an ARCHIVED table
+```

--- a/internal/service/dynamodb/status.go
+++ b/internal/service/dynamodb/status.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -53,12 +52,10 @@ func statusReplicaUpdate(conn *dynamodb.DynamoDB, tableName, region string) reso
 			TableName: aws.String(tableName),
 		})
 		if err != nil {
-			return 42, "", err
+			return nil, "", err
 		}
-		log.Printf("[DEBUG] DynamoDB replicas: %s", result.Table.Replicas)
 
 		var targetReplica *dynamodb.ReplicaDescription
-
 		for _, replica := range result.Table.Replicas {
 			if aws.StringValue(replica.RegionName) == region {
 				targetReplica = replica
@@ -80,12 +77,10 @@ func statusReplicaDelete(conn *dynamodb.DynamoDB, tableName, region string) reso
 			TableName: aws.String(tableName),
 		})
 		if err != nil {
-			return 42, "", err
+			return nil, "", err
 		}
 
-		log.Printf("[DEBUG] all replicas for waiting: %s", result.Table.Replicas)
 		var targetReplica *dynamodb.ReplicaDescription
-
 		for _, replica := range result.Table.Replicas {
 			if aws.StringValue(replica.RegionName) == region {
 				targetReplica = replica

--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -50,13 +50,11 @@ func sweepTables(region string) error {
 
 			// read concurrently and gather errors
 			g.Go(func() error {
-				// Need to Read first to fill in byte_match_tuples attribute
+				// Need to Read first to fill in `replica` attribute
 				err := r.Read(d, client)
 
 				if err != nil {
-					sweeperErr := fmt.Errorf("error reading DynamoDB Table (%s): %w", id, err)
-					log.Printf("[ERROR] %s", sweeperErr)
-					return sweeperErr
+					return err
 				}
 
 				// In case it was already deleted


### PR DESCRIPTION
When reading a table in `ARCHIVED` status, the call to `DescribeContinuousBackups` fails with a `TableNotFoundException` as follows:

> error reading DynamoDB Table (tf-acc-test-5583795887817721678): reading Amazon DynamoDB Table (tf-acc-test-5583795887817721678): continuous backups: TableNotFoundException: Table not found: tf-acc-test-5583795887817721678

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26577

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable

--- PASS: TestAccDynamoDBTable_disappears (37.48s)
--- PASS: TestAccDynamoDBTable_basic (45.73s)
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (72.15s)
--- PASS: TestAccDynamoDBTableDataSource_basic (72.51s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (80.89s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (86.91s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (87.73s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (92.24s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (5.11s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (105.91s)
--- PASS: TestAccDynamoDBTableItem_update (73.74s)
--- PASS: TestAccDynamoDBTable_enablePITR (113.58s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (122.55s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (54.24s)
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (36.57s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (52.23s)
--- PASS: TestAccDynamoDBTableItem_wonkyItems (39.05s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (80.44s)
--- PASS: TestAccDynamoDBTable_tags (52.52s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (10.92s)
--- PASS: TestAccDynamoDBTableItem_rangeKey (37.89s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (89.23s)
--- PASS: TestAccDynamoDBTable_streamSpecification (73.86s)
--- PASS: TestAccDynamoDBTable_encryption (111.60s)
--- PASS: TestAccDynamoDBTable_backupEncryption (310.40s)
--- PASS: TestAccDynamoDBTableItem_basic (21.49s)
--- PASS: TestAccDynamoDBTableReplica_tableClass (347.80s)
--- PASS: TestAccDynamoDBTableItem_disappears (21.68s)
--- PASS: TestAccDynamoDBTableReplica_disappears (190.65s)
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (287.90s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (266.29s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (44.60s)
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (263.23s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (285.76s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (426.70s)
--- PASS: TestAccDynamoDBTableReplica_tags (428.47s)
--- PASS: TestAccDynamoDBTable_extended (501.26s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (425.38s)
--- PASS: TestAccDynamoDBTableReplica_pitr (270.65s)
--- PASS: TestAccDynamoDBTableReplica_basic (258.82s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (500.60s)
--- PASS: TestAccDynamoDBTable_Replica_single (542.56s)
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (669.32s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (872.09s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (874.97s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (717.78s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (949.37s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (1272.23s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (1076.57s)
```
