### PR TITLE
Add retry to resourceReplicationSubnetGroupCreate

### DIFF
--- a/.changelog/26768.txt
+++ b/.changelog/26768.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_replication_subnet_group: Add retry to create step, resolving `AccessDeniedFault` error
+```

--- a/internal/service/dms/replication_subnet_group.go
+++ b/internal/service/dms/replication_subnet_group.go
@@ -7,10 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -72,9 +75,26 @@ func resourceReplicationSubnetGroupCreate(d *schema.ResourceData, meta interface
 
 	log.Println("[DEBUG] DMS create replication subnet group:", request)
 
-	_, err := conn.CreateReplicationSubnetGroup(request)
-	if err != nil {
-		return err
+	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
+		_, err := conn.CreateReplicationSubnetGroup(request)
+
+		if tfawserr.ErrCodeEquals(err, dms.ErrCodeAccessDeniedFault) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.CreateReplicationSubnetGroup(request)
+
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId(d.Get("replication_subnet_group_id").(string))

--- a/internal/service/dms/wait.go
+++ b/internal/service/dms/wait.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	propagationTimeout            = 2 * time.Minute
 	replicationTaskRunningTimeout = 5 * time.Minute
 )
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #11025.

Acceptance test passing:

```
❯ make testacc TESTS=TestAccDMSReplicationSubnetGroup PKG=dms           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSReplicationSubnetGroup'  -timeout 180m
=== RUN   TestAccDMSReplicationSubnetGroup_basic
=== PAUSE TestAccDMSReplicationSubnetGroup_basic
=== CONT  TestAccDMSReplicationSubnetGroup_basic
--- PASS: TestAccDMSReplicationSubnetGroup_basic (33.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        33.744s
```