### PR TITLE
r/aws_db_instance: add custom_iam_instance_profile attribute

### DIFF
--- a/.changelog/26765.txt
+++ b/.changelog/26765.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ resource/aws_db_instance: Add `custom_iam_instance_profile` attribute
+```

--- a/internal/service/rds/consts_test.go
+++ b/internal/service/rds/consts_test.go
@@ -2,11 +2,12 @@ package rds_test
 
 const (
 	// Please make sure GovCloud and commercial support these since they vary
-	postgresPreferredInstanceClasses    = `"db.t3.micro", "db.t3.small", "db.t2.small", "db.t2.medium"`
-	mySQLPreferredInstanceClasses       = `"db.t3.micro", "db.t3.small", "db.t2.small", "db.t2.medium"`
-	mariaDBPreferredInstanceClasses     = `"db.t3.micro", "db.t3.small", "db.t2.small", "db.t2.medium"`
-	oraclePreferredInstanceClasses      = `"db.t3.medium", "db.t2.medium", "db.t3.large", "db.t2.large"` // Oracle requires at least a medium instance as a replica source
-	sqlServerPreferredInstanceClasses   = `"db.t2.small", "db.t3.small"`
-	sqlServerSEPreferredInstanceClasses = `"db.m5.large", "db.m4.large", "db.r4.large"`
-	oracleSE2PreferredInstanceClasses   = `"db.m5.large", "db.m4.large", "db.r4.large"`
+	postgresPreferredInstanceClasses        = `"db.t3.micro", "db.t3.small", "db.t2.small", "db.t2.medium"`
+	mySQLPreferredInstanceClasses           = `"db.t3.micro", "db.t3.small", "db.t2.small", "db.t2.medium"`
+	mariaDBPreferredInstanceClasses         = `"db.t3.micro", "db.t3.small", "db.t2.small", "db.t2.medium"`
+	oraclePreferredInstanceClasses          = `"db.t3.medium", "db.t2.medium", "db.t3.large", "db.t2.large"` // Oracle requires at least a medium instance as a replica source
+	sqlServerCustomPreferredInstanceClasses = `"db.m5.large", "db.m5.xlarge"`
+	sqlServerPreferredInstanceClasses       = `"db.t2.small", "db.t3.small"`
+	sqlServerSEPreferredInstanceClasses     = `"db.m5.large", "db.m4.large", "db.r4.large"`
+	oracleSE2PreferredInstanceClasses       = `"db.m5.large", "db.m4.large", "db.r4.large"`
 )

--- a/internal/service/rds/errors.go
+++ b/internal/service/rds/errors.go
@@ -2,4 +2,5 @@ package rds
 
 const (
 	errCodeInvalidParameterValue = "InvalidParameterValue"
+	errCodeValidationError       = "ValidationError"
 )

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/rds"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -367,7 +368,10 @@ func TestAccRDSInstance_customIAMInstanceProfile(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckInstanceDestroy,

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -357,6 +357,32 @@ func TestAccRDSInstance_kmsKey(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstance_customIAMInstanceProfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v rds.DBInstance
+	resourceName := "aws_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_customIAMInstanceProfile(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_iam_instance_profile"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_subnetGroup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -4531,6 +4557,10 @@ func testAccInstanceConfig_orderableClassSQLServerEx() string {
 
 func testAccInstanceConfig_orderableClassSQLServerSe() string {
 	return testAccInstanceConfig_orderableClass("sqlserver-se", "license-included", "standard", sqlServerSEPreferredInstanceClasses)
+}
+
+func testAccInstanceConfig_orderableClassCustomSQLServerWeb() string {
+	return testAccInstanceConfig_orderableClass("custom-sqlserver-web", "", "gp2", sqlServerCustomPreferredInstanceClasses)
 }
 
 func testAccInstanceConfig_basic(rName string) string {
@@ -8873,6 +8903,34 @@ resource "aws_db_instance" "test" {
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
+}
+`, rName))
+}
+
+func testAccInstanceConfig_customIAMInstanceProfile(rName string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_orderableClassCustomSQLServerWeb(),
+		fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name          = %[1]q
+  capabilities  = ["CAPABILITY_NAMED_IAM"]
+  template_body = file("test-fixtures/custom-sql-cloudformation.json")
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage           = 20
+  auto_minor_version_upgrade  = false
+  custom_iam_instance_profile = aws_cloudformation_stack.test.outputs["RDSCustomSQLServerInstanceProfile"]
+  engine                      = data.aws_rds_engine_version.default.engine
+  identifier                  = %[1]q
+  instance_class              = data.aws_rds_orderable_db_instance.test.instance_class
+  kms_key_id                  = aws_cloudformation_stack.test.outputs["RDSCustomSQLServerKMSKey"]
+  password                    = "avoid-plaintext-passwords"
+  username                    = "tfacctest"
+  skip_final_snapshot         = true
+  storage_encrypted           = true
+  vpc_security_group_ids      = [aws_cloudformation_stack.test.outputs["RDSCustomSecurityGroup"]]
+  db_subnet_group_name        = aws_cloudformation_stack.test.outputs["DBSubnetGroup"]
 }
 `, rName))
 }

--- a/internal/service/rds/test-fixtures/custom-sql-cloudformation.json
+++ b/internal/service/rds/test-fixtures/custom-sql-cloudformation.json
@@ -1,0 +1,1403 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Parameters": {
+    "VpcCidr": {
+      "Type": "String",
+      "Description": "Specify an IPv4 CIDR block (or IP address range) for your VPC. The CIDR block size must have a size between /16 and /28",
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+      "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+      "Default": "10.0.0.0/16"
+    },
+    "FirstSubnetCidr": {
+      "Type": "String",
+      "Description": "Specify an IPv4 CIDR block (or IP address range) for your first subnet. The CIDR block size must be within the IP range of the VPC, and have a size between /16 and /28",
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+      "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+      "Default": "10.0.128.0/20"
+    },
+    "SecondSubnetCidr": {
+      "Type": "String", 
+      "Description": "Specify an IPv4 CIDR block (or IP address range) for your second subnet. The CIDR block size must be within the IP range of the VPC, not overlapping with the first subnet, and have a size between /16 and /28",
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+      "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+      "Default": "10.0.144.0/20"
+    }
+  },
+  "Metadata" : {
+    "AWS::CloudFormation::Interface" : {
+      "ParameterGroups" : [
+        {
+          "Label" : { "default" : "Network configuration for RDS Custom for SQL Server" },
+          "Parameters" : [ "VpcCidr", "FirstSubnetCidr", "SecondSubnetCidr" ]
+        }
+      ],
+      "ParameterLabels" : {
+        "VpcCidr" : { "default" : "IPv4 CIDR block for VPC" },
+        "FirstSubnetCidr" : { "default" : "IPv4 CIDR block for 1 of 2 subnets" },
+        "SecondSubnetCidr" : { "default" : "IPv4 CIDR block for 2 of 2 subnets" }
+      }
+    }
+  },
+  "Mappings": {
+    "S3VPCEndpointRegionalPrefixLists": {
+      "ap-northeast-1": {
+        "prefixlistid": "pl-61a54008",
+        "prefixlistname": "com.amazonaws.ap-northeast-1.s3"
+      },
+      "ap-northeast-2": {
+        "prefixlistid": "pl-78a54011",
+        "prefixlistname": "com.amazonaws.ap-northeast-2.s3"
+      },
+      "ap-northeast-3": {
+        "prefixlistid": "pl-a4a540cd",
+        "prefixlistname": "com.amazonaws.ap-northeast-3.s3"
+      },
+      "ap-south-1": {
+        "prefixlistid": "pl-78a54011",
+        "prefixlistname": "com.amazonaws.ap-south-1.s3"
+      },
+      "ap-southeast-1": {
+        "prefixlistid": "pl-6fa54006",
+        "prefixlistname": "com.amazonaws.ap-southeast-1.s3"
+      },
+      "ap-southeast-2": {
+        "prefixlistid": "pl-6ca54005",
+        "prefixlistname": "com.amazonaws.ap-southeast-2.s3"
+      },
+      "ca-central-1": {
+        "prefixlistid": "pl-7da54014",
+        "prefixlistname": "com.amazonaws.ca-central-1.s3"
+      },
+      "cn-north-1": {
+        "prefixlistid": "pl-62a5400b",
+        "prefixlistname": "com.amazonaws.cn-north-1.s3"
+      },
+      "cn-northwest-1": {
+        "prefixlistid": "pl-79a54010",
+        "prefixlistname": "com.amazonaws.cn-northwest-1.s3"
+      },
+      "eu-central-1": {
+        "prefixlistid": "pl-6ea54007",
+        "prefixlistname": "com.amazonaws.eu-central-1.s3"
+      },
+      "eu-north-1": {
+        "prefixlistid": "pl-c3aa4faa",
+        "prefixlistname": "com.amazonaws.eu-north-1.s3"
+      },
+      "eu-west-1": {
+        "prefixlistid": "pl-6da54004",
+        "prefixlistname": "com.amazonaws.eu-west-1.s3"
+      },
+      "eu-west-2": {
+        "prefixlistid": "pl-7ca54015",
+        "prefixlistname": "com.amazonaws.eu-west-2.s3"
+      },
+      "eu-west-3": {
+        "prefixlistid": "pl-23ad484a",
+        "prefixlistname": "com.amazonaws.eu-west-3.s3"
+      },
+      "sa-east-1": {
+        "prefixlistid": "pl-6aa54003",
+        "prefixlistname": "com.amazonaws.sa-east-1.s3"
+      },
+      "us-east-1": {
+        "prefixlistid": "pl-63a5400a",
+        "prefixlistname": "com.amazonaws.us-east-1.s3"
+      },
+      "us-east-2": {
+        "prefixlistid": "pl-7ba54012",
+        "prefixlistname": "com.amazonaws.us-east-2.s3"
+      },
+      "us-west-1": {
+        "prefixlistid": "pl-6ba54002",
+        "prefixlistname": "com.amazonaws.us-west-1.s3"
+      },
+      "us-west-2": {
+        "prefixlistid": "pl-68a54001",
+        "prefixlistname": "com.amazonaws.us-west-2.s3"
+      }
+    }
+  },
+  "Conditions": {
+    "NVirginiaRegionCondition": {
+      "Fn::Equals": [{
+          "Ref": "AWS::Region"
+        },
+        "us-east-1"
+      ]
+    }
+  },
+  "Resources": {
+    "RDSCustomKMSKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "KMS Key to encrypt RDS Custom instances",
+        "Enabled": true,
+        "EnableKeyRotation": false,
+        "PendingWindowInDays": 30,
+        "KeyPolicy": {
+          "Version": "2012-10-17",
+          "Id": "key-default-1",
+          "Statement": [
+            {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+                }
+              },
+              "Action": "kms:*",
+              "Resource": "*"
+            }
+          ]
+        },
+        "KeySpec": "SYMMETRIC_DEFAULT",
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "MultiRegion": false
+      }
+    },
+    "RDSCustomKMSKeyAlias": {
+      "Type": "AWS::KMS::Alias",
+      "Properties": {
+        "AliasName": {
+          "Fn::Sub": "alias/${AWS::StackName}-kms-key"
+        },
+        "TargetKeyId": {
+          "Ref": "RDSCustomKMSKey"
+        }
+      },
+      "DependsOn": "RDSCustomKMSKey"
+    },
+    "RDSCustomSQLServerInstanceServiceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": {
+          "Fn::Sub": "AWSRDSCustom-${AWS::StackName}-${AWS::Region}"
+        },
+        "Description": "IAM role associated to instance profile used by RDS Custom instances",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "AWSRDSCustomEc2InstanceRolePolicy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "ssmAgent1",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssm:GetDeployablePatchSnapshotForInstance",
+                    "ssm:ListAssociations",
+                    "ssm:PutInventory",
+                    "ssm:PutConfigurePackageResult",
+                    "ssm:UpdateInstanceInformation",
+                    "ssm:GetManifest"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "ssmAgent2",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssm:ListInstanceAssociations",
+                    "ssm:PutComplianceItems",
+                    "ssm:UpdateAssociationStatus",
+                    "ssm:DescribeAssociation",
+                    "ssm:UpdateInstanceAssociationStatus"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+                  },
+                  "Condition": {
+                    "StringLike": {
+                      "aws:ResourceTag/AWSRDSCustom": "custom-sqlserver"
+                    }
+                  }
+                },
+                {
+                  "Sid": "ssmAgent3",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssm:UpdateAssociationStatus",
+                    "ssm:DescribeAssociation",
+                    "ssm:GetDocument",
+                    "ssm:DescribeDocument"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:ssm:*:*:document/*"
+                  }
+                },
+                {
+                  "Sid": "ssmAgent4",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssmmessages:CreateControlChannel",
+                    "ssmmessages:CreateDataChannel",
+                    "ssmmessages:OpenControlChannel",
+                    "ssmmessages:OpenDataChannel"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "ssmAgent5",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2messages:AcknowledgeMessage",
+                    "ec2messages:DeleteMessage",
+                    "ec2messages:FailMessage",
+                    "ec2messages:GetEndpoint",
+                    "ec2messages:GetMessages",
+                    "ec2messages:SendReply"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "ssmAgent6",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssm:GetParameters",
+                    "ssm:GetParameter"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:ssm:*:*:parameter/*"
+                  }
+                },
+                {
+                  "Sid": "ssmAgent7",
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssm:UpdateInstanceAssociationStatus",
+                    "ssm:DescribeAssociation"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:ssm:*:*:association/*"
+                  }
+                },
+                {
+                  "Sid": "eccSnapshot1",
+                  "Effect": "Allow",
+                  "Action": "ec2:CreateSnapshot",
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+                    }
+                  ],
+                  "Condition": {
+                    "StringLike": {
+                      "aws:ResourceTag/AWSRDSCustom": "custom-sqlserver"
+                    }
+                  }
+                },
+                {
+                  "Sid": "eccSnapshot2",
+                  "Effect": "Allow",
+                  "Action": "ec2:CreateSnapshot",
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*"
+                    }
+                  ],
+                  "Condition": {
+                    "StringLike": {
+                      "aws:RequestTag/AWSRDSCustom": "custom-sqlserver"
+                    }
+                  }
+                },
+                {
+                  "Sid": "eccCreateTag",
+                  "Effect": "Allow",
+                  "Action": "ec2:CreateTags",
+                  "Resource": "*",
+                  "Condition": {
+                    "StringLike": {
+                      "aws:RequestTag/AWSRDSCustom": "custom-sqlserver",
+                      "ec2:CreateAction": [
+                        "CreateSnapshot"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "Sid": "s3BucketAccess",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:putObject",
+                    "s3:getObject",
+                    "s3:getObjectVersion",
+                    "s3:AbortMultipartUpload"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:s3:::do-not-delete-rds-custom-*/*"
+                    }
+                  ]
+                },
+                {
+                  "Sid": "customerCMKEncryption",
+                  "Effect": "Allow",
+                  "Action": [
+                    "kms:Decrypt",
+                    "kms:GenerateDataKey*"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [ "RDSCustomKMSKey", "Arn" ]
+                    }
+                  ]
+                },
+                {
+                  "Sid": "readSecretsFromCP",
+                  "Effect": "Allow",
+                  "Action": [
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:DescribeSecret"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:do-not-delete-rds-custom-*"
+                    }
+                  ],
+                  "Condition": {
+                    "StringLike": {
+                      "aws:ResourceTag/AWSRDSCustom": "custom-sqlserver"
+                    }
+                  }
+                },
+                {
+                  "Sid": "publishCWMetrics",
+                  "Effect": "Allow",
+                  "Action": "cloudwatch:PutMetricData",
+                  "Resource": "*",
+                  "Condition": {
+                    "StringEquals": {
+                      "cloudwatch:namespace": "rdscustom/rds-custom-sqlserver-agent"
+                    }
+                  }
+                },
+                {
+                  "Sid": "putEventsToEventBus",
+                  "Effect": "Allow",
+                  "Action": "events:PutEvents",
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"
+                  }
+                },
+                {
+                  "Sid": "cwlOperations1",
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:PutRetentionPolicy",
+                    "logs:PutLogEvents",
+                    "logs:DescribeLogStreams",
+                    "logs:CreateLogStream",
+                    "logs:CreateLogGroup"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:rds-custom-instance-*"
+                  }
+                },
+                {
+                  "Sid": "cwlOperations2",
+                  "Effect": "Allow",
+                  "Action": "logs:DescribeLogGroups",
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "DependsOn": "RDSCustomKMSKey"
+    },
+    "RDSCustomSQLServerInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "InstanceProfileName": {
+          "Fn::Sub": "AWSRDSCustom-${AWS::StackName}-${AWS::Region}"
+        },
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "RDSCustomSQLServerInstanceServiceRole"
+          }
+        ]
+      },
+      "DependsOn": "RDSCustomSQLServerInstanceServiceRole"
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": {
+          "Ref": "VpcCidr"
+        },
+        "InstanceTenancy": "default",
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "Tags": [{
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-vpc"
+            }
+          }
+        ]
+      }
+    },
+    "DHCPOptions": {
+      "Type": "AWS::EC2::DHCPOptions",
+      "Properties": {
+        "DomainName": {
+          "Fn::If": [
+            "NVirginiaRegionCondition",
+            "ec2.internal",
+            {
+              "Fn::Join": [
+                "",
+                [{
+                    "Ref": "AWS::Region"
+                  },
+                  ".compute.internal"
+                ]
+              ]
+            }
+          ]
+        },
+        "DomainNameServers": [
+          "AmazonProvidedDNS"
+        ],
+        "Tags": [{
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-dhcp"
+            }
+          }
+        ]
+      }
+    },
+    "VPCDHCPOptionsAssociation": {
+      "Type": "AWS::EC2::VPCDHCPOptionsAssociation",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "DhcpOptionsId": {
+          "Ref": "DHCPOptions"
+        }
+      },
+      "DependsOn": "DHCPOptions"
+    },
+    "FirstSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "FirstSubnetCidr"
+        },
+        "AvailabilityZone": {
+          "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ]
+        },
+        "MapPublicIpOnLaunch" : false,
+        "Tags": [{
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-subnet-1"
+            }
+          }
+        ]
+      },
+      "DependsOn": "VPC"
+    },
+    "SecondSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "SecondSubnetCidr"
+        },
+        "AvailabilityZone": {
+          "Fn::Select" : [ "1", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ]
+        },
+        "MapPublicIpOnLaunch" : false,
+        "Tags": [{
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-subnet-2"
+            }
+          }
+        ]
+      },
+      "DependsOn": "VPC"
+    },
+    "PrivateRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [{
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-route-table"
+            }
+          }
+        ]
+      },
+      "DependsOn": "VPC"
+    },
+    "PrivateRouteTableSubnet1Association": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "FirstSubnet"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "PrivateRouteTable"]
+    },
+    "PrivateRouteTableSubnet2Association": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "SecondSubnet"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      },
+      "DependsOn": [ "SecondSubnet", "PrivateRouteTable"]
+    },
+    "PrivateNetworkACL": {
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [{
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-network-acl"
+            }
+          }
+        ]
+      },
+      "DependsOn": "VPC"
+    },
+    "PrivateNetworkACLHttpsInboundRule": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkACL"
+        },
+        "RuleNumber": 10,
+        "Protocol": 6,
+        "RuleAction": "allow",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": 32768,
+          "To": 65535
+        }
+      },
+      "DependsOn": "PrivateNetworkACL"
+    },
+    "PrivateNetworkACLHttpsOutboundRule": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkACL"
+        },
+        "RuleNumber": 10,
+        "Protocol": 6,
+        "Egress": true,
+        "RuleAction": "allow",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": 443,
+          "To": 443
+        }
+      },
+      "DependsOn": "PrivateNetworkACL"
+    },
+    "PrivateNetworkACLDenyAllInboundRule": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkACL"
+        },
+        "RuleNumber": 20,
+        "Protocol": -1,
+        "RuleAction": "deny",
+        "CidrBlock": "0.0.0.0/0"
+      },
+      "DependsOn": "PrivateNetworkACL"
+    },
+    "PrivateNetworkACLDenyAllOutboundRule": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkACL"
+        },
+        "RuleNumber": 20,
+        "Protocol": -1,
+        "Egress": true,
+        "RuleAction": "deny",
+        "CidrBlock": "0.0.0.0/0"
+      },
+      "DependsOn": "PrivateNetworkACL"
+    },
+    "PrivateNetworkAclSubnet1Association" : {
+      "Type" : "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "FirstSubnet" },
+        "NetworkAclId" : { "Ref" : "PrivateNetworkACL" }
+      },
+      "DependsOn": [ "FirstSubnet", "PrivateNetworkACL"]
+    },
+    "PrivateNetworkAclSubnet2Association" : {
+      "Type" : "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "SecondSubnet" },
+        "NetworkAclId" : { "Ref" : "PrivateNetworkACL" }
+      },
+      "DependsOn": [ "SecondSubnet", "PrivateNetworkACL"]
+    },
+    "RDSCustomSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupName": {
+              "Fn::Sub": "${AWS::StackName}-rds-custom-instance-sg"
+        },
+        "GroupDescription" : "Security group attached to RDS Custom DB instance",
+        "VpcId" : {"Ref" : "VPC"}
+      },
+      "DependsOn": "VPC"
+    },
+    "VPCEndpointSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupName": {
+              "Fn::Sub": "${AWS::StackName}-vpc-endpoint-sg"
+        },
+        "GroupDescription" : "Security group attached to VPC endpoints in RDS Custom VPC",
+        "VpcId" : {"Ref" : "VPC"}
+      },
+      "DependsOn": "VPC"
+    },
+    "VPCEndpointSecurityGroupIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "VPCEndpointSecurityGroup"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": 443,
+        "ToPort": 443,
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "RDSCustomSecurityGroup",
+            "GroupId"
+          ]
+        }
+      },
+      "DependsOn": "VPCEndpointSecurityGroup"
+    },
+    "RDSCustomSecurityGroupVpceEgress": {
+     "Type": "AWS::EC2::SecurityGroupEgress",
+     "Properties":{
+      "IpProtocol": "tcp",
+        "FromPort": 443,
+        "ToPort": 443,
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "VPCEndpointSecurityGroup",
+            "GroupId"
+          ]
+        },
+        "GroupId": {
+          "Ref": "RDSCustomSecurityGroup"
+        }
+      },
+      "DependsOn": "RDSCustomSecurityGroup"
+    },
+    "RDSCustomSecurityGroupS3Egress": {
+     "Type": "AWS::EC2::SecurityGroupEgress",
+     "Properties":{
+      "IpProtocol": "tcp",
+        "FromPort": 443,
+        "ToPort": 443,
+        "DestinationPrefixListId": {
+          "Fn::FindInMap": [
+            "S3VPCEndpointRegionalPrefixLists",
+            {
+              "Ref": "AWS::Region"
+            },
+            "prefixlistid"
+          ]
+        },
+        "GroupId": {
+          "Ref": "RDSCustomSecurityGroup"
+        }
+      },
+      "DependsOn": "RDSCustomSecurityGroup"
+    },
+    "DBSubnetGroup": {
+      "Type": "AWS::RDS::DBSubnetGroup",
+      "Properties": {
+        "DBSubnetGroupName": {
+          "Fn::Sub": "${AWS::StackName}-db-subnet-group"
+        },
+        "DBSubnetGroupDescription": "DB Subnet Group for RDS Custom Private Network",
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ]
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet"]
+    },
+    "vpceS3": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "RouteTableIds": [
+          {
+            "Ref": "PrivateRouteTable"
+          }
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.s3"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:putObject",
+                "s3:getObject",
+                "s3:getObjectVersion",
+                "s3:AbortMultipartUpload"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::do-not-delete-rds-custom-*/*"
+                }
+              ],
+              "Principal": "*",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:PrincipalArn": {
+                    "Fn::GetAtt": [
+                      "RDSCustomSQLServerInstanceServiceRole",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": "s3:GetObject",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-windows-downloads-${AWS::Region}/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::amazon-ssm-${AWS::Region}/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${AWS::Region}-birdwatcher-prod/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-ssm-distributor-file-${AWS::Region}/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-ssm-document-attachments-${AWS::Region}/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-ssm-${AWS::Region}/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::amazoncloudwatch-agent-${AWS::Region}/*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-rds-custom-sqlserver-${AWS::Region}/*"
+                }
+              ],
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "PrivateRouteTable", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceEC2": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.ec2"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "ec2:CreateSnapshot",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+                }
+              ],
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              },
+              "Condition": {
+                "StringLike": {
+                  "aws:ResourceTag/AWSRDSCustom": "custom-sqlserver"
+                }
+              }
+            },
+            {
+              "Action": "ec2:CreateSnapshot",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*"
+                }
+              ],
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              },
+              "Condition": {
+                "StringLike": {
+                  "aws:RequestTag/AWSRDSCustom": "custom-sqlserver"
+                }
+              }
+            },
+            {
+              "Action": "ec2:CreateTags",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              },
+              "Condition": {
+                "StringLike": {
+                  "aws:RequestTag/AWSRDSCustom": "custom-sqlserver",
+                  "ec2:CreateAction": [
+                    "CreateSnapshot"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceEC2Messages": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.ec2messages"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply"
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceMonitoring": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.monitoring"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "cloudwatch:namespace": "rdscustom/rds-custom-sqlserver-agent"
+                }
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceSSM": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.ssm"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "ssm:GetDeployablePatchSnapshotForInstance",
+                "ssm:ListAssociations",
+                "ssm:PutInventory",
+                "ssm:PutConfigurePackageResult",
+                "ssm:UpdateInstanceInformation",
+                "ssm:GetManifest"
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            },
+            {
+              "Action": [
+                "ssm:ListInstanceAssociations",
+                "ssm:PutComplianceItems",
+                "ssm:UpdateAssociationStatus",
+                "ssm:DescribeAssociation",
+                "ssm:UpdateInstanceAssociationStatus"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              },
+              "Condition": {
+                "StringLike": {
+                  "aws:ResourceTag/AWSRDSCustom": "custom-sqlserver"
+                }
+              }
+            },
+            {
+              "Action": [
+                "ssm:UpdateAssociationStatus",
+                "ssm:DescribeAssociation",
+                "ssm:GetDocument",
+                "ssm:DescribeDocument"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:ssm:*:*:document/*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:ssm:*:*:parameter/*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            },
+            {
+              "Action": [
+                "ssm:UpdateInstanceAssociationStatus",
+                "ssm:DescribeAssociation"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:ssm:*:*:association/*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceSSMMessages": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.ssmmessages"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel"
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceLogs": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.logs"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+                "logs:CreateLogStream",
+                "logs:CreateLogGroup"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:rds-custom-instance-*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            },
+            {
+              "Action": "logs:DescribeLogGroups",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceEvents": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.events"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "*",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    },
+    "vpceSecretsManager": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {"Ref": "VPCEndpointSecurityGroup"}
+        ],
+        "SubnetIds": [
+          {"Ref": "FirstSubnet"},
+          {"Ref": "SecondSubnet"}
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.secretsmanager"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:do-not-delete-rds-custom-*"                
+              },
+              "Principal": {
+                "AWS": { 
+                  "Fn::GetAtt": [
+                    "RDSCustomSQLServerInstanceServiceRole",
+                    "Arn"
+                  ]
+                }
+              },
+              "Condition": {
+                "StringLike": {
+                  "aws:ResourceTag/AWSRDSCustom": "custom-sqlserver"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [ "FirstSubnet", "SecondSubnet", "VPCEndpointSecurityGroup", "RDSCustomSQLServerInstanceServiceRole" ]
+    }
+  },
+  "Outputs": {
+    "DBSubnetGroup" : {
+      "Description" : "DB Subnet group specified while creating an RDS Custom instance by using the parameter --db-subnet-group-name.",
+      "Value" : {"Ref": "DBSubnetGroup"}
+    },
+    "VPC" : {
+      "Description" : "VPC for which DB Subnet Group is created.",
+      "Value" : {
+        "Fn::Sub": [
+          "${VPCId}",
+          {
+            "VPCId": { "Ref": "VPC" }
+          }
+        ]
+      }
+    },
+    "RDSCustomSecurityGroup" : {
+      "Description" : "Security group to be attached to the RDS Custom instances while creating an RDS Custom instance by using the parameter --vpc-security-group-ids.",
+      "Value" : {
+        "Fn::Sub": [
+          "${SGId}",
+          {
+            "SGId": { "Ref": "RDSCustomSecurityGroup" }
+          }
+        ]
+      }
+    },
+    "RDSCustomSQLServerInstanceProfile" : {
+      "Description" : "Instance IAM profile specified while creating an RDS Custom instance by using the parameter --custom-iam-instance-profile.",
+      "Value" : {"Ref": "RDSCustomSQLServerInstanceProfile"}
+    },
+    "RDSCustomSQLServerKMSKey" : {
+      "Description" : "KMS key to encrypt data managed by RDS Custom instances, specified while creating an RDS Custom instance by using the parameter --kms-key-id.",
+      "Value" : {
+        "Fn::Sub": [ 
+          "${Key}",
+          { 
+            "Key": { "Fn::GetAtt" : [ "RDSCustomKMSKey", "Arn" ] }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -314,11 +314,12 @@ func waitDBInstanceUpdated(conn *rds.RDS, id string, timeout time.Duration) (*rd
 			InstanceStatusStorageFull,
 			InstanceStatusUpgrading,
 		},
-		Target:     []string{InstanceStatusAvailable, InstanceStatusStorageOptimization},
-		Refresh:    statusDBInstance(conn, id),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
+		Target:                    []string{InstanceStatusAvailable, InstanceStatusStorageOptimization},
+		Refresh:                   statusDBInstance(conn, id),
+		Timeout:                   timeout,
+		MinTimeout:                10 * time.Second,
+		Delay:                     30 * time.Second,
+		ContinuousTargetOccurence: 3,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -97,6 +97,7 @@ encoding in Oracle and Microsoft SQL instances (collation). This can't be change
 Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
 or [Server-Level Collation for Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.CommonDBATasks.Collation.html) for more information.
 * `copy_tags_to_snapshot` – (Optional, boolean) Copy all Instance `tags` to snapshots. Default is `false`.
+* `custom_iam_instance_profile` - (Optional) The instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.
 * `db_name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
 * `db_subnet_group_name` - (Optional) Name of [DB subnet group](/docs/providers/aws/r/db_subnet_group.html). DB instance will
 be created in the VPC associated with the DB subnet group. If unspecified, will


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22084

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestAccRDSInstance_ PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_'  -timeout 180m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_identifierPrefix
=== PAUSE TestAccRDSInstance_identifierPrefix
=== RUN   TestAccRDSInstance_identifierGenerated
=== PAUSE TestAccRDSInstance_identifierGenerated
=== RUN   TestAccRDSInstance_disappears
=== PAUSE TestAccRDSInstance_disappears
=== RUN   TestAccRDSInstance_tags
=== PAUSE TestAccRDSInstance_tags
=== RUN   TestAccRDSInstance_nameDeprecated
=== PAUSE TestAccRDSInstance_nameDeprecated
=== RUN   TestAccRDSInstance_onlyMajorVersion
=== PAUSE TestAccRDSInstance_onlyMajorVersion
=== RUN   TestAccRDSInstance_kmsKey
=== PAUSE TestAccRDSInstance_kmsKey
=== RUN   TestAccRDSInstance_customIAMInstanceProfile
=== PAUSE TestAccRDSInstance_customIAMInstanceProfile
=== RUN   TestAccRDSInstance_subnetGroup
=== PAUSE TestAccRDSInstance_subnetGroup
=== RUN   TestAccRDSInstance_networkType
=== PAUSE TestAccRDSInstance_networkType
=== RUN   TestAccRDSInstance_optionGroup
=== PAUSE TestAccRDSInstance_optionGroup
=== RUN   TestAccRDSInstance_iamAuth
=== PAUSE TestAccRDSInstance_iamAuth
=== RUN   TestAccRDSInstance_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_dbSubnetGroupName
=== RUN   TestAccRDSInstance_DBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_deletionProtection
=== PAUSE TestAccRDSInstance_deletionProtection
=== RUN   TestAccRDSInstance_finalSnapshotIdentifier
=== PAUSE TestAccRDSInstance_finalSnapshotIdentifier
=== RUN   TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== PAUSE TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== RUN   TestAccRDSInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSInstance_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_maxAllocatedStorage
=== RUN   TestAccRDSInstance_password
=== PAUSE TestAccRDSInstance_password
=== RUN   TestAccRDSInstance_ReplicateSourceDB_basic
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_basic
=== RUN   TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== RUN   TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== RUN   TestAccRDSInstance_ReplicateSourceDB_addLater
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_addLater
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
=== RUN   TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_deletionProtection
    acctest.go:69: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== RUN   TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== RUN   TestAccRDSInstance_ReplicateSourceDB_networkType
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_networkType
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== RUN   TestAccRDSInstance_ReplicateSourceDB_port
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_port
=== RUN   TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== RUN   TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== RUN   TestAccRDSInstance_S3Import_basic
    acctest.go:69: RestoreDBInstanceFromS3 cannot restore from MySQL version 5.6
