### PR TITLE
Add support for EKS local clusters on Outposts

### DIFF
--- a/.changelog/26866.txt
+++ b/.changelog/26866.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add `outpost_config` argument to support EKS local clusers on Outposts
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
-	github.com/aws/aws-sdk-go v1.44.94
+	github.com/aws/aws-sdk-go v1.44.96
 	github.com/aws/aws-sdk-go-v2 v1.16.14
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.15
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.18.10

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.44.94 h1:hDqJSv03ZVvqT448gUE63JEIHKx++vKLoDkiZxbNmIk=
-github.com/aws/aws-sdk-go v1.44.94/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.96 h1:S9paaqnJ0AJ95t5AB+iK8RM6YNZN0W0Lek1gOVJsEr8=
+github.com/aws/aws-sdk-go v1.44.96/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.3/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
 github.com/aws/aws-sdk-go-v2 v1.16.14 h1:db6GvO4Z2UqHt5gvT0lr6J5x5P+oQ7bdRzczVaRekMU=
 github.com/aws/aws-sdk-go-v2 v1.16.14/go.mod h1:s/G+UV29dECbF5rf+RNj1xhlmvoNurGSr+McVSRj59w=

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -182,9 +182,9 @@ func ResourceCluster() *schema.Resource {
 							Required: true,
 							MinItems: 1,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								// 	Required:     true,
-								// 	// ValidateFunc: verify.ValidARN,
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
 							},
 						},
 					},

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -278,13 +278,17 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		EncryptionConfig:   testAccClusterConfig_expandEncryption(d.Get("encryption_config").([]interface{})),
 		Logging:            expandLoggingTypes(d.Get("enabled_cluster_log_types").(*schema.Set)),
 		Name:               aws.String(name),
-		OutpostConfig:      expandEksOutpostConfigRequest(d.Get("outpost_config").([]interface{})),
 		ResourcesVpcConfig: testAccClusterConfig_expandVPCRequest(d.Get("vpc_config").([]interface{})),
 		RoleArn:            aws.String(d.Get("role_arn").(string)),
 	}
 
 	if _, ok := d.GetOk("kubernetes_network_config"); ok {
 		input.KubernetesNetworkConfig = expandNetworkConfigRequest(d.Get("kubernetes_network_config").([]interface{}))
+	}
+
+	if _, ok := d.GetOk("outpost_config"); ok {
+		input.OutpostConfig = expandEksOutpostConfigRequest(d.Get("outpost_config").([]interface{}))
+		input.ResourcesVpcConfig.EndpointPrivateAccess = aws.Bool(true)
 	}
 
 	if v, ok := d.GetOk("version"); ok {

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -76,9 +76,9 @@ func ResourceCluster() *schema.Resource {
 				Set: schema.HashString,
 			},
 			"encryption_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Optional:      true,
 				ConflictsWith: []string{"outpost_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -131,10 +131,10 @@ func ResourceCluster() *schema.Resource {
 				},
 			},
 			"kubernetes_network_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
 				ConflictsWith: []string{"outpost_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -165,9 +165,9 @@ func ResourceCluster() *schema.Resource {
 				ValidateFunc: validClusterName,
 			},
 			"outpost_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Optional:      true,
 				ConflictsWith: []string{"encryption_config", "kubernetes_network_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -181,10 +181,10 @@ func ResourceCluster() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							MinItems: 1,
-							Elem:     &schema.Schema{
-							 	Type:         schema.TypeString,
-							// 	Required:     true,
-							// 	// ValidateFunc: verify.ValidARN,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								// 	Required:     true,
+								// 	// ValidateFunc: verify.ValidARN,
 							},
 						},
 					},
@@ -223,21 +223,21 @@ func ResourceCluster() *schema.Resource {
 							Computed: true,
 						},
 						"endpoint_private_access": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed:  true,
+							Type:          schema.TypeBool,
+							Optional:      true,
+							Computed:      true,
 							ConflictsWith: []string{"outpost_config"},
 						},
 						"endpoint_public_access": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed:  true,
