### PR TITLE
Update rds_cluster_role_association.html.markdown to fix example typo

### DIFF
--- a/website/docs/r/rds_cluster_role_association.html.markdown
+++ b/website/docs/r/rds_cluster_role_association.html.markdown
@@ -19,7 +19,7 @@ Manages a RDS DB Cluster association with an IAM Role. Example use cases:
 resource "aws_rds_cluster_role_association" "example" {
   db_cluster_identifier = aws_rds_cluster.example.id
   feature_name          = "S3_INTEGRATION"
-  role_arn              = aws_iam_role.example.id
+  role_arn              = aws_iam_role.example.arn
 }
 ```
 


### PR DESCRIPTION
Updated documentation example to use `iam_role.example.arn` attribute instead of `id`, as that is what is expected by the API.

When `.id` is used, the following error is thrown:
```
Error: "role_arn" (<role id>) is an invalid ARN: arn: invalid prefix
```
