### PR TITLE
New Resource: aws_kms_custom_key_store

### DIFF
--- a/.changelog/26997.txt
+++ b/.changelog/26997.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+ aws_kms_custom_key_store
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1660,6 +1660,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 
 			"aws_kms_alias":                kms.ResourceAlias(),
 			"aws_kms_ciphertext":           kms.ResourceCiphertext(),
+			"aws_kms_custom_key_store":     kms.ResourceCustomKeyStore(),
 			"aws_kms_external_key":         kms.ResourceExternalKey(),
 			"aws_kms_grant":                kms.ResourceGrant(),
 			"aws_kms_key":                  kms.ResourceKey(),

--- a/internal/service/kms/custom_key_store.go
+++ b/internal/service/kms/custom_key_store.go
@@ -72,7 +72,7 @@ func resourceCustomKeyStoreCreate(ctx context.Context, d *schema.ResourceData, m
 
 	out, err := conn.CreateCustomKeyStoreWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.KMS, create.ErrActionCreating, ResNameCustomKeyStore, d.Get("name").(string), err)
+		return create.DiagError(names.KMS, create.ErrActionCreating, ResNameCustomKeyStore, d.Get("custom_key_store_name").(string), err)
 	}
 
 	if out == nil {
@@ -240,4 +240,3 @@ func resourceCustomKeyStoreDelete(ctx context.Context, d *schema.ResourceData, m
 //		return out, aws.ToString(out.Status), nil
 //	}
 //}
-

--- a/internal/service/kms/custom_key_store.go
+++ b/internal/service/kms/custom_key_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -29,9 +30,9 @@ func ResourceCustomKeyStore() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -45,8 +46,9 @@ func ResourceCustomKeyStore() *schema.Resource {
 				Required: true,
 			},
 			"key_store_password": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(7, 32)),
 			},
 			"trust_anchor_certificate": {
 				Type:     schema.TypeString,
@@ -103,7 +105,7 @@ func resourceCustomKeyStoreRead(ctx context.Context, d *schema.ResourceData, met
 		return create.DiagError(names.KMS, create.ErrActionReading, ResNameCustomKeyStore, d.Id(), err)
 	}
 
-	d.Set("cloud_hms_cluster_id", out.CloudHsmClusterId)
+	d.Set("cloud_hsm_cluster_id", out.CloudHsmClusterId)
 	d.Set("custom_key_store_name", out.CustomKeyStoreName)
 	d.Set("trust_anchor_certificate", out.TrustAnchorCertificate)
 

--- a/internal/service/kms/custom_key_store.go
+++ b/internal/service/kms/custom_key_store.go
@@ -1,0 +1,243 @@
+package kms
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceCustomKeyStore() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceCustomKeyStoreCreate,
+		ReadWithoutTimeout:   resourceCustomKeyStoreRead,
+		UpdateWithoutTimeout: resourceCustomKeyStoreUpdate,
+		DeleteWithoutTimeout: resourceCustomKeyStoreDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cloud_hsm_cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"custom_key_store_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key_store_password": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"trust_anchor_certificate": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+const (
+	ResNameCustomKeyStore = "Custom Key Store"
+)
+
+func resourceCustomKeyStoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).KMSConn
+
+	in := &kms.CreateCustomKeyStoreInput{
+		CloudHsmClusterId:      aws.String(d.Get("cloud_hsm_cluster_id").(string)),
+		CustomKeyStoreName:     aws.String(d.Get("custom_key_store_name").(string)),
+		KeyStorePassword:       aws.String(d.Get("key_store_password").(string)),
+		TrustAnchorCertificate: aws.String(d.Get("trust_anchor_certificate").(string)),
+	}
+
+	out, err := conn.CreateCustomKeyStoreWithContext(ctx, in)
+	if err != nil {
+		return create.DiagError(names.KMS, create.ErrActionCreating, ResNameCustomKeyStore, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.KMS, create.ErrActionCreating, ResNameCustomKeyStore, d.Get("custom_key_store_name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.StringValue(out.CustomKeyStoreId))
+
+	//if _, err := waitCustomKeyStoreCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+	//	return create.DiagError(names.KMS, create.ErrActionWaitingForCreation, ResNameCustomKeyStore, d.Id(), err)
+	//}
+
+	return resourceCustomKeyStoreRead(ctx, d, meta)
+}
+
+func resourceCustomKeyStoreRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).KMSConn
+
+	out, err := FindCustomKeyStoreByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] KMS CustomKeyStore (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.KMS, create.ErrActionReading, ResNameCustomKeyStore, d.Id(), err)
+	}
+
+	d.Set("cloud_hms_cluster_id", out.CloudHsmClusterId)
+	d.Set("custom_key_store_name", out.CustomKeyStoreName)
+	d.Set("trust_anchor_certificate", out.TrustAnchorCertificate)
+
+	return nil
+}
+
+func resourceCustomKeyStoreUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).KMSConn
+
+	update := false
+
+	in := &kms.UpdateCustomKeyStoreInput{
+		CustomKeyStoreId:  aws.String(d.Id()),
+		CloudHsmClusterId: aws.String(d.Get("cloud_hsm_cluster_id").(string)),
+	}
+
+	if d.HasChange("key_store_password") {
+		in.KeyStorePassword = aws.String(d.Get("key_store_password").(string))
+		update = true
+	}
+
+	if d.HasChange("custom_key_store_name") {
+		in.NewCustomKeyStoreName = aws.String(d.Get("custom_key_store_name").(string))
+		update = true
+	}
+
+	if !update {
+		return nil
+	}
+
+	log.Printf("[DEBUG] Updating KMS CustomKeyStore (%s): %#v", d.Id(), in)
+	_, err := conn.UpdateCustomKeyStoreWithContext(ctx, in)
+	if err != nil {
+		return create.DiagError(names.KMS, create.ErrActionUpdating, ResNameCustomKeyStore, d.Id(), err)
+	}
+
+	//if _, err := waitCustomKeyStoreUpdated(ctx, conn, aws.ToString(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	//	return create.DiagError(names.KMS, create.ErrActionWaitingForUpdate, ResNameCustomKeyStore, d.Id(), err)
+	//}
+
+	return resourceCustomKeyStoreRead(ctx, d, meta)
+}
+
+func resourceCustomKeyStoreDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).KMSConn
+
+	log.Printf("[INFO] Deleting KMS CustomKeyStore %s", d.Id())
+
+	_, err := conn.DeleteCustomKeyStoreWithContext(ctx, &kms.DeleteCustomKeyStoreInput{
+		CustomKeyStoreId: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	//if _, err := waitCustomKeyStoreDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	//	return create.DiagError(names.KMS, create.ErrActionWaitingForDeletion, ResNameCustomKeyStore, d.Id(), err)
+	//}
+
+	return nil
+}
+
+//const (
+//	statusChangePending = "Pending"
+//	statusDeleting      = "Deleting"
+//	statusNormal        = "Normal"
+//	statusUpdated       = "Updated"
+//)
+//
+//func waitCustomKeyStoreCreated(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*kms.CustomKeyStore, error) {
+//	stateConf := &resource.StateChangeConf{
+//		Pending:                   []string{},
+//		Target:                    []string{statusNormal},
+//		Refresh:                   statusCustomKeyStore(ctx, conn, id),
+//		Timeout:                   timeout,
+//		NotFoundChecks:            20,
+//		ContinuousTargetOccurence: 2,
+//	}
+//
+//	outputRaw, err := stateConf.WaitForStateContext(ctx)
+//	if out, ok := outputRaw.(*kms.CustomKeyStore); ok {
+//		return out, err
+//	}
+//
+//	return nil, err
+//}
+//
+//func waitCustomKeyStoreUpdated(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*kms.CustomKeyStore, error) {
+//	stateConf := &resource.StateChangeConf{
+//		Pending:                   []string{statusChangePending},
+//		Target:                    []string{statusUpdated},
+//		Refresh:                   statusCustomKeyStore(ctx, conn, id),
+//		Timeout:                   timeout,
+//		NotFoundChecks:            20,
+//		ContinuousTargetOccurence: 2,
+//	}
+//
+//	outputRaw, err := stateConf.WaitForStateContext(ctx)
+//	if out, ok := outputRaw.(*kms.CustomKeyStore); ok {
+//		return out, err
+//	}
+//
+//	return nil, err
+//}
+//
+//func waitCustomKeyStoreDeleted(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*kms.CustomKeyStore, error) {
+//	stateConf := &resource.StateChangeConf{
+//		Pending: []string{statusDeleting, statusNormal},
+//		Target:  []string{},
+//		Refresh: statusCustomKeyStore(ctx, conn, id),
+//		Timeout: timeout,
+//	}
+//
+//	outputRaw, err := stateConf.WaitForStateContext(ctx)
+//	if out, ok := outputRaw.(*kms.CustomKeyStore); ok {
+//		return out, err
+//	}
+//
+//	return nil, err
+//}
+//
+//func statusCustomKeyStore(ctx context.Context, conn *kms.Client, id string) resource.StateRefreshFunc {
+//	return func() (interface{}, string, error) {
+//		out, err := findCustomKeyStoreByID(ctx, conn, id)
+//		if tfresource.NotFound(err) {
+//			return nil, "", nil
+//		}
+//
+//		if err != nil {
+//			return nil, "", err
+//		}
+//
+//		return out, aws.ToString(out.Status), nil
+//	}
+//}
+

--- a/internal/service/kms/custom_key_store.go
+++ b/internal/service/kms/custom_key_store.go
@@ -83,10 +83,6 @@ func resourceCustomKeyStoreCreate(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId(aws.StringValue(out.CustomKeyStoreId))
 
-	//if _, err := waitCustomKeyStoreCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-	//	return create.DiagError(names.KMS, create.ErrActionWaitingForCreation, ResNameCustomKeyStore, d.Id(), err)
-	//}
-
 	return resourceCustomKeyStoreRead(ctx, d, meta)
 }
 
@@ -142,10 +138,6 @@ func resourceCustomKeyStoreUpdate(ctx context.Context, d *schema.ResourceData, m
 		return create.DiagError(names.KMS, create.ErrActionUpdating, ResNameCustomKeyStore, d.Id(), err)
 	}
 
-	//if _, err := waitCustomKeyStoreUpdated(ctx, conn, aws.ToString(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
-	//	return create.DiagError(names.KMS, create.ErrActionWaitingForUpdate, ResNameCustomKeyStore, d.Id(), err)
-	//}
-
 	return resourceCustomKeyStoreRead(ctx, d, meta)
 }
 
