### PR TITLE
r/aws_ec2_managed_prefix_list - Fix: `MaxEntries` and `Entry` can be changed in same apply

### DIFF
--- a/.changelog/26845.txt
+++ b/.changelog/26845.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_managed_prefix_list: MaxEntires and Entry(s) can now be changed in the same apply
+```

--- a/.changelog/26845.txt
+++ b/.changelog/26845.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ec2_managed_prefix_list: MaxEntires and Entry(s) can now be changed in the same apply
+resource/aws_ec2_managed_prefix_list: MaxEntries and Entry(s) can now be changed in the same apply
 ```

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -276,7 +276,7 @@ func resourceManagedPrefixListUpdate(ctx context.Context, d *schema.ResourceData
 
 			if len(removals) > 0 {
 				input.RemoveEntries = removals
-
+			} else {
 				// Prevent this error if RemoveEntries is list with no elements after removals:
 				//   InvalidRequest: The request received was invalid.
 				input.RemoveEntries = nil

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -483,12 +483,12 @@ resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
 
   dynamic entry {
-	for_each = toset(slice(["1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8"], 0, %[2]d))
+	  for_each = toset(slice(["1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8"], 0, %[2]d))
 
-	content {
-		cidr        = entry.key
-		description = entry.key
-	}
+	  content {
+      cidr        = entry.key
+      description = entry.key
+	  }
   }
 }
 `, rName, maxEntryLength)

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -483,12 +483,12 @@ resource "aws_ec2_managed_prefix_list" "test" {
   name           = %[1]q
 
   dynamic entry {
-	  for_each = toset(slice(["1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8"], 0, %[2]d))
+    for_each = toset(slice(["1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8"], 0, %[2]d))
 
-	  content {
+    content {
       cidr        = entry.key
       description = entry.key
-	  }
+    }
   }
 }
 `, rName, maxEntryLength)

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -218,6 +218,49 @@ func TestAccVPCManagedPrefixList_Entry_description(t *testing.T) {
 	})
 }
 
