### PR TITLE
Updating front end api of terraform provider from taint to taints

### DIFF
--- a/.changelog/26875.txt
+++ b/.changelog/26875.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_eks_node_group: Modify `taint` attribute to `taints`
+```

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -223,7 +223,7 @@ func ResourceNodeGroup() *schema.Resource {
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
-			"taint": {
+			"taints": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				MaxItems: 50,
@@ -337,7 +337,7 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.ScalingConfig = expandNodegroupScalingConfig(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	if v, ok := d.GetOk("taint"); ok && v.(*schema.Set).Len() > 0 {
+	if v, ok := d.GetOk("taints"); ok && v.(*schema.Set).Len() > 0 {
 		input.Taints = expandTaints(v.(*schema.Set).List())
 	}
 
@@ -438,8 +438,8 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error setting subnets: %s", err)
 	}
 
-	if err := d.Set("taint", flattenTaints(nodeGroup.Taints)); err != nil {
-		return diag.Errorf("error setting taint: %s", err)
+	if err := d.Set("taints", flattenTaints(nodeGroup.Taints)); err != nil {
+		return diag.Errorf("error setting taints: %s", err)
 	}
 
 	if nodeGroup.UpdateConfig != nil {
@@ -527,9 +527,9 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	if d.HasChanges("labels", "scaling_config", "taint", "update_config") {
+	if d.HasChanges("labels", "scaling_config", "taints", "update_config") {
 		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
-		oldTaintsRaw, newTaintsRaw := d.GetChange("taint")
+		oldTaintsRaw, newTaintsRaw := d.GetChange("taints")
 
 		input := &eks.UpdateNodegroupConfigInput{
 			ClientRequestToken: aws.String(resource.UniqueId()),

--- a/internal/service/eks/node_group_data_source.go
+++ b/internal/service/eks/node_group_data_source.go
@@ -212,7 +212,7 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err := d.Set("taints", flattenTaints(nodeGroup.Taints)); err != nil {
-		return diag.Errorf("error setting taint: %s", err)
+		return diag.Errorf("error setting taints: %s", err)
 	}
 
 	d.Set("version", nodeGroup.Version)

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -59,7 +59,7 @@ func TestAccEKSNodeGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", eks.NodegroupStatusActive),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "taint.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "taints.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "version", eksClusterResourceName, "version"),
 				),
@@ -833,8 +833,8 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 				Config: testAccNodeGroupConfig_taints1(rName, "key1", "value1", "NO_SCHEDULE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "taint.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "taints.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taints.*", map[string]string{
 						"key":    "key1",
 						"value":  "value1",
 						"effect": "NO_SCHEDULE",
@@ -852,13 +852,13 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 					"key2", "value2", "NO_SCHEDULE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "taint.#", "2"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "taints.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taints.*", map[string]string{
 						"key":    "key1",
 						"value":  "value1updated",
 						"effect": "NO_EXECUTE",
 					}),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taints.*", map[string]string{
 						"key":    "key2",
 						"value":  "value2",
 						"effect": "NO_SCHEDULE",
@@ -869,8 +869,8 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 				Config: testAccNodeGroupConfig_taints1(rName, "key2", "value2", "NO_SCHEDULE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "taint.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "taints.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taints.*", map[string]string{
 						"key":    "key2",
 						"value":  "value2",
 						"effect": "NO_SCHEDULE",

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -138,7 +138,7 @@ The following arguments are optional:
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
 * `remote_access` - (Optional) Configuration block with remote access settings. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `taint` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. Detailed below.
+* `taints` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. Detailed below.
 * `version` – (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
 
 ### launch_template Configuration Block
@@ -160,7 +160,7 @@ The following arguments are optional:
 * `max_size` - (Required) Maximum number of worker nodes.
 * `min_size` - (Required) Minimum number of worker nodes.
 
-### taint Configuration Block
+### taints Configuration Block
 
 * `key` - (Required) The key of the taint. Maximum length of 63.
 * `value` - (Optional) The value of the taint. Maximum length of 63.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/

If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates 

For Example:

Relates #0000
or 
Closes #0000
--->
Relates OR Closes #19482 & #23452

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
The goal is to make taints plural since it can be used up to 50 taints. The documentation and api call shows incorrect here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#taint

It is also incorrect here:
https://github.com/hashicorp/terraform-provider-aws/blob/586f11b0d227f53a4dec1963faa19dd44b1b4ce3/website/docs/r/eks_node_group.html.markdown

But it is correct here:
https://github.com/hashicorp/terraform-provider-aws/blob/586f11b0d227f53a4dec1963faa19dd44b1b4ce3/website/docs/d/eks_node_group.html.markdown
 