### PR TITLE
enhancement(resourcegroups): Add configuration type and attribute

### DIFF
--- a/.changelog/26934.txt
+++ b/.changelog/26934.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_resourcegroups_group: Support `configuration` attribute for configuration type groups
+resource/aws_resourcegroups_group: Add `configuration` argument
 ```

--- a/.changelog/26934.txt
+++ b/.changelog/26934.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_resourcegroups_group: Support `configuration` attribute for configuration type groups
+```

--- a/internal/service/resourcegroups/group.go
+++ b/internal/service/resourcegroups/group.go
@@ -377,7 +377,7 @@ func statusGroupConfiguration(ctx context.Context, conn *resourcegroups.Resource
 	}
 }
 
-func waitGroupConfigurationUpdated(ctx context.Context, conn *resourcegroups.ResourceGroups, groupName string, timeout time.Duration) (*resourcegroups.GroupConfiguration, error) {
+func waitGroupConfigurationUpdated(ctx context.Context, conn *resourcegroups.ResourceGroups, groupName string, timeout time.Duration) (*resourcegroups.GroupConfiguration, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{resourcegroups.GroupConfigurationStatusUpdating},
 		Target:  []string{resourcegroups.GroupConfigurationStatusUpdateComplete},

--- a/internal/service/resourcegroups/group.go
+++ b/internal/service/resourcegroups/group.go
@@ -34,23 +34,16 @@ func ResourceGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"arn": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
 			},
-
 			"configuration": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ConflictsWith: []string{"resource_query"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
 						"parameters": {
 							Type:     schema.TypeSet,
 							Required: true,
@@ -60,7 +53,6 @@ func ResourceGroup() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-
 									"values": {
 										Type:     schema.TypeList,
 										Required: true,
@@ -71,15 +63,22 @@ func ResourceGroup() *schema.Resource {
 								},
 							},
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
 					},
 				},
 			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"resource_query": {
 				Type:          schema.TypeList,
 				Optional:      true,
@@ -92,7 +91,6 @@ func ResourceGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -103,11 +101,6 @@ func ResourceGroup() *schema.Resource {
 						},
 					},
 				},
