### PR TITLE
enhancement(rds): Support default_only, include_all, and filter for aws_rds_engine_version

### DIFF
--- a/.changelog/26923.txt
+++ b/.changelog/26923.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_rds_engine_version: Support `default_only`, `include_all`, and `filter`
+```

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -19,6 +19,11 @@ func DataSourceEngineVersion() *schema.Resource {
 				Computed: true,
 			},
 
+			"default_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"engine": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -144,7 +149,9 @@ func dataSourceEngineVersionRead(d *schema.ResourceData, meta interface{}) error
 		input.EngineVersion = aws.String(v.(string))
 	}
 
-	if _, ok := d.GetOk("version"); !ok {
+	if v, ok := d.GetOk("default_only"); ok {
+		input.DefaultOnly = aws.Bool(v.(bool))
+	} else if _, ok := d.GetOk("version"); !ok {
 		if _, ok := d.GetOk("preferred_versions"); !ok {
 			input.DefaultOnly = aws.Bool(true)
 		}

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
 )
 
 func DataSourceEngineVersion() *schema.Resource {
@@ -40,6 +41,8 @@ func DataSourceEngineVersion() *schema.Resource {
 				Computed: true,
 				Set:      schema.HashString,
 			},
+
+			"filter": namevaluesfilters.Schema(),
 
 			"parameter_group_family": {
 				Type:     schema.TypeString,
@@ -139,6 +142,10 @@ func dataSourceEngineVersionRead(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("engine"); ok {
 		input.Engine = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
 	}
 
 	if v, ok := d.GetOk("parameter_group_family"); ok {

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -44,6 +44,11 @@ func DataSourceEngineVersion() *schema.Resource {
 
 			"filter": namevaluesfilters.Schema(),
 
+			"include_all": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"parameter_group_family": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -146,6 +151,10 @@ func dataSourceEngineVersionRead(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("filter"); ok {
 		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
+	}
+
+	if v, ok := d.GetOk("include_all"); ok {
+		input.IncludeAll = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("parameter_group_family"); ok {

--- a/website/docs/d/rds_engine_version.markdown
+++ b/website/docs/d/rds_engine_version.markdown
@@ -17,25 +17,21 @@ Information about an RDS engine version.
 ```terraform
 data "aws_rds_engine_version" "test" {
   engine             = "mysql"
-  preferred_versions = ["5.7.42", "5.7.19", "5.7.17"]
+  preferred_versions = ["8.0.27", "8.0.26"]
 }
 ```
 
-### With Filters
+### With `filter`
 
 ```terraform
 data "aws_rds_engine_version" "test" {
-  engine             = "mysql"
-  preferred_versions = ["5.7.42", "5.7.19", "5.7.17"]
+  engine      = "aurora-postgresql"
+  version     = "10.14"
+  include_all = true
 
   filter {
     name   = "engine-mode"
-    values = ["provisioned"]
-  }
-
-  filter {
-    name   = "status"
-    values = ["available"]
+    values = ["serverless"]
   }
 }
 ```

--- a/website/docs/d/rds_engine_version.markdown
+++ b/website/docs/d/rds_engine_version.markdown
@@ -16,6 +16,16 @@ Information about an RDS engine version.
 data "aws_rds_engine_version" "test" {
   engine             = "mysql"
   preferred_versions = ["5.7.42", "5.7.19", "5.7.17"]
+
+  filter {
+    name   = "engine-mode"
+    values = ["provisioned"]
+  }
+
+  filter {
+    name   = "status"
+    values = ["available"]
+  }
 }
 ```
 
@@ -24,6 +34,9 @@ data "aws_rds_engine_version" "test" {
 The following arguments are supported:
 
 * `engine` - (Required) DB engine. Engine values include `aurora`, `aurora-mysql`, `aurora-postgresql`, `docdb`, `mariadb`, `mysql`, `neptune`, `oracle-ee`, `oracle-se`, `oracle-se1`, `oracle-se2`, `postgres`, `sqlserver-ee`, `sqlserver-ex`, `sqlserver-se`, and `sqlserver-web`.
+* `default_only` - (Optional) When set to `true`, the default version for the specified `engine` or combination of `engine` and major `version` will be returned. Can be used to limit responses to a single version when they would otherwise fail for returning multiple versions.
+* `filter` - (Optional) One or more name/value pairs to filter off of. There are several valid keys; for a full reference, check out [describe-db-engine-versions in the AWS CLI reference](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/describe-db-engine-versions.html).
+* `include_all` - (Optional) When set to `true`, the specified `version` or member of `preferred_versions` will be returned even if it is `deprecated`. Otherwise, only `available` versions will be returned.
 * `parameter_group_family` - (Optional) Name of a specific DB parameter group family. Examples of parameter group families are `mysql8.0`, `mariadb10.4`, and `postgres12`.
 * `preferred_versions` - (Optional) Ordered list of preferred engine versions. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
 * `version` - (Optional) Version of the DB engine. For example, `5.7.22`, `10.1.34`, and `12.3`. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.

--- a/website/docs/d/rds_engine_version.markdown
+++ b/website/docs/d/rds_engine_version.markdown
@@ -12,6 +12,17 @@ Information about an RDS engine version.
 
 ## Example Usage
 
+### Basic Usage
+
+```terraform
+data "aws_rds_engine_version" "test" {
+  engine             = "mysql"
+  preferred_versions = ["5.7.42", "5.7.19", "5.7.17"]
+}
+```
+
+### With Filters
+
 ```terraform
 data "aws_rds_engine_version" "test" {
   engine             = "mysql"


### PR DESCRIPTION
This PR adds support for `default_only`, `include_all`, and `filter` to the `aws_rds_engine_version` data source. Adding these flags make it possible to get the default minor version given only a major version for an engine, to distinguish between `provisioned` and `serverless` engine modes, or to allow querying of deprecated versions, among other things.

Closes #19715
Closes #26867