### PR TITLE
Handle 'Disabled' status on `aws_cloudfront_monitoring_subscription`

### DIFF
--- a/internal/service/cloudfront/find.go
+++ b/internal/service/cloudfront/find.go
@@ -141,13 +141,6 @@ func FindMonitoringSubscriptionByDistributionID(conn *cloudfront.CloudFront, id 
 
 	output, err := conn.GetMonitoringSubscription(input)
 
-	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/cloudfront/monitoring_subscription_test.go
+++ b/internal/service/cloudfront/monitoring_subscription_test.go
@@ -2,10 +2,10 @@ package cloudfront_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"


### PR DESCRIPTION
Handles the situation where setting a `aws_cloudfront_monitoring_subscription` to status of 'Disabled' does not result in any resource being created on AWS, and that it is not possible to update an existing `aws_cloudfront_monitoring_subscription` after it has been created.

The current integration tests (prior to this change) fail due to a 409 Conflict error when attempting to update a 'Enabled' monitoring subscription to 'Disabled' (see output below). Presumably AWS have changed the behavior of this API since the original Terraform implementation of this resource was created. This API is now has no effect creating a Monitoring Subscription with status of 'Disabled' and is immutable once created with a status of 'Enabled'

```
make testacc TESTS=TestAccCloudFrontMonitoringSubscription_update PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 10 -run='TestAccCloudFrontMonitoringSubscription_update'  -timeout 180m
=== RUN   TestAccCloudFrontMonitoringSubscription_update
=== PAUSE TestAccCloudFrontMonitoringSubscription_update
=== CONT  TestAccCloudFrontMonitoringSubscription_update
    monitoring_subscription_test.go:71: Step 3/3 error: Error running apply: exit status 1

        Error: error creating CloudFront Monitoring Subscription (ELN3YLPE2OEH5): MonitoringSubscriptionAlreadyExists: A monitoring subscription already exists for this distribution
        	status code: 409, request id: 1f27d1ed-785e-41fe-9de6-54439e023cf5

          with aws_cloudfront_monitoring_subscription.test,
          on terraform_plugin_test.tf line 44, in resource "aws_cloudfront_monitoring_subscription" "test":
          44: resource "aws_cloudfront_monitoring_subscription" "test" {

--- FAIL: TestAccCloudFrontMonitoringSubscription_update (391.37s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	394.317s
FAIL
make: *** [testacc] Error 1
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #26422

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccCloudFrontMonitoringSubscription_update PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 10 -run='TestAccCloudFrontMonitoringSubscription_update'  -timeout 180m
=== RUN   TestAccCloudFrontMonitoringSubscription_update
=== PAUSE TestAccCloudFrontMonitoringSubscription_update
=== CONT  TestAccCloudFrontMonitoringSubscription_update
--- PASS: TestAccCloudFrontMonitoringSubscription_update (509.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	512.880s
...
```
