### PR TITLE
workflows: Updates paths to `tools` directory in GitHub workflows

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -9,9 +9,9 @@ on:
       - .github/workflows/acctest-terraform-lint.yml
       - .go-version
       - .ci/.tflint.hcl
-      - 'internal/service/**/*_test.go'
       - .ci/scripts/validate-terraform.sh
-      - tools/go.mod
+      - .ci/tools/go.mod
+      - 'internal/service/**/*_test.go'
 
 env:
   TEST_FILES_PARTITION1: '\./internal/service/[a-f].*/.*_test\.go'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,8 +8,8 @@ on:
       - .github/workflows/examples.yml
       - .go-version
       - .ci/.tflint.hcl
+      - .ci/tools/go.mod
       - examples/**
-      - tools/go.mod
 
 env:
   AWS_DEFAULT_REGION: us-west-2

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -11,6 +11,7 @@ on:
       - .ci/scripts/providerlint.sh
       - .go-version
       - .ci/.golangci.yml
+      - .ci/tools/go.mod
       - .markdownlint.yml
       - internal/**
       - docs/index.md
@@ -21,7 +22,6 @@ on:
       - GNUmakefile
       - main.go
       - names/**
-      - tools/**
       - website/**
 
 env:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,9 +13,9 @@ on:
       - .go-version
       - .ci/.markdownlinkcheck.json
       - .ci/.tflint.hcl
+      - .ci/tools/go.mod
       - .markdownlint.yml
       - website/docs/**
-      - tools/go.mod
 
 jobs:
   markdown-link-check-a-h-markdown:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/*
+      - .ci/tools/go.mod
 jobs:
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The GitHub workflow for `Workflow Linting` did not reference the `tools` directory to trigger a run if `actionlint` is updated.

Other references were not updated for the move of `tools` into the `.ci` directory.
