### PR TITLE
r/route53_record docs for import: remove "delegated" word as it is unncessary and confusing.

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -188,7 +188,7 @@ Route53 Records can be imported using ID of the record, which is the zone identi
 $ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS
 ```
 
-If the record also contains a delegated set identifier, it can be appended:
+If the record also contains a set identifier, it should be appended:
 
 ```
 $ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS_dev


### PR DESCRIPTION
Also change "can" to "should" in the same sentence because you do need
to specify the set identifier in the import command or the provider
won't be able to find the record.