@@ -162,83 +154,5 @@ func resourceCustomKeyStoreDelete(ctx context.Context, d *schema.ResourceData, m
 		return nil
 	}
 
-	//if _, err := waitCustomKeyStoreDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-	//	return create.DiagError(names.KMS, create.ErrActionWaitingForDeletion, ResNameCustomKeyStore, d.Id(), err)
-	//}
-
 	return nil
 }
-
-//const (
-//	statusChangePending = "Pending"
-//	statusDeleting      = "Deleting"
-//	statusNormal        = "Normal"
-//	statusUpdated       = "Updated"
-//)
-//
-//func waitCustomKeyStoreCreated(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*kms.CustomKeyStore, error) {
-//	stateConf := &resource.StateChangeConf{
-//		Pending:                   []string{},
-//		Target:                    []string{statusNormal},
-//		Refresh:                   statusCustomKeyStore(ctx, conn, id),
-//		Timeout:                   timeout,
-//		NotFoundChecks:            20,
-//		ContinuousTargetOccurence: 2,
-//	}
-//
-//	outputRaw, err := stateConf.WaitForStateContext(ctx)
-//	if out, ok := outputRaw.(*kms.CustomKeyStore); ok {
-//		return out, err
-//	}
-//
-//	return nil, err
-//}
-//
-//func waitCustomKeyStoreUpdated(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*kms.CustomKeyStore, error) {
-//	stateConf := &resource.StateChangeConf{
-//		Pending:                   []string{statusChangePending},
-//		Target:                    []string{statusUpdated},
-//		Refresh:                   statusCustomKeyStore(ctx, conn, id),
-//		Timeout:                   timeout,
-//		NotFoundChecks:            20,
-//		ContinuousTargetOccurence: 2,
-//	}
-//
-//	outputRaw, err := stateConf.WaitForStateContext(ctx)
-//	if out, ok := outputRaw.(*kms.CustomKeyStore); ok {
-//		return out, err
-//	}
-//
-//	return nil, err
-//}
-//
-//func waitCustomKeyStoreDeleted(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*kms.CustomKeyStore, error) {
-//	stateConf := &resource.StateChangeConf{
-//		Pending: []string{statusDeleting, statusNormal},
-//		Target:  []string{},
-//		Refresh: statusCustomKeyStore(ctx, conn, id),
-//		Timeout: timeout,
-//	}
-//
-//	outputRaw, err := stateConf.WaitForStateContext(ctx)
-//	if out, ok := outputRaw.(*kms.CustomKeyStore); ok {
-//		return out, err
-//	}
-//
-//	return nil, err
-//}
-//
-//func statusCustomKeyStore(ctx context.Context, conn *kms.Client, id string) resource.StateRefreshFunc {
-//	return func() (interface{}, string, error) {
-//		out, err := findCustomKeyStoreByID(ctx, conn, id)
-//		if tfresource.NotFound(err) {
-//			return nil, "", nil
-//		}
-//
-//		if err != nil {
-//			return nil, "", err
-//		}
-//
-//		return out, aws.ToString(out.Status), nil
-//	}
-//}

