### PR TITLE
ec2/iso: Fix disableAPIStop bug for instances

### DIFF
--- a/.changelog/26745.txt
+++ b/.changelog/26745.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Prevents errors in ISO regions when not using DisableApiStop attribute
+```

--- a/internal/service/cloudwatch/composite_alarm.go
+++ b/internal/service/cloudwatch/composite_alarm.go
@@ -102,7 +102,7 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 	_, err := conn.PutCompositeAlarmWithContext(ctx, &input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating CloudWatch Composite Alarm (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
@@ -129,7 +129,7 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 		err = UpdateTags(conn, aws.StringValue(alarm.AlarmArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 			return resourceCompositeAlarmRead(ctx, d, meta)
 		}
@@ -191,7 +191,7 @@ func resourceCompositeAlarmRead(ctx context.Context, d *schema.ResourceData, met
 	tags, err := ListTags(conn, aws.StringValue(alarm.AlarmArn))
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 		return nil
 	}
@@ -232,7 +232,7 @@ func resourceCompositeAlarmUpdate(ctx context.Context, d *schema.ResourceData, m
 		err := UpdateTags(conn, arn, o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 			return resourceCompositeAlarmRead(ctx, d, meta)
 		}

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -308,7 +308,7 @@ func resourceMetricAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 	_, err = conn.PutMetricAlarm(&params)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating CloudWatch Metric Alarm (%s) with tags: %s. Trying create without tags.", d.Get("alarm_name").(string), err)
 		params.Tags = nil
 
@@ -336,7 +336,7 @@ func resourceMetricAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 		err = UpdateTags(conn, aws.StringValue(resp.AlarmArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 			return resourceMetricAlarmRead(d, meta)
 		}
@@ -431,7 +431,7 @@ func resourceMetricAlarmRead(d *schema.ResourceData, meta interface{}) error {
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 		return nil
 	}
@@ -466,7 +466,7 @@ func resourceMetricAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, arn, o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 			return resourceMetricAlarmRead(d, meta)
 		}

--- a/internal/service/cloudwatch/metric_stream.go
+++ b/internal/service/cloudwatch/metric_stream.go
@@ -203,7 +203,7 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.PutMetricStreamWithContext(ctx, &params)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating CloudWatch Metric Stream (%s) with tags: %s. Trying create without tags.", name, err)
 		params.Tags = nil
 
@@ -222,7 +222,7 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 		err := UpdateTags(conn, aws.StringValue(output.Arn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 			return resourceMetricStreamRead(ctx, d, meta)
 		}
@@ -287,7 +287,7 @@ func resourceMetricStreamRead(ctx context.Context, d *schema.ResourceData, meta 
 	tags, err := ListTags(conn, aws.StringValue(output.Arn))
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -818,7 +818,6 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		CapacityReservationSpecification:  instanceOpts.CapacityReservationSpecification,
 		CpuOptions:                        instanceOpts.CpuOptions,
 		CreditSpecification:               instanceOpts.CreditSpecification,
-		DisableApiStop:                    instanceOpts.DisableAPIStop,
 		DisableApiTermination:             instanceOpts.DisableAPITermination,
 		EbsOptimized:                      instanceOpts.EBSOptimized,
 		EnclaveOptions:                    instanceOpts.EnclaveOptions,
@@ -845,6 +844,10 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		SubnetId:                          instanceOpts.SubnetID,
 		TagSpecifications:                 tagSpecifications,
 		UserData:                          instanceOpts.UserData64,
+	}
+
+	if instanceOpts.DisableAPIStop != nil {
+		input.DisableApiStop = instanceOpts.DisableAPIStop
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Instance: %s", input)
@@ -1199,10 +1202,12 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			Attribute:  aws.String(ec2.InstanceAttributeNameDisableApiStop),
 			InstanceId: aws.String(d.Id()),
 		})
-		if err != nil {
+		if err != nil && !verify.CheckISOErrorTagsUnsupported(meta.(*conns.AWSClient).Partition, err) {
 			return fmt.Errorf("reading EC2 Instance (%s) attribute: %w ", d.Id(), err)
 		}
-		d.Set("disable_api_stop", attr.DisableApiStop.Value)
+		if !verify.CheckISOErrorTagsUnsupported(meta.(*conns.AWSClient).Partition, err) {
+			d.Set("disable_api_stop", attr.DisableApiStop.Value)
+		}
 	}
 	{
 		if isSnowballEdgeInstance(d.Id()) {
@@ -1822,8 +1827,10 @@ func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API termination: %s", d.Id(), err)
 	}
 
-	if err := disableInstanceAPIStop(conn, d.Id(), d.Get("disable_api_stop").(bool)); err != nil {
-		log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API stop: %s", d.Id(), err)
+	if v, ok := d.GetOk("disable_api_stop"); ok {
+		if err := disableInstanceAPIStop(conn, d.Id(), v.(bool)); err != nil {
+			log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API stop: %s", d.Id(), err)
+		}
 	}
 
 	if err := terminateInstance(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
@@ -2543,11 +2550,14 @@ func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*instanceOpts,
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	opts := &instanceOpts{
-		DisableAPIStop:        aws.Bool(d.Get("disable_api_stop").(bool)),
 		DisableAPITermination: aws.Bool(d.Get("disable_api_termination").(bool)),
 		EBSOptimized:          aws.Bool(d.Get("ebs_optimized").(bool)),
 		EnclaveOptions:        expandEnclaveOptions(d.Get("enclave_options").([]interface{})),
 		MetadataOptions:       expandInstanceMetadataOptions(d.Get("metadata_options").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("disable_api_stop"); ok {
+		opts.DisableAPIStop = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("ami"); ok {

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1202,10 +1202,10 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			Attribute:  aws.String(ec2.InstanceAttributeNameDisableApiStop),
 			InstanceId: aws.String(d.Id()),
 		})
-		if err != nil && !verify.CheckISOErrorTagsUnsupported(meta.(*conns.AWSClient).Partition, err) {
+		if err != nil && !verify.ErrorISOUnsupported(meta.(*conns.AWSClient).Partition, err) {
 			return fmt.Errorf("reading EC2 Instance (%s) attribute: %w ", d.Id(), err)
 		}
-		if !verify.CheckISOErrorTagsUnsupported(meta.(*conns.AWSClient).Partition, err) {
+		if !verify.ErrorISOUnsupported(meta.(*conns.AWSClient).Partition, err) {
 			d.Set("disable_api_stop", attr.DisableApiStop.Value)
 		}
 	}

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -141,7 +141,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	out, err := conn.CreateRepository(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ECR Repository (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
@@ -163,7 +163,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(repository.RepositoryArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}
@@ -241,7 +241,7 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}
@@ -331,7 +331,7 @@ func resourceRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, arn, o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -116,7 +116,7 @@ func dataSourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -126,7 +126,7 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 	output, err := conn.CreateCapacityProvider(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Capacity Provider (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
@@ -143,7 +143,7 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)
@@ -239,7 +239,7 @@ func resourceCapacityProviderUpdate(d *schema.ResourceData, meta interface{}) er
 		err := UpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)
 		}

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -203,7 +203,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	out, err := retryClusterCreate(conn, input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Cluster (%s) with tags: %s. Trying create without tags.", clusterName, err)
 		input.Tags = nil
 
@@ -226,7 +226,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Cluster (%s): %s", d.Id(), err)
 			return resourceClusterRead(d, meta)
@@ -366,7 +366,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Cluster (%s): %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -22,7 +22,7 @@ func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider
 	output, err := conn.DescribeCapacityProviders(input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Capacity Provider (%s) with tags: %s; retrying without tags", arn, err)
 
 		input.Include = nil
@@ -61,7 +61,7 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	output, err := conn.DescribeClustersWithContext(ctx, input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed describing ECS Cluster (%s) including tags: %s; retrying without tags", nameOrARN, err)
 
 		input.Include = aws.StringSlice([]string{ecs.ClusterFieldConfigurations, ecs.ClusterFieldSettings})
@@ -69,7 +69,7 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	}
 
 	// Some partitions (i.e., ISO) may not support describe including configuration, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed describing ECS Cluster (%s) including configuration: %s; retrying without configuration", nameOrARN, err)
 
 		input.Include = aws.StringSlice([]string{ecs.ClusterFieldSettings})
@@ -162,7 +162,7 @@ func FindServiceByIDWaitForActive(ctx context.Context, conn *ecs.ECS, id, cluste
 func FindService(ctx context.Context, conn *ecs.ECS, input *ecs.DescribeServicesInput) (*ecs.Service, error) {
 	output, err := conn.DescribeServices(input)
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) && input.Include != nil {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) && input.Include != nil {
 		id := aws.StringValueSlice(input.Services)[0]
 		log.Printf("[WARN] failed describing ECS Service (%s) with tags: %s; retrying without tags", id, err)
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -534,7 +534,7 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := serviceCreateWithRetry(conn, input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ECS Service (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
@@ -569,7 +569,7 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for ECS Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}
@@ -1101,7 +1101,7 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for ECS Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -518,7 +518,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 	out, err := conn.RegisterTaskDefinition(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Task Definition (%s) with tags: %s. Trying create without tags.", d.Get("family").(string), err)
 		input.Tags = nil
 
@@ -542,7 +542,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 		err := UpdateTags(conn, aws.StringValue(taskDefinition.TaskDefinitionArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Task Definition (%s): %s", d.Id(), err)
 			return resourceTaskDefinitionRead(d, meta)
 		}
@@ -570,7 +570,7 @@ func resourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error 
 	out, err := conn.DescribeTaskDefinition(&input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Task Definition (%s) with tags: %s; retrying without tags", d.Id(), err)
 
 		input.Include = nil
@@ -732,7 +732,7 @@ func resourceTaskDefinitionUpdate(d *schema.ResourceData, meta interface{}) erro
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Task Definition (%s): %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -334,7 +334,7 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryTaskSetCreate(conn, input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed creating Task Set with tags: %s. Trying create without tags.", err)
 		input.Tags = nil
 
@@ -360,7 +360,7 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, aws.StringValue(output.TaskSet.TaskSetArn), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] ECS tagging failed adding tags after create for Task Set (%s): %s", d.Id(), err)
 			return resourceTaskSetRead(d, meta)
@@ -401,7 +401,7 @@ func resourceTaskSetRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Task Set (%s) with tags: %s; retrying without tags", d.Id(), err)
 
 		input.Include = nil
@@ -505,7 +505,7 @@ func resourceTaskSetUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] ECS tagging failed updating tags for Task Set (%s): %s", d.Id(), err)
 			return resourceTaskSetRead(d, meta)
 		}

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -439,7 +439,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, arn, nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache Cache Cluster (%s): %w", d.Id(), err)
 			}
@@ -510,7 +510,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(c.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("error listing tags for ElastiCache Cache Cluster (%s): %w", d.Id(), err)
 	}
 
@@ -710,7 +710,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// ISO partitions may not support tagging, giving error
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Cache Cluster (%s) tags: %w", d.Get("arn").(string), err)
 			}
@@ -788,7 +788,7 @@ func createCacheCluster(conn *elasticache.ElastiCache, input *elasticache.Create
 	output, err := conn.CreateCacheCluster(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Cache Cluster with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -233,7 +233,7 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(cluster.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("error listing tags for Elasticache Cluster (%s): %w", d.Id(), err)
 	}
 

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -95,7 +95,7 @@ func resourceParameterGroupCreate(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Create ElastiCache Parameter Group: %#v", createOpts)
 	resp, err := conn.CreateCacheParameterGroup(&createOpts)
 
-	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if createOpts.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Parameter Group with tags: %s. Trying create without tags.", err)
 
 		createOpts.Tags = nil
@@ -143,7 +143,7 @@ func resourceParameterGroupRead(d *schema.ResourceData, meta interface{}) error 
 
 	tags, err := ListTags(conn, aws.StringValue(parameterGroup.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("error listing tags for ElastiCache Parameter Group (%s): %w", d.Id(), err)
 	}
 
@@ -291,7 +291,7 @@ func resourceParameterGroupUpdate(d *schema.ResourceData, meta interface{}) erro
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Parameter Group (%s) tags: %w", d.Get("arn").(string), err)
 			}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -565,7 +565,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := conn.CreateReplicationGroup(params)
 
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Replication Group with tags: %s. Trying create without tags.", err)
 
 		params.Tags = nil
@@ -598,7 +598,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 		err := UpdateTags(conn, aws.StringValue(resp.ReplicationGroup.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache Replication Group (%s): %w", d.Id(), err)
 			}
@@ -717,7 +717,7 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 	tags, err := ListTags(conn, aws.StringValue(rgp.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache Replication Group (%s): %w", aws.StringValue(rgp.ARN), err)
 	}
 
@@ -970,7 +970,7 @@ func resourceReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Replication Group (%s) tags: %w", d.Id(), err)
 			}

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -103,7 +103,7 @@ func resourceSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	output, err := conn.CreateCacheSubnetGroup(req)
 
-	if req.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if req.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Subnet Group with tags: %s. Trying create without tags.", err)
 
 		req.Tags = nil
@@ -125,7 +125,7 @@ func resourceSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(output.CacheSubnetGroup.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache Subnet Group (%s): %w", d.Id(), err)
 			}
@@ -183,7 +183,7 @@ func resourceSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Get("arn").(string))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache Subnet Group (%s): %w", d.Id(), err)
 	}
 
@@ -236,7 +236,7 @@ func resourceSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache Subnet Group (%s) tags: %w", d.Id(), err)
 			}

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -100,7 +100,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	out, err := conn.CreateUser(input)
 
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache User with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil
@@ -118,7 +118,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(out.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache User (%s): %w", d.Id(), err)
 			}
@@ -154,7 +154,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(resp.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache User (%s): %w", aws.StringValue(resp.ARN), err)
 	}
 
@@ -222,7 +222,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache User (%s) tags: %w", d.Get("arn").(string), err)
 			}

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -85,7 +85,7 @@ func resourceUserGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	out, err := conn.CreateUserGroup(input)
 
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache User Group with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil
@@ -118,7 +118,7 @@ func resourceUserGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, aws.StringValue(out.ARN), nil, tags)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed adding tags after create for ElastiCache User Group (%s): %w", d.Id(), err)
 			}
@@ -153,7 +153,7 @@ func resourceUserGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, aws.StringValue(resp.ARN))
 
-	if err != nil && !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		return fmt.Errorf("listing tags for ElastiCache User Group (%s): %w", aws.StringValue(resp.ARN), err)
 	}
 
@@ -230,7 +230,7 @@ func resourceUserGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Get("arn").(string), o, n)
 
 		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
 				// explicitly setting tags or not an iso-unsupported error
 				return fmt.Errorf("failed updating ElastiCache User Group (%s) tags: %w", d.Get("arn").(string), err)
 			}

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -435,7 +435,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryListenerCreate(conn, params)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
 		params.Tags = nil
 		output, err = retryListenerCreate(conn, params)
@@ -459,7 +459,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	if params.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for ELBv2 Listener (%s): %s", d.Id(), err)
 			return resourceListenerRead(d, meta)
@@ -542,7 +542,7 @@ func resourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return nil
 	}
@@ -651,7 +651,7 @@ func resourceListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Listener %s: %s", d.Id(), err)
 			return resourceListenerRead(d, meta)
 		}

--- a/internal/service/elbv2/listener_data_source.go
+++ b/internal/service/elbv2/listener_data_source.go
@@ -346,7 +346,7 @@ func dataSourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -513,7 +513,7 @@ func resourceListenerRuleCreate(d *schema.ResourceData, meta interface{}) error 
 	resp, err := retryListenerRuleCreate(conn, d, params, listenerArn)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Listener Rule (%s) create failed (%s) with tags. Trying create without tags.", listenerArn, err)
 		params.Tags = nil
 		resp, err = retryListenerRuleCreate(conn, d, params, listenerArn)
@@ -529,7 +529,7 @@ func resourceListenerRuleCreate(d *schema.ResourceData, meta interface{}) error 
 	if params.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for ELBv2 Listener Rule (%s): %s", d.Id(), err)
 			return resourceListenerRuleRead(d, meta)
@@ -767,7 +767,7 @@ func resourceListenerRuleRead(d *schema.ResourceData, meta interface{}) error {
 	// tags at the end because, if not supported, will skip the rest of Read
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
 		return nil
 	}
@@ -866,7 +866,7 @@ func resourceListenerRuleUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
 			return resourceListenerRuleRead(d, meta)
 		}

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -368,7 +368,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 	resp, err := conn.CreateLoadBalancer(elbOpts)
 
 	// Some partitions may not support tag-on-create
-	if elbOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if elbOpts.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Load Balancer (%s) create failed (%s) with tags. Trying create without tags.", name, err)
 		elbOpts.Tags = nil
 		resp, err = conn.CreateLoadBalancer(elbOpts)
@@ -396,7 +396,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for ELBv2 Load Balancer (%s): %s", d.Id(), err)
 			return resourceLoadBalancerUpdate(d, meta)
 		}
@@ -638,7 +638,7 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 
 			_, err := waitLoadBalancerActive(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
@@ -928,7 +928,7 @@ func flattenResource(d *schema.ResourceData, meta interface{}, lb *elbv2.LoadBal
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -320,7 +320,7 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -381,7 +381,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.CreateTargetGroup(params)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Target Group (%s) create failed (%s) with tags. Trying create without tags.", groupName, err)
 		params.Tags = nil
 		resp, err = conn.CreateTargetGroup(params)
@@ -542,7 +542,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for ELBv2 Target Group (%s): %s", d.Id(), err)
 			return resourceTargetGroupRead(d, meta)
 		}
@@ -799,7 +799,7 @@ func resourceTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Target Group %s: %s", d.Id(), err)
 			return resourceTargetGroupRead(d, meta)
 		}
@@ -988,7 +988,7 @@ func flattenTargetGroupResource(d *schema.ResourceData, meta interface{}, target
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/target_group_data_source.go
+++ b/internal/service/elbv2/target_group_data_source.go
@@ -274,7 +274,7 @@ func dataSourceTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -71,7 +71,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateEventBus(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] EventBridge Bus (%s) create failed (%s) with tags. Trying create without tags.", eventBusName, err)
 		input.Tags = nil
 		output, err = conn.CreateEventBus(input)
@@ -89,7 +89,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, aws.StringValue(output.EventBusArn), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for EventBridge Bus (%s): %s", d.Id(), err)
 			return resourceBusRead(d, meta)
 		}
@@ -127,7 +127,7 @@ func resourceBusRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, aws.StringValue(output.Arn))
 
 	// ISO partitions may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for EventBridge Bus %s: %s", d.Id(), err)
 		return nil
 	}
@@ -159,7 +159,7 @@ func resourceBusUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, arn, o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for EventBridge Bus %s: %s", d.Id(), err)
 			return resourceBusRead(d, meta)
 		}

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -123,7 +123,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	arn, err := retryPutRule(conn, input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] EventBridge Rule (%s) create failed (%s) with tags. Trying create without tags.", name, err)
 		input.Tags = nil
 		arn, err = retryPutRule(conn, input)
@@ -139,7 +139,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, arn, nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] error adding tags after create for EventBridge Rule (%s): %s", d.Id(), err)
 			return resourceRuleRead(d, meta)
 		}
@@ -202,7 +202,7 @@ func resourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// ISO partitions may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for EventBridge Rule %s: %s", d.Id(), err)
 		return nil
 	}
@@ -269,7 +269,7 @@ func resourceRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, arn, o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] Unable to update tags for EventBridge Rule %s: %s", d.Id(), err)
 			return resourceRuleRead(d, meta)
 		}

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -104,7 +104,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 	response, err := conn.CreateInstanceProfile(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if request.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Instance Profile (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -135,7 +135,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 		err := instanceProfileUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Instance Profile (%s): %s", d.Id(), err)
 			return resourceInstanceProfileUpdate(d, meta)
 		}
@@ -228,7 +228,7 @@ func resourceInstanceProfileUpdate(d *schema.ResourceData, meta interface{}) err
 		err := instanceProfileUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Instance Profile (%s): %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -80,7 +80,7 @@ func resourceOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{
 	out, err := conn.CreateOpenIDConnectProvider(input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM OIDC Provider with tags: %s. Trying create without tags.", err)
 		input.Tags = nil
 
@@ -98,7 +98,7 @@ func resourceOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{
 		err := openIDConnectProviderUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM OIDC Provider (%s): %s", d.Id(), err)
 			return resourceOpenIDConnectProviderRead(d, meta)
 		}
@@ -169,7 +169,7 @@ func resourceOpenIDConnectProviderUpdate(d *schema.ResourceData, meta interface{
 		err := openIDConnectProviderUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM OIDC Provider (%s): %s", d.Id(), err)
 			return resourceOpenIDConnectProviderRead(d, meta)
 		}

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -115,7 +115,7 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	response, err := conn.CreatePolicy(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if request.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Policy (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -133,7 +133,7 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 		err := policyUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Policy (%s): %s", d.Id(), err)
 			return resourcePolicyRead(d, meta)
 		}
@@ -307,7 +307,7 @@ func resourcePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := policyUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Policy (%s): %s", d.Id(), err)
 			return resourcePolicyRead(d, meta)
 		}

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -199,7 +199,7 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryCreateRole(conn, input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Role (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
@@ -233,7 +233,7 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		err := roleUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Role (%s): %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}
@@ -492,7 +492,7 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := roleUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Role %s: %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -78,7 +78,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.CreateSAMLProvider(input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM SAML Provider (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
@@ -96,7 +96,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 		err := samlProviderUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM SAML Provider (%s): %s", d.Id(), err)
 			return resourceSAMLProviderRead(ctx, d, meta)
 		}
@@ -178,7 +178,7 @@ func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, met
 		err := samlProviderUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM SAML Provider (%s): %s", d.Id(), err)
 			return resourceSAMLProviderRead(ctx, d, meta)
 		}

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -139,7 +139,7 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 	resp, err := conn.UploadServerCertificate(createOpts)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if createOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if createOpts.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Server Certificate (%s) with tags: %s. Trying create without tags.", sslCertName, err)
 		createOpts.Tags = nil
 
@@ -158,7 +158,7 @@ func resourceServerCertificateCreate(d *schema.ResourceData, meta interface{}) e
 		err := serverCertificateUpdateTags(conn, d.Get("name").(string), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Server Certificate (%s): %s", d.Id(), err)
 			return resourceServerCertificateRead(d, meta)
 		}
@@ -233,7 +233,7 @@ func resourceServerCertificateUpdate(d *schema.ResourceData, meta interface{}) e
 		err := serverCertificateUpdateTags(conn, d.Get("name").(string), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Server Certificate (%s): %s", d.Id(), err)
 			return resourceServerCertificateRead(d, meta)
 		}

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -115,7 +115,7 @@ func resourceServiceLinkedRoleCreate(d *schema.ResourceData, meta interface{}) e
 		err = roleUpdateTags(conn, roleName, nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Service Linked Role (%s): %s", d.Id(), err)
 			return resourceServiceLinkedRoleRead(d, meta)
 		}
@@ -207,7 +207,7 @@ func resourceServiceLinkedRoleUpdate(d *schema.ResourceData, meta interface{}) e
 		err := roleUpdateTags(conn, roleName, o, n)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM Service Linked Role (%s): %s", d.Id(), err)
 			return resourceServiceLinkedRoleRead(d, meta)
 		}

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -103,7 +103,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 	createResp, err := conn.CreateUser(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM User (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -121,7 +121,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 		err := userUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM User (%s): %s", d.Id(), err)
 			return resourceUserRead(d, meta)
 		}
@@ -251,7 +251,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := userUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed updating tags for IAM User (%s): %s", d.Id(), err)
 			return resourceUserRead(d, meta)
 		}

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -80,7 +80,7 @@ func resourceVirtualMFADeviceCreate(d *schema.ResourceData, meta interface{}) er
 	output, err := conn.CreateVirtualMFADevice(request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if request.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating IAM Virtual MFA Device (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -102,7 +102,7 @@ func resourceVirtualMFADeviceCreate(d *schema.ResourceData, meta interface{}) er
 		err := virtualMFAUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			log.Printf("[WARN] failed adding tags after create for IAM Virtual MFA Device (%s): %s", d.Id(), err)
 			return resourceVirtualMFADeviceRead(d, meta)
 		}
@@ -166,7 +166,7 @@ func resourceVirtualMFADeviceUpdate(d *schema.ResourceData, meta interface{}) er
 	err := virtualMFAUpdateTags(conn, d.Id(), o, n)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed updating tags for IAM Virtual MFA Device (%s): %s", d.Id(), err)
 		return resourceVirtualMFADeviceRead(d, meta)
 	}

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -250,7 +250,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateTopic(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating SNS Topic (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 		output, err = conn.CreateTopic(input)
@@ -272,7 +272,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] failed adding tags after create for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)
@@ -325,7 +325,7 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		// ISO partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SNS Topic (%s): %s", d.Id(), err)
 		return nil
@@ -371,7 +371,7 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// ISO partitions may not support tagging, giving error
 			log.Printf("[WARN] failed updating tags for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -219,7 +219,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}, sqs.ErrCodeQueueDeletedRecently)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating SQS Queue (%s) with tags: %s. Trying create without tags.", name, err)
 
 		input.Tags = nil
@@ -244,7 +244,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] failed adding tags after create for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)
@@ -308,7 +308,7 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return ListTags(conn, d.Id())
 	}, sqs.ErrCodeQueueDoesNotExist)
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
 		return nil
@@ -365,7 +365,7 @@ func resourceQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 			// Some partitions may not support tagging, giving error
 			log.Printf("[WARN] failed updating tags for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -62,7 +62,7 @@ func dataSourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, queueURL)
 
-	if verify.CheckISOErrorTagsUnsupported(conn.PartitionID, err) {
+	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
 		return nil

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -53,8 +53,18 @@ const (
 	ErrCodeValidationException         = "ValidationException"
 )
 
+// CheckISOErrorTagsUnsupported checks the partition and specific error to make
+// an educated guess about whether the problem stems from a feature not being
+// available in ISO (or non standard partitions) that is normally available.
+// true means that there is an error AND it suggests a feature is not supported
+// in ISO. Be careful with false, which means either there is NO error or there
+// is an error but not one that suggests an unsupported feature in ISO.
 func CheckISOErrorTagsUnsupported(partition string, err error) bool {
 	if partition == endpoints.AwsPartitionID {
+		return false
+	}
+
+	if err == nil { // not strictly necessary but make logic clearer
 		return false
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -53,13 +53,13 @@ const (
 	ErrCodeValidationException         = "ValidationException"
 )
 
-// CheckISOErrorTagsUnsupported checks the partition and specific error to make
+// ErrorISOUnsupported checks the partition and specific error to make
 // an educated guess about whether the problem stems from a feature not being
 // available in ISO (or non standard partitions) that is normally available.
 // true means that there is an error AND it suggests a feature is not supported
 // in ISO. Be careful with false, which means either there is NO error or there
 // is an error but not one that suggests an unsupported feature in ISO.
-func CheckISOErrorTagsUnsupported(partition string, err error) bool {
+func ErrorISOUnsupported(partition string, err error) bool {
 	if partition == endpoints.AwsPartitionID {
 		return false
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18593
Closes #26424

### Note

This PR renames `verify.CheckISOErrorTagsUnsupported()` to `verify.ErrorISOUnsupported()` across the code base.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccEC2Instance_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_'  -timeout 180m
--- PASS: TestAccEC2Instance_CapacityReservationPreference_none (115.10s)
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (115.93s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_open (124.62s)
--- PASS: TestAccEC2Instance_basic (129.15s)
--- PASS: TestAccEC2Instance_UserData (130.67s)
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (134.34s)
--- PASS: TestAccEC2Instance_UserData_emptyStringToUnspecified (145.92s)
--- PASS: TestAccEC2Instance_UserData_unspecifiedToEmptyString (156.70s)
--- PASS: TestAccEC2Instance_enclaveOptions (167.31s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (171.48s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyTarget (172.56s)
--- PASS: TestAccEC2Instance_metadataOptions (177.13s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On (207.44s)
--- PASS: TestAccEC2Instance_UserData_update (207.52s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited (75.07s)
--- PASS: TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable (65.52s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64 (228.62s)
--- PASS: TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices (235.66s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits (106.65s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off (236.93s)
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On_Base64 (237.60s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits (119.45s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g (86.55s)
--- PASS: TestAccEC2Instance_UserData_stringToEncodedString (265.81s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2 (114.06s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3a (127.66s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3 (126.86s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits (175.84s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint (192.98s)
--- PASS: TestAccEC2Instance_CreditSpecification_updateCPUCredits (153.83s)
--- PASS: TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard (105.64s)
--- PASS: TestAccEC2Instance_LaunchTemplate_spotAndStop (78.56s)
--- PASS: TestAccEC2Instance_LaunchTemplate_swapIDAndName (87.59s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable (119.43s)
--- PASS: TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits (127.59s)
--- PASS: TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable (115.29s)
--- PASS: TestAccEC2Instance_LaunchTemplate_overrideTemplate (66.29s)
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (65.61s)
--- PASS: TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion (116.94s)
--- PASS: TestAccEC2Instance_LaunchTemplate_setSpecificVersion (112.35s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs (66.88s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePublic (117.08s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePrivate (119.02s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPrivate (107.15s)
--- PASS: TestAccEC2Instance_hibernation (423.88s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPrivate (116.34s)
--- PASS: TestAccEC2Instance_GetPasswordData_trueToFalse (189.20s)
--- PASS: TestAccEC2Instance_CreditSpecification_standardCPUCredits (217.69s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPublic (116.47s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPublic (124.23s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs (99.69s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate (135.18s)
--- PASS: TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint (347.58s)
--- PASS: TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck (106.46s)
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (257.56s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate (166.75s)
--- PASS: TestAccEC2Instance_networkCardIndex (107.88s)
--- PASS: TestAccEC2Instance_gp3RootBlockDevice (107.33s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination (105.20s)
--- PASS: TestAccEC2Instance_primaryNetworkInterface (117.21s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs (184.81s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (125.81s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize (124.96s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3 (124.95s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination (127.44s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2 (119.09s)
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (76.86s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyAll (136.81s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1 (128.83s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifySize (120.34s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyType (126.40s)
--- PASS: TestAccEC2Instance_LaunchTemplate_updateTemplateVersion (366.78s)
--- PASS: TestAccEC2Instance_keyPairCheck (93.15s)
--- PASS: TestAccEC2Instance_Empty_privateIP (105.27s)
--- PASS: TestAccEC2Instance_associatePublicIPAndPrivateIP (103.94s)
--- PASS: TestAccEC2Instance_privateIP (103.90s)
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (1.66s)
--- PASS: TestAccEC2Instance_gp2WithIopsValue (8.82s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (110.16s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (120.10s)
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccEC2Instance_outpost (0.50s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (118.40s)
--- PASS: TestAccEC2Instance_changeInstanceType (186.20s)
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (168.59s)
--- PASS: TestAccEC2Instance_PrivateDNSNameOptions_configured (156.73s)
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserData (210.87s)
--- PASS: TestAccEC2Instance_PrivateDNSNameOptions_computed (169.61s)
--- PASS: TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs (113.44s)
--- PASS: TestAccEC2Instance_placementGroup (71.54s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (159.75s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_withAttachedVolume (164.64s)
--- PASS: TestAccEC2Instance_dedicatedInstance (68.47s)
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserDataBase64 (262.13s)
--- PASS: TestAccEC2Instance_addSecurityGroupNetworkInterface (391.34s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (10.61s)
--- PASS: TestAccEC2Instance_rootBlockDeviceMismatch (234.07s)
--- PASS: TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups (138.00s)
--- PASS: TestAccEC2Instance_placementPartitionNumber (101.49s)
--- PASS: TestAccEC2Instance_addSecondaryInterface (396.69s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (116.80s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (12.26s)
--- PASS: TestAccEC2Instance_networkInstanceSecurityGroups (127.96s)
--- PASS: TestAccEC2Instance_instanceProfileChange (221.12s)
--- PASS: TestAccEC2Instance_disableAPITerminationFinalTrue (124.95s)
--- PASS: TestAccEC2Instance_noAMIEphemeralDevices (115.03s)
--- PASS: TestAccEC2Instance_blockDevices (96.37s)
--- PASS: TestAccEC2Instance_disableAPITerminationFinalFalse (153.39s)
--- PASS: TestAccEC2Instance_gp2IopsDevice (97.86s)
--- PASS: TestAccEC2Instance_RootBlockDevice_kmsKeyARN (83.33s)
--- PASS: TestAccEC2Instance_rootInstanceStore (116.21s)
--- PASS: TestAccEC2Instance_disableAPIStop (154.54s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_kmsKeyARN (73.96s)
--- PASS: TestAccEC2Instance_autoRecovery (155.95s)
--- PASS: TestAccEC2Instance_userDataBase64 (121.80s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgID (120.50s)
--- PASS: TestAccEC2Instance_sourceDestCheck (183.73s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgName (118.38s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed (138.46s)
--- PASS: TestAccEC2Instance_tags (135.12s)
--- PASS: TestAccEC2Instance_userDataBase64_updateWithBashFile (206.00s)
--- PASS: TestAccEC2Instance_atLeastOneOtherEBSVolume (185.90s)
--- PASS: TestAccEC2Instance_userDataBase64_update (233.79s)
--- PASS: TestAccEC2Instance_userDataBase64_updateWithZipFile (235.16s)
--- PASS: TestAccEC2Instance_disappears (284.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1102.198s
```
