### PR TITLE
resource/aws_iam_role: Add sweeper dependency on `aws_iot_topic_rule_destination`

### DIFF
--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -67,6 +67,7 @@ func init() {
 			"aws_glue_crawler",
 			"aws_glue_job",
 			"aws_instance",
+			"aws_iot_topic_rule_destination",
 			"aws_lambda_function",
 			"aws_launch_configuration",
 			"aws_redshift_cluster",


### PR DESCRIPTION
If the associated IAM role is deleted before a `aws_iot_topic_rule_destination`, it may get stuck in `Deleting` status. Add dependency.
