### PR TITLE
resource/aws_network_interface : Add sweeper dependency on `aws_db_proxy`

### DIFF
--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -149,6 +149,7 @@ func init() {
 		Name: "aws_network_interface",
 		F:    sweepNetworkInterfaces,
 		Dependencies: []string{
+			"aws_db_proxy",
 			"aws_directory_service_directory",
 			"aws_ec2_client_vpn_endpoint",
 			"aws_ec2_transit_gateway_vpc_attachment",


### PR DESCRIPTION
`aws_db_proxy` creates an ENI, so it must be swept before `aws_network_interface`