### PR TITLE
fix: retry find the association in resourceNetworkACLAssociationRead

### DIFF
--- a/.changelog/26838.txt
+++ b/.changelog/26838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_network_acl_association: Add retry to read step, resolving `empty result` error
+```


### PR DESCRIPTION
Signed-off-by: Ringo De Smet <ringo@de-smet.name>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #23142

Similar to [this comment](https://github.com/hashicorp/terraform-provider-aws/issues/23142#issuecomment-1099539922), we have frequent errors returning:

`Error: error reading EC2 Network ACL Association (aclassoc-XXXXX): empty result`

The change wraps a retry around the function to find the network acl association, until the `propagationTimeout` (currently 2 minutes). This lowers the nr of `emtpy result` cases for the network acl association drastically in the setups where we encountered this previously.

Output from acceptance testing:

```
make testacc TESTS='TestAccVPCNetworkACLAssociation_' PKG=ec2                                                                                                                                                       main ●  01:06 Dur  13:05:43
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLAssociation_'  -timeout 180m
=== RUN   TestAccVPCNetworkACLAssociation_basic
=== PAUSE TestAccVPCNetworkACLAssociation_basic
=== RUN   TestAccVPCNetworkACLAssociation_disappears
=== PAUSE TestAccVPCNetworkACLAssociation_disappears
=== RUN   TestAccVPCNetworkACLAssociation_disappears_NACL
=== PAUSE TestAccVPCNetworkACLAssociation_disappears_NACL
=== RUN   TestAccVPCNetworkACLAssociation_disappears_Subnet
=== PAUSE TestAccVPCNetworkACLAssociation_disappears_Subnet
=== RUN   TestAccVPCNetworkACLAssociation_twoAssociations
=== PAUSE TestAccVPCNetworkACLAssociation_twoAssociations
=== RUN   TestAccVPCNetworkACLAssociation_associateWithDefaultNACL
=== PAUSE TestAccVPCNetworkACLAssociation_associateWithDefaultNACL
=== CONT  TestAccVPCNetworkACLAssociation_basic
=== CONT  TestAccVPCNetworkACLAssociation_disappears_Subnet
=== CONT  TestAccVPCNetworkACLAssociation_disappears_NACL
=== CONT  TestAccVPCNetworkACLAssociation_associateWithDefaultNACL
=== CONT  TestAccVPCNetworkACLAssociation_disappears
=== CONT  TestAccVPCNetworkACLAssociation_twoAssociations
--- PASS: TestAccVPCNetworkACLAssociation_disappears_Subnet (47.24s)
--- PASS: TestAccVPCNetworkACLAssociation_disappears (47.72s)
--- PASS: TestAccVPCNetworkACLAssociation_disappears_NACL (47.73s)
--- PASS: TestAccVPCNetworkACLAssociation_associateWithDefaultNACL (50.77s)
--- PASS: TestAccVPCNetworkACLAssociation_basic (51.21s)
--- PASS: TestAccVPCNetworkACLAssociation_twoAssociations (57.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        59.880s
Time: 0h:01m:14s                                                                         
```
