### PR TITLE
resource/aws_sqs_queue: Fix panic in sweeper

### DIFF
--- a/internal/service/sqs/sweep.go
+++ b/internal/service/sqs/sweep.go
@@ -49,7 +49,7 @@ func sweepQueues(region string) error {
 			r := ResourceQueue()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(queueUrl))
-			err = r.Delete(d, client)
+			err = sweep.DeleteResource(r, d, client)
 
 			if err != nil {
 				log.Printf("[ERROR] %s", err)


### PR DESCRIPTION
The update to `aws_sqs_queue` to use WithoutTimeout CRUD handlers in #26733 caused a panic the sweeper because the sweeper directly referenced the `Delete` function.

Previously:

```
[DEBUG] Running Sweeper (aws_sqs_queue) in region (us-east-1)
panic: runtime error: invalid memory address or nil pointer dereference
```

Now:

```
[DEBUG] Running Sweeper (aws_sqs_queue) in region (us-east-1)
	- aws_sqs_queue
[DEBUG] Completed Sweeper (aws_sqs_queue) in region (us-east-1) in 1.424072016s
Completed Sweepers for region (us-east-1) in 1.424115238s
```