--- SKIP: TestAccRDSInstance_S3Import_basic (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_basic
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_basic
=== RUN   TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== RUN   TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== RUN   TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_monitoring
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_monitoring
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== RUN   TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_port
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_port
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_tags
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tagsRemove
    acctest.go:69: To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/5959
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_tagsRemove (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== RUN   TestAccRDSInstance_monitoringInterval
=== PAUSE TestAccRDSInstance_monitoringInterval
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== RUN   TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== RUN   TestAccRDSInstance_separateIopsUpdate
=== PAUSE TestAccRDSInstance_separateIopsUpdate
=== RUN   TestAccRDSInstance_portUpdate
=== PAUSE TestAccRDSInstance_portUpdate
=== RUN   TestAccRDSInstance_MSSQL_tz
=== PAUSE TestAccRDSInstance_MSSQL_tz
=== RUN   TestAccRDSInstance_MSSQL_domain
=== PAUSE TestAccRDSInstance_MSSQL_domain
=== RUN   TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== PAUSE TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== RUN   TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== PAUSE TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== RUN   TestAccRDSInstance_minorVersion
=== PAUSE TestAccRDSInstance_minorVersion
=== RUN   TestAccRDSInstance_cloudWatchLogsExport
=== PAUSE TestAccRDSInstance_cloudWatchLogsExport
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSInstance_noDeleteAutomatedBackups
=== PAUSE TestAccRDSInstance_noDeleteAutomatedBackups
=== RUN   TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
=== PAUSE TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
=== RUN   TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== PAUSE TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== RUN   TestAccRDSInstance_performanceInsightsKMSKeyID
=== PAUSE TestAccRDSInstance_performanceInsightsKMSKeyID
=== RUN   TestAccRDSInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSInstance_performanceInsightsRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_caCertificateIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== RUN   TestAccRDSInstance_RestoreToPointInTime_monitoring
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_monitoring
=== RUN   TestAccRDSInstance_NationalCharacterSet_oracle
=== PAUSE TestAccRDSInstance_NationalCharacterSet_oracle
=== RUN   TestAccRDSInstance_NoNationalCharacterSet_oracle
=== PAUSE TestAccRDSInstance_NoNationalCharacterSet_oracle
=== RUN   TestAccRDSInstance_coIPEnabled
=== PAUSE TestAccRDSInstance_coIPEnabled
=== RUN   TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== PAUSE TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== RUN   TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== PAUSE TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== RUN   TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== PAUSE TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== RUN   TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== PAUSE TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== RUN   TestAccRDSInstance_license
=== PAUSE TestAccRDSInstance_license
=== CONT  TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== CONT  TestAccRDSInstance_dbSubnetGroupName
=== CONT  TestAccRDSInstance_license
=== CONT  TestAccRDSInstance_allowMajorVersionUpgrade
=== CONT  TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== CONT  TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== CONT  TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== CONT  TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== CONT  TestAccRDSInstance_coIPEnabled
=== CONT  TestAccRDSInstance_NoNationalCharacterSet_oracle
=== CONT  TestAccRDSInstance_NationalCharacterSet_oracle
=== CONT  TestAccRDSInstance_RestoreToPointInTime_monitoring
=== CONT  TestAccRDSInstance_disappears
=== CONT  TestAccRDSInstance_DBSubnetGroupName_ramShared
=== CONT  TestAccRDSInstance_nameDeprecated
=== CONT  TestAccRDSInstance_tags
=== CONT  TestAccRDSInstance_onlyMajorVersion
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== CONT  TestAccRDSInstance_DBSubnetGroupName_ramShared
    acctest.go:644: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRDSInstance_DBSubnetGroupName_ramShared (0.89s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== CONT  TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_restoreToPointInTime (1.31s)
=== CONT  TestAccRDSInstance_caCertificateIdentifier
=== CONT  TestAccRDSInstance_coIPEnabled
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_coIPEnabled (1.34s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== CONT  TestAccRDSInstance_CoIPEnabled_disabledToEnabled
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_disabledToEnabled (1.34s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== CONT  TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_snapshotIdentifier (1.35s)
=== CONT  TestAccRDSInstance_performanceInsightsRetentionPeriod
=== CONT  TestAccRDSInstance_CoIPEnabled_enabledToDisabled
    acctest.go:1346: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_enabledToDisabled (1.43s)
=== CONT  TestAccRDSInstance_performanceInsightsKMSKeyID
--- PASS: TestAccRDSInstance_nameDeprecated (406.68s)
=== CONT  TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
--- PASS: TestAccRDSInstance_dbSubnetGroupName (527.99s)
=== CONT  TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
--- PASS: TestAccRDSInstance_disappears (534.62s)
=== CONT  TestAccRDSInstance_noDeleteAutomatedBackups
--- PASS: TestAccRDSInstance_allowMajorVersionUpgrade (555.68s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSInstance_basic (557.26s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
--- PASS: TestAccRDSInstance_caCertificateIdentifier (557.89s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
--- PASS: TestAccRDSInstance_tags (586.45s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
--- PASS: TestAccRDSInstance_onlyMajorVersion (587.70s)
=== CONT  TestAccRDSInstance_cloudWatchLogsExport
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (835.91s)
=== CONT  TestAccRDSInstance_minorVersion
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (848.22s)
=== CONT  TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
--- PASS: TestAccRDSInstance_license (1019.02s)
=== CONT  TestAccRDSInstance_MSSQL_domainSnapshotRestore
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (498.26s)
=== CONT  TestAccRDSInstance_MSSQL_domain
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (515.38s)
=== CONT  TestAccRDSInstance_MSSQL_tz
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (1087.80s)
=== CONT  TestAccRDSInstance_portUpdate
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (598.51s)
=== CONT  TestAccRDSInstance_separateIopsUpdate
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (1218.67s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (704.92s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (725.17s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (888.69s)
=== CONT  TestAccRDSInstance_monitoringInterval
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1329.35s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
--- PASS: TestAccRDSInstance_minorVersion (510.14s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1438.97s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_tags
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1488.31s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_port
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1511.02s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1599.51s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (1079.02s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== CONT  TestAccRDSInstance_SnapshotIdentifier_monitoring
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (1060.63s)
--- PASS: TestAccRDSInstance_portUpdate (569.92s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1708.13s)
=== CONT  TestAccRDSInstance_kmsKey
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1763.93s)
=== CONT  TestAccRDSInstance_iamAuth
--- PASS: TestAccRDSInstance_separateIopsUpdate (766.06s)
=== CONT  TestAccRDSInstance_optionGroup
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (736.82s)
=== CONT  TestAccRDSInstance_networkType
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (861.13s)
=== CONT  TestAccRDSInstance_subnetGroup
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (838.30s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
--- PASS: TestAccRDSInstance_kmsKey (550.05s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
--- PASS: TestAccRDSInstance_iamAuth (522.57s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_nameGenerated
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1051.25s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_namePrefix
--- PASS: TestAccRDSInstance_optionGroup (490.99s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_basic
--- PASS: TestAccRDSInstance_monitoringInterval (1167.16s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1170.93s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_replicaMode
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (909.08s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1171.62s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1321.05s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_port
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (2008.17s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
--- PASS: TestAccRDSInstance_networkType (936.10s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1394.46s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
--- PASS: TestAccRDSInstance_MSSQL_tz (1920.93s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1348.48s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_networkType
--- PASS: TestAccRDSInstance_subnetGroup (931.30s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1722.48s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1169.26s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (1216.09s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1166.61s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
    acctest.go:644: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared (0.00s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1446.36s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1316.51s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1388.35s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1377.32s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_availabilityZone
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1428.22s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1364.82s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3379.80s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_io1Storage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1515.69s)
=== CONT  TestAccRDSInstance_identifierGenerated
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1741.10s)
=== CONT  TestAccRDSInstance_password
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1726.60s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iops
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1276.22s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1245.86s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_addLater
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1173.54s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_nameGenerated
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1153.56s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_namePrefix
--- PASS: TestAccRDSInstance_MSSQL_domain (3710.59s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_basic
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1192.51s)
=== CONT  TestAccRDSInstance_customIAMInstanceProfile
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1774.93s)
=== CONT  TestAccRDSInstance_identifierPrefix
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1966.23s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_monitoring
--- PASS: TestAccRDSInstance_identifierGenerated (373.52s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2448.33s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
--- PASS: TestAccRDSInstance_password (483.04s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
--- PASS: TestAccRDSInstance_identifierPrefix (452.74s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (2818.93s)
=== CONT  TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1303.86s)
=== CONT  TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
    acctest.go:644: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared (0.00s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (1713.39s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_backupWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1579.75s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (1324.40s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_availabilityZone
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1318.64s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1478.30s)
=== CONT  TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1786.51s)
=== CONT  TestAccRDSInstance_maxAllocatedStorage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1442.97s)
=== CONT  TestAccRDSInstance_isAlreadyBeingDeleted
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1559.36s)
=== CONT  TestAccRDSInstance_deletionProtection
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1523.12s)
=== CONT  TestAccRDSInstance_finalSnapshotIdentifier
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1774.69s)
=== CONT  TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1557.53s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_multiAZ
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1490.33s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (2056.27s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1448.31s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (475.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1795.24s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1506.90s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (663.44s)
--- PASS: TestAccRDSInstance_deletionProtection (551.19s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (494.25s)
--- PASS: TestAccRDSInstance_maxAllocatedStorage (713.83s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1438.31s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1529.92s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1642.52s)
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (1020.28s)
--- PASS: TestAccRDSInstance_customIAMInstanceProfile (2614.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1431.38s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (2221.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs (2232.98s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2368.53s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (7238.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	8842.114s
...
```