--- a/internal/service/kms/custom_key_store_test.go
+++ b/internal/service/kms/custom_key_store_test.go
@@ -1,0 +1,178 @@
+package kms_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/kms"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfkms "github.com/hashicorp/terraform-provider-aws/internal/service/kms"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccKMSCustomKeyStore_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var customkeystore kms.CustomKeyStoresListEntry
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_kms_custom_key_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(kms.EndpointsID, t)
+			testAccCustomKeyStoresPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomKeyStoreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomKeyStoreConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomKeyStoreExists(resourceName, &customkeystore),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`customkeystore:+.`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKMSCustomKeyStore_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var customkeystore kms.CustomKeyStoresListEntry
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_kms_custom_key_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(kms.EndpointsID, t)
+			testAccCustomKeyStoresPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomKeyStoreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomKeyStoreConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomKeyStoreExists(resourceName, &customkeystore),
+					acctest.CheckResourceDisappears(acctest.Provider, tfkms.ResourceCustomKeyStore(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCustomKeyStoreDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_kms_custom_key_store" {
+			continue
+		}
+
+		_, err := tfkms.FindCustomKeyStoreByID(ctx, conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		return create.Error(names.KMS, create.ErrActionCheckingDestroyed, tfkms.ResNameCustomKeyStore, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckCustomKeyStoreExists(name string, customkeystore *kms.CustomKeyStoresListEntry) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.KMS, create.ErrActionCheckingExistence, tfkms.ResNameCustomKeyStore, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.KMS, create.ErrActionCheckingExistence, tfkms.ResNameCustomKeyStore, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn
+		ctx := context.Background()
+		resp, err := tfkms.FindCustomKeyStoreByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.KMS, create.ErrActionCheckingExistence, tfkms.ResNameCustomKeyStore, rs.Primary.ID, err)
+		}
+
+		*customkeystore = *resp
+
+		return nil
+	}
+}
+
+func testAccCustomKeyStoresPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn
+	ctx := context.Background()
+
+	input := &kms.DescribeCustomKeyStoresInput{}
+	_, err := conn.DescribeCustomKeyStoresWithContext(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCustomKeyStoreConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_custom_key_store" "test" {
+  custom_key_store_name             = %[1]q
+  engine_type             = "ActiveKMS"
+  host_instance_type      = "kms.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName)
+}