-			},
-
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/resourcegroups/group_test.go
+++ b/internal/service/resourcegroups/group_test.go
@@ -19,7 +19,7 @@ import (
 func TestAccResourceGroupsGroup_basic(t *testing.T) {
 	var v resourcegroups.Group
 	resourceName := "aws_resourcegroups_group.test"
-	n := fmt.Sprintf("test-group-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	desc1 := "Hello World"
 	desc2 := "Foo Bar"
@@ -45,10 +45,10 @@ func TestAccResourceGroupsGroup_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig_basic(n, desc1, testAccResourceGroupQueryConfig),
+				Config: testAccGroupConfig_basic(rName, desc1, testAccResourceGroupQueryConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "name", n),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", desc1),
 					resource.TestCheckResourceAttr(resourceName, "resource_query.0.query", testAccResourceGroupQueryConfig+"\n"),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
@@ -60,7 +60,7 @@ func TestAccResourceGroupsGroup_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGroupConfig_basic(n, desc2, query2),
+				Config: testAccGroupConfig_basic(rName, desc2, query2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", desc2),
 					resource.TestCheckResourceAttr(resourceName, "resource_query.0.query", query2+"\n"),
@@ -73,7 +73,7 @@ func TestAccResourceGroupsGroup_basic(t *testing.T) {
 func TestAccResourceGroupsGroup_tags(t *testing.T) {
 	var v resourcegroups.Group
 	resourceName := "aws_resourcegroups_group.test"
-	n := fmt.Sprintf("test-group-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	desc1 := "Hello World"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -83,7 +83,7 @@ func TestAccResourceGroupsGroup_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig_tags1(n, desc1, testAccResourceGroupQueryConfig, "key1", "value1"),
+				Config: testAccGroupConfig_tags1(rName, desc1, testAccResourceGroupQueryConfig, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -96,7 +96,7 @@ func TestAccResourceGroupsGroup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGroupConfig_tags2(n, desc1, testAccResourceGroupQueryConfig, "key1", "value1updated", "key2", "value2"),
+				Config: testAccGroupConfig_tags2(rName, desc1, testAccResourceGroupQueryConfig, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -105,7 +105,7 @@ func TestAccResourceGroupsGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGroupConfig_tags1(n, desc1, testAccResourceGroupQueryConfig, "key2", "value2"),
+				Config: testAccGroupConfig_tags1(rName, desc1, testAccResourceGroupQueryConfig, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -119,7 +119,7 @@ func TestAccResourceGroupsGroup_tags(t *testing.T) {
 func TestAccResourceGroupsGroup_Configuration(t *testing.T) {
 	var v resourcegroups.Group
 	resourceName := "aws_resourcegroups_group.test"
-	n := fmt.Sprintf("test-group-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	desc1 := "Hello World"
 	desc2 := "Foo Bar"
@@ -133,10 +133,10 @@ func TestAccResourceGroupsGroup_Configuration(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig_configuration(n, desc1, configType1, configType2, false),
+				Config: testAccGroupConfig_configuration(rName, desc1, configType1, configType2, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "name", n),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", desc1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", configType1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.1.type", configType2),
@@ -154,10 +154,10 @@ func TestAccResourceGroupsGroup_Configuration(t *testing.T) {
 			},
 			// Check that changing the auto-allocate value is represented
 			{
-				Config: testAccGroupConfig_configuration(n, desc1, configType1, configType2, true),
+				Config: testAccGroupConfig_configuration(rName, desc1, configType1, configType2, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "name", n),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", desc1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", configType1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.1.type", configType2),
@@ -169,14 +169,14 @@ func TestAccResourceGroupsGroup_Configuration(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGroupConfig_configuration(n, desc2, configType1, configType2, true),
+				Config: testAccGroupConfig_configuration(rName, desc2, configType1, configType2, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", desc2),
 				),
 			},
 			// Check that trying to change the configuration group to a resource-query group fails
 			{
-				Config:      testAccGroupConfig_basic(n, desc1, testAccResourceGroupQueryConfig),
+				Config:      testAccGroupConfig_basic(rName, desc1, testAccResourceGroupQueryConfig),
 				ExpectError: regexp.MustCompile(`conversion between resource-query and configuration group types is not possible`),
 			},
 		},
@@ -249,12 +249,12 @@ const testAccResourceGroupQueryConfig = `{
 func testAccGroupConfig_basic(rName, desc, query string) string {
 	return fmt.Sprintf(`
 resource "aws_resourcegroups_group" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[2]q
 
   resource_query {
     query = <<JSON
-%s
+%[3]s
 JSON
 
   }
@@ -265,18 +265,18 @@ JSON
 func testAccGroupConfig_tags1(rName, desc, query, tag1Key, tag1Value string) string {
 	return fmt.Sprintf(`
 resource "aws_resourcegroups_group" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[2]q
 
   resource_query {
     query = <<JSON
-%s
+%[3]s
 JSON
 
   }
 
   tags = {
-    %q = %q
+    %[4]q = %[5]q
   }
 }
 `, rName, desc, query, tag1Key, tag1Value)
@@ -285,19 +285,19 @@ JSON
 func testAccGroupConfig_tags2(rName, desc, query, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_resourcegroups_group" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[2]q
 
   resource_query {
     query = <<JSON
-%s
+%[3]s
 JSON
 
   }
 
   tags = {
-    %q = %q
-    %q = %q
+    %[4]q = %[5]q
+    %[6]q = %[7]q
   }
 }
 `, rName, desc, query, tag1Key, tag1Value, tag2Key, tag2Value)
@@ -306,11 +306,11 @@ JSON
 func testAccGroupConfig_configuration(rName, desc, cType1, cType2 string, autoAllocateHost bool) string {
 	return fmt.Sprintf(`
 resource "aws_resourcegroups_group" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[2]q
 
   configuration {
-    type = "%s"
+    type = %[3]q
 
     parameters {
       name = "allowed-host-families"
@@ -329,7 +329,7 @@ resource "aws_resourcegroups_group" "test" {
     parameters {
       name = "auto-allocate-host"
       values = [
-        "%t",
+        "%[4]t",
       ]
     }
 
@@ -342,7 +342,7 @@ resource "aws_resourcegroups_group" "test" {
   }
 
   configuration {
-    type = "%s"
+    type = %[5]q
 
     parameters {
       name = "allowed-resource-types"

--- a/internal/service/resourcegroups/group_test.go
+++ b/internal/service/resourcegroups/group_test.go
@@ -1,6 +1,7 @@
 package resourcegroups_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -195,7 +196,7 @@ func testAccCheckResourceGroupExists(n string, v *resourcegroups.Group) resource
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ResourceGroupsConn
 
-		output, err := tfresourcegroups.FindGroupByName(conn, rs.Primary.ID)
+		output, err := tfresourcegroups.FindGroupByName(context.Background(), conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -215,7 +216,7 @@ func testAccCheckResourceGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfresourcegroups.FindGroupByName(conn, rs.Primary.ID)
+		_, err := tfresourcegroups.FindGroupByName(context.Background(), conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue

--- a/internal/service/resourcegroups/group_test.go
+++ b/internal/service/resourcegroups/group_test.go
@@ -320,28 +320,28 @@ resource "aws_resourcegroups_group" "test" {
     type = "%s"
 
     parameters {
-      name   = "allowed-host-families"
+      name = "allowed-host-families"
       values = [
         "mac1",
       ]
     }
 
     parameters {
-      name   = "any-host-based-license-configuration"
+      name = "any-host-based-license-configuration"
       values = [
         "true",
       ]
     }
 
     parameters {
-      name   = "auto-allocate-host"
+      name = "auto-allocate-host"
       values = [
         "%t",
       ]
     }
 
     parameters {
-      name   = "auto-release-host"
+      name = "auto-release-host"
       values = [
         "true",
       ]

--- a/internal/service/resourcegroups/group_test.go
+++ b/internal/service/resourcegroups/group_test.go
@@ -2,6 +2,7 @@ package resourcegroups_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -63,6 +64,73 @@ func TestAccResourceGroupsGroup_Resource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", desc2),
 					resource.TestCheckResourceAttr(resourceName, "resource_query.0.query", query2+"\n"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceGroupsGroup_Resource_Configuration(t *testing.T) {
+	var v resourcegroups.Group
+	resourceName := "aws_resourcegroups_group.test"
+	n := fmt.Sprintf("test-group-%d", sdkacctest.RandInt())
+
+	desc1 := "Hello World"
+	desc2 := "Foo Bar"
+	configType1 := "AWS::EC2::HostManagement"
+	configType2 := "AWS::ResourceGroups::Generic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, resourcegroups.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupConfig_config(n, desc1, configType1, configType2, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", n),
+					resource.TestCheckResourceAttr(resourceName, "description", desc1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", configType1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.1.type", configType2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.0.name", "allowed-host-families"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.0.values.0", "mac1"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Check that changing the auto-allocate value is represented
+			{
+				Config: testAccGroupConfig_config(n, desc1, configType1, configType2, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", n),
+					resource.TestCheckResourceAttr(resourceName, "description", desc1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", configType1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.1.type", configType2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.2.name", "auto-allocate-host"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.2.values.0", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+			{
+				Config: testAccGroupConfig_config(n, desc2, configType1, configType2, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", desc2),
+				),
+			},
+			// Check that trying to change the configuration group to a resource-query group fails
+			{
+				Config:      testAccGroupConfig_basic(n, desc1, testAccResourceGroupQueryConfig),
+				ExpectError: regexp.MustCompile(`conversion between resource-query and configuration group types is not possible`),
 			},
 		},
 	})
@@ -240,4 +308,63 @@ JSON
   }
 }
 `, rName, desc, query, tag1Key, tag1Value, tag2Key, tag2Value)
+}
+
+func testAccGroupConfig_config(rName, desc, cType1, cType2 string, autoAllocateHost bool) string {
+	return fmt.Sprintf(`
+resource "aws_resourcegroups_group" "test" {
+  name        = "%s"
+  description = "%s"
+
+  configuration {
+    type = "%s"
+
+    parameters {
+      name   = "allowed-host-families"
+      values = [
+        "mac1",
+      ]
+    }
+
+    parameters {
+      name   = "any-host-based-license-configuration"
+      values = [
+        "true",
+      ]
+    }
+
+    parameters {
+      name   = "auto-allocate-host"
+      values = [
+        "%t",
+      ]
+    }
+
+    parameters {
+      name   = "auto-release-host"
+      values = [
+        "true",
+      ]
+    }
+  }
+
+  configuration {
+    type = "%s"
+
+    parameters {
+      name = "allowed-resource-types"
+      values = [
+        "AWS::EC2::Host",
+      ]
+    }
+
+    parameters {
+      name = "deletion-protection"
+      values = [
+        "UNLESS_EMPTY"
+      ]
+    }
+  }
+}
+`, rName, desc, cType1, autoAllocateHost, cType2)
 }

--- a/website/docs/r/resourcegroups_group.html.markdown
+++ b/website/docs/r/resourcegroups_group.html.markdown
@@ -39,14 +39,25 @@ JSON
 The following arguments are supported:
 
 * `name` - (Required) The resource group's name. A resource group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`.
+* `configuration` - (Optional) A configuration associates the resource group with an AWS service and specifies how the service can interact with the resources in the group. See below for details.
 * `description` - (Optional) A description of the resource group.
 * `resource_query` - (Required) A `resource_query` block. Resource queries are documented below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-An `resource_query` block supports the following arguments:
+The `resource_query` block supports the following arguments:
 
 * `query` - (Required) The resource query as a JSON string.
 * `type` - (Required) The type of the resource query. Defaults to `TAG_FILTERS_1_0`.
+
+The `configuration` block supports the following arguments:
+
+* `type` - (Required) Specifies the type of group configuration item.
+* `parameters` - (Optional) A collection of parameters for this group configuration item. See below for details.
+
+The `parameters` block supports the following arguments:
+
+* `name` - (Required) The name of the group configuration parameter.
+* `values` - (Optional) The value or values to be used for the specified parameter.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #26933

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I added some new acceptance tests for the configuration group and also verified that the additions don't fail the existing acceptance tests. 

```
$ make testacc TESTS=TestAccResourceGroupsGroup PKG=resourcegroups
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/resourcegroups/... -v -count 1 -parallel 20 -run='TestAccResourceGroupsGroup'  -timeout 180m
=== RUN   TestAccResourceGroupsGroup_Resource_basic
=== PAUSE TestAccResourceGroupsGroup_Resource_basic
=== RUN   TestAccResourceGroupsGroup_Resource_Configuration
=== PAUSE TestAccResourceGroupsGroup_Resource_Configuration
=== RUN   TestAccResourceGroupsGroup_Resource_tags
=== PAUSE TestAccResourceGroupsGroup_Resource_tags
=== CONT  TestAccResourceGroupsGroup_Resource_basic
=== CONT  TestAccResourceGroupsGroup_Resource_Configuration
=== CONT  TestAccResourceGroupsGroup_Resource_tags
--- PASS: TestAccResourceGroupsGroup_Resource_basic (30.40s)
--- PASS: TestAccResourceGroupsGroup_Resource_tags (47.49s)
--- PASS: TestAccResourceGroupsGroup_Resource_Configuration (55.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups	57.856s
...
```