+func TestAccVPCManagedPrefixList_updateEntryAndMaxEntry(t *testing.T) {
+	resourceName := "aws_ec2_managed_prefix_list.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckManagedPrefixList(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckManagedPrefixListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:       testAccVPCManagedPrefixListConfig_entryMaxEntry(rName, 2),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccManagedPrefixListExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "2"),
+				),
+			},
+			{
+				Config:       testAccVPCManagedPrefixListConfig_entryMaxEntry(rName, 3),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccManagedPrefixListExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:       testAccVPCManagedPrefixListConfig_entryMaxEntry(rName, 1),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccManagedPrefixListExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCManagedPrefixList_name(t *testing.T) {
 	resourceName := "aws_ec2_managed_prefix_list.test"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -430,6 +473,25 @@ resource "aws_ec2_managed_prefix_list" "test" {
   }
 }
 `, rName, description)
+}
+
+func testAccVPCManagedPrefixListConfig_entryMaxEntry(rName string, maxEntryLength int) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = %[2]d
+  name           = %[1]q
+
+  dynamic entry {
+	for_each = toset(slice(["1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8"], 0, %[2]d))
+
+	content {
+		cidr        = entry.key
+		description = entry.key
+	}
+  }
+}
+`, rName, maxEntryLength)
 }
 
 func testAccVPCManagedPrefixListConfig_name(rName string) string {


### PR DESCRIPTION
Closes #26639

Output from acceptance testing:

```
$ make testacc TESTS=TestAccVPCManagedPrefixList PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCManagedPrefixList'  -timeout 180m
=== RUN   TestAccVPCManagedPrefixListDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListDataSource_basic
=== RUN   TestAccVPCManagedPrefixListDataSource_filter
=== PAUSE TestAccVPCManagedPrefixListDataSource_filter
=== RUN   TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== PAUSE TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== RUN   TestAccVPCManagedPrefixListEntry_ipv4
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv4
=== RUN   TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== RUN   TestAccVPCManagedPrefixListEntry_ipv6
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv6
=== RUN   TestAccVPCManagedPrefixListEntry_expectInvalidTypeError
=== PAUSE TestAccVPCManagedPrefixListEntry_expectInvalidTypeError
=== RUN   TestAccVPCManagedPrefixListEntry_expectInvalidCIDR
=== PAUSE TestAccVPCManagedPrefixListEntry_expectInvalidCIDR
=== RUN   TestAccVPCManagedPrefixListEntry_description
=== PAUSE TestAccVPCManagedPrefixListEntry_description
=== RUN   TestAccVPCManagedPrefixListEntry_disappears
=== PAUSE TestAccVPCManagedPrefixListEntry_disappears
=== RUN   TestAccVPCManagedPrefixList_basic
=== PAUSE TestAccVPCManagedPrefixList_basic
=== RUN   TestAccVPCManagedPrefixList_disappears
=== PAUSE TestAccVPCManagedPrefixList_disappears
=== RUN   TestAccVPCManagedPrefixList_AddressFamily_ipv6
=== PAUSE TestAccVPCManagedPrefixList_AddressFamily_ipv6
=== RUN   TestAccVPCManagedPrefixList_Entry_cidr
=== PAUSE TestAccVPCManagedPrefixList_Entry_cidr
=== RUN   TestAccVPCManagedPrefixList_Entry_description
=== PAUSE TestAccVPCManagedPrefixList_Entry_description
=== RUN   TestAccVPCManagedPrefixList_updateEntryAndMaxEntry
=== PAUSE TestAccVPCManagedPrefixList_updateEntryAndMaxEntry
=== RUN   TestAccVPCManagedPrefixList_name
=== PAUSE TestAccVPCManagedPrefixList_name
=== RUN   TestAccVPCManagedPrefixList_tags
=== PAUSE TestAccVPCManagedPrefixList_tags
=== RUN   TestAccVPCManagedPrefixListsDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListsDataSource_basic
=== RUN   TestAccVPCManagedPrefixListsDataSource_tags
=== PAUSE TestAccVPCManagedPrefixListsDataSource_tags
=== RUN   TestAccVPCManagedPrefixListsDataSource_noMatches
=== PAUSE TestAccVPCManagedPrefixListsDataSource_noMatches
=== CONT  TestAccVPCManagedPrefixListDataSource_basic
=== CONT  TestAccVPCManagedPrefixList_disappears
=== CONT  TestAccVPCManagedPrefixList_name
=== CONT  TestAccVPCManagedPrefixList_AddressFamily_ipv6
=== CONT  TestAccVPCManagedPrefixListsDataSource_tags
=== CONT  TestAccVPCManagedPrefixList_updateEntryAndMaxEntry
=== CONT  TestAccVPCManagedPrefixListsDataSource_basic
=== CONT  TestAccVPCManagedPrefixList_Entry_description
=== CONT  TestAccVPCManagedPrefixListEntry_expectInvalidTypeError
=== CONT  TestAccVPCManagedPrefixList_Entry_cidr
=== CONT  TestAccVPCManagedPrefixList_basic
=== CONT  TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== CONT  TestAccVPCManagedPrefixListEntry_description
=== CONT  TestAccVPCManagedPrefixListEntry_disappears
=== CONT  TestAccVPCManagedPrefixListsDataSource_noMatches
=== CONT  TestAccVPCManagedPrefixListEntry_ipv4
=== CONT  TestAccVPCManagedPrefixListEntry_ipv6
=== CONT  TestAccVPCManagedPrefixList_tags
=== CONT  TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== CONT  TestAccVPCManagedPrefixListDataSource_filter
--- PASS: TestAccVPCManagedPrefixListEntry_expectInvalidTypeError (11.44s)
=== CONT  TestAccVPCManagedPrefixListEntry_expectInvalidCIDR
--- PASS: TestAccVPCManagedPrefixListDataSource_matchesTooMany (21.29s)
--- PASS: TestAccVPCManagedPrefixListEntry_expectInvalidCIDR (17.40s)
--- PASS: TestAccVPCManagedPrefixList_disappears (81.41s)
--- PASS: TestAccVPCManagedPrefixListsDataSource_noMatches (82.23s)
--- PASS: TestAccVPCManagedPrefixListDataSource_basic (83.32s)
--- PASS: TestAccVPCManagedPrefixListsDataSource_basic (84.19s)
--- PASS: TestAccVPCManagedPrefixListDataSource_filter (87.24s)
--- PASS: TestAccVPCManagedPrefixListsDataSource_tags (95.10s)
--- PASS: TestAccVPCManagedPrefixListEntry_disappears (96.67s)
--- PASS: TestAccVPCManagedPrefixListEntry_ipv4Multiple (101.23s)
--- PASS: TestAccVPCManagedPrefixList_AddressFamily_ipv6 (107.37s)
--- PASS: TestAccVPCManagedPrefixListEntry_description (107.97s)
--- PASS: TestAccVPCManagedPrefixListEntry_ipv6 (108.65s)
--- PASS: TestAccVPCManagedPrefixListEntry_ipv4 (108.81s)
--- PASS: TestAccVPCManagedPrefixList_name (131.27s)
--- PASS: TestAccVPCManagedPrefixList_Entry_description (134.53s)
--- PASS: TestAccVPCManagedPrefixList_basic (139.63s)
--- PASS: TestAccVPCManagedPrefixList_Entry_cidr (141.11s)
--- PASS: TestAccVPCManagedPrefixList_tags (151.47s)
--- PASS: TestAccVPCManagedPrefixList_updateEntryAndMaxEntry (158.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	162.623
...
```