### PR TITLE
WIP: Updated indexing_configuration thing_indexing_configuration with filter

### DIFF
--- a/.changelog/26859.txt
+++ b/.changelog/26859.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_indexing_configuration: Add filter to thing_indexing_configuration, resolving `InvalidRequestException: NamedShadowNames Filter must not be empty for enabling NamedShadowIndexingMode` error
+```

--- a/internal/service/iot/indexing_configuration.go
+++ b/internal/service/iot/indexing_configuration.go
@@ -3,6 +3,7 @@ package iot
 import (
 	"context"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -104,6 +105,30 @@ func ResourceIndexingConfiguration() *schema.Resource {
 							Optional:     true,
 							Default:      iot.DeviceDefenderIndexingModeOff,
 							ValidateFunc: validation.StringInSlice(iot.DeviceDefenderIndexingMode_Values(), false),
+						},
+						"filter": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"named_shadow_names": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Computed: true,
+										MinItems: 1,
+										MaxItems: 10, // TODO What should this be? 10 or 64? https://docs.aws.amazon.com/iot/latest/apireference/API_IndexingFilter.html
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(1, 64),
+												validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9:_-]+`), "must contain only alphanumeric characters, underscores, colons, and hyphens"),
+											),
+										},
+									},
+								},
+							},
 						},
 						"managed_field": {
 							Type:     schema.TypeSet,

--- a/internal/service/iot/indexing_configuration_test.go
+++ b/internal/service/iot/indexing_configuration_test.go
@@ -91,6 +91,8 @@ func testAccIndexingConfiguration_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.named_shadow_indexing_mode", "ON"),
 					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.thing_connectivity_indexing_mode", "STATUS"),
 					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.thing_indexing_mode", "REGISTRY_AND_SHADOW"),
+					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.filter.named_shadow_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.filter.named_shadow_names.0", "thing1shadow"),
 				),
 			},
 			{
@@ -125,6 +127,10 @@ resource "aws_iot_indexing_configuration" "test" {
     thing_connectivity_indexing_mode = "STATUS"
     device_defender_indexing_mode    = "VIOLATIONS"
     named_shadow_indexing_mode       = "ON"
+
+	filter {
+      named_shadow_names = [ "thing1shadow" ]
+    }
 
     custom_field {
       name = "attributes.version"

--- a/website/docs/r/iot_indexing_configuration.html.markdown
+++ b/website/docs/r/iot_indexing_configuration.html.markdown
@@ -19,6 +19,10 @@ resource "aws_iot_indexing_configuration" "example" {
     thing_connectivity_indexing_mode = "STATUS"
     device_defender_indexing_mode    = "VIOLATIONS"
     named_shadow_indexing_mode       = "ON"
+    
+    filter {
+      named_shadow_name = [ "thing1shadow" ]
+    }
 
     custom_field {
       name = "shadow.desired.power"
@@ -61,6 +65,7 @@ The `thing_indexing_configuration` configuration block supports the following:
 * `device_defender_indexing_mode` - (Optional) Device Defender indexing mode. Valid values: `VIOLATIONS`, `OFF`. Default: `OFF`.
 * `managed_field` - (Optional) Contains fields that are indexed and whose types are already known by the Fleet Indexing service. See below.
 * `named_shadow_indexing_mode` - (Optional) [Named shadow](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html) indexing mode. Valid values: `ON`, `OFF`. Default: `OFF`.
+* `filter` - (Optional) Required if `named_shadow_indexing_mode` is `ON`. Enables to add named shadows filtered by `filter` to fleet indexing configuration.
 * `thing_connectivity_indexing_mode` - (Optional) Thing connectivity indexing mode. Valid values: `STATUS`, `OFF`. Default: `OFF`.
 * `thing_indexing_mode` - (Required) Thing indexing mode. Valid values: `REGISTRY`, `REGISTRY_AND_SHADOW`, `OFF`.
 
@@ -70,6 +75,11 @@ The `custom_field` and `managed_field` configuration blocks supports the followi
 
 * `name` - (Optional) The name of the field.
 * `type` - (Optional) The data type of the field. Valid values: `Number`, `String`, `Boolean`.
+
+### filter
+
+The `filter` configuration block supports the following:
+* `named_shadow_names` - (Optional) List of shadow names that you select to index. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
AWS updated the [Create|Get|Update]IndexingConfiguration requests with a new optional parameter: filter 
This filter attribute is required, when named_shadow_indexing_mode is set to ON. https://docs.aws.amazon.com/iot/latest/apireference/API_ThingIndexingConfiguration.html

If filter is missing in the described case above, then the following error message is returned when trying to add a similar configuration:

```
resource "aws_iot_indexing_configuration" "indexing-config" {
  thing_indexing_configuration {
    thing_indexing_mode              = "REGISTRY_AND_SHADOW"
    thing_connectivity_indexing_mode = "STATUS"
    named_shadow_indexing_mode       = "ON"

    custom_field {
      name = "shadow.name.shadowName.desired.someStringValue"
      type = "String"
    }
  }
}
```


```
Error: error updating IoT Indexing Configuration: InvalidRequestException: NamedShadowNames Filter must not be empty for enabling NamedShadowIndexingMode
```

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/

If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates 

For Example:

Relates #0000
or 
Closes #0000
--->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
