### PR TITLE
docs(iam_access_key): add instructions about the expected `pgp_key` format

### DIFF
--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -67,7 +67,7 @@ output "aws_iam_smtp_password_v4" {
 
 The following arguments are supported:
 
-* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:some_person_that_exists`, for use in the `encrypted_secret` output attribute.
+* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:some_person_that_exists`, for use in the `encrypted_secret` output attribute. If providing a base-64 encoded PGP public key, make sure to provide the "raw" version and not the "armored" one (e.g. avoid passing the `-a` option to `gpg --export`).
 * `status` - (Optional) Access key status to apply. Defaults to `Active`. Valid values are `Active` and `Inactive`.
 * `user` - (Required) IAM user to associate with this access key.
 


### PR DESCRIPTION
Relates to #10835

When providing a base-64 encoded PGP public key as `pgp_key` for the `iam_access_key` resource, only a "raw" export is accepted - not an ASCII "armored" one with `BEGIN` and `END` markers. This commit make this explicit for a better user experience, given that previously users would just get a `invalid data: tag byte does not have MSB set` cryptic error as reported in https://github.com/hashicorp/terraform/issues/10835

This documentation addition was suggested in 2017 but never got contributed until now: https://github.com/hashicorp/terraform/issues/10835#issuecomment-348593664
