### PR TITLE
Correct examples in `aws_kendra_faq`

### DIFF
--- a/website/docs/r/kendra_faq.html.markdown
+++ b/website/docs/r/kendra_faq.html.markdown
@@ -20,7 +20,7 @@ resource "aws_kendra_faq" "example" {
   name     = "Example"
   role_arn = aws_iam_role.example.arn
 
-  source_s3_path {
+  s3_path {
     bucket = aws_s3_bucket.example.id
     key    = aws_s3_object.example.key
   }
@@ -40,7 +40,7 @@ resource "aws_kendra_faq" "example" {
   file_format = "CSV"
   role_arn    = aws_iam_role.example.arn
 
-  source_s3_path {
+  s3_path {
     bucket = aws_s3_bucket.example.id
     key    = aws_s3_object.example.key
   }
@@ -56,7 +56,7 @@ resource "aws_kendra_faq" "example" {
   language_code = "en"
   role_arn      = aws_iam_role.example.arn
 
-  source_s3_path {
+  s3_path {
     bucket = aws_s3_bucket.example.id
     key    = aws_s3_object.example.key
   }


### PR DESCRIPTION
Closes #26877

Output from acceptance testing: N/a, docs

### Information

The `aws_kendra_faq` resource documentation previously showed an argument of `source_s3_path`. The correct argument is `s3_path`, so this PR aims to correct that reference.

### References

- [`aws_kendra_faq` schema](https://github.com/hashicorp/terraform-provider-aws/blob/da38070f1ae31cda55c4000a0348d3004cb3acfb/internal/service/kendra/faq.go#L110-L129)