### PR TITLE
Allow destruction of invalid aws_batch_compute_environment

### DIFF
--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -404,7 +404,7 @@ func resourceComputeEnvironmentDelete(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if _, err := waitComputeEnvironmentDisabled(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-			return fmt.Errorf("error waiting for Batch Compute Environment (%s) disable: %w", d.Id(), err)
+			log.Printf("[WARN] error waiting for Batch Compute Environment (%s) disable: %s", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
With this change any error in disabling the Batch Compute Environment will just be logged and will proceed to deletion of the resource.

Closes #26930

Output from acceptance testing:
I do not have the resources to run tests. Also, this specific scenario would need to be tested manually as I am now aware of a way to invalidate Batch CE through Terraform.