--- a/internal/service/kms/custom_key_store_test.go
+++ b/internal/service/kms/custom_key_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -20,6 +21,10 @@ import (
 )
 
 func TestAccKMSCustomKeyStore_basic(t *testing.T) {
+	if os.Getenv("CLOUD_HSM_CLUSTER_ID") == "" {
+		t.Skip("CLOUD_HSM_CLUSTER_ID environment variable not set")
+	}
+
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -63,6 +68,10 @@ func TestAccKMSCustomKeyStore_basic(t *testing.T) {
 }
 
 func TestAccKMSCustomKeyStore_disappears(t *testing.T) {
+	if os.Getenv("CLOUD_HSM_CLUSTER_ID") == "" {
+		t.Skip("CLOUD_HSM_CLUSTER_ID environment variable not set")
+	}
+
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}

--- a/internal/service/kms/find.go
+++ b/internal/service/kms/find.go
@@ -1,6 +1,8 @@
 package kms
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
@@ -37,6 +39,29 @@ func FindAliasByName(conn *kms.KMS, name string) (*kms.AliasListEntry, error) {
 	}
 
 	return output, nil
+}
+
+func FindCustomKeyStoreByID(ctx context.Context, conn *kms.KMS, id string) (*kms.CustomKeyStoresListEntry, error) {
+	in := &kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreId: aws.String(id),
+	}
+	out, err := conn.DescribeCustomKeyStoresWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.CustomKeyStores[0] == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.CustomKeyStores[0], nil
 }
 
 func FindKeyByID(conn *kms.KMS, id string) (*kms.KeyMetadata, error) {

--- a/internal/service/kms/find.go
+++ b/internal/service/kms/find.go
@@ -47,7 +47,7 @@ func FindCustomKeyStoreByID(ctx context.Context, conn *kms.KMS, id string) (*kms
 	}
 	out, err := conn.DescribeCustomKeyStoresWithContext(ctx, in)
 
-	if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, kms.ErrCodeCustomKeyStoreNotFoundException) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: in,

