### PR TITLE
Fix PartitionKey and ClusteringKey Types in Schema

### DIFF
--- a/.changelog/26812.txt
+++ b/.changelog/26812.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_keyspaces_table: Change `schema_definition.clustering_key` and `schema_definition.partition_key` to lists in order to respect configured orderings
+```

--- a/internal/service/keyspaces/table.go
+++ b/internal/service/keyspaces/table.go
@@ -802,16 +802,16 @@ func expandSchemaDefinition(tfMap map[string]interface{}) *keyspaces.SchemaDefin
 
 	apiObject := &keyspaces.SchemaDefinition{}
 
+	if v, ok := tfMap["clustering_key"].([]interface{}); ok && len(v) > 0 {
+		apiObject.ClusteringKeys = expandClusteringKeys(v)
+	}
+
 	if v, ok := tfMap["column"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.AllColumns = expandColumnDefinitions(v.List())
 	}
 
-	if v, ok := tfMap["clustering_key"].(*schema.Set); ok && v.Len() > 0 {
-		apiObject.ClusteringKeys = expandClusteringKeys(v.List())
-	}
-
-	if v, ok := tfMap["partition_key"].(*schema.Set); ok && v.Len() > 0 {
-		apiObject.PartitionKeys = expandPartitionKeys(v.List())
+	if v, ok := tfMap["partition_key"].([]interface{}); ok && len(v) > 0 {
+		apiObject.PartitionKeys = expandPartitionKeys(v)
 	}
 
 	if v, ok := tfMap["static_column"].(*schema.Set); ok && v.Len() > 0 {

--- a/internal/service/keyspaces/table.go
+++ b/internal/service/keyspaces/table.go
@@ -164,7 +164,7 @@ func ResourceTable() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"clustering_key": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
@@ -218,7 +218,7 @@ func ResourceTable() *schema.Resource {
 							},
 						},
 						"partition_key": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							ForceNew: true,
 							Elem: &schema.Resource{


### PR DESCRIPTION
In Cassandra and Amazon Keyspaces, the order of column names in a partition key and clustering key should be ordered and not changed. Today, the schema type is unordered creating issues when creating and maintaining resources. This change switches type to a list schema type which is ordered.

https://cassandra.apache.org/doc/latest/cassandra/data_modeling/data_modeling_logical.html

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/26276.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
