### PR TITLE
Remove incorrect reference to `aws_redshiftserverless_endpoint_access.security_group_ids`

### DIFF
--- a/website/docs/r/redshiftserverless_endpoint_access.html.markdown
+++ b/website/docs/r/redshiftserverless_endpoint_access.html.markdown
@@ -24,7 +24,6 @@ resource "aws_redshiftserverless_endpoint_access" "example" {
 The following arguments are supported:
 
 * `endpoint_name` - (Required) The name of the endpoint.
-* `security_group_ids` - (Optional) An array of security group IDs to associate with the endpoint.
 * `subnet_ids` - (Required) An array of VPC subnet IDs to associate with the endpoint.
 * `vpc_security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.
 * `workgroup_name` - (Required) The name of the workgroup.


### PR DESCRIPTION
### Description

This PR removes reference to a `security_group_ids` argument for `aws_redshiftserverless_endpoint_access` resources. This argument does not exist in the schema.

Closes #26888

Output from acceptance testing: N/a, docs

### Information

- [Resource schema](https://github.com/hashicorp/terraform-provider-aws/blob/f3434154a1621a054f18955cbe7b39d91ca2601a/internal/service/redshiftserverless/endpoint_access.go#L28-L109)