--- a/internal/service/kms/kms_test.go
+++ b/internal/service/kms/kms_test.go
@@ -1,0 +1,27 @@
+package kms_test
+
+import (
+	"testing"
+)
+
+func TestAccKMS_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"CustomKeyStore": {
+			"basic":      testAccCustomKeyStore_basic,
+			"update":     testAccCustomKeyStore_update,
+			"disappears": testAccCustomKeyStore_disappears,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/website/docs/r/kms_custom_key_store.html.markdown
+++ b/website/docs/r/kms_custom_key_store.html.markdown
@@ -15,7 +15,12 @@ Terraform resource for managing an AWS KMS (Key Management) Custom Key Store.
 ### Basic Usage
 
 ```terraform
-resource "aws_kms_custom_key_store" "example" {
+resource "aws_kms_custom_key_store" "test" {
+  cloud_hsm_cluster_id  = var.clous_hsm_cluster_id
+  custom_key_store_name = "kms-custom-key-store-test"
+  key_store_password    = "noplaintextpasswords1"
+
+  trust_anchor_certificate = file("anchor-certificate.crt")
 }
 ```
 
@@ -23,31 +28,29 @@ resource "aws_kms_custom_key_store" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-The following arguments are optional:
-
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `cloud_hsm_cluster_id` - (Required) Cluster ID of CloudHSM.
+* `custom_key_store_name` - (Required) Unique name for Custom Key Store.
+* `key_store_password` - (Required) Password for `kmsuser` on CloudHSM.
+* `trust_anchor_certificate` - (Required) Customer certificate used for signing on CloudHSM.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the Custom Key Store. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `id` - The Custom Key Store ID
 
 ## Timeouts
 
 [Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `15m`)
+* `update` - (Default `15m`)
+* `delete` - (Default `15m`)
 
 ## Import
 
-KMS (Key Management) Custom Key Store can be imported using the `example_id_arg`, e.g.,
+KMS (Key Management) Custom Key Store can be imported using the `id`, e.g.,
 
 ```
-$ terraform import aws_kms_custom_key_store.example rft-8012925589
+$ terraform import aws_kms_custom_key_store.example cks-5ebd4ef395a96288e
 ```

--- a/website/docs/r/kms_custom_key_store.html.markdown
+++ b/website/docs/r/kms_custom_key_store.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "KMS (Key Management)"
+layout: "aws"
+page_title: "AWS: aws_kms_custom_key_store"
+description: |-
+  Terraform resource for managing an AWS KMS (Key Management) Custom Key Store.
+---
+
+# Resource: aws_kms_custom_key_store
+
+Terraform resource for managing an AWS KMS (Key Management) Custom Key Store.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_kms_custom_key_store" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Custom Key Store. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+KMS (Key Management) Custom Key Store can be imported using the `example_id_arg`, e.g.,
+
+```
+$ terraform import aws_kms_custom_key_store.example rft-8012925589
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

New resource for `aws_kms_custom_key_store`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #16491

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccKMS_serial/CustomKeyStore' PKG=kms ACCTEST_TIMEOUT=180m

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMS_serial/CustomKeyStore -timeout 180m
=== RUN   TestAccKMS_serial
=== RUN   TestAccKMS_serial/CustomKeyStore
=== RUN   TestAccKMS_serial/CustomKeyStore/disappears
=== RUN   TestAccKMS_serial/CustomKeyStore/basic
=== RUN   TestAccKMS_serial/CustomKeyStore/update
--- PASS: TestAccKMS_serial (39.01s)
    --- PASS: TestAccKMS_serial/CustomKeyStore (39.01s)
        --- PASS: TestAccKMS_serial/CustomKeyStore/disappears (11.29s)
        --- PASS: TestAccKMS_serial/CustomKeyStore/basic (14.52s)
        --- PASS: TestAccKMS_serial/CustomKeyStore/update (13.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	41.671s
...
```
