### PR TITLE
resource/aws_appautoscalingpolicy: add computed attribute `alarmARNs`

### DIFF
--- a/.changelog/27011.txt
+++ b/.changelog/27011.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appautoscaling_policy: Add `alarm_arns` attribute
+```

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -153,15 +153,9 @@ func ResourcePolicy() *schema.Resource {
 										Required: true,
 									},
 									"statistic": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											applicationautoscaling.MetricStatisticAverage,
-											applicationautoscaling.MetricStatisticMinimum,
-											applicationautoscaling.MetricStatisticMaximum,
-											applicationautoscaling.MetricStatisticSampleCount,
-											applicationautoscaling.MetricStatisticSum,
-										}, false),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(applicationautoscaling.MetricStatistic_Values(), false),
 									},
 									"unit": {
 										Type:     schema.TypeString,

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -45,6 +45,11 @@ func ResourcePolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"alarm_arns": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schema.TypeString,
+			},
 			"policy_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -290,6 +295,12 @@ func resourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("resource_id", p.ResourceId)
 	d.Set("scalable_dimension", p.ScalableDimension)
 	d.Set("service_namespace", p.ServiceNamespace)
+
+	var alarmARNs = make([]string, 0, len(p.Alarms))
+	for _, alarm := range p.Alarms {
+		alarmARNs = append(alarmARNs, aws.StringValue(alarm.AlarmARN))
+	}
+	d.Set("alarm_arns", alarmARNs)
 
 	if err := d.Set("step_scaling_policy_configuration", flattenStepScalingPolicyConfiguration(p.StepScalingPolicyConfiguration)); err != nil {
 		return create.SettingError(names.AppAutoScaling, ResNamePolicy, d.Id(), "step_scaling_policy_configuration", err)

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -34,21 +34,21 @@ func ResourcePolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"alarm_arns": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schema.TypeString,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 				// https://github.com/boto/botocore/blob/9f322b1/botocore/data/autoscaling/2011-01-01/service-2.json#L1862-L1873
 				ValidateFunc: validation.StringLenBetween(0, 255),
-			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"alarm_arns": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     schema.TypeString,
 			},
 			"policy_type": {
 				Type:     schema.TypeString,
@@ -170,6 +170,11 @@ func ResourcePolicy() *schema.Resource {
 								},
 							},
 						},
+						"disable_scale_in": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							Optional: true,
+						},
 						"predefined_metric_specification": {
 							Type:          schema.TypeList,
 							MaxItems:      1,
@@ -188,11 +193,6 @@ func ResourcePolicy() *schema.Resource {
 									},
 								},
 							},
-						},
-						"disable_scale_in": {
-							Type:     schema.TypeBool,
-							Default:  false,
-							Optional: true,
 						},
 						"scale_in_cooldown": {
 							Type:     schema.TypeInt,

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -283,18 +283,17 @@ func resourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Read ApplicationAutoScaling policy: %s, SP: %s, Obj: %s", d.Get("name"), d.Get("name"), p)
 
+	var alarmARNs = make([]string, 0, len(p.Alarms))
+	for _, alarm := range p.Alarms {
+		alarmARNs = append(alarmARNs, aws.StringValue(alarm.AlarmARN))
+	}
+	d.Set("alarm_arns", alarmARNs)
 	d.Set("arn", p.PolicyARN)
 	d.Set("name", p.PolicyName)
 	d.Set("policy_type", p.PolicyType)
 	d.Set("resource_id", p.ResourceId)
 	d.Set("scalable_dimension", p.ScalableDimension)
 	d.Set("service_namespace", p.ServiceNamespace)
-
-	var alarmARNs = make([]string, 0, len(p.Alarms))
-	for _, alarm := range p.Alarms {
-		alarmARNs = append(alarmARNs, aws.StringValue(alarm.AlarmARN))
-	}
-	d.Set("alarm_arns", alarmARNs)
 
 	if err := d.Set("step_scaling_policy_configuration", flattenStepScalingPolicyConfiguration(p.StepScalingPolicyConfiguration)); err != nil {
 		return create.SettingError(names.AppAutoScaling, ResNamePolicy, d.Id(), "step_scaling_policy_configuration", err)

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -37,7 +37,9 @@ func ResourcePolicy() *schema.Resource {
 			"alarm_arns": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     schema.TypeString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/internal/service/appautoscaling/policy_test.go
+++ b/internal/service/appautoscaling/policy_test.go
@@ -96,6 +96,7 @@ func TestAccAppAutoScalingPolicy_basic(t *testing.T) {
 				Config: testAccPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "alarm_arns.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_type", "StepScaling"),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_id", appAutoscalingTargetResourceName, "resource_id"),
@@ -136,7 +137,7 @@ func TestAccAppAutoScalingPolicy_disappears(t *testing.T) {
 				Config: testAccPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicyExists(resourceName, &policy),
-					testAccCheckPolicyDisappears(&policy),
+					acctest.CheckResourceDisappears(acctest.Provider, tfappautoscaling.ResourcePolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -483,23 +484,6 @@ func testAccCheckPolicyDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckPolicyDisappears(policy *applicationautoscaling.ScalingPolicy) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AppAutoScalingConn
-
-		input := &applicationautoscaling.DeleteScalingPolicyInput{
-			PolicyName:        policy.PolicyName,
-			ResourceId:        policy.ResourceId,
-			ScalableDimension: policy.ScalableDimension,
-			ServiceNamespace:  policy.ServiceNamespace,
-		}
-
-		_, err := conn.DeleteScalingPolicy(input)
-
-		return err
-	}
 }
 
 func testAccPolicyConfig_basic(rName string) string {

--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -231,6 +231,7 @@ The `target_tracking_scaling_policy_configuration` `predefined_metric_specificat
 
 In addition to all arguments above, the following attributes are exported:
 
