### PR TITLE
f-aws_ec2_traffic_mirror_target

### DIFF
--- a/.changelog/26767.txt
+++ b/.changelog/26767.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_traffic_mirror_target: Add `gateway_load_balancer_endpoint_id` argument
+```

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -73,6 +73,7 @@ const (
 	errCodeInvalidSubnetCIDRReservationIDNotFound         = "InvalidSubnetCidrReservationID.NotFound"
 	errCodeInvalidSubnetIDNotFound                        = "InvalidSubnetID.NotFound"
 	errCodeInvalidSubnetIdNotFound                        = "InvalidSubnetId.NotFound"
+	errCodeInvalidTrafficMirrorTargetIdNotFound           = "InvalidTrafficMirrorTargetId.NotFound"
 	errCodeInvalidTransitGatewayAttachmentIDNotFound      = "InvalidTransitGatewayAttachmentID.NotFound"
 	errCodeInvalidTransitGatewayConnectPeerIDNotFound     = "InvalidTransitGatewayConnectPeerID.NotFound"
 	errCodeInvalidTransitGatewayIDNotFound                = "InvalidTransitGatewayID.NotFound"

--- a/internal/service/ec2/vpc_traffic_mirror_target.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target.go
@@ -36,11 +36,22 @@ func ResourceTrafficMirrorTarget() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"gateway_load_balancer_endpoint_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ExactlyOneOf: []string{
+					"gateway_load_balancer_endpoint_id",
+					"network_interface_id",
+					"network_load_balancer_arn",
+				},
+			},
 			"network_interface_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				ExactlyOneOf: []string{
+					"gateway_load_balancer_endpoint_id",
 					"network_interface_id",
 					"network_load_balancer_arn",
 				},
@@ -50,6 +61,7 @@ func ResourceTrafficMirrorTarget() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ExactlyOneOf: []string{
+					"gateway_load_balancer_endpoint_id",
 					"network_interface_id",
 					"network_load_balancer_arn",
 				},
@@ -74,6 +86,10 @@ func resourceTrafficMirrorTargetCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("gateway_load_balancer_endpoint_id"); ok {
+		input.GatewayLoadBalancerEndpointId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("network_interface_id"); ok {
@@ -141,6 +157,7 @@ func resourceTrafficMirrorTargetRead(d *schema.ResourceData, meta interface{}) e
 
 	target := out.TrafficMirrorTargets[0]
 	d.Set("description", target.Description)
+	d.Set("gateway_load_balancer_endpoint_id", target.GatewayLoadBalancerEndpointId)
 	d.Set("network_interface_id", target.NetworkInterfaceId)
 	d.Set("network_load_balancer_arn", target.NetworkLoadBalancerArn)
 

--- a/internal/service/ec2/vpc_traffic_mirror_target.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target.go
@@ -7,10 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -104,26 +104,13 @@ func resourceTrafficMirrorTargetCreate(d *schema.ResourceData, meta interface{})
 		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeTrafficMirrorTarget)
 	}
 
-	out, err := conn.CreateTrafficMirrorTarget(input)
+	output, err := conn.CreateTrafficMirrorTarget(input)
+
 	if err != nil {
-		return fmt.Errorf("Error creating traffic mirror target %v", err)
+		return fmt.Errorf("creating EC2 Traffic Mirror Target: %w", err)
 	}
 
-	d.SetId(aws.StringValue(out.TrafficMirrorTarget.TrafficMirrorTargetId))
-
-	return resourceTrafficMirrorTargetRead(d, meta)
-}
-
-func resourceTrafficMirrorTargetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).EC2Conn
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating EC2 Traffic Mirror Target (%s) tags: %s", d.Id(), err)
-		}
-	}
+	d.SetId(aws.StringValue(output.TrafficMirrorTarget.TrafficMirrorTargetId))
 
 	return resourceTrafficMirrorTargetRead(d, meta)
 }
@@ -133,71 +120,71 @@ func resourceTrafficMirrorTargetRead(d *schema.ResourceData, meta interface{}) e
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	targetId := d.Id()
-	input := &ec2.DescribeTrafficMirrorTargetsInput{
-		TrafficMirrorTargetIds: []*string{&targetId},
-	}
+	target, err := FindTrafficMirrorTargetByID(conn, d.Id())
 
-	out, err := conn.DescribeTrafficMirrorTargets(input)
-	if tfawserr.ErrCodeEquals(err, "InvalidTrafficMirrorTargetId.NotFound") {
-		log.Printf("[WARN] EC2 Traffic Mirror Target (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] EC2 Traffic Mirror Target %s not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error describing EC2 Traffic Mirror Target (%s): %w", targetId, err)
+		return fmt.Errorf("reading EC2 Traffic Mirror Target (%s): %w", d.Id(), err)
 	}
 
-	if out == nil || len(out.TrafficMirrorTargets) == 0 {
-		log.Printf("[WARN] EC2 Traffic Mirror Target (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	target := out.TrafficMirrorTargets[0]
+	ownerID := aws.StringValue(target.OwnerId)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   ec2.ServiceName,
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: ownerID,
+		Resource:  fmt.Sprintf("traffic-mirror-target/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 	d.Set("description", target.Description)
 	d.Set("gateway_load_balancer_endpoint_id", target.GatewayLoadBalancerEndpointId)
 	d.Set("network_interface_id", target.NetworkInterfaceId)
 	d.Set("network_load_balancer_arn", target.NetworkLoadBalancerArn)
+	d.Set("owner_id", ownerID)
 
 	tags := KeyValueTags(target.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
-	d.Set("owner_id", target.OwnerId)
-
-	arn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Service:   ec2.ServiceName,
-		Region:    meta.(*conns.AWSClient).Region,
-		AccountID: aws.StringValue(target.OwnerId),
-		Resource:  fmt.Sprintf("traffic-mirror-target/%s", d.Id()),
-	}.String()
-
-	d.Set("arn", arn)
-
 	return nil
+}
+
+func resourceTrafficMirrorTargetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("updating EC2 Traffic Mirror Target (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceTrafficMirrorTargetRead(d, meta)
 }
 
 func resourceTrafficMirrorTargetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	targetId := d.Id()
-	input := &ec2.DeleteTrafficMirrorTargetInput{
-		TrafficMirrorTargetId: &targetId,
-	}
+	log.Printf("[DEBUG] Deleting EC2 Traffic Mirror Target: %s", d.Id())
+	_, err := conn.DeleteTrafficMirrorTarget(&ec2.DeleteTrafficMirrorTargetInput{
+		TrafficMirrorTargetId: aws.String(d.Id()),
+	})
 
-	_, err := conn.DeleteTrafficMirrorTarget(input)
 	if nil != err {
-		return fmt.Errorf("error deleting EC2 Traffic Mirror Target (%s): %w", targetId, err)
+		return fmt.Errorf("deleting EC2 Traffic Mirror Target (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -38,7 +38,7 @@ func TestAccVPCTrafficMirrorTarget_nlb(t *testing.T) {
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-target/tmt-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttrPair(resourceName, "network_load_balancer_arn", "aws_lb.lb", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_load_balancer_arn", "aws_lb.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -161,7 +161,6 @@ func TestAccVPCTrafficMirrorTarget_disappears(t *testing.T) {
 }
 
 func TestAccVPCTrafficMirrorTarget_gwlb(t *testing.T) {
-
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
 	description := "test gwlb endpoint target"
@@ -189,6 +188,36 @@ func TestAccVPCTrafficMirrorTarget_gwlb(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckTrafficMirrorTargetDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_traffic_mirror_target" {
+			continue
+		}
+
+		out, err := conn.DescribeTrafficMirrorTargets(&ec2.DescribeTrafficMirrorTargetsInput{
+			TrafficMirrorTargetIds: []*string{
+				aws.String(rs.Primary.ID),
+			},
+		})
+
+		if tfawserr.ErrCodeEquals(err, "InvalidTrafficMirrorTargetId.NotFound") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if len(out.TrafficMirrorTargets) != 0 {
+			return fmt.Errorf("Traffic mirror target %s still not destroyed", rs.Primary.ID)
+		}
+	}
+
+	return nil
 }
 
 func testAccCheckTrafficMirrorTargetExists(name string, target *ec2.TrafficMirrorTarget) resource.TestCheckFunc {
@@ -222,79 +251,33 @@ func testAccCheckTrafficMirrorTargetExists(name string, target *ec2.TrafficMirro
 	}
 }
 
-func testAccTrafficMirrorTargetConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "azs" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "vpc" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "sub1" {
-  vpc_id            = aws_vpc.vpc.id
-  cidr_block        = "10.0.0.0/24"
-  availability_zone = data.aws_availability_zones.azs.names[0]
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "sub2" {
-  vpc_id            = aws_vpc.vpc.id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = data.aws_availability_zones.azs.names[1]
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName)
-}
-
 func testAccVPCTrafficMirrorTargetConfig_nlb(rName, description string) string {
-	return acctest.ConfigCompose(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
-resource "aws_lb" "lb" {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_lb" "test" {
   name               = %[1]q
   internal           = true
   load_balancer_type = "network"
-  subnets            = [aws_subnet.sub1.id, aws_subnet.sub2.id]
+  subnets            = aws_subnet.test[*].id
 
   enable_deletion_protection = false
-
-  tags = {
-    Name        = %[1]q
-    Environment = "production"
-  }
 }
 
 resource "aws_ec2_traffic_mirror_target" "test" {
   description               = %[2]q
-  network_load_balancer_arn = aws_lb.lb.arn
+  network_load_balancer_arn = aws_lb.test.arn
 }
 `, rName, description))
 }
 
 func testAccVPCTrafficMirrorTargetConfig_eni(rName, description string) string {
 	return acctest.ConfigCompose(
-		testAccTrafficMirrorTargetConfigBase(rName),
+		acctest.ConfigVPCWithSubnets(rName, 1),
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
 		fmt.Sprintf(`
-resource "aws_instance" "src" {
+resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
-  subnet_id     = aws_subnet.sub1.id
+  subnet_id     = aws_subnet.test[0].id
 
   tags = {
     Name = %[1]q
@@ -303,30 +286,25 @@ resource "aws_instance" "src" {
 
 resource "aws_ec2_traffic_mirror_target" "test" {
   description          = %[2]q
-  network_interface_id = aws_instance.src.primary_network_interface_id
+  network_interface_id = aws_instance.test.primary_network_interface_id
 }
 `, rName, description))
 }
 
 func testAccVPCTrafficMirrorTargetConfig_tags1(rName, description, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
-resource "aws_lb" "lb" {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_lb" "test" {
   name               = %[1]q
   internal           = true
   load_balancer_type = "network"
-  subnets            = [aws_subnet.sub1.id, aws_subnet.sub2.id]
+  subnets            = aws_subnet.test[*].id
 
   enable_deletion_protection = false
-
-  tags = {
-    Name        = %[1]q
-    Environment = "production"
-  }
 }
 
 resource "aws_ec2_traffic_mirror_target" "test" {
   description               = %[2]q
-  network_load_balancer_arn = aws_lb.lb.arn
+  network_load_balancer_arn = aws_lb.test.arn
 
   tags = {
     %[3]q = %[4]q
@@ -336,24 +314,19 @@ resource "aws_ec2_traffic_mirror_target" "test" {
 }
 
 func testAccVPCTrafficMirrorTargetConfig_tags2(rName, description, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
-resource "aws_lb" "lb" {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_lb" "test" {
   name               = %[1]q
   internal           = true
   load_balancer_type = "network"
-  subnets            = [aws_subnet.sub1.id, aws_subnet.sub2.id]
+  subnets            = aws_subnet.test[*].id
 
   enable_deletion_protection = false
-
-  tags = {
-    Name        = %[1]q
-    Environment = "production"
-  }
 }
 
 resource "aws_ec2_traffic_mirror_target" "test" {
   description               = %[2]q
-  network_load_balancer_arn = aws_lb.lb.arn
+  network_load_balancer_arn = aws_lb.test.arn
 
   tags = {
     %[3]q = %[4]q
@@ -368,11 +341,10 @@ func testAccVPCTrafficMirrorTargetConfig_gwlb(rName, description string) string 
 		testAccVPCEndpointConfig_gatewayLoadBalancer(rName),
 		fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_target" "test" {
-  description                       = %[2]q
+  description                       = %[1]q
   gateway_load_balancer_endpoint_id = aws_vpc_endpoint.test.id
-  depends_on                        = [aws_vpc_endpoint.test]
 }
-`, rName, description))
+`, description))
 }
 
 func testAccPreCheckTrafficMirrorTarget(t *testing.T) {
@@ -387,34 +359,4 @@ func testAccPreCheckTrafficMirrorTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unexpected PreCheck error: ", err)
 	}
-}
-
-func testAccCheckTrafficMirrorTargetDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_ec2_traffic_mirror_target" {
-			continue
-		}
-
-		out, err := conn.DescribeTrafficMirrorTargets(&ec2.DescribeTrafficMirrorTargetsInput{
-			TrafficMirrorTargetIds: []*string{
-				aws.String(rs.Primary.ID),
-			},
-		})
-
-		if tfawserr.ErrCodeEquals(err, "InvalidTrafficMirrorTargetId.NotFound") {
-			continue
-		}
-
-		if err != nil {
-			return err
-		}
-
-		if len(out.TrafficMirrorTargets) != 0 {
-			return fmt.Errorf("Traffic mirror target %s still not destroyed", rs.Primary.ID)
-		}
-	}
-
-	return nil
 }

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -179,7 +179,7 @@ func TestAccVPCTrafficMirrorTarget_gwlb(t *testing.T) {
 				Config: testAccVPCTrafficMirrorTargetConfig_gwlb(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestMatchResourceAttr(resourceName, "gateway_load_balancer_endpoint_id", regexp.MustCompile("vpce-.*")),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_load_balancer_endpoint_id", "aws_vpc_endpoint.test", "id"),
 				),
 			},
 			{
@@ -365,7 +365,6 @@ resource "aws_ec2_traffic_mirror_target" "test" {
 
 func testAccVPCTrafficMirrorTargetConfig_gwlb(rName, description string) string {
 	return acctest.ConfigCompose(
-		//testAccTrafficMirrorTargetConfigBase(rName),
 		testAccVPCEndpointConfig_gatewayLoadBalancer(rName),
 		fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_target" "test" {

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -371,7 +371,7 @@ func testAccVPCTrafficMirrorTargetConfig_gwlb(rName, description string) string 
 resource "aws_ec2_traffic_mirror_target" "test" {
   description                       = %[2]q
   gateway_load_balancer_endpoint_id = aws_vpc_endpoint.test.id
-  depends_on                        = [aws_vpc_endpoint.test]						
+  depends_on                        = [aws_vpc_endpoint.test]
 }
 `, rName, description))
 }

--- a/website/docs/r/ec2_traffic_mirror_target.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_target.html.markdown
@@ -25,6 +25,11 @@ resource "aws_ec2_traffic_mirror_target" "eni" {
   description          = "ENI target"
   network_interface_id = aws_instance.test.primary_network_interface_id
 }
+
+resource "aws_ec2_traffic_mirror_target" "gwlb" {
+  description                       = "GWLB target"
+  gateway_load_balancer_endpoint_id = aws_lb.lb.arn
+}
 ```
 
 ## Argument Reference
@@ -34,6 +39,7 @@ The following arguments are supported:
 * `description` - (Optional, Forces new) A description of the traffic mirror session.
 * `network_interface_id` - (Optional, Forces new) The network interface ID that is associated with the target.
 * `network_load_balancer_arn` - (Optional, Forces new) The Amazon Resource Name (ARN) of the Network Load Balancer that is associated with the target.
+* `gateway_load_balancer_endpoint_id` - (Optional, Forces new) The VPC Endpoint Id of the Gateway Load Balancer that is associated with the target.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 **NOTE:** Either `network_interface_id` or `network_load_balancer_arn` should be specified and both should not be specified together

--- a/website/docs/r/ec2_traffic_mirror_target.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_target.html.markdown
@@ -28,7 +28,7 @@ resource "aws_ec2_traffic_mirror_target" "eni" {
 
 resource "aws_ec2_traffic_mirror_target" "gwlb" {
   description                       = "GWLB target"
-  gateway_load_balancer_endpoint_id = aws_lb.lb.arn
+  gateway_load_balancer_endpoint_id = aws_vpc_endpoint.example.id
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/

If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates 

For Example:

Relates #0000
or 
Closes #0000
--->
Relates to #26767

Output from acceptance testing:
<!--
:~/terraform-provider-aws (f-aws_ec2_traffic_mirror_target) $ make testacc PKG=ec2 TESTS=TestAccVPCTrafficMirrorTarget_gwlb ==> Checking that code complies with gofmt requirements... TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCTrafficMirrorTarget_gwlb' -timeout 180m === RUN TestAccVPCTrafficMirrorTarget_gwlb === PAUSE TestAccVPCTrafficMirrorTarget_gwlb === CONT TestAccVPCTrafficMirrorTarget_gwlb --- PASS: TestAccVPCTrafficMirrorTarget_gwlb (339.78s) PASS ok github.com/hashicorp/terraform-provider-aws/internal/service/ec2 339.869s :~/terraform-provider-aws (f-aws_ec2_traffic_mirror_target) $
-->
```
$ make testacc PKG=ec2 TESTS=TestAccVPCTrafficMirrorTarget_gwlb
~/terraform-provider-aws (f-aws_ec2_traffic_mirror_target) $ make testacc PKG=ec2 TESTS=TestAccVPCTrafficMirrorTarget_gwlb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCTrafficMirrorTarget_gwlb'  -timeout 180m
=== RUN   TestAccVPCTrafficMirrorTarget_gwlb
=== PAUSE TestAccVPCTrafficMirrorTarget_gwlb
=== CONT  TestAccVPCTrafficMirrorTarget_gwlb
--- PASS: TestAccVPCTrafficMirrorTarget_gwlb (258.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        258.244s
:~/terraform-provider-aws (f-aws_ec2_traffic_mirror_target) $ 
:~/terraform-provider-aws (f-aws_ec2_traffic_mirror_target) $ 
...
```