+							Type:          schema.TypeBool,
+							Optional:      true,
+							Computed:      true,
 							ConflictsWith: []string{"outpost_config"},
 						},
 						"public_access_cidrs": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
+							Type:          schema.TypeSet,
+							Optional:      true,
+							Computed:      true,
 							ConflictsWith: []string{"outpost_config"},
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -284,7 +284,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, ok := d.GetOk("outpost_config"); ok {
-		input.OutpostConfig = expandEksOutpostConfigRequest(d.Get("outpost_config").([]interface{}))
+		input.OutpostConfig = expandOutpostConfigRequest(d.Get("outpost_config").([]interface{}))
 	}
 
 	if v, ok := d.GetOk("version"); ok {
@@ -626,7 +626,7 @@ func expandProvider(tfList []interface{}) *eks.Provider {
 	return apiObject
 }
 
-func expandEksOutpostConfigRequest(l []interface{}) *eks.OutpostConfigRequest {
+func expandOutpostConfigRequest(l []interface{}) *eks.OutpostConfigRequest {
 	tfMap, ok := l[0].(map[string]interface{})
 
 	if !ok {

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -79,6 +79,7 @@ func ResourceCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				ConflictsWith: []string{"outpost_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {
@@ -134,6 +135,7 @@ func ResourceCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
+				ConflictsWith: []string{"outpost_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_family": {
@@ -166,6 +168,7 @@ func ResourceCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				ConflictsWith: []string{"encryption_config", "kubernetes_network_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"control_plane_instance_type": {
@@ -177,10 +180,11 @@ func ResourceCluster() *schema.Resource {
 						"outpost_arns": {
 							Type:     schema.TypeSet,
 							Required: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								Required:     true,
-								ValidateFunc: verify.ValidARN,
+							MinItems: 1,
+							Elem:     &schema.Schema{
+							 	Type:         schema.TypeString,
+							// 	Required:     true,
+							// 	// ValidateFunc: verify.ValidARN,
 							},
 						},
 					},
@@ -221,17 +225,20 @@ func ResourceCluster() *schema.Resource {
 						"endpoint_private_access": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Computed:  true,
+							ConflictsWith: []string{"outpost_config"},
 						},
 						"endpoint_public_access": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
+							Computed:  true,
+							ConflictsWith: []string{"outpost_config"},
 						},
 						"public_access_cidrs": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
+							ConflictsWith: []string{"outpost_config"},
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: verify.ValidCIDRNetworkAddress,

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -395,7 +395,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting kubernetes_network_config: %w", err)
 	}
 
-	if err := d.Set("outpost_config", flattenEksOutpostConfig(cluster.OutpostConfig)); err != nil {
+	if err := d.Set("outpost_config", flattenOutpostConfig(cluster.OutpostConfig)); err != nil {
 		return fmt.Errorf("error setting outpost_config: %w", err)
 	}
 
@@ -842,7 +842,7 @@ func flattenNetworkConfig(apiObject *eks.KubernetesNetworkConfigResponse) []inte
 	return []interface{}{tfMap}
 }
 
-func flattenEksOutpostConfig(apiObject *eks.OutpostConfigResponse) []interface{} {
+func flattenOutpostConfig(apiObject *eks.OutpostConfigResponse) []interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -226,7 +226,7 @@ func ResourceCluster() *schema.Resource {
 							Type:          schema.TypeBool,
 							Optional:      true,
 							Computed:      true,
-							ConflictsWith: []string{"outpost_config"},
+							
 						},
 						"endpoint_public_access": {
 							Type:          schema.TypeBool,

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -175,16 +175,13 @@ func ResourceCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							// ValidateFunc: validControlPlaneInstanceType,
 						},
 						"outpost_arns": {
 							Type:     schema.TypeSet,
 							Required: true,
 							MinItems: 1,
 							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								Required:     true,
-								ValidateFunc: verify.ValidARN,
+								Type: schema.TypeString,
 							},
 						},
 					},

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -223,22 +223,19 @@ func ResourceCluster() *schema.Resource {
 							Computed: true,
 						},
 						"endpoint_private_access": {
-							Type:          schema.TypeBool,
-							Optional:      true,
-							Computed:      true,
-							ConflictsWith: []string{"outpost_config"},
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"endpoint_public_access": {
-							Type:          schema.TypeBool,
-							Optional:      true,
-							Computed:      true,
-							ConflictsWith: []string{"outpost_config"},
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
 						},
 						"public_access_cidrs": {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							Computed:      true,
-							ConflictsWith: []string{"outpost_config"},
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: verify.ValidCIDRNetworkAddress,
@@ -288,7 +285,6 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if _, ok := d.GetOk("outpost_config"); ok {
 		input.OutpostConfig = expandEksOutpostConfigRequest(d.Get("outpost_config").([]interface{}))
-		input.ResourcesVpcConfig.EndpointPrivateAccess = aws.Bool(true)
 	}
 
 	if v, ok := d.GetOk("version"); ok {

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -226,7 +226,7 @@ func ResourceCluster() *schema.Resource {
 							Type:          schema.TypeBool,
 							Optional:      true,
 							Computed:      true,
-							
+							ConflictsWith: []string{"outpost_config"},
 						},
 						"endpoint_public_access": {
 							Type:          schema.TypeBool,

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -162,6 +162,30 @@ func ResourceCluster() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validClusterName,
 			},
+			"outpost_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"control_plane_instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							// ValidateFunc: validControlPlaneInstanceType,
+						},
+						"outpost_arns": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+				},
+			},
 			"platform_version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -247,6 +271,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		EncryptionConfig:   testAccClusterConfig_expandEncryption(d.Get("encryption_config").([]interface{})),
 		Logging:            expandLoggingTypes(d.Get("enabled_cluster_log_types").(*schema.Set)),
 		Name:               aws.String(name),
+		OutpostConfig:      expandEksOutpostConfigRequest(d.Get("outpost_config").([]interface{})),
 		ResourcesVpcConfig: testAccClusterConfig_expandVPCRequest(d.Get("vpc_config").([]interface{})),
 		RoleArn:            aws.String(d.Get("role_arn").(string)),
 	}
@@ -361,6 +386,10 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("kubernetes_network_config", flattenNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
 		return fmt.Errorf("error setting kubernetes_network_config: %w", err)
+	}
+
+	if err := d.Set("outpost_config", flattenEksOutpostConfig(cluster.OutpostConfig)); err != nil {
+		return fmt.Errorf("error setting outpost_config: %w", err)
 	}
 
 	d.Set("name", cluster.Name)
@@ -590,6 +619,26 @@ func expandProvider(tfList []interface{}) *eks.Provider {
 	return apiObject
 }
 
+func expandEksOutpostConfigRequest(l []interface{}) *eks.OutpostConfigRequest {
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	outpostConfigRequest := &eks.OutpostConfigRequest{}
+
+	if v, ok := tfMap["control_plane_instance_type"].(string); ok && v != "" {
+		outpostConfigRequest.ControlPlaneInstanceType = aws.String(v)
+	}
+
+	if v, ok := tfMap["outpost_arns"].(*schema.Set); ok && v.Len() > 0 {
+		outpostConfigRequest.OutpostArns = flex.ExpandStringSet(v)
+	}
+
+	return outpostConfigRequest
+}
+
 func testAccClusterConfig_expandVPCRequest(l []interface{}) *eks.VpcConfigRequest {
 	if len(l) == 0 {
 		return nil
@@ -781,6 +830,19 @@ func flattenNetworkConfig(apiObject *eks.KubernetesNetworkConfigResponse) []inte
 	tfMap := map[string]interface{}{
 		"service_ipv4_cidr": aws.StringValue(apiObject.ServiceIpv4Cidr),
 		"ip_family":         aws.StringValue(apiObject.IpFamily),
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenEksOutpostConfig(apiObject *eks.OutpostConfigResponse) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"control_plane_instance_type": aws.StringValue(apiObject.ControlPlaneInstanceType),
+		"outpost_arns":                aws.StringValueSlice(apiObject.OutpostArns),
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -198,7 +198,7 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting kubernetes_network_config: %w", err)
 	}
 
-	if err := d.Set("outpost_config", flattenEksOutpostConfig(cluster.OutpostConfig)); err != nil {
+	if err := d.Set("outpost_config", flattenOutpostConfig(cluster.OutpostConfig)); err != nil {
 		return fmt.Errorf("error setting outpost_config: %w", err)
 	}
 

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -85,6 +85,25 @@ func DataSourceCluster() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validClusterName,
 			},
+			"outpost_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"control_plane_instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"outpost_arns": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 			"platform_version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -177,6 +196,10 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("kubernetes_network_config", flattenNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
 		return fmt.Errorf("error setting kubernetes_network_config: %w", err)
+	}
+
+	if err := d.Set("outpost_config", flattenEksOutpostConfig(cluster.OutpostConfig)); err != nil {
+		return fmt.Errorf("error setting outpost_config: %w", err)
 	}
 
 	d.Set("name", cluster.Name)

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -612,7 +612,7 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_OutpostConfig(rName, "op-062c383102b6f92a2"),
+				Config: testAccClusterConfig_OutpostConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.#", "1"),
@@ -1037,31 +1037,24 @@ resource "aws_eks_cluster" "test" {
 `, rName, ipFamily))
 }
 
-func testAccClusterConfig_OutpostConfig(rName string, outpostID string) string {
+func testAccClusterConfig_OutpostConfig(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_Base(rName), fmt.Sprintf(`
 data "aws_outposts_outpost" "test" {
-  id = %[2]q
-} 
-
-resource "aws_kms_key" "test" {
-  description             = %[1]q
-  deletion_window_in_days = 7
+  id = "op-062c383102b6f92a2"
 }
 
 resource "aws_eks_cluster" "test" {
   name     = %[1]q
-  role_arn = aws_iam_role.test.arn
+  role_arn = "arn:aws:iam::374958015927:role/my-cluster-role"
 
   outpost_config {
 	control_plane_instance_type = "m5d.large"
-    outpost_arns = [data.aws_outposts_outpost.arn]
+    outpost_arns = [data.aws_outposts_outpost.test.arn]
   }
 
   vpc_config {
-    subnet_ids = aws_subnet.test[*].id
+    subnet_ids = ["subnet-0a625ebe4ce3d66aa"]
   }
-
-  depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, rName, outpostID))
+`, rName))
 }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -612,7 +612,7 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_OutpostConfig(rName),
+				Config: testAccClusterConfig_outpost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.#", "1"),
@@ -1037,7 +1037,7 @@ resource "aws_eks_cluster" "test" {
 `, rName, ipFamily))
 }
 
-func testAccClusterConfig_OutpostConfig(rName string) string {
+func testAccClusterConfig_outpost(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_Base(rName), fmt.Sprintf(`
 data "aws_iam_role" "test" {
   name = "AmazonEKSLocalOutpostClusterRole"

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -608,7 +608,7 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, eks.EndpointsID),
-		Providers:    acctest.Providers,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1045,7 +1045,7 @@ data "aws_outposts_outpost" "test" {
 
 resource "aws_eks_cluster" "test" {
   name     = %[1]q
-  role_arn = "arn:aws:iam::374958015927:role/my-cluster-role"
+  role_arn = "arn:aws:iam::374958015927:role/AmazonEKSLocalOutpostClusterRole"
 
   outpost_config {
 	control_plane_instance_type = "m5d.large"
@@ -1053,6 +1053,8 @@ resource "aws_eks_cluster" "test" {
   }
 
   vpc_config {
+	endpoint_private_access = true
+	endpoint_public_access = false
     subnet_ids = ["subnet-0a625ebe4ce3d66aa"]
   }
 }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -1047,7 +1047,7 @@ data "aws_outposts_outposts" "test" {}
 
 data "aws_subnets" test {
   filter {
-    name = "outpost-arn"
+    name   = "outpost-arn"
     values = [tolist(data.aws_outposts_outposts.test.arns)[0]]
   }
 }
@@ -1058,13 +1058,13 @@ resource "aws_eks_cluster" "test" {
 
   outpost_config {
     control_plane_instance_type = "m5d.large"
-    outpost_arns = [tolist(data.aws_outposts_outposts.test.arns)[0]]
+    outpost_arns                = [tolist(data.aws_outposts_outposts.test.arns)[0]]
   }
 
   vpc_config {
     endpoint_private_access = true
-    endpoint_public_access = false
-    subnet_ids = [tolist(data.aws_subnets.test.ids)[0]]
+    endpoint_public_access  = false
+    subnet_ids              = [tolist(data.aws_subnets.test.ids)[0]]
   }
 }
 `, rName))

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -1039,18 +1039,17 @@ resource "aws_eks_cluster" "test" {
 
 func testAccClusterConfig_OutpostConfig(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_Base(rName), fmt.Sprintf(`
-
 data "aws_iam_role" "test" {
-	name = "AmazonEKSLocalOutpostClusterRole"
+  name = "AmazonEKSLocalOutpostClusterRole"
 }
 
 data "aws_outposts_outposts" "test" {}
 
 data "aws_subnets" test {
-	filter {
-		name = "outpost-arn"
-		values = [tolist(data.aws_outposts_outposts.test.arns)[0]]
-	}
+  filter {
+    name = "outpost-arn"
+    values = [tolist(data.aws_outposts_outposts.test.arns)[0]]
+  }
 }
 
 resource "aws_eks_cluster" "test" {
@@ -1058,13 +1057,13 @@ resource "aws_eks_cluster" "test" {
   role_arn = data.aws_iam_role.test.arn
 
   outpost_config {
-	control_plane_instance_type = "m5d.large"
+    control_plane_instance_type = "m5d.large"
     outpost_arns = [tolist(data.aws_outposts_outposts.test.arns)[0]]
   }
 
   vpc_config {
-	endpoint_private_access = true
-	endpoint_public_access = false
+    endpoint_private_access = true
+    endpoint_public_access = false
     subnet_ids = [tolist(data.aws_subnets.test.ids)[0]]
   }
 }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+const (
+	clusterVersionUpgradeInitial = "1.21"
+	clusterVersionUpgradeUpdated = "1.22"
+)
+
 func TestAccEKSCluster_basic(t *testing.T) {
 	var cluster eks.Cluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -173,14 +178,14 @@ func TestAccEKSCluster_Encryption_versionUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_encryptionVersion(rName, "1.19"),
+				Config: testAccClusterConfig_encryptionVersion(rName, clusterVersionUpgradeInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "encryption_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.provider.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_config.0.provider.0.key_arn", kmsKeyResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.19"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeInitial),
 				),
 			},
 			{
@@ -189,7 +194,7 @@ func TestAccEKSCluster_Encryption_versionUpdate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_encryptionVersion(rName, "1.20"),
+				Config: testAccClusterConfig_encryptionVersion(rName, clusterVersionUpgradeUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster2),
 					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
@@ -197,7 +202,7 @@ func TestAccEKSCluster_Encryption_versionUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.provider.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_config.0.provider.0.key_arn", kmsKeyResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.20"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeUpdated),
 				),
 			},
 		},
@@ -216,10 +221,10 @@ func TestAccEKSCluster_version(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_version(rName, "1.19"),
+				Config: testAccClusterConfig_version(rName, clusterVersionUpgradeInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.19"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeInitial),
 				),
 			},
 			{
@@ -228,11 +233,11 @@ func TestAccEKSCluster_version(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClusterConfig_version(rName, "1.20"),
+				Config: testAccClusterConfig_version(rName, clusterVersionUpgradeUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster2),
 					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.20"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeUpdated),
 				),
 			},
 		},

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -252,10 +252,10 @@ func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 		CheckDestroy:             testAccCheckNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodeGroupConfig_forceUpdateVersion(rName, "1.19"),
+				Config: testAccNodeGroupConfig_forceUpdateVersion(rName, clusterVersionUpgradeInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.19"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeInitial),
 				),
 			},
 			{
@@ -265,10 +265,10 @@ func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_update_version"},
 			},
 			{
-				Config: testAccNodeGroupConfig_forceUpdateVersion(rName, "1.20"),
+				Config: testAccNodeGroupConfig_forceUpdateVersion(rName, clusterVersionUpgradeUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.20"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeUpdated),
 				),
 			},
 		},
@@ -931,10 +931,10 @@ func TestAccEKSNodeGroup_version(t *testing.T) {
 		CheckDestroy:             testAccCheckNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodeGroupConfig_version(rName, "1.19"),
+				Config: testAccNodeGroupConfig_version(rName, clusterVersionUpgradeInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.19"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeInitial),
 				),
 			},
 			{
@@ -943,11 +943,11 @@ func TestAccEKSNodeGroup_version(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNodeGroupConfig_version(rName, "1.20"),
+				Config: testAccNodeGroupConfig_version(rName, clusterVersionUpgradeUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup2),
 					testAccCheckNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.20"),
+					resource.TestCheckResourceAttr(resourceName, "version", clusterVersionUpgradeUpdated),
 				),
 			},
 		},

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -79,7 +79,7 @@ func waitAddonUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, 
 
 func waitClusterCreated(conn *eks.EKS, name string, timeout time.Duration) (*eks.Cluster, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{eks.ClusterStatusCreating},
+		Pending: []string{eks.ClusterStatusPending, eks.ClusterStatusCreating},
 		Target:  []string{eks.ClusterStatusActive},
 		Refresh: statusCluster(conn, name),
 		Timeout: timeout,

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -50,7 +50,7 @@ output "identity-oidc-issuer" {
 * `kubernetes_network_config` - Nested list containing Kubernetes Network Configuration.
     * `service_ipv4_cidr` - The CIDR block to assign Kubernetes service IP addresses from.
 * `outpost_config` - Contains Outpost Configuration.
-    * `control_plane_instance_type` - The Amazon EC2 instance type for all Kubernetes control plane instances. 
+    * `control_plane_instance_type` - The Amazon EC2 instance type for all Kubernetes control plane instances.
     * `outpost_arns` - List of ARNs of the Outposts hosting the EKS cluster. Only a single ARN is supported currently.
 * `platform_version` - Platform version for the cluster.
 * `role_arn` - ARN of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -49,6 +49,9 @@ output "identity-oidc-issuer" {
         * `issuer` - Issuer URL for the OpenID Connect identity provider.
 * `kubernetes_network_config` - Nested list containing Kubernetes Network Configuration.
     * `service_ipv4_cidr` - The CIDR block to assign Kubernetes service IP addresses from.
+* `outpost_config` - Contains Outpost Configuration.
+    * `control_plane_instance_type` - The Amazon EC2 instance type for all Kubernetes control plane instances. 
+    * `outpost_arns` - List of ARNs of the Outposts hosting the EKS cluster. Only a single ARN is supported currently.
 * `platform_version` - Platform version for the cluster.
 * `role_arn` - ARN of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
 * `status` - Status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -166,6 +166,8 @@ resource "aws_eks_cluster" "example" {
   role_arn = aws_iam_role.example.arn
 
   vpc_config {
+    endpoint_private_access = true
+    endpoint_public_access = false
     # ... other configuration ...
   }
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -153,7 +153,7 @@ resource "aws_iam_role" "example" {
 
 ### EKS Cluster on AWS Outpost
 
-[Creating a local Amazon EKS cluster on an AWS Outpost](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster-outpost.html) 
+[Creating a local Amazon EKS cluster on an AWS Outpost](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster-outpost.html)
 
 ```terraform
 resource "aws_iam_role" "example" {
@@ -167,13 +167,13 @@ resource "aws_eks_cluster" "example" {
 
   vpc_config {
     endpoint_private_access = true
-    endpoint_public_access = false
+    endpoint_public_access  = false
     # ... other configuration ...
   }
 
   outpost_config {
     control_plane_instance_type = "m5d.large"
-    outpost_arns = [data.aws_outposts_outpost.example.arn]
+    outpost_arns                = [data.aws_outposts_outpost.example.arn]
   }
 }
 ```


### PR DESCRIPTION
Add support for EKS local clusters on Outposts

Closes #26913

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEKSCluster_ PKG=eks

TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 2 -run='TestAccEKSCluster_'  -timeout 180m
=== RUN   TestAccEKSCluster_basic
=== PAUSE TestAccEKSCluster_basic
=== RUN   TestAccEKSCluster_disappears
=== PAUSE TestAccEKSCluster_disappears
=== RUN   TestAccEKSCluster_Encryption_create
=== PAUSE TestAccEKSCluster_Encryption_create
=== RUN   TestAccEKSCluster_Encryption_update
=== PAUSE TestAccEKSCluster_Encryption_update
=== RUN   TestAccEKSCluster_Encryption_versionUpdate
=== PAUSE TestAccEKSCluster_Encryption_versionUpdate
=== RUN   TestAccEKSCluster_version
=== PAUSE TestAccEKSCluster_version
=== RUN   TestAccEKSCluster_logging
=== PAUSE TestAccEKSCluster_logging
=== RUN   TestAccEKSCluster_tags
=== PAUSE TestAccEKSCluster_tags
=== RUN   TestAccEKSCluster_VPC_securityGroupIDs
=== PAUSE TestAccEKSCluster_VPC_securityGroupIDs
=== RUN   TestAccEKSCluster_VPC_endpointPrivateAccess
=== PAUSE TestAccEKSCluster_VPC_endpointPrivateAccess
=== RUN   TestAccEKSCluster_VPC_endpointPublicAccess
=== PAUSE TestAccEKSCluster_VPC_endpointPublicAccess
=== RUN   TestAccEKSCluster_VPC_publicAccessCIDRs
=== PAUSE TestAccEKSCluster_VPC_publicAccessCIDRs
=== RUN   TestAccEKSCluster_Network_serviceIPv4CIDR
=== PAUSE TestAccEKSCluster_Network_serviceIPv4CIDR
=== RUN   TestAccEKSCluster_Network_ipFamily
=== PAUSE TestAccEKSCluster_Network_ipFamily
=== RUN   TestAccEKSCluster_Outpost_create
=== PAUSE TestAccEKSCluster_Outpost_create
=== CONT  TestAccEKSCluster_basic
=== CONT  TestAccEKSCluster_VPC_securityGroupIDs
--- PASS: TestAccEKSCluster_VPC_securityGroupIDs (710.43s)
=== CONT  TestAccEKSCluster_Encryption_versionUpdate
--- PASS: TestAccEKSCluster_basic (806.92s)
=== CONT  TestAccEKSCluster_tags
--- PASS: TestAccEKSCluster_tags (793.93s)
=== CONT  TestAccEKSCluster_logging
--- PASS: TestAccEKSCluster_Encryption_versionUpdate (1646.97s)
=== CONT  TestAccEKSCluster_version
--- PASS: TestAccEKSCluster_logging (836.04s)
=== CONT  TestAccEKSCluster_Encryption_create
--- PASS: TestAccEKSCluster_Encryption_create (841.02s)
=== CONT  TestAccEKSCluster_Encryption_update
--- PASS: TestAccEKSCluster_version (1197.46s)
=== CONT  TestAccEKSCluster_disappears
--- PASS: TestAccEKSCluster_disappears (782.33s)
=== CONT  TestAccEKSCluster_Network_serviceIPv4CIDR
--- PASS: TestAccEKSCluster_Network_serviceIPv4CIDR (1458.33s)
=== CONT  TestAccEKSCluster_Outpost_create
--- PASS: TestAccEKSCluster_Encryption_update (2955.74s)
=== CONT  TestAccEKSCluster_Network_ipFamily
--- PASS: TestAccEKSCluster_Outpost_create (658.56s)
=== CONT  TestAccEKSCluster_VPC_endpointPublicAccess
--- PASS: TestAccEKSCluster_Network_ipFamily (1560.61s)
=== CONT  TestAccEKSCluster_VPC_publicAccessCIDRs
--- PASS: TestAccEKSCluster_VPC_endpointPublicAccess (1454.42s)
=== CONT  TestAccEKSCluster_VPC_endpointPrivateAccess
--- PASS: TestAccEKSCluster_VPC_publicAccessCIDRs (939.61s) 
--- PASS: TestAccEKSCluster_VPC_endpointPrivateAccess (1767.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks         9679.710s

...
```
