### PR TITLE
linters: Remove deprecated linters and replace with suggested alternative

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -9,7 +9,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - gofmt
@@ -22,11 +21,10 @@ linters:
     - nilerr
     - nolintlint
     - staticcheck
-    - structcheck
     - stylecheck
     - unconvert
     - unparam
-    - varcheck
+    - unused
     - vet
 
 linters-settings:
@@ -56,7 +54,7 @@ linters-settings:
           - strconv.ParseInt
           - strings.SplitN
   nolintlint:
-    allow-unused: true # Because of the disabled rules with Go 1.18
+    allow-unused: false
     allow-leading-space: false
     require-explanation: true
     require-specific: true

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -527,7 +527,7 @@ func TestAccProvider_AssumeRole_empty(t *testing.T) {
 }
 
 // Replaces FactoriesInternal.
-func testAccProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (*schema.Provider, error) { //nolint:unparam
+func testAccProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (*schema.Provider, error) {
 	p, err := provider.New(context.Background())
 
 	if err != nil {

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -825,7 +825,7 @@ Outputs:
 `, rName)
 }
 
-func testAccStackSetTemplateBodyParametersDefault1(rName string) string {
+func testAccStackSetTemplateBodyParametersDefault1(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 Parameters:
   Parameter1:
@@ -849,7 +849,7 @@ Outputs:
 `, rName)
 }
 
-func testAccStackSetTemplateBodyParametersNoEcho1(rName string) string {
+func testAccStackSetTemplateBodyParametersNoEcho1(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 Parameters:
   Parameter1:
@@ -1200,7 +1200,7 @@ TEMPLATE
 `, rName, testAccStackSetTemplateBodyParameters2(rName), value1, value2)
 }
 
-func testAccStackSetConfig_parametersDefault0(rName string) string {
+func testAccStackSetConfig_parametersDefault0(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
@@ -1236,7 +1236,7 @@ TEMPLATE
 `, rName, testAccStackSetTemplateBodyParametersDefault1(rName))
 }
 
-func testAccStackSetConfig_parametersDefault1(rName, value1 string) string {
+func testAccStackSetConfig_parametersDefault1(rName, value1 string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
@@ -1276,7 +1276,7 @@ TEMPLATE
 `, rName, testAccStackSetTemplateBodyParametersDefault1(rName), value1)
 }
 
-func testAccStackSetConfig_parametersNoEcho1(rName, value1 string) string {
+func testAccStackSetConfig_parametersNoEcho1(rName, value1 string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
@@ -1539,7 +1539,7 @@ resource "aws_cloudformation_stack_set" "test" {
 `, rName, testAccStackSetTemplateBodyVPC(rName+"2"))
 }
 
-func testAccStackSetConfig_permissionModel(rName string) string {
+func testAccStackSetConfig_permissionModel(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack_set" "test" {
   name             = %[1]q

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -4722,7 +4722,7 @@ resource "aws_codebuild_project" "test" {
 `, rName, bucketName))
 }
 
-func testAccProjectConfig_secondaryArtifactsName(rName string, name string) string {
+func testAccProjectConfig_secondaryArtifactsName(rName string, name string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return acctest.ConfigCompose(
 		testAccProjectConfig_Base_ServiceRole(rName),
 		fmt.Sprintf(`

--- a/internal/service/datasync/task_test.go
+++ b/internal/service/datasync/task_test.go
@@ -693,7 +693,6 @@ func TestAccDataSyncTask_DefaultSyncOptions_verifyMode(t *testing.T) {
 }
 
 func TestAccDataSyncTask_tags(t *testing.T) {
-	acctest.Skip(t, "Tagging on creation is inconsistent")
 	var task1, task2, task3 datasync.DescribeTaskOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datasync_task.test"

--- a/internal/service/dynamodb/backup.go
+++ b/internal/service/dynamodb/backup.go
@@ -7,11 +7,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
-func listBackupsPages(conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error { //nolint:deadcode // used in sweeper
+func listBackupsPages(conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error { //nolint:unused // This function is called from a sweeper.
 	return listBackupsPagesWithContext(context.Background(), conn, input, fn)
 }
 
-func listBackupsPagesWithContext(ctx context.Context, conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error {
+func listBackupsPagesWithContext(ctx context.Context, conn *dynamodb.DynamoDB, input *dynamodb.ListBackupsInput, fn func(*dynamodb.ListBackupsOutput, bool) bool) error { //nolint:unused // This function is called from a sweeper.
 	for {
 		output, err := conn.ListBackupsWithContext(ctx, input)
 		if err != nil {

--- a/internal/service/ec2/ec2_capacity_reservation_test.go
+++ b/internal/service/ec2/ec2_capacity_reservation_test.go
@@ -354,8 +354,6 @@ func TestAccEC2CapacityReservation_tags(t *testing.T) {
 }
 
 func TestAccEC2CapacityReservation_tenancy(t *testing.T) {
-	// Error creating EC2 Capacity Reservation: Unsupported: The requested configuration is currently not supported. Please check the documentation for supported configurations.
-	acctest.Skip(t, "EC2 Capacity Reservations do not currently support dedicated tenancy.")
 	var cr ec2.CapacityReservation
 	resourceName := "aws_ec2_capacity_reservation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -604,10 +602,10 @@ resource "aws_ec2_capacity_reservation" "test" {
 func testAccCapacityReservationConfig_tenancy(rName, tenancy string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
+  availability_zone = data.aws_availability_zones.available.names[1]
   instance_count    = 1
   instance_platform = "Linux/UNIX"
-  instance_type     = "t2.micro"
+  instance_type     = "a1.4xlarge"
   tenancy           = %[2]q
 
   tags = {

--- a/internal/service/ec2/ec2_fleet_test.go
+++ b/internal/service/ec2/ec2_fleet_test.go
@@ -1905,8 +1905,6 @@ func TestAccEC2Fleet_LaunchTemplateOverride_instanceType(t *testing.T) {
 }
 
 func TestAccEC2Fleet_LaunchTemplateOverride_maxPrice(t *testing.T) {
-	acctest.Skip(t, "EC2 API is not correctly returning MaxPrice override")
-
 	var fleet1, fleet2 ec2.FleetData
 	resourceName := "aws_ec2_fleet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/firehose/list_pages.go
+++ b/internal/service/firehose/list_pages.go
@@ -12,11 +12,11 @@ import (
 
 // Custom Kinesis Firehose service lister functions using the same format as generated code.
 
-func listDeliveryStreamsPages(conn *firehose.Firehose, input *firehose.ListDeliveryStreamsInput, fn func(*firehose.ListDeliveryStreamsOutput, bool) bool) error { //nolint:deadcode // This function is called from a sweeper.
+func listDeliveryStreamsPages(conn *firehose.Firehose, input *firehose.ListDeliveryStreamsInput, fn func(*firehose.ListDeliveryStreamsOutput, bool) bool) error { //nolint:unused // This function is called from a sweeper.
 	return listDeliveryStreamsPagesWithContext(context.Background(), conn, input, fn)
 }
 
-func listDeliveryStreamsPagesWithContext(ctx context.Context, conn *firehose.Firehose, input *firehose.ListDeliveryStreamsInput, fn func(*firehose.ListDeliveryStreamsOutput, bool) bool) error {
+func listDeliveryStreamsPagesWithContext(ctx context.Context, conn *firehose.Firehose, input *firehose.ListDeliveryStreamsInput, fn func(*firehose.ListDeliveryStreamsOutput, bool) bool) error { //nolint:unused // This function is called from a sweeper.
 	for {
 		output, err := conn.ListDeliveryStreamsWithContext(ctx, input)
 		if err != nil {

--- a/internal/service/glue/data_catalog_encryption_settings_data_source_test.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testAccDataCatalogEncryptionSettingsDataSource_basic(t *testing.T) {
-	t.Skipf("Skipping aws_glue_data_catalog_encryption_settings tests")
+	t.Skipf("Skipping aws_glue_data_catalog_encryption_settings tests due to potential KMS key corruption")
 
 	resourceName := "aws_glue_data_catalog_encryption_settings.test"
 	dataSourceName := "data.aws_glue_data_catalog_encryption_settings.test"
@@ -30,7 +30,7 @@ func testAccDataCatalogEncryptionSettingsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDataCatalogEncryptionSettingsDataSourceConfig_basic() string {
+func testAccDataCatalogEncryptionSettingsDataSourceConfig_basic() string { //nolint:unused // This function is used in a skipped acceptance test
 	return `
 resource "aws_glue_data_catalog_encryption_settings" "test" {
   data_catalog_encryption_settings {

--- a/internal/service/glue/data_catalog_encryption_settings_test.go
+++ b/internal/service/glue/data_catalog_encryption_settings_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
-	t.Skipf("Skipping aws_glue_data_catalog_encryption_settings tests")
+	t.Skipf("Skipping aws_glue_data_catalog_encryption_settings tests due to potential KMS key corruption")
 
 	var settings glue.DataCatalogEncryptionSettings
 
@@ -76,7 +76,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataCatalogEncryptionSettingsExists(resourceName string, v *glue.DataCatalogEncryptionSettings) resource.TestCheckFunc {
+func testAccCheckDataCatalogEncryptionSettingsExists(resourceName string, v *glue.DataCatalogEncryptionSettings) resource.TestCheckFunc { //nolint:unused // This function is used in a skipped acceptance test
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -103,7 +103,7 @@ func testAccCheckDataCatalogEncryptionSettingsExists(resourceName string, v *glu
 	}
 }
 
-func testAccDataCatalogEncryptionSettingsConfig_encrypted(rName string) string {
+func testAccDataCatalogEncryptionSettingsConfig_encrypted(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q
@@ -142,7 +142,7 @@ resource "aws_glue_data_catalog_encryption_settings" "test" {
 `, rName)
 }
 
-func testAccDataCatalogEncryptionSettingsConfig_nonEncrypted() string {
+func testAccDataCatalogEncryptionSettingsConfig_nonEncrypted() string { //nolint:unused // This function is used in a skipped acceptance test
 	return `
 resource "aws_glue_data_catalog_encryption_settings" "test" {
   data_catalog_encryption_settings {

--- a/internal/service/mediaconvert/queue_test.go
+++ b/internal/service/mediaconvert/queue_test.go
@@ -343,7 +343,7 @@ resource "aws_media_convert_queue" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccQueueConfig_reserved(rName, commitment, renewalType string, reservedSlots int) string {
+func testAccQueueConfig_reserved(rName, commitment, renewalType string, reservedSlots int) string { //nolint:unused // This function is used in a skipped accteptance test.
 	return fmt.Sprintf(`
 resource "aws_media_convert_queue" "test" {
   name         = %[1]q

--- a/internal/service/networkmanager/transit_gateway_peering.go
+++ b/internal/service/networkmanager/transit_gateway_peering.go
@@ -241,7 +241,7 @@ func StatusTransitGatewayPeeringState(ctx context.Context, conn *networkmanager.
 	}
 }
 
-func waitTransitGatewayPeeringCreated(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayPeering, error) { //nolint:unparam
+func waitTransitGatewayPeeringCreated(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayPeering, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{networkmanager.PeeringStateCreating},
 		Target:  []string{networkmanager.PeeringStateAvailable},
@@ -258,7 +258,7 @@ func waitTransitGatewayPeeringCreated(ctx context.Context, conn *networkmanager.
 	return nil, err
 }
 
-func waitTransitGatewayPeeringDeleted(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayPeering, error) { //nolint:unparam
+func waitTransitGatewayPeeringDeleted(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayPeering, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{networkmanager.PeeringStateDeleting},
 		Target:  []string{},

--- a/internal/service/networkmanager/transit_gateway_route_table_attachment.go
+++ b/internal/service/networkmanager/transit_gateway_route_table_attachment.go
@@ -256,7 +256,7 @@ func StatusTransitGatewayRouteTableAttachmentState(ctx context.Context, conn *ne
 	}
 }
 
-func waitTransitGatewayRouteTableAttachmentCreated(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayRouteTableAttachment, error) { //nolint:unparam
+func waitTransitGatewayRouteTableAttachmentCreated(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayRouteTableAttachment, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{networkmanager.AttachmentStateCreating, networkmanager.AttachmentStatePendingNetworkUpdate},
 		Target:  []string{networkmanager.AttachmentStateAvailable, networkmanager.AttachmentStatePendingAttachmentAcceptance},

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -108,7 +108,7 @@ func TestAccRDSInstance_identifierPrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_identifierPrefix("tf-acc-test-prefix-"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, "identifier", "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", "tf-acc-test-prefix-"),
@@ -142,7 +142,7 @@ func TestAccRDSInstance_identifierGenerated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_identifierGenerated(),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.CheckResourceAttrNameGenerated(resourceName, "identifier"),
 					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", resource.UniqueIdPrefix),
@@ -177,7 +177,7 @@ func TestAccRDSInstance_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfrds.ResourceInstance(), resourceName),
 				),
@@ -204,7 +204,7 @@ func TestAccRDSInstance_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_tags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
@@ -224,7 +224,7 @@ func TestAccRDSInstance_tags(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -233,7 +233,7 @@ func TestAccRDSInstance_tags(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_tags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -299,7 +299,7 @@ func TestAccRDSInstance_onlyMajorVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_majorVersionOnly(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "engine", "mysql"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "8.0"),
@@ -336,7 +336,7 @@ func TestAccRDSInstance_kmsKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_kmsKeyID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testAccCheckInstanceAttributes(&v),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
@@ -404,14 +404,14 @@ func TestAccRDSInstance_subnetGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_subnetGroup(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "db_subnet_group_name", rName),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_subnetGroupUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "db_subnet_group_name", fmt.Sprintf("%s-2", rName)),
 				),
@@ -437,14 +437,14 @@ func TestAccRDSInstance_networkType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_networkType(rName, "IPV4"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "network_type", "IPV4"),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_networkType(rName, "DUAL"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "network_type", "DUAL"),
 				),
@@ -470,7 +470,7 @@ func TestAccRDSInstance_optionGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_optionGroup(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testAccCheckInstanceAttributes(&v),
 					resource.TestCheckResourceAttr(resourceName, "option_group_name", rName),
@@ -497,7 +497,7 @@ func TestAccRDSInstance_iamAuth(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_iamAuth(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testAccCheckInstanceAttributes(&v),
 					resource.TestCheckResourceAttr(resourceName, "iam_database_authentication_enabled", "true"),
@@ -525,7 +525,7 @@ func TestAccRDSInstance_allowMajorVersionUpgrade(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_allowMajorVersionUpgrade(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance1),
 					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "true"),
 				),
@@ -544,7 +544,7 @@ func TestAccRDSInstance_allowMajorVersionUpgrade(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_allowMajorVersionUpgrade(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance1),
 					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "false"),
 				),
@@ -573,7 +573,7 @@ func TestAccRDSInstance_dbSubnetGroupName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_dbSubnetGroupName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckSubnetGroupExists(resourceName, &dbSubnetGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, "name"),
@@ -603,7 +603,7 @@ func TestAccRDSInstance_DBSubnetGroupName_ramShared(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_DBSubnetGroupName_ramShared(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckSubnetGroupExists(dbSubnetGroupResourceName, &dbSubnetGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, "name"),
@@ -633,7 +633,7 @@ func TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_DBSubnetGroupName_vpcSecurityGroupIDs(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckSubnetGroupExists(resourceName, &dbSubnetGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, "name"),
@@ -661,7 +661,7 @@ func TestAccRDSInstance_deletionProtection(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_deletionProtection(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "true"),
 				),
@@ -680,7 +680,7 @@ func TestAccRDSInstance_deletionProtection(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_deletionProtection(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
 				),
@@ -709,7 +709,7 @@ func TestAccRDSInstance_finalSnapshotIdentifier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_finalSnapshotID(rName1, rName1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
@@ -717,7 +717,7 @@ func TestAccRDSInstance_finalSnapshotIdentifier(t *testing.T) {
 			// https://github.com/hashicorp/terraform-provider-aws/issues/26280
 			{
 				Config: testAccInstanceConfig_finalSnapshotID(rName1, rName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
@@ -742,7 +742,7 @@ func TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_FinalSnapshotID_skipFinalSnapshot(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
@@ -768,7 +768,7 @@ func TestAccRDSInstance_isAlreadyBeingDeleted(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_mariaDB(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 				),
 			},
@@ -810,28 +810,28 @@ func TestAccRDSInstance_maxAllocatedStorage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_maxAllocatedStorage(rName, 10),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "max_allocated_storage", "10"),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_maxAllocatedStorage(rName, 5),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "max_allocated_storage", "0"),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_maxAllocatedStorage(rName, 15),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "max_allocated_storage", "15"),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_maxAllocatedStorage(rName, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "max_allocated_storage", "0"),
 				),
@@ -862,7 +862,7 @@ func TestAccRDSInstance_password(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_password(rName, "valid-password"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "password", "valid-password"),
 				),
@@ -1050,7 +1050,7 @@ func TestAccRDSInstance_ReplicateSourceDB_allocatedStorage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_allocatedStorage(rName, 10),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1080,7 +1080,7 @@ func TestAccRDSInstance_ReplicateSourceDB_iops(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_iops(rName, 1000),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1110,7 +1110,7 @@ func TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_allocatedStorageAndIOPS(rName, 220, 2200),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1141,7 +1141,7 @@ func TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_allowMajorVersionUpgrade(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1171,7 +1171,7 @@ func TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_autoMinorVersionUpgrade(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1201,7 +1201,7 @@ func TestAccRDSInstance_ReplicateSourceDB_availabilityZone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_availabilityZone(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1229,7 +1229,7 @@ func TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_backupRetentionPeriod(rName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1259,7 +1259,7 @@ func TestAccRDSInstance_ReplicateSourceDB_backupWindow(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_backupWindow(rName, "00:00-08:00", "sun:23:00-sun:23:30"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1293,7 +1293,7 @@ func TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_dbSubnetGroupName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckSubnetGroupExists(resourceName, &dbSubnetGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, "name"),
@@ -1328,7 +1328,7 @@ func TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_DBSubnetGroupName_ramShared(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckSubnetGroupExists(dbSubnetGroupResourceName, &dbSubnetGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, "name"),
@@ -1361,7 +1361,7 @@ func TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs(t
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_DBSubnetGroupName_vpcSecurityGroupIDs(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckSubnetGroupExists(resourceName, &dbSubnetGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, "name"),
@@ -1398,7 +1398,7 @@ func TestAccRDSInstance_ReplicateSourceDB_deletionProtection(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_deletionProtection(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1408,7 +1408,7 @@ func TestAccRDSInstance_ReplicateSourceDB_deletionProtection(t *testing.T) {
 			// Ensure we disable deletion protection before attempting to delete :)
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_deletionProtection(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1438,7 +1438,7 @@ func TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_iamDatabaseAuthenticationEnabled(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1468,7 +1468,7 @@ func TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_maintenanceWindow(rName, "00:00-08:00", "sun:23:00-sun:23:30"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1498,7 +1498,7 @@ func TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_maxAllocatedStorage(rName, 10),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1528,7 +1528,7 @@ func TestAccRDSInstance_ReplicateSourceDB_monitoring(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_monitoring(rName, 5),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1558,13 +1558,13 @@ func TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_monitoring_sourceOnly(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_monitoring(rName, 5),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1594,7 +1594,7 @@ func TestAccRDSInstance_ReplicateSourceDB_multiAZ(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_multiAZ(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1624,7 +1624,7 @@ func TestAccRDSInstance_ReplicateSourceDB_networkType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_networkType(rName, "IPV4"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1783,7 +1783,7 @@ func TestAccRDSInstance_ReplicateSourceDB_port(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_port(rName, 9999),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1813,7 +1813,7 @@ func TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_vpcSecurityGroupIDs(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1844,7 +1844,7 @@ func TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_caCertificateID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1875,7 +1875,7 @@ func TestAccRDSInstance_ReplicateSourceDB_replicaMode(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -1950,7 +1950,7 @@ func TestAccRDSInstance_S3Import_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_S3Import_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "identifier", rName),
 					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", ""),
@@ -1989,7 +1989,7 @@ func TestAccRDSInstance_SnapshotIdentifier_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_snapshotID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2030,7 +2030,7 @@ func TestAccRDSInstance_SnapshotIdentifier_namePrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotIdentifier_namePrefix(identifierPrefix, sourceName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, "identifier", identifierPrefix),
 					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", identifierPrefix),
@@ -2067,7 +2067,7 @@ func TestAccRDSInstance_SnapshotIdentifier_nameGenerated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotIdentifier_nameGenerated(sourceName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					acctest.CheckResourceAttrNameGenerated(resourceName, "identifier"),
 					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", resource.UniqueIdPrefix),
@@ -2105,13 +2105,13 @@ func TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_snapshotID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance1),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_SnapshotID_associationRemoved(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance2),
 					testAccCheckInstanceNotRecreated(&dbInstance1, &dbInstance2),
 					resource.TestCheckResourceAttrPair(resourceName, "allocated_storage", sourceDbResourceName, "allocated_storage"),
@@ -2144,7 +2144,7 @@ func TestAccRDSInstance_SnapshotIdentifier_allocatedStorage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_allocatedStorage(rName, 10),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2176,7 +2176,7 @@ func TestAccRDSInstance_SnapshotIdentifier_io1Storage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_io1Storage(rName, 1000),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2208,7 +2208,7 @@ func TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_allowMajorVersionUpgrade(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2240,7 +2240,7 @@ func TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_autoMinorVersionUpgrade(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2272,7 +2272,7 @@ func TestAccRDSInstance_SnapshotIdentifier_availabilityZone(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_availabilityZone(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2303,7 +2303,7 @@ func TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_backupRetentionPeriod(rName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2335,7 +2335,7 @@ func TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_BackupRetentionPeriod_unset(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2367,7 +2367,7 @@ func TestAccRDSInstance_SnapshotIdentifier_backupWindow(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_backupWindow(rName, "00:00-08:00", "sun:23:00-sun:23:30"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2401,7 +2401,7 @@ func TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_dbSubnetGroupName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2440,7 +2440,7 @@ func TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_DBSubnetGroupName_ramShared(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2475,7 +2475,7 @@ func TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs(
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_DBSubnetGroupName_vpcSecurityGroupIDs(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2508,7 +2508,7 @@ func TestAccRDSInstance_SnapshotIdentifier_deletionProtection(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_deletionProtection(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2518,7 +2518,7 @@ func TestAccRDSInstance_SnapshotIdentifier_deletionProtection(t *testing.T) {
 			// Ensure we disable deletion protection before attempting to delete :)
 			{
 				Config: testAccInstanceConfig_SnapshotID_deletionProtection(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2550,7 +2550,7 @@ func TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled(t *t
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_iamDatabaseAuthenticationEnabled(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2582,7 +2582,7 @@ func TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_maintenanceWindow(rName, "00:00-08:00", "sun:23:00-sun:23:30"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2614,7 +2614,7 @@ func TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_maxAllocatedStorage(rName, 10),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2646,7 +2646,7 @@ func TestAccRDSInstance_SnapshotIdentifier_monitoring(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_monitoring(rName, 5),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2678,7 +2678,7 @@ func TestAccRDSInstance_SnapshotIdentifier_multiAZ(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_multiAZ(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2710,7 +2710,7 @@ func TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_MultiAZ_sqlServer(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2742,7 +2742,7 @@ func TestAccRDSInstance_SnapshotIdentifier_parameterGroupName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_parameterGroupName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2775,7 +2775,7 @@ func TestAccRDSInstance_SnapshotIdentifier_port(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_port(rName, 9999),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2807,7 +2807,7 @@ func TestAccRDSInstance_SnapshotIdentifier_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_tags(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2815,12 +2815,20 @@ func TestAccRDSInstance_SnapshotIdentifier_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"snapshot_identifier",
+				},
+			},
 		},
 	})
 }
 
 func TestAccRDSInstance_SnapshotIdentifier_tagsRemove(t *testing.T) {
-	acctest.Skip(t, "To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/5959")
+	acctest.Skip(t, "To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/26808")
 	// --- FAIL: TestAccRDSInstance_SnapshotIdentifierTags_unset (1086.15s)
 	//     testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'tags.%' expected "0", got "1"
 
@@ -2839,13 +2847,21 @@ func TestAccRDSInstance_SnapshotIdentifier_tagsRemove(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_SnapshotID_Tags_clear(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccInstanceConfig_SnapshotID_tagsRemove(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -2872,7 +2888,7 @@ func TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_vpcSecurityGroupIDs(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2907,7 +2923,7 @@ func TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_VPCSecurityGroupIDs_tags(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -2936,7 +2952,7 @@ func TestAccRDSInstance_monitoringInterval(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_monitoringInterval(rName, 30),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "30"),
 				),
@@ -2954,21 +2970,21 @@ func TestAccRDSInstance_monitoringInterval(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_monitoringInterval(rName, 60),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "60"),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_monitoringInterval(rName, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "0"),
 				),
 			},
 			{
 				Config: testAccInstanceConfig_monitoringInterval(rName, 30),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "30"),
 				),
@@ -2995,7 +3011,7 @@ func TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_monitoringRoleARN(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "monitoring_role_arn", iamRoleResourceName, "arn"),
 				),
@@ -3013,7 +3029,7 @@ func TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_monitoringInterval(rName, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "0"),
 				),
@@ -3040,7 +3056,7 @@ func TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_monitoringRoleARN(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "monitoring_role_arn", iamRoleResourceName, "arn"),
 				),
@@ -3058,7 +3074,7 @@ func TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_monitoringRoleARNRemoved(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 				),
 			},
@@ -3084,7 +3100,7 @@ func TestAccRDSInstance_MonitoringRoleARN_removedToEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_monitoringRoleARNRemoved(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 				),
 			},
@@ -3101,7 +3117,7 @@ func TestAccRDSInstance_MonitoringRoleARN_removedToEnabled(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_monitoringRoleARN(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "monitoring_role_arn", iamRoleResourceName, "arn"),
 				),
@@ -3130,7 +3146,7 @@ func TestAccRDSInstance_separateIopsUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotInstanceConfig_iopsUpdate(rName, 1000),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists("aws_db_instance.bar", &v),
 					testAccCheckInstanceAttributes(&v),
 				),
@@ -3138,7 +3154,7 @@ func TestAccRDSInstance_separateIopsUpdate(t *testing.T) {
 
 			{
 				Config: testAccInstanceConfig_SnapshotInstanceConfig_iopsUpdate(rName, 2000),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists("aws_db_instance.bar", &v),
 					testAccCheckInstanceAttributes(&v),
 				),
@@ -3165,7 +3181,7 @@ func TestAccRDSInstance_portUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotInstanceConfig_mySQLPort(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "port", "3306"),
 				),
@@ -3173,7 +3189,7 @@ func TestAccRDSInstance_portUpdate(t *testing.T) {
 
 			{
 				Config: testAccInstanceConfig_SnapshotInstanceConfig_updateMySQLPort(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "port", "3305"),
 				),
@@ -3199,7 +3215,7 @@ func TestAccRDSInstance_MSSQL_tz(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_MSSQL_timezone(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testAccCheckInstanceAttributes_MSSQL(&v, ""),
 					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "20"),
@@ -3209,7 +3225,7 @@ func TestAccRDSInstance_MSSQL_tz(t *testing.T) {
 
 			{
 				Config: testAccInstanceConfig_MSSQL_timezone_AKST(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testAccCheckInstanceAttributes_MSSQL(&v, "Alaskan Standard Time"),
 					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "20"),
@@ -3241,7 +3257,7 @@ func TestAccRDSInstance_MSSQL_domain(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_mssqlDomain(rName, domain1, domain2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &vBefore),
 					testAccCheckInstanceDomainAttributes(domain1, &vBefore),
 					resource.TestCheckResourceAttrSet(resourceName, "domain"),
@@ -3250,7 +3266,7 @@ func TestAccRDSInstance_MSSQL_domain(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_mssqlUpdateDomain(rName, domain1, domain2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &vAfter),
 					testAccCheckInstanceDomainAttributes(domain2, &vAfter),
 					resource.TestCheckResourceAttrSet(resourceName, "domain"),
@@ -3280,7 +3296,7 @@ func TestAccRDSInstance_MSSQL_domainSnapshotRestore(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_mssqlDomainSnapshotRestore(rName, domain),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &vRestoredInstance),
 					testAccCheckInstanceExists(originResourceName, &v),
 					testAccCheckInstanceDomainAttributes(domain, &vRestoredInstance),
@@ -3310,7 +3326,7 @@ func TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_mySQLSnapshotRestoreEngineVersion(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(restoreResourceName, &vRestoredInstance),
 					testAccCheckInstanceExists(resourceName, &v),
 					// Hardcoded older version. Will to update when no longer compatible to upgrade from this to the default version.
@@ -3338,7 +3354,7 @@ func TestAccRDSInstance_minorVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_autoMinorVersion(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists("aws_db_instance.bar", &v),
 				),
 			},
@@ -3363,7 +3379,7 @@ func TestAccRDSInstance_cloudWatchLogsExport(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_cloudWatchLogsExportConfiguration(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "audit"),
@@ -3403,7 +3419,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_cloudWatchLogsExportConfiguration(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "audit"),
@@ -3412,7 +3428,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_cloudWatchLogsExportConfigurationAdd(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "audit"),
@@ -3422,7 +3438,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_cloudWatchLogsExportConfigurationModify(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "audit"),
@@ -3432,7 +3448,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_cloudWatchLogsExportConfigurationDelete(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "0"),
 				),
@@ -3458,7 +3474,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_EnabledCloudWatchLogsExports_mssql(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "2"),
 				),
@@ -3495,7 +3511,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_EnabledCloudWatchLogsExports_oracle(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "3"),
 				),
@@ -3533,7 +3549,7 @@ func TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_EnabledCloudWatchLogsExports_postgreSQL(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "2"),
 				),
@@ -3572,7 +3588,7 @@ func TestAccRDSInstance_noDeleteAutomatedBackups(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_noDeleteAutomatedBackups(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 				),
 			},
@@ -3598,7 +3614,7 @@ func TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_performanceInsightsDisabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "false"),
 				),
@@ -3615,7 +3631,7 @@ func TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled(t *testing.
 			},
 			{
 				Config: testAccInstanceConfig_performanceInsightsEnabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 				),
@@ -3641,7 +3657,7 @@ func TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_performanceInsightsEnabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 				),
@@ -3658,7 +3674,7 @@ func TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled(t *testing.
 			},
 			{
 				Config: testAccInstanceConfig_performanceInsightsDisabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "false"),
 				),
@@ -3685,7 +3701,7 @@ func TestAccRDSInstance_performanceInsightsKMSKeyID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_performanceInsightsKMSKeyID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, "arn"),
@@ -3703,7 +3719,7 @@ func TestAccRDSInstance_performanceInsightsKMSKeyID(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_performanceInsightsKMSKeyIdDisabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "false"),
 					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, "arn"),
@@ -3711,7 +3727,7 @@ func TestAccRDSInstance_performanceInsightsKMSKeyID(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_performanceInsightsKMSKeyID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, "arn"),
@@ -3738,7 +3754,7 @@ func TestAccRDSInstance_performanceInsightsRetentionPeriod(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 731),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "731"),
@@ -3756,7 +3772,7 @@ func TestAccRDSInstance_performanceInsightsRetentionPeriod(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 7),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "7"),
@@ -3764,7 +3780,7 @@ func TestAccRDSInstance_performanceInsightsRetentionPeriod(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 155),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "155"),
@@ -3794,7 +3810,7 @@ func TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_ReplicateSourceDB_performanceInsightsEnabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
@@ -3829,7 +3845,7 @@ func TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_SnapshotID_performanceInsightsEnabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -3860,7 +3876,7 @@ func TestAccRDSInstance_caCertificateIdentifier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_caCertificateID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "ca_cert_identifier", dataSourceName, "id"),
 				),
@@ -3887,7 +3903,7 @@ func TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_RestoreToPointInTime_sourceID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 				),
@@ -3928,7 +3944,7 @@ func TestAccRDSInstance_RestoreToPointInTime_sourceResourceID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_RestoreToPointInTime_sourceResourceID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 				),
@@ -3969,7 +3985,7 @@ func TestAccRDSInstance_RestoreToPointInTime_monitoring(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_RestoreToPointInTime_monitoring(rName, 5),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "5"),
@@ -3997,7 +4013,7 @@ func TestAccRDSInstance_NationalCharacterSet_oracle(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_NationalCharacterSet_oracle(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "nchar_character_set_name", "UTF8"),
 				),
@@ -4036,7 +4052,7 @@ func TestAccRDSInstance_NoNationalCharacterSet_oracle(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_NoNationalCharacterSet_oracle(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "nchar_character_set_name", "AL16UTF16"),
 				),
@@ -4070,7 +4086,7 @@ func TestAccRDSInstance_coIPEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_Outpost_coIPEnabled(rName, true, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testAccCheckInstanceAttributes(&v),
 					resource.TestCheckResourceAttr(
@@ -4094,7 +4110,7 @@ func TestAccRDSInstance_CoIPEnabled_disabledToEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_Outpost_coIPEnabled(rName, false, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "false"),
 				),
@@ -4111,7 +4127,7 @@ func TestAccRDSInstance_CoIPEnabled_disabledToEnabled(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_Outpost_coIPEnabled(rName, true, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
 				),
@@ -4133,7 +4149,7 @@ func TestAccRDSInstance_CoIPEnabled_enabledToDisabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_Outpost_coIPEnabled(rName, true, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
 				),
@@ -4150,7 +4166,7 @@ func TestAccRDSInstance_CoIPEnabled_enabledToDisabled(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_Outpost_coIPEnabled(rName, false, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "false"),
 				),
@@ -4173,7 +4189,7 @@ func TestAccRDSInstance_CoIPEnabled_restoreToPointInTime(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_CoIPEnabled_restorePointInTime(rName, false, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
@@ -4214,7 +4230,7 @@ func TestAccRDSInstance_CoIPEnabled_snapshotIdentifier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_CoIPEnabled_snapshotID(rName, false, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDBSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(resourceName, &dbInstance),
@@ -4242,7 +4258,7 @@ func TestAccRDSInstance_license(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfig_license(rName, "license-included"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "license_model", "license-included"),
 				),
@@ -4261,7 +4277,7 @@ func TestAccRDSInstance_license(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceConfig_license(rName, "bring-your-own-license"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "license_model", "bring-your-own-license"),
 				),
@@ -4999,7 +5015,7 @@ resource "aws_db_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_baseS3Import(rName string) string {
+func testAccInstanceConfig_baseS3Import(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return acctest.ConfigCompose(
 		testAccInstanceConfig_baseVPC(rName),
 		fmt.Sprintf(`
@@ -5084,7 +5100,7 @@ data "aws_rds_orderable_db_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_S3Import_basic(rName string) string {
+func testAccInstanceConfig_S3Import_basic(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return acctest.ConfigCompose(
 		testAccInstanceConfig_baseS3Import(rName),
 		fmt.Sprintf(`
@@ -6933,7 +6949,7 @@ resource "aws_db_instance" "test" {
 `, rName, mySQLPreferredInstanceClasses))
 }
 
-func testAccInstanceConfig_ReplicateSourceDB_deletionProtection(rName string, deletionProtection bool) string {
+func testAccInstanceConfig_ReplicateSourceDB_deletionProtection(rName string, deletionProtection bool) string { //nolint:unused // This function is used in a skipped acceptance test
 	return acctest.ConfigCompose(testAccInstanceConfig_orderableClassMySQL(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
@@ -8372,7 +8388,7 @@ resource "aws_db_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_SnapshotID_Tags_clear(rName string) string {
+func testAccInstanceConfig_SnapshotID_tagsRemove(rName string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return acctest.ConfigCompose(
 		testAccInstanceConfig_orderableClassMariadb(),
 		fmt.Sprintf(`

--- a/internal/service/redshift/consts.go
+++ b/internal/service/redshift/consts.go
@@ -2,7 +2,6 @@ package redshift
 
 import "time"
 
-//nolint:deadcode,varcheck // These constants are missing from the AWS SDK
 const (
 	clusterAvailabilityStatusAvailable   = "Available"
 	clusterAvailabilityStatusFailed      = "Failed"

--- a/internal/service/route53/list_pages.go
+++ b/internal/service/route53/list_pages.go
@@ -12,11 +12,11 @@ import (
 
 // Custom Route 53 service lister functions using the same format as generated code.
 
-func listTrafficPolicyInstancesPages(conn *route53.Route53, input *route53.ListTrafficPolicyInstancesInput, fn func(*route53.ListTrafficPolicyInstancesOutput, bool) bool) error { //nolint:deadcode // This function is called from a sweeper.
+func listTrafficPolicyInstancesPages(conn *route53.Route53, input *route53.ListTrafficPolicyInstancesInput, fn func(*route53.ListTrafficPolicyInstancesOutput, bool) bool) error { //nolint:unused // This function is called from a sweeper.
 	return listTrafficPolicyInstancesPagesWithContext(context.Background(), conn, input, fn)
 }
 
-func listTrafficPolicyInstancesPagesWithContext(ctx context.Context, conn *route53.Route53, input *route53.ListTrafficPolicyInstancesInput, fn func(*route53.ListTrafficPolicyInstancesOutput, bool) bool) error {
+func listTrafficPolicyInstancesPagesWithContext(ctx context.Context, conn *route53.Route53, input *route53.ListTrafficPolicyInstancesInput, fn func(*route53.ListTrafficPolicyInstancesOutput, bool) bool) error { //nolint:unused // This function is called from a sweeper.
 	for {
 		output, err := conn.ListTrafficPolicyInstancesWithContext(ctx, input)
 		if err != nil {

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1952,7 +1952,7 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 }`, rName, rNameDestination)
 }
 
-func testAccBucketReplicationConfigurationConfig_existingObject(rName, rNameDestination string) string {
+func testAccBucketReplicationConfigurationConfig_existingObject(rName, rNameDestination string) string { //nolint:unused // used in skipped acceptance test
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/s3control/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3control/bucket_lifecycle_configuration_test.go
@@ -575,7 +575,7 @@ resource "aws_s3control_bucket_lifecycle_configuration" "test" {
 `, rName, days)
 }
 
-func testAccBucketLifecycleConfigurationConfig_ruleExpirationExpiredObjectDeleteMarker(rName string, expiredObjectDeleteMarker bool) string {
+func testAccBucketLifecycleConfigurationConfig_ruleExpirationExpiredObjectDeleteMarker(rName string, expiredObjectDeleteMarker bool) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/s3control/bucket_test.go
+++ b/internal/service/s3control/bucket_test.go
@@ -196,7 +196,7 @@ resource "aws_s3control_bucket" "test" {
 `, rName)
 }
 
-func testAccBucketConfig_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccBucketConfig_tags1(rName, tagKey1, tagValue1 string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -215,7 +215,7 @@ resource "aws_s3control_bucket" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccBucketConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccBucketConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string { //nolint:unused // This function is used in a skipped acceptance test
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 

--- a/internal/service/ses/template_test.go
+++ b/internal/service/ses/template_test.go
@@ -47,7 +47,6 @@ func TestAccSESTemplate_basic(t *testing.T) {
 }
 
 func TestAccSESTemplate_update(t *testing.T) {
-	acctest.Skip(t, "Skip due to SES.UpdateTemplate eventual consistency issues")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ses_template.test"
 	var template ses.Template

--- a/internal/service/storagegateway/cached_iscsi_volume_test.go
+++ b/internal/service/storagegateway/cached_iscsi_volume_test.go
@@ -509,7 +509,7 @@ resource "aws_storagegateway_cached_iscsi_volume" "test" {
 `, rName))
 }
 
-func testAccCachediSCSIVolumeConfig_sourceARN(rName string) string {
+func testAccCachediSCSIVolumeConfig_sourceARN(rName string) string { //nolint:unused // This function is used in a skipped accteptance test.
 	return acctest.ConfigCompose(
 		testAccCachediSCSIVolumeBaseConfig(rName),
 		fmt.Sprintf(`

--- a/internal/service/storagegateway/enum.go
+++ b/internal/service/storagegateway/enum.go
@@ -108,7 +108,6 @@ const (
 	fileSystemAssociationDeleteTimeout = 10 * time.Minute
 )
 
-//nolint:deadcode,varcheck // These constants are missing from the AWS SDK
 const (
 	fileSystemAssociationStatusAvailable     = "AVAILABLE"
 	fileSystemAssociationStatusCreating      = "CREATING"


### PR DESCRIPTION
`golangci-lint` v1.49.0 deprecates `deadcode`, `structcheck`, and `varcheck`. `unused` is the suggested replacement.


Previously:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make lint

WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649. 
...
```

Now gets no warnings or errors.

Acceptance test results:

```
--- PASS: TestAccProvider_Region_commercial (113.47s)
--- PASS: TestAccProvider_Region_govCloud (115.88s)
--- PASS: TestAccProvider_Region_c2s (119.00s)
--- PASS: TestAccProvider_Region_sc2s (119.17s)
--- PASS: TestAccProvider_Region_stsRegion (122.11s)
--- PASS: TestAccProvider_Region_china (122.27s)
--- PASS: TestAccProvider_IgnoreTagsKeys_multiple (134.75s)
--- PASS: TestAccProvider_IgnoreTagsKeys_none (136.81s)
--- PASS: TestAccProvider_IgnoreTagsKeys_one (144.35s)
--- PASS: TestAccProvider_IgnoreTags_emptyBlock (146.21s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_none (147.12s)
--- PASS: TestAccProvider_DefaultTags_emptyBlock (147.92s)
--- PASS: TestAccProvider_unusualEndpoints (148.13s)
--- PASS: TestAccProvider_DefaultTagsTags_one (148.42s)
--- PASS: TestAccProvider_endpoints (148.99s)
--- PASS: TestAccProvider_AssumeRole_empty (153.35s)
--- PASS: TestAccProvider_DefaultTagsTags_multiple (57.53s)
--- PASS: TestAccProvider_DefaultTagsTags_none (55.31s)
--- PASS: TestAccProvider_fipsEndpoint (289.98s)
--- SKIP: TestAccCloudFormationStackSet_Parameters_default (0.00s)
--- SKIP: TestAccCloudFormationStackSet_Parameters_noEcho (0.00s)
--- SKIP: TestAccCloudFormationStackSet_PermissionModel_serviceManaged (0.00s)
--- SKIP: TestAccCloudFormationStackSetInstance_deploymentTargets (1.08s)
--- SKIP: TestAccCloudFormationStackSetInstance_operationPreferences (4.35s)
--- PASS: TestAccCloudFormationStackSet_disappears (101.89s)
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_name (0.00s)
--- PASS: TestAccCloudFormationStackSet_basic (117.44s)
--- PASS: TestAccCloudFormationStackSetInstance_disappears (223.71s)
--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (223.73s)
--- PASS: TestAccCloudFormationStackSet_description (231.75s)
--- PASS: TestAccCloudFormationStackSet_templateBody (243.93s)
--- PASS: TestAccCloudFormationStackSet_administrationRoleARN (244.07s)
--- PASS: TestAccCloudFormationStackSet_executionRoleName (244.21s)
--- PASS: TestAccCloudFormationStackSet_templateURL (246.24s)
--- PASS: TestAccCloudFormationStackSet_name (248.26s)
--- PASS: TestAccCloudFormationStackSetInstance_basic (248.75s)
--- PASS: TestAccCloudFormationStackSet_tags (356.80s)
--- PASS: TestAccCloudFormationStackSet_parameters (366.09s)
--- PASS: TestAccCodeBuildProject_SecondarySources_codeCommit (267.49s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_type (277.63s)
--- PASS: TestAccCloudFormationStackSetInstance_retainStack (413.53s)
--- PASS: TestAccCloudFormationStackSet_operationPreferences (462.63s)
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (467.79s)
--- PASS: TestAccCodeBuildProject_Artifacts_bucketOwnerAccess (396.39s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_namespaceType (399.35s)
--- PASS: TestAccCodeBuildProject_concurrentBuildLimit (407.35s)
--- PASS: TestAccCodeBuildProject_secondaryArtifacts (409.30s)
--- PASS: TestAccCodeBuildProject_Artifacts_name (411.01s)
--- PASS: TestAccCodeBuildProject_Environment_registryCredential (413.33s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName (414.68s)
--- PASS: TestAccCodeBuildProject_Artifacts_path (416.47s)
--- PASS: TestAccCodeBuildProject_Artifacts_namespaceType (418.47s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_path (420.15s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_packaging (427.08s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled (432.43s)
--- PASS: TestAccCodeBuildProject_Artifacts_overrideArtifactName (436.27s)
--- PASS: TestAccCodeBuildProject_Artifacts_type (436.45s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_location (437.18s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier (437.40s)
--- PASS: TestAccCodeBuildProject_Artifacts_packaging (437.74s)
--- PASS: TestAccCodeBuildProject_publicVisibility (539.56s)
--- PASS: TestAccCodeBuildProject_SourceType_noSourceInvalid (166.31s)
--- PASS: TestAccCodeBuildProject_armContainer (218.65s)
--- PASS: TestAccCodeBuildProject_Artifacts_location (356.92s)
--- PASS: TestAccCodeBuildProject_Artifacts_encryptionDisabled (349.84s)
--- PASS: TestAccCodeBuildProject_SourceType_noSource (222.61s)
--- PASS: TestAccCodeBuildProject_windowsServer2019Container (230.08s)
--- PASS: TestAccCodeBuildProject_SourceType_codeCommit (217.77s)
--- PASS: TestAccCodeBuildProject_SourceType_gitHubEnterprise (226.54s)
--- PASS: TestAccCodeBuildProject_SourceType_s3 (231.27s)
--- PASS: TestAccCodeBuildProject_SourceType_codePipeline (234.37s)
--- PASS: TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise (224.99s)
--- PASS: TestAccCodeBuildProject_SourceType_bitbucket (230.38s)
--- PASS: TestAccCodeBuildProject_Artifacts_artifactIdentifier (364.23s)
--- PASS: TestAccCodeBuildProject_tags (372.18s)
--- PASS: TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket (391.48s)
--- PASS: TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise (400.88s)
--- PASS: TestAccCodeBuildProject_Source_insecureSSL (408.10s)
--- PASS: TestAccCodeBuildProject_SourceReportBuildStatus_gitHub (412.05s)
--- PASS: TestAccDataSyncTask_basic (498.69s)
--- PASS: TestAccCodeBuildProject_Environment_certificate (303.45s)
--- PASS: TestAccCodeBuildProject_vpc (581.49s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise (411.46s)
--- PASS: TestAccDataSyncTask_disappears (627.40s)
--- PASS: TestAccCodeBuildProject_sourceVersion (206.01s)
--- PASS: TestAccCodeBuildProject_encryptionKey (237.51s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub (457.46s)
--- PASS: TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise (466.23s)
--- PASS: TestAccCodeBuildProject_SourceGitSubmodules_codeCommit (457.24s)
--- PASS: TestAccCodeBuildProject_Source_gitCloneDepth (449.97s)
--- PASS: TestAccCodeBuildProject_SourceGitSubmodules_gitHub (457.61s)
--- PASS: TestAccCodeBuildProject_buildBatch (449.98s)
--- PASS: TestAccEC2CapacityReservation_basic (395.46s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit (597.64s)
--- PASS: TestAccCodeBuildProject_Logs_s3Logs (583.34s)
--- PASS: TestAccDataSyncTask_excludes (826.08s)
--- PASS: TestAccCodeBuildProject_Logs_cloudWatchLogs (586.49s)
--- PASS: TestAccCodeBuildProject_description (392.61s)
--- PASS: TestAccCodeBuildProject_badgeEnabled (208.13s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_transferMode (842.77s)
--- PASS: TestAccCodeBuildProject_disappears (195.27s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesVersions (723.87s)
--- PASS: TestAccCodeBuildProject_basic (188.41s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_preserveDeletedFiles (860.47s)
--- PASS: TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type (525.94s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_gid (887.39s)
--- PASS: TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value (639.39s)
--- PASS: TestAccCodeBuildProject_buildTimeout (312.47s)
--- PASS: TestAccCodeBuildProject_queuedTimeout (314.38s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_uid (896.65s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_posixPermissions (897.21s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_taskQueueing (900.66s)
--- PASS: TestAccCodeBuildProject_Environment_environmentVariable (529.63s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_preserveDevices (920.77s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_bytesPerSecond (930.87s)
--- PASS: TestAccDataSyncTask_cloudWatchLogGroupARN (932.95s)
--- PASS: TestAccDataSyncTask_includes (933.73s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_logLevel (933.77s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_overwriteMode (941.42s)
--- PASS: TestAccCodeBuildProject_fileSystemLocations (506.84s)
--- PASS: TestAccDataSyncTask_schedule (943.92s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_atimeMtime (950.15s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_defaultTargetCapacityType (610.53s)
--- PASS: TestAccEC2SpotFleetRequest_placementTenancyAndGroup (616.25s)
--- PASS: TestAccDataSyncTask_tags (988.80s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_verifyMode (997.48s)
--- PASS: TestAccEC2SpotFleetRequest_withEBSDisk (628.09s)
--- PASS: TestAccEC2SpotFleetRequest_LaunchSpecificationRootBlockDevice_kmsKeyID (632.85s)
--- PASS: TestAccEC2SpotFleetRequest_LaunchSpecificationEBSBlockDevice_kmsKeyID (632.88s)
--- PASS: TestAccEC2SpotFleetRequest_noTerminateInstancesWithExpiration (638.98s)
--- PASS: TestAccEC2SpotFleetRequest_LaunchSpecification_rootBlockDeviceGP3 (640.56s)
--- PASS: TestAccEC2SpotFleetRequest_withoutSpotPrice (644.67s)
--- PASS: TestAccEC2SpotFleetRequest_withInstanceStoreAMI (648.54s)
--- PASS: TestAccEC2SpotFleetRequest_overridingSpotPrice (648.84s)
--- PASS: TestAccEC2SpotFleetRequest_withTags (654.07s)
--- PASS: TestAccEC2SpotFleetRequest_withWeightedCapacity (658.17s)
--- PASS: TestAccEC2SpotFleetRequest_diversifiedAllocation (658.17s)
--- PASS: TestAccEC2SpotFleetRequest_multipleInstancePools (659.09s)
--- PASS: TestAccEC2SpotFleetRequest_LaunchSpecification_ebsBlockDeviceGP3 (659.88s)
--- PASS: TestAccEC2SpotFleetRequest_capacityRebalance (660.89s)
--- PASS: TestAccEC2SpotFleetRequest_withELBs (682.27s)
--- PASS: TestAccCodeBuildProject_cache (514.91s)
--- PASS: TestAccEC2SpotFleetRequest_withTargetGroups (759.70s)
--- PASS: TestAccEC2SpotFleetRequest_multipleInstanceTypesInSameSubnet (394.69s)
--- PASS: TestAccEC2SpotFleetRequest_multipleInstanceTypesInSameAz (188.81s)
--- PASS: TestAccEC2SpotFleetRequest_Zero_capacity (802.47s)
--- PASS: TestAccEC2SpotFleetRequest_lowestPriceAzOrSubnetInRegion (227.32s)
--- PASS: TestAccEC2SpotFleetRequest_lowestPriceSubnetInGivenList (256.68s)
--- PASS: TestAccEC2SpotFleetRequest_lowestPriceAzInGivenList (272.98s)
--- PASS: TestAccEC2SpotFleetRequest_fleetType (259.95s)
--- PASS: TestAccEC2SpotFleetRequest_iamInstanceProfileARN (264.03s)
--- PASS: TestAccEC2SpotFleetRequest_instanceInterruptionBehavior (260.84s)
--- PASS: TestAccEC2SpotFleetRequest_onDemandAllocationStrategy (269.37s)
--- PASS: TestAccEC2SpotFleetRequest_launchTemplateWithInstanceRequirementsOverrides (267.31s)
--- PASS: TestAccEC2SpotFleetRequest_onDemandMaxTotalPrice (273.27s)
--- PASS: TestAccEC2SpotFleetRequest_launchTemplateWithInstanceTypeOverrides (285.88s)
--- PASS: TestAccEC2SpotFleetRequest_LaunchTemplate_multiple (225.54s)
--- PASS: TestAccEC2SpotFleetRequest_launchTemplate (206.24s)
--- PASS: TestAccEC2SpotFleetRequest_associatePublicIPAddress (206.39s)
--- PASS: TestAccEC2Fleet_disappears (109.10s)
--- PASS: TestAccEC2Fleet_type (136.33s)
--- PASS: TestAccEC2Fleet_capacityRebalanceInvalidType (32.42s)
--- PASS: TestAccEC2SpotFleetRequest_disappears (222.74s)
--- PASS: TestAccEC2SpotFleetRequest_updateExcessCapacityTerminationPolicy (455.85s)
--- PASS: TestAccEC2SpotFleetRequest_launchSpecToLaunchTemplate (449.41s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_spot (147.32s)
--- PASS: TestAccEC2SpotFleetRequest_launchTemplateToLaunchSpec (457.48s)
--- PASS: TestAccEC2SpotFleetRequest_changePriceForcesNewRequest (482.65s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecificationDefaultTargetCapacityType_onDemand (159.18s)
--- PASS: TestAccEC2SpotFleetRequest_basic (253.88s)
--- PASS: TestAccEC2Fleet_terminateInstancesWithExpiration (259.22s)
--- PASS: TestAccEC2Fleet_SpotOptions_capacityRebalance (166.31s)
--- PASS: TestAccEC2SpotFleetRequest_tags (446.75s)
--- SKIP: TestAccMediaConvertQueue_reservationPlanSettings (0.00s)
--- PASS: TestAccEC2SpotFleetRequest_onDemandTargetCapacity (609.68s)
--- PASS: TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount (266.15s)
--- PASS: TestAccMediaConvertQueue_disappears (67.00s)
--- PASS: TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior (307.69s)
--- PASS: TestAccEC2SpotFleetRequest_targetCapacityUnitType (463.91s)
--- PASS: TestAccEC2SpotFleetRequest_updateTargetCapacity (720.40s)
--- PASS: TestAccMediaConvertQueue_basic (108.88s)
--- PASS: TestAccEC2Fleet_replaceUnhealthyInstances (311.42s)
--- PASS: TestAccEC2Fleet_SpotOptions_allocationStrategy (318.76s)
--- PASS: TestAccEC2Fleet_OnDemandOptions_allocationStrategy (295.45s)
--- PASS: TestAccMediaConvertQueue_withDescription (151.37s)
--- PASS: TestAccMediaConvertQueue_withStatus (162.95s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType (505.24s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverrideWeightedCapacity_multiple (329.28s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_weightedCapacity (331.65s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice (184.20s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_subnetID (347.57s)
--- PASS: TestAccMediaConvertQueue_withTags (220.47s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverridePriority_multiple (338.67s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_priority (332.23s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (173.80s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_maxPrice (333.04s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_burstablePerformance (520.56s)
--- PASS: TestAccEC2Fleet_templateMultipleNetworkInterfaces (640.76s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity (677.95s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceType (374.88s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_requireHibernateSupport (393.70s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorageTypes (367.33s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_instanceGenerations (363.55s)
--- PASS: TestAccEC2Fleet_excessCapacityTerminationPolicy (324.81s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_excludedInstanceTypes (343.56s)
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
--- SKIP: TestAccRDSInstance_S3Import_basic (0.00s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_tagsRemove (0.00s)
--- SKIP: TestAccRDSInstance_coIPEnabled (0.27s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_enabledToDisabled (0.28s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_restoreToPointInTime (0.37s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_snapshotIdentifier (0.41s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_disabledToEnabled (14.87s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_totalLocalStorageGB (565.14s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTypes (344.79s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorNames (366.63s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_networkInterfaceCount (541.98s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorManufacturers (403.76s)
--- PASS: TestAccEC2CapacityReservation_instanceMatchCriteria (157.23s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount (401.81s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_localStorage (550.21s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_availabilityZone (351.00s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_version (347.58s)
--- PASS: TestAccEC2Fleet_basic (198.93s)
--- PASS: TestAccEC2CapacityReservation_tenancy (165.45s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps (528.84s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_bareMetal (528.84s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateName (334.77s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB (521.65s)
--- PASS: TestAccEC2CapacityReservation_ephemeralStorage (123.37s)
--- PASS: TestAccEC2CapacityReservation_ebsOptimized (111.77s)
--- PASS: TestAccEC2CapacityReservation_disappears (87.90s)
--- PASS: TestAccEC2Fleet_LaunchTemplateOverride_instanceRequirements_acceleratorCount (526.67s)
--- PASS: TestAccEC2CapacityReservation_instanceType (188.86s)
--- PASS: TestAccEC2CapacityReservation_instanceCount (173.00s)
--- PASS: TestAccEC2CapacityReservation_tags (246.34s)
--- PASS: TestAccEC2CapacityReservation_endDate (149.36s)
--- PASS: TestAccEC2Fleet_LaunchTemplateLaunchTemplateSpecification_launchTemplateID (307.78s)
--- PASS: TestAccEC2Fleet_tags (302.18s)
--- PASS: TestAccEC2CapacityReservation_endDateType (202.39s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleExpiration_expiredObjectDeleteMarker (0.00s)
--- SKIP: TestAccS3ControlBucket_tags (0.00s)
--- SKIP: TestAccS3ControlBucketPolicy_disappears (0.33s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags (0.42s)
--- SKIP: TestAccS3ControlBucket_disappears (0.43s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_Rule_status (0.44s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleExpiration_date (0.44s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_disappears (0.52s)
--- SKIP: TestAccS3ControlBucketPolicy_policy (6.78s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_Rule_id (6.78s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleExpiration_days (6.81s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_basic (6.88s)
--- SKIP: TestAccS3ControlBucketPolicy_basic (6.88s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload_daysAfterInitiation (6.90s)
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_prefix (7.03s)
--- SKIP: TestAccS3ControlBucket_basic (7.04s)
--- PASS: TestAccSESTemplate_disappears (29.83s)
--- PASS: TestAccSESTemplate_basic (40.17s)
--- PASS: TestAccSESTemplate_update (71.21s)
--- SKIP: TestAccStorageGatewayCachediSCSIVolume_sourceVolumeARN (0.00s)
--- PASS: TestAccStorageGatewayCachediSCSIVolume_kms (229.39s)
--- PASS: TestAccStorageGatewayCachediSCSIVolume_basic (268.66s)
--- PASS: TestAccStorageGatewayCachediSCSIVolume_snapshotID (279.71s)
--- PASS: TestAccNetworkManagerTransitGatewayPeering_disappears (1450.59s)
--- PASS: TestAccRDSInstance_caCertificateIdentifier (1219.04s)
--- PASS: TestAccStorageGatewayCachediSCSIVolume_tags (305.36s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (1240.70s)
--- PASS: TestAccStorageGatewayCachediSCSIVolume_disappears (354.49s)
--- PASS: TestAccNetworkManagerTransitGatewayPeering_tags (1522.25s)
--- PASS: TestAccNetworkManagerTransitGatewayPeering_basic (1531.57s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (1343.42s)
--- PASS: TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic (1597.86s)
--- PASS: TestAccNetworkManagerTransitGatewayRouteTableAttachment_tags (1730.21s)
--- PASS: TestAccNetworkManagerTransitGatewayRouteTableAttachment_disappears (1870.62s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (1634.37s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (1716.17s)
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (1854.49s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (1883.99s)
--- PASS: TestAccRDSInstance_license (1884.70s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (1884.37s)
--- PASS: TestAccRDSInstance_minorVersion (686.40s)
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (740.23s)
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (1983.61s)
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (2045.26s)
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (2050.11s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (2063.02s)
--- PASS: TestAccRDSInstanceAutomatedBackupsReplication_basic (2232.38s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (2259.70s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (2398.61s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (2398.62s)
--- PASS: TestAccRDSInstance_portUpdate (706.18s)
--- PASS: TestAccRDSInstance_separateIopsUpdate (783.48s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (836.63s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (871.58s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared (0.00s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (1015.32s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1049.88s)
--- PASS: TestAccRDSInstance_monitoringInterval (1236.19s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1206.14s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1229.21s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1303.47s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1270.37s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (2088.82s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1182.32s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1219.13s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1386.70s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1111.45s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (959.76s)
--- PASS: TestAccRDSInstance_MSSQL_tz (2164.91s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1716.53s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1364.47s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1270.14s)
```