### PR TITLE
sweeper: DynamoDB backups

### DIFF
--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -1210,7 +1210,7 @@ func sweepThings(region string) error {
   }
 
   conn := client.(*conns.AWSClient).ExampleConn
-  sweepResources := make([]*sweep.SweepResource, 0)
+  sweepResources := make([]sweep.Sweepable, 0)
   var errs *multierror.Error
 
   input := &example.ListThingsInput{}
@@ -1276,7 +1276,7 @@ func sweepThings(region string) error {
   }
 
   conn := client.(*conns.AWSClient).ExampleConn
-  sweepResources := make([]*sweep.SweepResource, 0)
+  sweepResources := make([]sweep.Sweepable, 0)
   var errs *multierror.Error
 
   input := &example.ListThingsInput{}

--- a/internal/service/accessanalyzer/sweep.go
+++ b/internal/service/accessanalyzer/sweep.go
@@ -28,7 +28,7 @@ func sweepAnalyzers(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AccessAnalyzerConn
 	input := &accessanalyzer.ListAnalyzersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListAnalyzersPages(input, func(page *accessanalyzer.ListAnalyzersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/apigateway/sweep.go
+++ b/internal/service/apigateway/sweep.go
@@ -101,7 +101,7 @@ func sweepVPCLinks(region string) error {
 	}
 	conn := client.(*conns.AWSClient).APIGatewayConn
 
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 
 	err = conn.GetVpcLinksPages(&apigateway.GetVpcLinksInput{}, func(page *apigateway.GetVpcLinksOutput, lastPage bool) bool {
@@ -139,7 +139,7 @@ func sweepClientCertificates(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).APIGatewayConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.GetClientCertificatesPages(&apigateway.GetClientCertificatesInput{}, func(page *apigateway.GetClientCertificatesOutput, lastPage bool) bool {
@@ -183,7 +183,7 @@ func sweepUsagePlans(region string) error {
 	log.Printf("[INFO] Sweeping API Gateway Usage Plans for %s", region)
 
 	conn := client.(*conns.AWSClient).APIGatewayConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.GetUsagePlansPages(&apigateway.GetUsagePlansInput{}, func(page *apigateway.GetUsagePlansOutput, lastPage bool) bool {
@@ -230,7 +230,7 @@ func sweepAPIKeys(region string) error {
 	log.Printf("[INFO] Sweeping API Gateway API Keys for %s", region)
 
 	conn := client.(*conns.AWSClient).APIGatewayConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.GetApiKeysPages(&apigateway.GetApiKeysInput{}, func(page *apigateway.GetApiKeysOutput, lastPage bool) bool {
@@ -276,7 +276,7 @@ func sweepDomainNames(region string) error {
 	log.Printf("[INFO] Sweeping API Gateway Domain Names for %s", region)
 
 	conn := client.(*conns.AWSClient).APIGatewayConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.GetDomainNamesPages(&apigateway.GetDomainNamesInput{}, func(page *apigateway.GetDomainNamesOutput, lastPage bool) bool {

--- a/internal/service/appconfig/sweep.go
+++ b/internal/service/appconfig/sweep.go
@@ -58,7 +58,7 @@ func sweepApplications(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppConfigConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appconfig.ListApplicationsInput{}
@@ -110,7 +110,7 @@ func sweepConfigurationProfiles(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppConfigConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appconfig.ListApplicationsInput{}
@@ -186,7 +186,7 @@ func sweepDeploymentStrategies(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppConfigConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appconfig.ListDeploymentStrategiesInput{}
@@ -244,7 +244,7 @@ func sweepEnvironments(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppConfigConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appconfig.ListApplicationsInput{}
@@ -320,7 +320,7 @@ func sweepHostedConfigurationVersions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppConfigConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appconfig.ListApplicationsInput{}

--- a/internal/service/applicationinsights/sweep.go
+++ b/internal/service/applicationinsights/sweep.go
@@ -30,7 +30,7 @@ func sweepApplications(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ApplicationInsightsConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.ListApplicationsPages(&applicationinsights.ListApplicationsInput{}, func(resp *applicationinsights.ListApplicationsOutput, lastPage bool) bool {

--- a/internal/service/apprunner/sweep.go
+++ b/internal/service/apprunner/sweep.go
@@ -43,7 +43,7 @@ func sweepAutoScalingConfigurationVersions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppRunnerConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	ctx := context.Background()
 	var errs *multierror.Error
 
@@ -108,7 +108,7 @@ func sweepConnections(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppRunnerConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	ctx := context.Background()
 
 	var errs *multierror.Error
@@ -169,7 +169,7 @@ func sweepServices(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).AppRunnerConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	ctx := context.Background()
 	var errs *multierror.Error
 

--- a/internal/service/appstream/sweep.go
+++ b/internal/service/appstream/sweep.go
@@ -43,7 +43,7 @@ func sweepDirectoryConfigs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AppStreamConn
 	input := &appstream.DescribeDirectoryConfigsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeDirectoryConfigsPages(conn, input, func(page *appstream.DescribeDirectoryConfigsOutput, lastPage bool) bool {
 		if page == nil {
@@ -86,7 +86,7 @@ func sweepFleets(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AppStreamConn
 	input := &appstream.DescribeFleetsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeFleetsPages(conn, input, func(page *appstream.DescribeFleetsOutput, lastPage bool) bool {
 		if page == nil {
@@ -129,7 +129,7 @@ func sweepImageBuilders(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AppStreamConn
 	input := &appstream.DescribeImageBuildersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeImageBuildersPages(conn, input, func(page *appstream.DescribeImageBuildersOutput, lastPage bool) bool {
 		if page == nil {
@@ -172,7 +172,7 @@ func sweepStacks(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AppStreamConn
 	input := &appstream.DescribeStacksInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeStacksPages(conn, input, func(page *appstream.DescribeStacksOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/appsync/sweep.go
+++ b/internal/service/appsync/sweep.go
@@ -41,7 +41,7 @@ func sweepGraphQLAPIs(region string) error {
 		return fmt.Errorf("Error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).AppSyncConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appsync.ListGraphqlApisInput{}
@@ -96,7 +96,7 @@ func sweepDomainNames(region string) error {
 		return fmt.Errorf("Error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).AppSyncConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appsync.ListDomainNamesInput{}
@@ -151,7 +151,7 @@ func sweepDomainNameAssociations(region string) error {
 		return fmt.Errorf("Error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).AppSyncConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &appsync.ListDomainNamesInput{}

--- a/internal/service/athena/sweep.go
+++ b/internal/service/athena/sweep.go
@@ -33,7 +33,7 @@ func sweepDatabases(region string) error {
 	}
 	var errs *multierror.Error
 
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	for {
 		output, err := conn.ListDatabases(input)
 

--- a/internal/service/autoscaling/sweep.go
+++ b/internal/service/autoscaling/sweep.go
@@ -34,7 +34,7 @@ func sweepGroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AutoScalingConn
 	input := &autoscaling.DescribeAutoScalingGroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeAutoScalingGroupsPages(input, func(page *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
 		if page == nil {
@@ -78,7 +78,7 @@ func sweepLaunchConfigurations(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AutoScalingConn
 	input := &autoscaling.DescribeLaunchConfigurationsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeLaunchConfigurationsPages(input, func(page *autoscaling.DescribeLaunchConfigurationsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/autoscalingplans/sweep.go
+++ b/internal/service/autoscalingplans/sweep.go
@@ -28,7 +28,7 @@ func sweepScalingPlans(region string) error {
 	}
 	conn := client.(*conns.AWSClient).AutoScalingPlansConn
 	input := &autoscalingplans.DescribeScalingPlansInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeScalingPlansPages(conn, input, func(page *autoscalingplans.DescribeScalingPlansOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/backup/sweep.go
+++ b/internal/service/backup/sweep.go
@@ -60,7 +60,7 @@ func sweepFramework(region string) error {
 	conn := client.(*conns.AWSClient).BackupConn
 	input := &backup.ListFrameworksInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListFrameworksPages(input, func(page *backup.ListFrameworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -102,7 +102,7 @@ func sweepReportPlan(region string) error {
 	conn := client.(*conns.AWSClient).BackupConn
 	input := &backup.ListReportPlansInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListReportPlansPages(input, func(page *backup.ListReportPlansOutput, lastPage bool) bool {
 		if page == nil {
@@ -144,7 +144,7 @@ func sweepVaultLockConfiguration(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).BackupConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &backup.ListBackupVaultsInput{}
@@ -193,7 +193,7 @@ func sweepVaultNotifications(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).BackupConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &backup.ListBackupVaultsInput{}
@@ -242,7 +242,7 @@ func sweepVaultPolicies(region string) error {
 	conn := client.(*conns.AWSClient).BackupConn
 	input := &backup.ListBackupVaultsInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListBackupVaultsPages(input, func(page *backup.ListBackupVaultsOutput, lastPage bool) bool {
 		if page == nil {
@@ -285,7 +285,7 @@ func sweepVaults(region string) error {
 	conn := client.(*conns.AWSClient).BackupConn
 	input := &backup.ListBackupVaultsInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListBackupVaultsPages(input, func(page *backup.ListBackupVaultsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/cloud9/sweep.go
+++ b/internal/service/cloud9/sweep.go
@@ -28,7 +28,7 @@ func sweepEnvironmentEC2s(region string) error {
 	}
 	conn := client.(*conns.AWSClient).Cloud9Conn
 	input := &cloud9.ListEnvironmentsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListEnvironmentsPages(input, func(page *cloud9.ListEnvironmentsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/cloudformation/sweep.go
+++ b/internal/service/cloudformation/sweep.go
@@ -48,7 +48,7 @@ func sweepStackSetInstances(region string) error {
 		Status: aws.String(cloudformation.StackSetStatusActive),
 	}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListStackSetsPages(input, func(page *cloudformation.ListStackSetsOutput, lastPage bool) bool {
 		if page == nil {
@@ -120,7 +120,7 @@ func sweepStackSets(region string) error {
 	input := &cloudformation.ListStackSetsInput{
 		Status: aws.String(cloudformation.StackSetStatusActive),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListStackSetsPages(input, func(page *cloudformation.ListStackSetsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/cloudfront/sweep.go
+++ b/internal/service/cloudfront/sweep.go
@@ -98,7 +98,7 @@ func sweepCachePolicies(region string) error {
 	input := &cloudfront.ListCachePoliciesInput{
 		Type: aws.String(cloudfront.ResponseHeadersPolicyTypeCustom),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = ListCachePoliciesPages(conn, input, func(page *cloudfront.ListCachePoliciesOutput, lastPage bool) bool {
 		if page == nil {
@@ -155,7 +155,7 @@ func sweepDistributions(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudFrontConn
 	input := &cloudfront.ListDistributionsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListDistributionsPages(input, func(page *cloudfront.ListDistributionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -425,7 +425,7 @@ func sweepFieldLevelEncryptionConfigs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudFrontConn
 	input := &cloudfront.ListFieldLevelEncryptionConfigsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = ListFieldLevelEncryptionConfigsPages(conn, input, func(page *cloudfront.ListFieldLevelEncryptionConfigsOutput, lastPage bool) bool {
 		if page == nil {
@@ -482,7 +482,7 @@ func sweepFieldLevelEncryptionProfiles(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudFrontConn
 	input := &cloudfront.ListFieldLevelEncryptionProfilesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = ListFieldLevelEncryptionProfilesPages(conn, input, func(page *cloudfront.ListFieldLevelEncryptionProfilesOutput, lastPage bool) bool {
 		if page == nil {
@@ -541,7 +541,7 @@ func sweepOriginRequestPolicies(region string) error {
 	input := &cloudfront.ListOriginRequestPoliciesInput{
 		Type: aws.String(cloudfront.ResponseHeadersPolicyTypeCustom),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = ListOriginRequestPoliciesPages(conn, input, func(page *cloudfront.ListOriginRequestPoliciesOutput, lastPage bool) bool {
 		if page == nil {
@@ -600,7 +600,7 @@ func sweepResponseHeadersPolicies(region string) error {
 	input := &cloudfront.ListResponseHeadersPoliciesInput{
 		Type: aws.String(cloudfront.ResponseHeadersPolicyTypeCustom),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = ListResponseHeadersPoliciesPages(conn, input, func(page *cloudfront.ListResponseHeadersPoliciesOutput, lastPage bool) bool {
 		if page == nil {
@@ -657,7 +657,7 @@ func sweepOriginAccessControls(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudFrontConn
 	input := &cloudfront.ListOriginAccessControlsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = ListOriginAccessControlsPages(conn, input, func(page *cloudfront.ListOriginAccessControlsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/cloudhsmv2/sweep.go
+++ b/internal/service/cloudhsmv2/sweep.go
@@ -34,7 +34,7 @@ func sweepClusters(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudHSMV2Conn
 	input := &cloudhsmv2.DescribeClustersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeClustersPages(input, func(page *cloudhsmv2.DescribeClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -80,7 +80,7 @@ func sweepHSMs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudHSMV2Conn
 	input := &cloudhsmv2.DescribeClustersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeClustersPages(input, func(page *cloudhsmv2.DescribeClustersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/cloudsearch/sweep.go
+++ b/internal/service/cloudsearch/sweep.go
@@ -28,7 +28,7 @@ func sweepDomains(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CloudSearchConn
 	input := &cloudsearch.DescribeDomainsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	domains, err := conn.DescribeDomains(input)
 

--- a/internal/service/codepipeline/sweep.go
+++ b/internal/service/codepipeline/sweep.go
@@ -30,7 +30,7 @@ func sweepPipelines(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).CodePipelineConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &codepipeline.ListPipelinesInput{}

--- a/internal/service/codestarconnections/sweep.go
+++ b/internal/service/codestarconnections/sweep.go
@@ -36,7 +36,7 @@ func sweepConnections(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CodeStarConnectionsConn
 	input := &codestarconnections.ListConnectionsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListConnectionsPages(input, func(page *codestarconnections.ListConnectionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -79,7 +79,7 @@ func sweepHosts(region string) error {
 	}
 	conn := client.(*conns.AWSClient).CodeStarConnectionsConn
 	input := &codestarconnections.ListHostsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListHostsPages(input, func(page *codestarconnections.ListHostsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/connect/sweep.go
+++ b/internal/service/connect/sweep.go
@@ -32,7 +32,7 @@ func sweepInstance(region string) error {
 	conn := client.(*conns.AWSClient).ConnectConn
 	ctx := context.Background()
 	var errs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	// MaxResults:  Maximum value of 10. https://docs.aws.amazon.com/connect/latest/APIReference/API_ListInstances.html
 	input := &connect.ListInstancesInput{MaxResults: aws.Int64(ListInstancesMaxResults)}

--- a/internal/service/dataexchange/sweep.go
+++ b/internal/service/dataexchange/sweep.go
@@ -30,7 +30,7 @@ func sweepDataSets(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DataExchangeConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &dataexchange.ListDataSetsInput{}

--- a/internal/service/deploy/sweep.go
+++ b/internal/service/deploy/sweep.go
@@ -30,7 +30,7 @@ func sweepApps(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DeployConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &codedeploy.ListApplicationsInput{}

--- a/internal/service/devicefarm/sweep.go
+++ b/internal/service/devicefarm/sweep.go
@@ -35,7 +35,7 @@ func sweepProjects(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DeviceFarmConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &devicefarm.ListProjectsInput{}
@@ -89,7 +89,7 @@ func sweepTestGridProjects(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DeviceFarmConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &devicefarm.ListTestGridProjectsInput{}

--- a/internal/service/directconnect/sweep.go
+++ b/internal/service/directconnect/sweep.go
@@ -115,7 +115,7 @@ func sweepGatewayAssociationProposals(region string) error {
 	conn := client.(*conns.AWSClient).DirectConnectConn
 	input := &directconnect.DescribeDirectConnectGatewayAssociationProposalsInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeGatewayAssociationProposalsPages(conn, input, func(page *directconnect.DescribeDirectConnectGatewayAssociationProposalsOutput, lastPage bool) bool {
 		if page == nil {
@@ -171,7 +171,7 @@ func sweepGatewayAssociations(region string) error {
 	conn := client.(*conns.AWSClient).DirectConnectConn
 	input := &directconnect.DescribeDirectConnectGatewaysInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeGatewaysPages(conn, input, func(page *directconnect.DescribeDirectConnectGatewaysOutput, lastPage bool) bool {
 		if page == nil {
@@ -307,7 +307,7 @@ func sweepGateways(region string) error {
 	conn := client.(*conns.AWSClient).DirectConnectConn
 	input := &directconnect.DescribeDirectConnectGatewaysInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeGatewaysPages(conn, input, func(page *directconnect.DescribeDirectConnectGatewaysOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/dlm/sweep.go
+++ b/internal/service/dlm/sweep.go
@@ -31,7 +31,7 @@ func sweepLifecyclePolicies(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DLMConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &dlm.GetLifecyclePoliciesInput{}

--- a/internal/service/dms/sweep.go
+++ b/internal/service/dms/sweep.go
@@ -38,7 +38,7 @@ func sweepReplicationInstances(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DMSConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeReplicationInstancesPages(&dms.DescribeReplicationInstancesInput{}, func(page *dms.DescribeReplicationInstancesOutput, lastPage bool) bool {
@@ -78,7 +78,7 @@ func sweepReplicationTasks(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DMSConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &dms.DescribeReplicationTasksInput{

--- a/internal/service/docdb/sweep.go
+++ b/internal/service/docdb/sweep.go
@@ -215,7 +215,7 @@ func sweepDBInstances(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DocDBConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &docdb.DescribeDBInstancesInput{}
 

--- a/internal/service/ds/sweep.go
+++ b/internal/service/ds/sweep.go
@@ -98,7 +98,7 @@ func sweepRegions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DSConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &directoryservice.DescribeDirectoriesInput{}

--- a/internal/service/dynamodb/backup.go
+++ b/internal/service/dynamodb/backup.go
@@ -1,0 +1,29 @@
+package dynamodb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+func listBackupsPages(conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error {
+	return listBackupsPagesWithContext(context.Background(), conn, input, fn)
+}
+
+func listBackupsPagesWithContext(ctx context.Context, conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error {
+	for {
+		output, err := conn.ListBackupsWithContext(ctx, input)
+		if err != nil {
+			return err
+		}
+
+		lastPage := aws.StringValue(output.LastEvaluatedBackupArn) == ""
+		if !fn(output, lastPage) || lastPage {
+			break
+		}
+
+		input.ExclusiveStartBackupArn = output.LastEvaluatedBackupArn
+	}
+	return nil
+}

--- a/internal/service/dynamodb/backup.go
+++ b/internal/service/dynamodb/backup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
-func listBackupsPages(conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error {
+func listBackupsPages(conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error { //nolint:deadcode // used in sweeper
 	return listBackupsPagesWithContext(context.Background(), conn, input, fn)
 }
 

--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -31,7 +31,7 @@ func sweepTables(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).DynamoDBConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}

--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -4,22 +4,30 @@
 package dynamodb
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func init() {
 	resource.AddTestSweepers("aws_dynamodb_table", &resource.Sweeper{
 		Name: "aws_dynamodb_table",
 		F:    sweepTables,
+	})
+
+	resource.AddTestSweepers("aws_dynamodb_backup", &resource.Sweeper{
+		Name: "aws_dynamodb_backup",
+		F:    sweepBackups,
 	})
 }
 
@@ -91,4 +99,89 @@ func sweepTables(region string) error {
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func sweepBackups(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).DynamoDBConn
+	sweepables := make([]sweep.Sweepable, 0)
+	var errs *multierror.Error
+	var g multierror.Group
+
+	input := &dynamodb.ListBackupsInput{
+		BackupType: aws.String(dynamodb.BackupTypeFilterAll),
+	}
+	err = listBackupsPages(conn, input, func(page *dynamodb.ListBackupsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, backup := range page.BackupSummaries {
+			if aws.StringValue(backup.BackupType) == dynamodb.BackupTypeFilterSystem {
+				log.Printf("[DEBUG] Skipping DynamoDB Backup %q, cannot delete %q backups", aws.StringValue(backup.BackupArn), dynamodb.BackupTypeFilterSystem)
+				continue
+			}
+
+			sweepables = append(sweepables, backupSweeper{
+				conn: conn,
+				arn:  backup.BackupArn,
+			})
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("listing DynamoDB Backups for %s: %w", region, err))
+	}
+
+	if err = g.Wait().ErrorOrNil(); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("reading DynamoDB Backups: %w", err))
+	}
+
+	if err = sweep.SweepOrchestrator(sweepables); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping DynamoDB Backups for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping DynamoDB Backups sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+type backupSweeper struct {
+	conn *dynamodb.DynamoDB
+	arn  *string
+}
+
+func (bs backupSweeper) Delete(ctx context.Context, rc sweep.RetryConfig) error {
+	input := &dynamodb.DeleteBackupInput{
+		BackupArn: bs.arn,
+	}
+	err := tfresource.RetryConfigContext(ctx, rc.Delay, rc.DelayRand, rc.MinTimeout, rc.PollInterval, rc.Timeout, func() *resource.RetryError {
+		_, err := bs.conn.DeleteBackupWithContext(ctx, input)
+		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeBackupNotFoundException) {
+			return nil
+		}
+		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeBackupInUseException, dynamodb.ErrCodeLimitExceededException) {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+	if tfresource.TimedOut(err) {
+		_, err = bs.conn.DeleteBackupWithContext(ctx, input)
+	}
+
+	return err
 }

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -489,7 +489,7 @@ func sweepClientVPNEndpoints(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeClientVpnEndpointsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeClientVpnEndpointsPages(input, func(page *ec2.DescribeClientVpnEndpointsOutput, lastPage bool) bool {
 		if page == nil {
@@ -533,7 +533,7 @@ func sweepClientVPNNetworkAssociations(region string) error {
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeClientVpnEndpointsInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeClientVpnEndpointsPages(input, func(page *ec2.DescribeClientVpnEndpointsOutput, lastPage bool) bool {
 		if page == nil {
@@ -600,7 +600,7 @@ func sweepFleet(region string) error {
 	conn := client.(*conns.AWSClient).EC2Conn
 
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeFleetsPages(&ec2.DescribeFleetsInput{}, func(page *ec2.DescribeFleetsOutput, lastPage bool) bool {
 		if page == nil {
@@ -690,7 +690,7 @@ func sweepEBSSnapshots(region string) error {
 		OwnerIds: aws.StringSlice([]string{"self"}),
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeSnapshotsPages(input, func(page *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
 		if page == nil {
@@ -733,7 +733,7 @@ func sweepEgressOnlyInternetGateways(region string) error {
 	}
 	input := &ec2.DescribeEgressOnlyInternetGatewaysInput{}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeEgressOnlyInternetGatewaysPages(input, func(page *ec2.DescribeEgressOnlyInternetGatewaysOutput, lastPage bool) bool {
 		if page == nil {
@@ -797,7 +797,7 @@ func sweepEIPs(region string) error {
 		return nil
 	}
 
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	for _, address := range output.Addresses {
@@ -838,7 +838,7 @@ func sweepFlowLogs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeFlowLogsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeFlowLogsPages(input, func(page *ec2.DescribeFlowLogsOutput, lastPage bool) bool {
 		if page == nil {
@@ -881,7 +881,7 @@ func sweepHosts(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeHostsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeHostsPages(input, func(page *ec2.DescribeHostsOutput, lastPage bool) bool {
 		if page == nil {
@@ -924,7 +924,7 @@ func sweepInstances(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeInstancesPages(&ec2.DescribeInstancesInput{}, func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
@@ -1000,7 +1000,7 @@ func sweepInternetGateways(region string) error {
 	}
 
 	input := &ec2.DescribeInternetGatewaysInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeInternetGatewaysPages(input, func(page *ec2.DescribeInternetGatewaysOutput, lastPage bool) bool {
 		if page == nil {
@@ -1140,7 +1140,7 @@ func sweepNATGateways(region string) error {
 	}
 	input := &ec2.DescribeNatGatewaysInput{}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeNatGatewaysPages(input, func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool {
 		if page == nil {
@@ -1183,7 +1183,7 @@ func sweepNetworkACLs(region string) error {
 	}
 	input := &ec2.DescribeNetworkAclsInput{}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeNetworkAclsPages(input, func(page *ec2.DescribeNetworkAclsOutput, lastPage bool) bool {
 		if page == nil {
@@ -1282,7 +1282,7 @@ func sweepNetworkInsightsPaths(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeNetworkInsightsPathsPages(&ec2.DescribeNetworkInsightsPathsInput{}, func(page *ec2.DescribeNetworkInsightsPathsOutput, lastPage bool) bool {
@@ -1322,7 +1322,7 @@ func sweepPlacementGroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribePlacementGroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribePlacementGroups(input)
 
@@ -1570,7 +1570,7 @@ func sweepSpotFleetRequests(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeSpotFleetRequestsPages(&ec2.DescribeSpotFleetRequestsInput{}, func(page *ec2.DescribeSpotFleetRequestsOutput, lastPage bool) bool {
@@ -1621,7 +1621,7 @@ func sweepSpotInstanceRequests(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeSpotInstanceRequestsPages(&ec2.DescribeSpotInstanceRequestsInput{}, func(page *ec2.DescribeSpotInstanceRequestsOutput, lastPage bool) bool {
@@ -1671,7 +1671,7 @@ func sweepSubnets(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeSubnetsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeSubnetsPages(input, func(page *ec2.DescribeSubnetsOutput, lastPage bool) bool {
 		if page == nil {
@@ -1719,7 +1719,7 @@ func sweepTransitGateways(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeTransitGatewaysInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeTransitGatewaysPages(input, func(page *ec2.DescribeTransitGatewaysOutput, lastPage bool) bool {
 		if page == nil {
@@ -1766,7 +1766,7 @@ func sweepTransitGatewayConnectPeers(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeTransitGatewayConnectPeersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeTransitGatewayConnectPeersPages(input, func(page *ec2.DescribeTransitGatewayConnectPeersOutput, lastPage bool) bool {
 		if page == nil {
@@ -1813,7 +1813,7 @@ func sweepTransitGatewayConnects(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeTransitGatewayConnectsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeTransitGatewayConnectsPages(input, func(page *ec2.DescribeTransitGatewayConnectsOutput, lastPage bool) bool {
 		if page == nil {
@@ -1860,7 +1860,7 @@ func sweepTransitGatewayMulticastDomains(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeTransitGatewayMulticastDomainsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeTransitGatewayMulticastDomainsPages(input, func(page *ec2.DescribeTransitGatewayMulticastDomainsOutput, lastPage bool) bool {
 		if page == nil {
@@ -1907,7 +1907,7 @@ func sweepTransitGatewayPeeringAttachments(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeTransitGatewayPeeringAttachmentsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeTransitGatewayPeeringAttachmentsPages(input, func(page *ec2.DescribeTransitGatewayPeeringAttachmentsOutput, lastPage bool) bool {
 		if page == nil {
@@ -1954,7 +1954,7 @@ func sweepTransitGatewayVPCAttachments(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeTransitGatewayVpcAttachmentsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeTransitGatewayVpcAttachmentsPages(input, func(page *ec2.DescribeTransitGatewayVpcAttachmentsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2001,7 +2001,7 @@ func sweepVPCDHCPOptions(region string) error {
 	}
 	input := &ec2.DescribeDhcpOptionsInput{}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeDhcpOptionsPages(input, func(page *ec2.DescribeDhcpOptionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2131,7 +2131,7 @@ func sweepVPCEndpoints(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeVpcEndpointsPages(&ec2.DescribeVpcEndpointsInput{}, func(page *ec2.DescribeVpcEndpointsOutput, lastPage bool) bool {
@@ -2185,7 +2185,7 @@ func sweepVPCPeeringConnections(region string) error {
 	}
 	input := &ec2.DescribeVpcPeeringConnectionsInput{}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeVpcPeeringConnectionsPages(input, func(page *ec2.DescribeVpcPeeringConnectionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2228,7 +2228,7 @@ func sweepVPCs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeVpcsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeVpcsPages(input, func(page *ec2.DescribeVpcsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2276,7 +2276,7 @@ func sweepVPNConnections(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeVpnConnectionsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeVpnConnections(input)
 
@@ -2317,7 +2317,7 @@ func sweepVPNGateways(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeVpnGatewaysInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeVpnGateways(input)
 
@@ -2366,7 +2366,7 @@ func sweepCustomerGateways(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeCustomerGatewaysInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeCustomerGateways(input)
 
@@ -2408,7 +2408,7 @@ func sweepIPAMPoolCIDRAllocations(region string) error {
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeIpamPoolsInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2478,7 +2478,7 @@ func sweepIPAMPoolCIDRs(region string) error {
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeIpamPoolsInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2544,7 +2544,7 @@ func sweepIPAMPools(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeIpamPoolsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2587,7 +2587,7 @@ func sweepIPAMScopes(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeIpamScopesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeIpamScopesPages(input, func(page *ec2.DescribeIpamScopesOutput, lastPage bool) bool {
 		if page == nil {
@@ -2637,7 +2637,7 @@ func sweepIPAMs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeIpamsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeIpamsPages(input, func(page *ec2.DescribeIpamsOutput, lastPage bool) bool {
 		if page == nil {
@@ -2682,7 +2682,7 @@ func sweepAMIs(region string) error {
 		Owners: aws.StringSlice([]string{"self"}),
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeImages(input)
 

--- a/internal/service/ecrpublic/sweep.go
+++ b/internal/service/ecrpublic/sweep.go
@@ -28,7 +28,7 @@ func sweepRepositories(region string) error {
 	}
 	conn := client.(*conns.AWSClient).ECRPublicConn
 	input := &ecrpublic.DescribeRepositoriesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeRepositoriesPages(input, func(page *ecrpublic.DescribeRepositoriesOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/ecs/sweep.go
+++ b/internal/service/ecs/sweep.go
@@ -55,7 +55,7 @@ func sweepCapacityProviders(region string) error {
 	conn := client.(*conns.AWSClient).ECSConn
 	input := &ecs.DescribeCapacityProvidersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeCapacityProvidersPages(conn, input, func(page *ecs.DescribeCapacityProvidersOutput, lastPage bool) bool {
 		if page == nil {
@@ -142,7 +142,7 @@ func sweepServices(region string) error {
 	conn := client.(*conns.AWSClient).ECSConn
 
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(&ecs.ListClustersInput{}, func(page *ecs.ListClustersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/eks/sweep.go
+++ b/internal/service/eks/sweep.go
@@ -58,7 +58,7 @@ func sweepAddon(region string) error {
 	conn := client.(*conns.AWSClient).EKSConn
 	input := &eks.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPagesWithContext(ctx, input, func(page *eks.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -123,7 +123,7 @@ func sweepClusters(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EKSConn
 	input := &eks.ListClustersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *eks.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -167,7 +167,7 @@ func sweepFargateProfiles(region string) error {
 	conn := client.(*conns.AWSClient).EKSConn
 	input := &eks.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *eks.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -234,7 +234,7 @@ func sweepIdentityProvidersConfig(region string) error {
 	conn := client.(*conns.AWSClient).EKSConn
 	input := &eks.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPagesWithContext(ctx, input, func(page *eks.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -300,7 +300,7 @@ func sweepNodeGroups(region string) error {
 	conn := client.(*conns.AWSClient).EKSConn
 	input := &eks.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *eks.ListClustersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/elasticache/sweep.go
+++ b/internal/service/elasticache/sweep.go
@@ -226,7 +226,7 @@ func sweepReplicationGroups(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ElastiCacheConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeReplicationGroupsPages(&elasticache.DescribeReplicationGroupsInput{}, func(page *elasticache.DescribeReplicationGroupsOutput, lastPage bool) bool {

--- a/internal/service/elasticsearch/sweep.go
+++ b/internal/service/elasticsearch/sweep.go
@@ -30,7 +30,7 @@ func sweepDomains(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ElasticsearchConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &elasticsearchservice.ListDomainNamesInput{}

--- a/internal/service/elbv2/sweep.go
+++ b/internal/service/elbv2/sweep.go
@@ -122,7 +122,7 @@ func sweepListeners(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ELBV2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeLoadBalancersPages(&elbv2.DescribeLoadBalancersInput{}, func(page *elbv2.DescribeLoadBalancersOutput, lastPage bool) bool {

--- a/internal/service/emr/sweep.go
+++ b/internal/service/emr/sweep.go
@@ -89,7 +89,7 @@ func sweepStudios(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).EMRConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 	input := &emr.ListStudiosInput{}
 

--- a/internal/service/emrcontainers/sweep.go
+++ b/internal/service/emrcontainers/sweep.go
@@ -28,7 +28,7 @@ func sweepVirtualClusters(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EMRContainersConn
 	input := &emrcontainers.ListVirtualClustersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListVirtualClustersPages(input, func(page *emrcontainers.ListVirtualClustersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/emrserverless/sweep.go
+++ b/internal/service/emrserverless/sweep.go
@@ -28,7 +28,7 @@ func sweepApplications(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EMRServerlessConn
 	input := &emrserverless.ListApplicationsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListApplicationsPages(input, func(page *emrserverless.ListApplicationsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/firehose/sweep.go
+++ b/internal/service/firehose/sweep.go
@@ -29,7 +29,7 @@ func sweepDeliveryStreams(region string) error {
 	}
 	conn := client.(*conns.AWSClient).FirehoseConn
 	input := &firehose.ListDeliveryStreamsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = listDeliveryStreamsPages(conn, input, func(page *firehose.ListDeliveryStreamsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/fis/sweep.go
+++ b/internal/service/fis/sweep.go
@@ -30,7 +30,7 @@ func sweepExperimentTemplates(region string) error {
 	}
 	conn := client.(*conns.AWSClient).FISConn
 	input := &fis.ListExperimentTemplatesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 
 	pg := fis.NewListExperimentTemplatesPaginator(conn, input)

--- a/internal/service/fsx/sweep.go
+++ b/internal/service/fsx/sweep.go
@@ -67,7 +67,7 @@ func sweepBackups(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeBackupsInput{}
 
@@ -111,7 +111,7 @@ func sweepLustreFileSystems(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeFileSystemsInput{}
 
@@ -159,7 +159,7 @@ func sweepOntapFileSystems(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeFileSystemsInput{}
 
@@ -207,7 +207,7 @@ func sweepOntapStorageVirtualMachine(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeStorageVirtualMachinesInput{}
 
@@ -251,7 +251,7 @@ func sweepOntapVolume(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeVolumesInput{}
 
@@ -302,7 +302,7 @@ func sweepOpenZFSFileSystems(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeFileSystemsInput{}
 
@@ -350,7 +350,7 @@ func sweepOpenZFSVolume(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeVolumesInput{}
 
@@ -401,7 +401,7 @@ func sweepWindowsFileSystems(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	input := &fsx.DescribeFileSystemsInput{}
 

--- a/internal/service/gamelift/sweep.go
+++ b/internal/service/gamelift/sweep.go
@@ -171,7 +171,7 @@ func sweepFleets(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).GameLiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &gamelift.ListFleetsInput{}
@@ -225,7 +225,7 @@ func sweepGameServerGroups(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).GameLiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &gamelift.ListGameServerGroupsInput{}

--- a/internal/service/glue/sweep.go
+++ b/internal/service/glue/sweep.go
@@ -256,7 +256,7 @@ func sweepDevEndpoints(region string) error {
 	}
 	input := &glue.GetDevEndpointsInput{}
 	conn := client.(*conns.AWSClient).GlueConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.GetDevEndpointsPages(input, func(page *glue.GetDevEndpointsOutput, lastPage bool) bool {
 		if page == nil {
@@ -305,7 +305,7 @@ func sweepJobs(region string) error {
 	}
 	input := &glue.GetJobsInput{}
 	conn := client.(*conns.AWSClient).GlueConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.GetJobsPages(input, func(page *glue.GetJobsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/imagebuilder/sweep.go
+++ b/internal/service/imagebuilder/sweep.go
@@ -352,7 +352,7 @@ func sweepImages(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ImageBuilderConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &imagebuilder.ListImagesInput{

--- a/internal/service/iot/sweep.go
+++ b/internal/service/iot/sweep.go
@@ -86,7 +86,7 @@ func sweepCertifcates(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListCertificatesInput{}
@@ -132,7 +132,7 @@ func sweepPolicyAttachments(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListPoliciesInput{}
@@ -198,7 +198,7 @@ func sweepPolicies(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListPoliciesInput{}
@@ -244,7 +244,7 @@ func sweepRoleAliases(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListRoleAliasesInput{}
@@ -290,7 +290,7 @@ func sweepThingPrincipalAttachments(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListThingsInput{}
@@ -356,7 +356,7 @@ func sweepThings(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListThingsInput{}
@@ -402,7 +402,7 @@ func sweepThingTypes(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).IoTConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &iot.ListThingTypesInput{}
@@ -494,7 +494,7 @@ func sweepThingGroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).IoTConn
 	input := &iot.ListThingGroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListThingGroupsPages(input, func(page *iot.ListThingGroupsOutput, lastPage bool) bool {
 		if page == nil {
@@ -537,7 +537,7 @@ func sweepTopicRuleDestinations(region string) error {
 	}
 	conn := client.(*conns.AWSClient).IoTConn
 	input := &iot.ListTopicRuleDestinationsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListTopicRuleDestinationsPages(input, func(page *iot.ListTopicRuleDestinationsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/kafka/sweep.go
+++ b/internal/service/kafka/sweep.go
@@ -40,7 +40,7 @@ func sweepClusters(region string) error {
 	}
 	conn := client.(*conns.AWSClient).KafkaConn
 	input := &kafka.ListClustersV2Input{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersV2Pages(input, func(page *kafka.ListClustersV2Output, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/kafkaconnect/sweep.go
+++ b/internal/service/kafkaconnect/sweep.go
@@ -36,7 +36,7 @@ func sweepConnectors(region string) error {
 	}
 	conn := client.(*conns.AWSClient).KafkaConnectConn
 	input := &kafkaconnect.ListConnectorsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListConnectorsPages(input, func(page *kafkaconnect.ListConnectorsOutput, lastPage bool) bool {
 		if page == nil {
@@ -79,7 +79,7 @@ func sweepCustomPlugins(region string) error {
 	}
 	conn := client.(*conns.AWSClient).KafkaConnectConn
 	input := &kafkaconnect.ListCustomPluginsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListCustomPluginsPages(input, func(page *kafkaconnect.ListCustomPluginsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/kendra/sweep.go
+++ b/internal/service/kendra/sweep.go
@@ -31,7 +31,7 @@ func sweepIndex(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).KendraConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &kendra.ListIndicesInput{}
 	var errs *multierror.Error
 

--- a/internal/service/keyspaces/sweep.go
+++ b/internal/service/keyspaces/sweep.go
@@ -29,7 +29,7 @@ func sweepKeyspaces(region string) error { // nosemgrep:ci.keyspaces-in-func-nam
 	}
 	conn := client.(*conns.AWSClient).KeyspacesConn
 	input := &keyspaces.ListKeyspacesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListKeyspacesPages(input, func(page *keyspaces.ListKeyspacesOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/lambda/sweep.go
+++ b/internal/service/lambda/sweep.go
@@ -38,7 +38,7 @@ func sweepFunctions(region string) error {
 	}
 	conn := client.(*conns.AWSClient).LambdaConn
 	input := &lambda.ListFunctionsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListFunctionsPages(input, func(page *lambda.ListFunctionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -83,7 +83,7 @@ func sweepLayerVersions(region string) error {
 	conn := client.(*conns.AWSClient).LambdaConn
 	input := &lambda.ListLayersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListLayersPages(input, func(page *lambda.ListLayersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/lexmodels/sweep.go
+++ b/internal/service/lexmodels/sweep.go
@@ -48,7 +48,7 @@ func sweepBotAliases(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LexModelsConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &lexmodelbuildingservice.GetBotsInput{}
@@ -121,7 +121,7 @@ func sweepBots(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LexModelsConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &lexmodelbuildingservice.GetBotsInput{}
@@ -167,7 +167,7 @@ func sweepIntents(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LexModelsConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &lexmodelbuildingservice.GetIntentsInput{}
@@ -213,7 +213,7 @@ func sweepSlotTypes(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LexModelsConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &lexmodelbuildingservice.GetSlotTypesInput{}

--- a/internal/service/licensemanager/sweep.go
+++ b/internal/service/licensemanager/sweep.go
@@ -28,7 +28,7 @@ func sweepLicenseConfigurations(region string) error {
 	}
 	conn := client.(*conns.AWSClient).LicenseManagerConn
 	input := &licensemanager.ListLicenseConfigurationsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = listLicenseConfigurationsPages(conn, input, func(page *licensemanager.ListLicenseConfigurationsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/lightsail/sweep.go
+++ b/internal/service/lightsail/sweep.go
@@ -42,7 +42,7 @@ func sweepContainerServices(region string) error {
 
 	input := &lightsail.GetContainerServicesInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.GetContainerServicesWithContext(context.TODO(), input)
 

--- a/internal/service/location/sweep.go
+++ b/internal/service/location/sweep.go
@@ -55,7 +55,7 @@ func sweepGeofenceCollections(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LocationConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &locationservice.ListGeofenceCollectionsInput{}
@@ -102,7 +102,7 @@ func sweepMaps(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LocationConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &locationservice.ListMapsInput{}
@@ -149,7 +149,7 @@ func sweepPlaceIndexes(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LocationConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &locationservice.ListPlaceIndexesInput{}
@@ -196,7 +196,7 @@ func sweepRouteCalculators(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LocationConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &locationservice.ListRouteCalculatorsInput{}
@@ -243,7 +243,7 @@ func sweepTrackers(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LocationConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &locationservice.ListTrackersInput{}
@@ -290,7 +290,7 @@ func sweepTrackerAssociations(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LocationConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &locationservice.ListTrackersInput{}

--- a/internal/service/logs/sweep.go
+++ b/internal/service/logs/sweep.go
@@ -113,7 +113,7 @@ func sweeplogQueryDefinitions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).LogsConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &cloudwatchlogs.DescribeQueryDefinitionsInput{}

--- a/internal/service/medialive/sweep.go
+++ b/internal/service/medialive/sweep.go
@@ -44,7 +44,7 @@ func sweepInputs(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).MediaLiveConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListInputsInput{}
 	var errs *multierror.Error
 
@@ -94,7 +94,7 @@ func sweepInputSecurityGroups(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).MediaLiveConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListInputSecurityGroupsInput{}
 	var errs *multierror.Error
 
@@ -144,7 +144,7 @@ func sweepMultiplexes(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).MediaLiveConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListMultiplexesInput{}
 	var errs *multierror.Error
 

--- a/internal/service/memorydb/sweep.go
+++ b/internal/service/memorydb/sweep.go
@@ -69,7 +69,7 @@ func sweepACLs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).MemoryDBConn
 	input := &memorydb.DescribeACLsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeACLsPages(conn, input, func(page *memorydb.DescribeACLsOutput, lastPage bool) bool {
 		if page == nil {
@@ -118,7 +118,7 @@ func sweepClusters(region string) error {
 	}
 	conn := client.(*conns.AWSClient).MemoryDBConn
 	input := &memorydb.DescribeClustersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeClustersPages(conn, input, func(page *memorydb.DescribeClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -161,7 +161,7 @@ func sweepParameterGroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).MemoryDBConn
 	input := &memorydb.DescribeParameterGroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeParameterGroupsPages(conn, input, func(page *memorydb.DescribeParameterGroupsOutput, lastPage bool) bool {
 		if page == nil {
@@ -210,7 +210,7 @@ func sweepSnapshots(region string) error {
 	}
 	conn := client.(*conns.AWSClient).MemoryDBConn
 	input := &memorydb.DescribeSnapshotsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeSnapshotsPages(conn, input, func(page *memorydb.DescribeSnapshotsOutput, lastPage bool) bool {
 		if page == nil {
@@ -253,7 +253,7 @@ func sweepSubnetGroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).MemoryDBConn
 	input := &memorydb.DescribeSubnetGroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeSubnetGroupsPages(conn, input, func(page *memorydb.DescribeSubnetGroupsOutput, lastPage bool) bool {
 		if page == nil {
@@ -302,7 +302,7 @@ func sweepUsers(region string) error {
 	}
 	conn := client.(*conns.AWSClient).MemoryDBConn
 	input := &memorydb.DescribeUsersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeUsersPages(conn, input, func(page *memorydb.DescribeUsersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/mq/sweep.go
+++ b/internal/service/mq/sweep.go
@@ -28,7 +28,7 @@ func sweepBrokers(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).MQConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &mq.ListBrokersInput{MaxResults: aws.Int64(100)}

--- a/internal/service/networkmanager/sweep.go
+++ b/internal/service/networkmanager/sweep.go
@@ -98,7 +98,7 @@ func sweepGlobalNetworks(region string) error {
 	}
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.DescribeGlobalNetworksInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeGlobalNetworksPages(input, func(page *networkmanager.DescribeGlobalNetworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -141,7 +141,7 @@ func sweepCoreNetworks(region string) error {
 	}
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.ListCoreNetworksInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListCoreNetworksPages(input, func(page *networkmanager.ListCoreNetworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -186,7 +186,7 @@ func sweepTransitGatewayPeerings(region string) error {
 	input := &networkmanager.ListPeeringsInput{
 		PeeringType: aws.String(networkmanager.PeeringTypeTransitGateway),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListPeeringsPages(input, func(page *networkmanager.ListPeeringsOutput, lastPage bool) bool {
 		if page == nil {
@@ -231,7 +231,7 @@ func sweepTransitGatewayRouteTableAttachments(region string) error {
 	input := &networkmanager.ListAttachmentsInput{
 		AttachmentType: aws.String(networkmanager.AttachmentTypeTransitGatewayRouteTable),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListAttachmentsPages(input, func(page *networkmanager.ListAttachmentsOutput, lastPage bool) bool {
 		if page == nil {
@@ -276,7 +276,7 @@ func sweepVPCAttachments(region string) error {
 	input := &networkmanager.ListAttachmentsInput{
 		AttachmentType: aws.String(networkmanager.AttachmentTypeVpc),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListAttachmentsPages(input, func(page *networkmanager.ListAttachmentsOutput, lastPage bool) bool {
 		if page == nil {
@@ -320,7 +320,7 @@ func sweepSites(region string) error {
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.DescribeGlobalNetworksInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeGlobalNetworksPages(input, func(page *networkmanager.DescribeGlobalNetworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -387,7 +387,7 @@ func sweepDevices(region string) error {
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.DescribeGlobalNetworksInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeGlobalNetworksPages(input, func(page *networkmanager.DescribeGlobalNetworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -454,7 +454,7 @@ func sweepLinks(region string) error {
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.DescribeGlobalNetworksInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeGlobalNetworksPages(input, func(page *networkmanager.DescribeGlobalNetworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -521,7 +521,7 @@ func sweepLinkAssociations(region string) error {
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.DescribeGlobalNetworksInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeGlobalNetworksPages(input, func(page *networkmanager.DescribeGlobalNetworksOutput, lastPage bool) bool {
 		if page == nil {
@@ -587,7 +587,7 @@ func sweepConnections(region string) error {
 	conn := client.(*conns.AWSClient).NetworkManagerConn
 	input := &networkmanager.DescribeGlobalNetworksInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeGlobalNetworksPages(input, func(page *networkmanager.DescribeGlobalNetworksOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/opensearch/sweep.go
+++ b/internal/service/opensearch/sweep.go
@@ -30,7 +30,7 @@ func sweepDomains(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpenSearchConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &opensearchservice.ListDomainNamesInput{}

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -67,7 +67,7 @@ func sweepApplication(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
 
@@ -118,7 +118,7 @@ func sweepInstance(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
 
@@ -170,7 +170,7 @@ func sweepRDSDBInstance(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
 
@@ -222,7 +222,7 @@ func sweepStacks(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
 
@@ -264,7 +264,7 @@ func sweepLayers(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeStacks(&opsworks.DescribeStacksInput{})
 
@@ -325,7 +325,7 @@ func sweepUserProfiles(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).OpsWorksConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.DescribeUserProfiles(&opsworks.DescribeUserProfilesInput{})
 

--- a/internal/service/qldb/sweep.go
+++ b/internal/service/qldb/sweep.go
@@ -38,7 +38,7 @@ func sweepLedgers(region string) error {
 	}
 	conn := client.(*conns.AWSClient).QLDBConn
 	input := &qldb.ListLedgersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListLedgersPages(input, func(page *qldb.ListLedgersOutput, lastPage bool) bool {
 		if page == nil {
@@ -82,7 +82,7 @@ func sweepStreams(region string) error {
 	conn := client.(*conns.AWSClient).QLDBConn
 	input := &qldb.ListLedgersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListLedgersPages(input, func(page *qldb.ListLedgersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -31,7 +31,7 @@ func sweepsDataSource(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).QuickSightConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	ctx := context.Background()

--- a/internal/service/ram/sweep.go
+++ b/internal/service/ram/sweep.go
@@ -30,7 +30,7 @@ func sweepResourceShares(region string) error {
 	input := &ram.GetResourceSharesInput{
 		ResourceOwner: aws.String(ram.ResourceOwnerSelf),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.GetResourceSharesPages(input, func(page *ram.GetResourceSharesOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -224,7 +224,7 @@ func sweepClusters(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RDSConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeDBClustersPages(&rds.DescribeDBClustersInput{}, func(out *rds.DescribeDBClustersOutput, lastPage bool) bool {
 		for _, cluster := range out.DBClusters {
@@ -271,7 +271,7 @@ func sweepEventSubscriptions(region string) error {
 	}
 	conn := client.(*conns.AWSClient).RDSConn
 	input := &rds.DescribeEventSubscriptionsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeEventSubscriptionsPages(input, func(page *rds.DescribeEventSubscriptionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -359,7 +359,7 @@ func sweepInstances(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RDSConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeDBInstancesPages(&rds.DescribeDBInstancesInput{}, func(out *rds.DescribeDBInstancesOutput, lastPage bool) bool {
 		for _, dbi := range out.DBInstances {
@@ -630,7 +630,7 @@ func sweepInstanceAutomatedBackupsReplication(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RDSConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 
 	backupARNs := []string{}

--- a/internal/service/redshift/sweep.go
+++ b/internal/service/redshift/sweep.go
@@ -118,7 +118,7 @@ func sweepClusters(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeClustersPages(&redshift.DescribeClustersInput{}, func(resp *redshift.DescribeClustersOutput, lastPage bool) bool {
@@ -164,7 +164,7 @@ func sweepEventSubscriptions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeEventSubscriptionsPages(&redshift.DescribeEventSubscriptionsInput{}, func(page *redshift.DescribeEventSubscriptionsOutput, lastPage bool) bool {
@@ -206,7 +206,7 @@ func sweepScheduledActions(region string) error {
 	}
 	conn := client.(*conns.AWSClient).RedshiftConn
 	input := &redshift.DescribeScheduledActionsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeScheduledActionsPages(input, func(page *redshift.DescribeScheduledActionsOutput, lastPage bool) bool {
 		if page == nil {
@@ -250,7 +250,7 @@ func sweepSnapshotSchedules(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &redshift.DescribeSnapshotSchedulesInput{}
@@ -304,7 +304,7 @@ func sweepSubnetGroups(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &redshift.DescribeClusterSubnetGroupsInput{}
@@ -359,7 +359,7 @@ func sweepHSMClientCertificates(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeHsmClientCertificatesPages(&redshift.DescribeHsmClientCertificatesInput{}, func(resp *redshift.DescribeHsmClientCertificatesOutput, lastPage bool) bool {
@@ -404,7 +404,7 @@ func sweepHSMConfigurations(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.DescribeHsmConfigurationsPages(&redshift.DescribeHsmConfigurationsInput{}, func(resp *redshift.DescribeHsmConfigurationsOutput, lastPage bool) bool {
@@ -449,7 +449,7 @@ func sweepAuthenticationProfiles(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RedshiftConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &redshift.DescribeAuthenticationProfilesInput{}

--- a/internal/service/redshiftserverless/sweep.go
+++ b/internal/service/redshiftserverless/sweep.go
@@ -37,7 +37,7 @@ func sweepNamespaces(region string) error {
 	}
 	conn := client.(*conns.AWSClient).RedshiftServerlessConn
 	input := &redshiftserverless.ListNamespacesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.ListNamespacesPages(input, func(page *redshiftserverless.ListNamespacesOutput, lastPage bool) bool {
@@ -80,7 +80,7 @@ func sweepWorkgroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).RedshiftServerlessConn
 	input := &redshiftserverless.ListWorkgroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.ListWorkgroupsPages(input, func(page *redshiftserverless.ListWorkgroupsOutput, lastPage bool) bool {

--- a/internal/service/route53/sweep.go
+++ b/internal/service/route53/sweep.go
@@ -70,7 +70,7 @@ func sweepHealthChecks(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).Route53Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &route53.ListHealthChecksInput{}
@@ -121,7 +121,7 @@ func sweepKeySigningKeys(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).Route53Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &route53.ListHostedZonesInput{}
@@ -242,7 +242,7 @@ func sweepTrafficPolicies(region string) error {
 	}
 	conn := client.(*conns.AWSClient).Route53Conn
 	input := &route53.ListTrafficPoliciesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = listTrafficPoliciesPages(conn, input, func(page *route53.ListTrafficPoliciesOutput, lastPage bool) bool {
 		if page == nil {
@@ -285,7 +285,7 @@ func sweepTrafficPolicyInstances(region string) error {
 	}
 	conn := client.(*conns.AWSClient).Route53Conn
 	input := &route53.ListTrafficPolicyInstancesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = listTrafficPolicyInstancesPages(conn, input, func(page *route53.ListTrafficPolicyInstancesOutput, lastPage bool) bool {
 		if page == nil {
@@ -329,7 +329,7 @@ func sweepZones(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).Route53Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &route53.ListHostedZonesInput{}

--- a/internal/service/route53recoverycontrolconfig/sweep.go
+++ b/internal/service/route53recoverycontrolconfig/sweep.go
@@ -51,7 +51,7 @@ func sweepClusters(region string) error {
 	}
 	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
 	input := &r53rcc.ListClustersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -95,7 +95,7 @@ func sweepControlPanels(region string) error {
 	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
 	input := &r53rcc.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -165,7 +165,7 @@ func sweepRoutingControls(region string) error {
 	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
 	input := &r53rcc.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
@@ -253,7 +253,7 @@ func sweepSafetyRules(region string) error {
 	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
 	input := &r53rcc.ListClustersInput{}
 	var sweeperErrs *multierror.Error
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/rum/sweep.go
+++ b/internal/service/rum/sweep.go
@@ -30,7 +30,7 @@ func sweepAppMonitors(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).RUMConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	err = conn.ListAppMonitorsPages(&cloudwatchrum.ListAppMonitorsInput{}, func(resp *cloudwatchrum.ListAppMonitorsOutput, lastPage bool) bool {

--- a/internal/service/s3control/sweep.go
+++ b/internal/service/s3control/sweep.go
@@ -46,7 +46,7 @@ func sweepAccessPoints(region string) error {
 	input := &s3control.ListAccessPointsInput{
 		AccountId: aws.String(accountID),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 
 	err = conn.ListAccessPointsPages(input, func(page *s3control.ListAccessPointsOutput, lastPage bool) bool {
@@ -111,7 +111,7 @@ func sweepMultiRegionAccessPoints(region string) error {
 	input := &s3control.ListMultiRegionAccessPointsInput{
 		AccountId: aws.String(accountID),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListMultiRegionAccessPointsPages(input, func(page *s3control.ListMultiRegionAccessPointsOutput, lastPage bool) bool {
 		if page == nil {
@@ -157,7 +157,7 @@ func sweepObjectLambdaAccessPoints(region string) error {
 	input := &s3control.ListAccessPointsForObjectLambdaInput{
 		AccountId: aws.String(accountID),
 	}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	conn.ListAccessPointsForObjectLambdaPages(input, func(page *s3control.ListAccessPointsForObjectLambdaOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/servicecatalog/sweep.go
+++ b/internal/service/servicecatalog/sweep.go
@@ -90,7 +90,7 @@ func sweepBudgetResourceAssociations(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.ListPortfoliosInput{}
@@ -201,7 +201,7 @@ func sweepConstraints(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	// no paginator or list operation for constraints directly, have to list portfolios and constraints of portfolios
@@ -270,7 +270,7 @@ func sweepPrincipalPortfolioAssociations(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.ListPortfoliosInput{}
@@ -342,7 +342,7 @@ func sweepProductPortfolioAssociations(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	// no paginator or list operation for associations directly, have to list products and associations of products
@@ -434,7 +434,7 @@ func sweepProducts(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.SearchProductsAsAdminInput{}
@@ -485,7 +485,7 @@ func sweepProvisionedProducts(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.SearchProvisionedProductsInput{
@@ -539,7 +539,7 @@ func sweepProvisioningArtifacts(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.SearchProductsAsAdminInput{}
@@ -620,7 +620,7 @@ func sweepServiceActions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.ListServiceActionsInput{}
@@ -671,7 +671,7 @@ func sweepTagOptionResourceAssociations(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.ListTagOptionsInput{}
@@ -742,7 +742,7 @@ func sweepTagOptions(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).ServiceCatalogConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &servicecatalog.ListTagOptionsInput{}

--- a/internal/service/servicediscovery/sweep.go
+++ b/internal/service/servicediscovery/sweep.go
@@ -52,7 +52,7 @@ func sweepHTTPNamespaces(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).ServiceDiscoveryConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	namespaces, err := findNamespacesByType(context.Background(), conn, servicediscovery.NamespaceTypeHttp)
 
@@ -88,7 +88,7 @@ func sweepPrivateDNSNamespaces(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).ServiceDiscoveryConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	namespaces, err := findNamespacesByType(context.Background(), conn, servicediscovery.NamespaceTypeDnsPrivate)
 
@@ -124,7 +124,7 @@ func sweepPublicDNSNamespaces(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).ServiceDiscoveryConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	namespaces, err := findNamespacesByType(context.Background(), conn, servicediscovery.NamespaceTypeDnsPublic)
 
@@ -161,7 +161,7 @@ func sweepServices(region string) error {
 	}
 	conn := client.(*conns.AWSClient).ServiceDiscoveryConn
 	input := &servicediscovery.ListServicesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	services, err := findServices(context.Background(), conn, input)
 

--- a/internal/service/ssm/sweep.go
+++ b/internal/service/ssm/sweep.go
@@ -91,7 +91,7 @@ func sweepResourceDataSyncs(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).SSMConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &ssm.ListResourceDataSyncInput{}

--- a/internal/service/transcribe/sweep.go
+++ b/internal/service/transcribe/sweep.go
@@ -59,7 +59,7 @@ func sweepLanguageModels(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).TranscribeConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListLanguageModelsInput{}
 	var errs *multierror.Error
 
@@ -109,7 +109,7 @@ func sweepMedicalVocabularies(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).TranscribeConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListMedicalVocabulariesInput{}
 	var errs *multierror.Error
 
@@ -160,7 +160,7 @@ func sweepVocabularies(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).TranscribeConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListVocabulariesInput{}
 	var errs *multierror.Error
 
@@ -211,7 +211,7 @@ func sweepVocabularyFilters(region string) error {
 
 	ctx := context.Background()
 	conn := client.(*conns.AWSClient).TranscribeConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListVocabularyFiltersInput{}
 	var errs *multierror.Error
 

--- a/internal/service/transfer/sweep.go
+++ b/internal/service/transfer/sweep.go
@@ -36,7 +36,7 @@ func sweepServers(region string) error {
 	}
 	conn := client.(*conns.AWSClient).TransferConn
 	input := &transfer.ListServersInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListServersPages(input, func(page *transfer.ListServersOutput, lastPage bool) bool {
 		if page == nil {
@@ -81,7 +81,7 @@ func sweepWorkflows(region string) error {
 	}
 	conn := client.(*conns.AWSClient).TransferConn
 	input := &transfer.ListWorkflowsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.ListWorkflowsPages(input, func(page *transfer.ListWorkflowsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/waf/sweep.go
+++ b/internal/service/waf/sweep.go
@@ -137,7 +137,7 @@ func sweepByteMatchSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -211,7 +211,7 @@ func sweepGeoMatchSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -285,7 +285,7 @@ func sweepIPSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -359,7 +359,7 @@ func sweepRateBasedRules(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -433,7 +433,7 @@ func sweepRegexMatchSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -507,7 +507,7 @@ func sweepRegexPatternSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -581,7 +581,7 @@ func sweepRuleGroups(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -655,7 +655,7 @@ func sweepRules(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -733,7 +733,7 @@ func sweepSizeConstraintSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -807,7 +807,7 @@ func sweepSQLInjectionMatchSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -881,7 +881,7 @@ func sweepWebACLs(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}
@@ -959,7 +959,7 @@ func sweepXSSMatchSet(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFConn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 	var g multierror.Group
 	var mutex = &sync.Mutex{}

--- a/internal/service/wafv2/sweep.go
+++ b/internal/service/wafv2/sweep.go
@@ -213,7 +213,7 @@ func sweepWebACLs(region string) error {
 	}
 
 	conn := client.(*conns.AWSClient).WAFV2Conn
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 	var errs *multierror.Error
 
 	input := &wafv2.ListWebACLsInput{

--- a/internal/service/workspaces/sweep.go
+++ b/internal/service/workspaces/sweep.go
@@ -40,7 +40,7 @@ func sweepDirectories(region string) error {
 	}
 	conn := client.(*conns.AWSClient).WorkSpacesConn
 	input := &workspaces.DescribeWorkspaceDirectoriesInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeWorkspaceDirectoriesPages(input, func(page *workspaces.DescribeWorkspaceDirectoriesOutput, lastPage bool) bool {
 		if page == nil {
@@ -83,7 +83,7 @@ func sweepIPGroups(region string) error {
 	}
 	conn := client.(*conns.AWSClient).WorkSpacesConn
 	input := &workspaces.DescribeIpGroupsInput{}
-	sweepResources := make([]*sweep.SweepResource, 0)
+	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeIPGroupsPages(conn, input, func(page *workspaces.DescribeIpGroupsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -96,6 +96,10 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 	return client, nil
 }
 
+type Sweepable interface {
+	Delete(ctx context.Context, rc RetryConfig) error
+}
+
 type SweepResource struct {
 	d        *schema.ResourceData
 	meta     interface{}
@@ -110,37 +114,56 @@ func NewSweepResource(resource *schema.Resource, d *schema.ResourceData, meta in
 	}
 }
 
-func SweepOrchestrator(sweepResources []*SweepResource) error {
-	return SweepOrchestratorWithContext(context.Background(), sweepResources, 0*time.Millisecond, 0*time.Millisecond, 0*time.Millisecond, 0*time.Millisecond, SweepThrottlingRetryTimeout)
+type RetryConfig struct {
+	Delay        time.Duration
+	DelayRand    time.Duration
+	MinTimeout   time.Duration
+	PollInterval time.Duration
+	Timeout      time.Duration
 }
 
-func SweepOrchestratorWithContext(ctx context.Context, sweepResources []*SweepResource, delay time.Duration, delayRand time.Duration, minTimeout time.Duration, pollInterval time.Duration, timeout time.Duration) error {
-	var g multierror.Group
+func (sr *SweepResource) Delete(ctx context.Context, rc RetryConfig) error {
+	err := tfresource.RetryConfigContext(ctx, rc.Delay, rc.DelayRand, rc.MinTimeout, rc.PollInterval, rc.Timeout, func() *resource.RetryError {
+		err := DeleteResource(sr.resource, sr.d, sr.meta)
 
-	for _, sweepResource := range sweepResources {
-		sweepResource := sweepResource
-
-		g.Go(func() error {
-			err := tfresource.RetryConfigContext(ctx, delay, delayRand, minTimeout, pollInterval, timeout, func() *resource.RetryError {
-				err := DeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
-
-				if err != nil {
-					if strings.Contains(err.Error(), "Throttling") {
-						log.Printf("[INFO] While sweeping resource (%s), encountered throttling error (%s). Retrying...", sweepResource.d.Id(), err)
-						return resource.RetryableError(err)
-					}
-
-					return resource.NonRetryableError(err)
-				}
-
-				return nil
-			})
-
-			if tfresource.TimedOut(err) {
-				err = DeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
+		if err != nil {
+			if strings.Contains(err.Error(), "Throttling") {
+				log.Printf("[INFO] While sweeping resource (%s), encountered throttling error (%s). Retrying...", sr.d.Id(), err)
+				return resource.RetryableError(err)
 			}
 
-			return err
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		err = DeleteResource(sr.resource, sr.d, sr.meta)
+	}
+
+	return err
+
+}
+
+func SweepOrchestrator(sweepables []Sweepable) error {
+	return SweepOrchestratorWithContext(context.Background(), sweepables, 0*time.Millisecond, 0*time.Millisecond, 0*time.Millisecond, 0*time.Millisecond, SweepThrottlingRetryTimeout)
+}
+
+func SweepOrchestratorWithContext(ctx context.Context, sweepables []Sweepable, delay time.Duration, delayRand time.Duration, minTimeout time.Duration, pollInterval time.Duration, timeout time.Duration) error {
+	var g multierror.Group
+
+	for _, sweepable := range sweepables {
+		sweepable := sweepable
+
+		g.Go(func() error {
+			return sweepable.Delete(ctx, RetryConfig{
+				Delay:        delay,
+				DelayRand:    delayRand,
+				MinTimeout:   minTimeout,
+				PollInterval: pollInterval,
+				Timeout:      timeout,
+			})
 		})
 	}
 


### PR DESCRIPTION
Adds sweeper for DynamoDB backups

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26578

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPERS=aws_dynamodb_backup

2022/09/12 14:40:05 [DEBUG] Skipping DynamoDB Backup "arn:aws:dynamodb:us-west-2:123456789012:table/tf-acc-test-1286782786994890407/backup/01662749916602-00000000", cannot delete "SYSTEM" backups
2022/09/12 14:40:05 [DEBUG] Skipping DynamoDB Backup "arn:aws:dynamodb:us-west-2:123456789012:table/tf-acc-test-20928988371839461-source/backup/01662750113504-00000000", cannot delete "SYSTEM" backups
2022/09/12 14:40:05 [DEBUG] Skipping DynamoDB Backup "arn:aws:dynamodb:us-west-2:123456789012:table/tf-acc-test-1003670874374409734/backup/01662750202614-00000000", cannot delete "SYSTEM" backups
2022/09/12 14:40:05 [DEBUG] Skipping DynamoDB Backup "arn:aws:dynamodb:us-west-2:123456789012:table/tf-acc-test-5408124299157327829-source/backup/01662750676184-00000000", cannot delete "SYSTEM" backups
2022/09/12 14:40:05 [DEBUG] Waiting for state to become: [success]
2022/09/12 14:40:05 [DEBUG] Waiting for state to become: [success]
2022/09/12 14:40:05 [DEBUG] Waiting for state to become: [success]
2022/09/12 14:40:05 [DEBUG] Completed Sweeper (aws_dynamodb_backup) in region (us-west-2) in 1.041854135s
2022/09/12 14:40:05 Completed Sweepers for region (us-west-2) in 1.042033697s
2022/09/12 14:40:05 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_dynamodb_backup
```
