### PR TITLE
r/aws_lb_target_group - check no target group with the same name exists

### DIFF
--- a/.changelog/26977.txt
+++ b/.changelog/26977.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb_target_group: when creating a new target group check for an existing target group with the same name
+```

--- a/.changelog/26977.txt
+++ b/.changelog/26977.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_lb_target_group: when creating a new target group check for an existing target group with the same name
+resource/aws_lb_target_group: When creating a new target group, return an error if there is an existing target group with the same name. Use [`terraform import`](https://developer.hashicorp.com/terraform/cli/commands/import) for existing target groups
 ```

--- a/internal/service/elbv2/find.go
+++ b/internal/service/elbv2/find.go
@@ -92,3 +92,19 @@ func FindTargetGroupByARN(conn *elbv2.ELBV2, arn string) (*elbv2.TargetGroup, er
 
 	return nil, nil
 }
+
+func FindTargetGroupByName(conn *elbv2.ELBV2, name string) (*elbv2.TargetGroup, error) {
+	output, err := conn.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
+		Names: aws.StringSlice([]string{name}),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.TargetGroups) == 0 {
+		return nil, nil
+	}
+
+	return output.TargetGroups[0], nil
+}

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -301,6 +301,14 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		groupName = resource.PrefixedUniqueId("tf-")
 	}
 
+	existingTg, err := FindTargetGroupByName(conn, groupName)
+	if err != nil && !tfawserr.ErrCodeEquals(err, elbv2.ErrCodeTargetGroupNotFoundException) {
+		return fmt.Errorf("finding target group by name (%s): %w", groupName, err)
+	}
+	if existingTg != nil {
+		return fmt.Errorf("target group with name (%s) already exists", groupName)
+	}
+
 	params := &elbv2.CreateTargetGroupInput{
 		Name:       aws.String(groupName),
 		TargetType: aws.String(d.Get("target_type").(string)),


### PR DESCRIPTION
When creating a target group check that a target group with the same name does not already exist.

The [create target group API](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html) is idempotent

> This operation is idempotent, which means that it completes at most one time. If you attempt to create multiple target groups with the same settings, each call succeeds.

As a result if we create 2 target groups with the same configuration Terraform will associate all the other identical target
groups with original's ARN.

We will now call the [describe target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeTargetGroups.html) API before creating a new target group with the name of the target group we are about to create. If an existing target group exists then we will now prevent the target group from being created.

This is not a perfect fix. AWS will prevent users creating two _different_ target groups with the same name, however
it will prevent the situation where the user may accidentally create a target group that is identical to an existing resource.

Note that these changes makes no attempt to fix this scenario occurring under race conditions (the user creates 2 identical target groups as part of the same Terraform apply). 

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/

If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates 

For Example:

Relates #0000
or 
Closes #0000
--->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccELBV2TargetGroup_Name_noDuplicates PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_Name_noDuplicates'  -timeout 180m
=== RUN   TestAccELBV2TargetGroup_Name_noDuplicates
=== PAUSE TestAccELBV2TargetGroup_Name_noDuplicates
=== CONT  TestAccELBV2TargetGroup_Name_noDuplicates
--- PASS: TestAccELBV2TargetGroup_Name_noDuplicates (37.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      38.020s

...
```