+* `alarm_arns` - List of CloudWatch alarm ARNs associated with the scaling policy.
 * `arn` - ARN assigned by AWS to the scaling policy.
 * `name` - Scaling policy's name.
 * `policy_type` - Scaling policy's type.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This is a suggested enhancement based on my own enhancement request here: https://github.com/hashicorp/terraform-provider-aws/issues/27010

The idea is to have an attribute with a list of the ARNs of the cloudwatch alarms that are managing an app autoscaling policy such as a `TargetTrackingPolicy`. This is useful data for external systems in order to be able to enable/disable the autoscaling behavior for example.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27010

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccAppAutoScalingPolicy PKG=appautoscaling                                                  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appautoscaling/... -v -count 1 -parallel 20 -run='TestAccAppAutoScalingPolicy'  -timeout 180m
=== RUN   TestAccAppAutoScalingPolicy_basic
=== PAUSE TestAccAppAutoScalingPolicy_basic
=== RUN   TestAccAppAutoScalingPolicy_disappears
=== PAUSE TestAccAppAutoScalingPolicy_disappears
=== RUN   TestAccAppAutoScalingPolicy_scaleOutAndIn
=== PAUSE TestAccAppAutoScalingPolicy_scaleOutAndIn
=== RUN   TestAccAppAutoScalingPolicy_spotFleetRequest
=== PAUSE TestAccAppAutoScalingPolicy_spotFleetRequest
=== RUN   TestAccAppAutoScalingPolicy_DynamoDB_table
=== PAUSE TestAccAppAutoScalingPolicy_DynamoDB_table
=== RUN   TestAccAppAutoScalingPolicy_DynamoDB_index
=== PAUSE TestAccAppAutoScalingPolicy_DynamoDB_index
=== RUN   TestAccAppAutoScalingPolicy_multiplePoliciesSameName
=== PAUSE TestAccAppAutoScalingPolicy_multiplePoliciesSameName
=== RUN   TestAccAppAutoScalingPolicy_multiplePoliciesSameResource
=== PAUSE TestAccAppAutoScalingPolicy_multiplePoliciesSameResource
=== RUN   TestAccAppAutoScalingPolicy_ResourceID_forceNew
=== PAUSE TestAccAppAutoScalingPolicy_ResourceID_forceNew
=== CONT  TestAccAppAutoScalingPolicy_basic
=== CONT  TestAccAppAutoScalingPolicy_DynamoDB_index
=== CONT  TestAccAppAutoScalingPolicy_multiplePoliciesSameName
=== CONT  TestAccAppAutoScalingPolicy_multiplePoliciesSameResource
=== CONT  TestAccAppAutoScalingPolicy_ResourceID_forceNew
=== CONT  TestAccAppAutoScalingPolicy_spotFleetRequest
=== CONT  TestAccAppAutoScalingPolicy_DynamoDB_table
=== CONT  TestAccAppAutoScalingPolicy_scaleOutAndIn
=== CONT  TestAccAppAutoScalingPolicy_disappears
=== CONT  TestAccAppAutoScalingPolicy_spotFleetRequest
    policy_test.go:234: Step 1/2 error: Error running apply: exit status 1
        
        Error: failed creating IAM Role ***REDACTED***: AccessDenied: User: ***REDACTED*** is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::***REDACTED*** because no identity-based policy allows the iam:CreateRole action
                status code: 403, request id: ***REDACTED***
        
          with aws_iam_role.fleet_role,
          on terraform_plugin_test.tf line 19, in resource "aws_iam_role" "fleet_role":
          19: resource "aws_iam_role" "fleet_role" {
        
--- FAIL: TestAccAppAutoScalingPolicy_spotFleetRequest (7.34s)
--- PASS: TestAccAppAutoScalingPolicy_multiplePoliciesSameName (23.12s)
--- PASS: TestAccAppAutoScalingPolicy_DynamoDB_table (24.30s)
--- PASS: TestAccAppAutoScalingPolicy_multiplePoliciesSameResource (25.20s)
--- PASS: TestAccAppAutoScalingPolicy_DynamoDB_index (30.29s)
--- PASS: TestAccAppAutoScalingPolicy_disappears (59.78s)
--- PASS: TestAccAppAutoScalingPolicy_basic (81.59s)
--- PASS: TestAccAppAutoScalingPolicy_ResourceID_forceNew (89.10s)
--- PASS: TestAccAppAutoScalingPolicy_scaleOutAndIn (93.85s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling     96.548s
FAIL
make: *** [testacc] Error 1
```

All acceptance tests succeed except for the `spotFleetRequest` one because it needs `iam:CreateRole` permissions, to which I don't have access because of security reasons.
