### PR TITLE
update apigatewayv2_deployment.html.markdown

### DIFF
--- a/website/docs/r/apigatewayv2_deployment.html.markdown
+++ b/website/docs/r/apigatewayv2_deployment.html.markdown
@@ -21,7 +21,7 @@ More information can be found in the [Amazon API Gateway Developer Guide](https:
 
 ```terraform
 resource "aws_apigatewayv2_deployment" "example" {
-  api_id      = aws_apigatewayv2_route.example.api_id
+  api_id      = aws_apigatewayv2_api.example.id
   description = "Example deployment"
 
   lifecycle {


### PR DESCRIPTION
### Description
`api_id` in the 1st example was pointing to a route instead of an api
