### PR TITLE
Add support for additional deployment_targets config for aws_cloudformation_stack_set_instance

### DIFF
--- a/.changelog/26935.txt
+++ b/.changelog/26935.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudformation_stack_set_instance: Extend `deployment_targets` argument
+```

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -71,7 +71,6 @@ func ResourceStackSetInstance() *schema.Resource {
 							Optional:      true,
 							ConflictsWith: []string{"account_id"},
 							ValidateFunc:  validation.StringInSlice(cloudformation.AccountFilterType_Values(), false),
-							Default:       cloudformation.CallAsSelf,
 						},
 						"accounts": {
 							Type:          schema.TypeSet,

--- a/internal/service/cloudformation/stack_set_instance_test.go
+++ b/internal/service/cloudformation/stack_set_instance_test.go
@@ -247,6 +247,9 @@ func TestAccCloudFormationStackSetInstance_deploymentTargets(t *testing.T) {
 					testAccCheckStackSetInstanceExists(resourceName, &stackInstance),
 					resource.TestCheckResourceAttr(resourceName, "deployment_targets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.organizational_unit_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.account_filter_type", "INTERSECTION"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.accounts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.accounts_url", "https://s3.eu-west-1.amazonaws.com/"),
 				),
 			},
 			{

--- a/internal/service/cloudformation/stack_set_instance_test.go
+++ b/internal/service/cloudformation/stack_set_instance_test.go
@@ -249,7 +249,7 @@ func TestAccCloudFormationStackSetInstance_deploymentTargets(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.organizational_unit_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.account_filter_type", "INTERSECTION"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.accounts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.accounts_url", "https://s3.eu-west-1.amazonaws.com/"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_targets.0.accounts_url", ""),
 				),
 			},
 			{
@@ -700,7 +700,9 @@ resource "aws_cloudformation_stack_set_instance" "test" {
   depends_on = [aws_iam_role_policy.Administration, aws_iam_role_policy.Execution]
 
   deployment_targets {
-    organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
+    account_filter_type = "INTERSECTION"
+	accounts = [data.aws_organizations_organization.test.non_master_accounts[0].id]
+	organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
   }
 
   stack_set_name = aws_cloudformation_stack_set.test.name
@@ -729,7 +731,9 @@ resource "aws_cloudformation_stack_set_instance" "test" {
   }
 
   deployment_targets {
-    organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
+    account_filter_type = "INTERSECTION"
+	accounts = [data.aws_organizations_organization.test.non_master_accounts[0].id]
+	organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
   }
 
   stack_set_name = aws_cloudformation_stack_set.test.name

--- a/internal/service/cloudformation/stack_set_instance_test.go
+++ b/internal/service/cloudformation/stack_set_instance_test.go
@@ -253,16 +253,6 @@ func TestAccCloudFormationStackSetInstance_deploymentTargets(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"retain_stack",
-					"deployment_targets",
-					"call_as",
-				},
-			},
-			{
 				Config: testAccStackSetInstanceConfig_serviceManaged(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStackSetInstanceExists(resourceName, &stackInstance),
@@ -700,9 +690,9 @@ resource "aws_cloudformation_stack_set_instance" "test" {
   depends_on = [aws_iam_role_policy.Administration, aws_iam_role_policy.Execution]
 
   deployment_targets {
-    account_filter_type = "INTERSECTION"
-	accounts = [data.aws_organizations_organization.test.non_master_accounts[0].id]
 	organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
+	account_filter_type = "INTERSECTION"
+	accounts = [data.aws_organizations_organization.test.non_master_accounts[0].id]
   }
 
   stack_set_name = aws_cloudformation_stack_set.test.name
@@ -731,8 +721,6 @@ resource "aws_cloudformation_stack_set_instance" "test" {
   }
 
   deployment_targets {
-    account_filter_type = "INTERSECTION"
-	accounts = [data.aws_organizations_organization.test.non_master_accounts[0].id]
 	organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
   }
 

--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 * `stack_set_name` - (Required) Name of the StackSet.
 * `account_id` - (Optional) Target AWS Account ID to create a Stack based on the StackSet. Defaults to current account.
-* `deployment_targets` - (Optional) The AWS Organizations accounts to which StackSets deploys. StackSets doesn't deploy stack instances to the organization management account, even if the organization management account is in your organization or in an OU in your organization. Drift detection is not possible for this argument. See [deployment_targets](#deployment_targets-argument-reference) below.
+* `deployment_targets` - (Optional) Key-value map of input parameters to specify deployment targets across AWS Organizational Units and Accounts with filters where required. StackSets doesn't deploy stack instances to the organization management account, even if the organization management account is in your organization or in an OU in your organization. Drift detection is not possible for this argument. See [deployment_targets](#deployment_targets-argument-reference) below.
 * `parameter_overrides` - (Optional) Key-value map of input parameters to override from the StackSet for this Instance.
 * `region` - (Optional) Target AWS Region to create a Stack based on the StackSet. Defaults to current region.
 * `retain_stack` - (Optional) During Terraform resource destroy, remove Instance from StackSet while keeping the Stack and its associated resources. Must be enabled in Terraform state _before_ destroy operation to take effect. You cannot reassociate a retained Stack or add an existing, saved Stack to a new StackSet. Defaults to `false`.
@@ -96,7 +96,10 @@ The following arguments are supported:
 
 The `deployment_targets` configuration block supports the following arguments:
 
-*`organizational_unit_ids` - (Optional) The organization root ID or organizational unit (OU) IDs to which StackSets deploys.
+*`organizational_unit_ids` - (Optional) The organization root ID or organizational unit (OU) IDs to which StackSets deploys. Providing only this parameter will deploy the stackset to all accounts specified in this Organizational Unit.
+*`account_filter_type` - (Optional) The filter type to be used to filter accounts within the specified organizational unit (OU). Valid values: `INTERSECTION`, `DIFFERENCE`, `UNION`, `NONE`.
+*`accounts` - (Optional) The list of accounts to deploy the StackSet in.
+*`accounts_url` - (Optional) Returns the value of the AccountsUrl property..
 
 ### `operation_preferences` Argument Reference
 


### PR DESCRIPTION
## Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

## Release Note:

* resource/aws_cloudformation_stack_set_instance: Extend `deployment_targets` argument

## Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccCloudFormationStackSet_\|TestAccCloudFormationStackSetInstance_' PKG=cloudformation ACCTEST_PARALLELISM=3 TF_ACC_LOG_PATH=/Users/harrison.hughes/repos/terraform-provider-aws/logs/log3.txt TF_LOG_CORE
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 3  -run=TestAccCloudFormationStackSet_\|TestAccCloudFormationStackSetInstance_ -timeout 180m
=== RUN   TestAccCloudFormationStackSetInstance_basic
=== PAUSE TestAccCloudFormationStackSetInstance_basic
=== RUN   TestAccCloudFormationStackSetInstance_disappears
=== PAUSE TestAccCloudFormationStackSetInstance_disappears
=== RUN   TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== PAUSE TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== RUN   TestAccCloudFormationStackSetInstance_parameterOverrides
=== PAUSE TestAccCloudFormationStackSetInstance_parameterOverrides
=== RUN   TestAccCloudFormationStackSetInstance_retainStack
=== PAUSE TestAccCloudFormationStackSetInstance_retainStack
=== RUN   TestAccCloudFormationStackSetInstance_deploymentTargets
=== PAUSE TestAccCloudFormationStackSetInstance_deploymentTargets
=== RUN   TestAccCloudFormationStackSetInstance_operationPreferences
=== PAUSE TestAccCloudFormationStackSetInstance_operationPreferences
=== RUN   TestAccCloudFormationStackSet_basic
=== PAUSE TestAccCloudFormationStackSet_basic
=== RUN   TestAccCloudFormationStackSet_disappears
=== PAUSE TestAccCloudFormationStackSet_disappears
=== RUN   TestAccCloudFormationStackSet_administrationRoleARN
=== PAUSE TestAccCloudFormationStackSet_administrationRoleARN
=== RUN   TestAccCloudFormationStackSet_description
=== PAUSE TestAccCloudFormationStackSet_description
=== RUN   TestAccCloudFormationStackSet_executionRoleName
=== PAUSE TestAccCloudFormationStackSet_executionRoleName
=== RUN   TestAccCloudFormationStackSet_name
=== PAUSE TestAccCloudFormationStackSet_name
=== RUN   TestAccCloudFormationStackSet_operationPreferences
=== PAUSE TestAccCloudFormationStackSet_operationPreferences
=== RUN   TestAccCloudFormationStackSet_parameters
=== PAUSE TestAccCloudFormationStackSet_parameters
=== RUN   TestAccCloudFormationStackSet_Parameters_default
    acctest.go:69: this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property
--- SKIP: TestAccCloudFormationStackSet_Parameters_default (0.00s)
=== RUN   TestAccCloudFormationStackSet_Parameters_noEcho
    acctest.go:69: this resource does not currently ignore CloudFormation template parameters with the NoEcho property
--- SKIP: TestAccCloudFormationStackSet_Parameters_noEcho (0.00s)
=== RUN   TestAccCloudFormationStackSet_PermissionModel_serviceManaged
    acctest.go:69: API does not support enabling Organizations access (in particular, creating the Stack Sets IAM Service-Linked Role)
--- SKIP: TestAccCloudFormationStackSet_PermissionModel_serviceManaged (0.00s)
=== RUN   TestAccCloudFormationStackSet_tags
=== PAUSE TestAccCloudFormationStackSet_tags
=== RUN   TestAccCloudFormationStackSet_templateBody
=== PAUSE TestAccCloudFormationStackSet_templateBody
=== RUN   TestAccCloudFormationStackSet_templateURL
=== PAUSE TestAccCloudFormationStackSet_templateURL
=== CONT  TestAccCloudFormationStackSetInstance_basic
=== CONT  TestAccCloudFormationStackSet_administrationRoleARN
=== CONT  TestAccCloudFormationStackSet_parameters
--- PASS: TestAccCloudFormationStackSet_administrationRoleARN (46.63s)
=== CONT  TestAccCloudFormationStackSetInstance_deploymentTargets
--- PASS: TestAccCloudFormationStackSet_parameters (85.57s)
=== CONT  TestAccCloudFormationStackSet_disappears
--- PASS: TestAccCloudFormationStackSetInstance_basic (96.40s)
=== CONT  TestAccCloudFormationStackSet_basic
--- PASS: TestAccCloudFormationStackSet_disappears (18.00s)
=== CONT  TestAccCloudFormationStackSetInstance_operationPreferences
--- PASS: TestAccCloudFormationStackSet_basic (24.31s)
=== CONT  TestAccCloudFormationStackSetInstance_parameterOverrides
--- PASS: TestAccCloudFormationStackSetInstance_deploymentTargets (129.52s)
=== CONT  TestAccCloudFormationStackSetInstance_retainStack
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (190.13s)
=== CONT  TestAccCloudFormationStackSet_name
--- PASS: TestAccCloudFormationStackSetInstance_retainStack (160.94s)
=== CONT  TestAccCloudFormationStackSet_operationPreferences
--- PASS: TestAccCloudFormationStackSet_name (42.72s)
=== CONT  TestAccCloudFormationStackSetInstance_Disappears_stackSet
--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (82.46s)
=== CONT  TestAccCloudFormationStackSetInstance_disappears
--- PASS: TestAccCloudFormationStackSet_operationPreferences (125.08s)
=== CONT  TestAccCloudFormationStackSet_templateBody
--- PASS: TestAccCloudFormationStackSet_templateBody (43.17s)
=== CONT  TestAccCloudFormationStackSet_templateURL
--- PASS: TestAccCloudFormationStackSetInstance_disappears (109.16s)
=== CONT  TestAccCloudFormationStackSet_executionRoleName
--- PASS: TestAccCloudFormationStackSet_templateURL (44.86s)
=== CONT  TestAccCloudFormationStackSet_description
--- PASS: TestAccCloudFormationStackSet_description (42.97s)
=== CONT  TestAccCloudFormationStackSet_tags
--- PASS: TestAccCloudFormationStackSet_executionRoleName (57.46s)
--- PASS: TestAccCloudFormationStackSetInstance_operationPreferences (514.53s)
--- PASS: TestAccCloudFormationStackSet_tags (108.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	703.273s

...
```

## Closes

Closes #26917 

## Other Notes

I've mostly adapted the work done by @jnixon-blue here https://github.com/hashicorp/terraform-provider-aws/pull/23908 

We have a use case where it would be great to have this support added to target multiple accounts within an organization with the use of SERVICE_MANAGED permissions. Ive tested these changes to the provider locally and they work as expected.


