### PR TITLE
Document `client_secret` attribute of `aws_cognito_user_pool_client` data source

### DIFF
--- a/website/docs/d/cognito_user_pool_client.markdown
+++ b/website/docs/d/cognito_user_pool_client.markdown
@@ -36,6 +36,7 @@ In addition to all arguments above, the following attributes are exported:
 * `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).
 * `analytics_configuration` - (Optional) Configuration block for Amazon Pinpoint analytics for collecting metrics for this user pool. [Detailed below](#analytics_configuration).
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
+* `client_secret` - Client secret of the user pool client.
 * `default_redirect_uri` - (Optional) Default redirect URI. Must be in the list of callback URLs.
 * `enable_token_revocation` - (Optional) Enables or disables token revocation.
 * `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH, ALLOW_ADMIN_USER_PASSWORD_AUTH, ALLOW_CUSTOM_AUTH, ALLOW_USER_PASSWORD_AUTH, ALLOW_USER_SRP_AUTH, ALLOW_REFRESH_TOKEN_AUTH).


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #26728

Output from acceptance testing: N/a, docs

### Information

This PR documents the previously undocumented `client_secret` attribute of the `aws_cognito_user_pool_client` data source.

### References

- [Schema reference](https://github.com/hashicorp/terraform-provider-aws/blob/d24492daf45b75153e554c16e61acd2bc41ee8fa/internal/service/cognitoidp/user_pool_client_data_source.go#L77-L81)
- [Documentation link for the same attribute in the `aws_cognito_user_pool_client` resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client#client_secret) (this is where I pulled the description from)