### PR TITLE
Documentation: use correct `assume_role_with_web_identity` config

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -197,7 +197,7 @@ Usage:
 
 ```terraform
 provider "aws" {
-  assume_role {
+  assume_role_with_web_identity {
     role_arn                = "arn:aws:iam::123456789012:role/ROLE_NAME"
     session_name            = "SESSION_NAME"
     web_identity_token_file = "/Users/tf_user/secrets/web-identity-token"

--- a/website/docs/r/acmpca_certificate_authority.html.markdown
+++ b/website/docs/r/acmpca_certificate_authority.html.markdown
@@ -100,8 +100,8 @@ The following arguments are supported:
 
 ### certificate_authority_configuration
 
-* `key_algorithm` - (Required) Type of the public key algorithm and size, in bits, of the key pair that your key pair creates when it issues a certificate. Valid values can be found in the [ACM PCA Documentation](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_CertificateAuthorityConfiguration.html).
-* `signing_algorithm` - (Required) Name of the algorithm your private CA uses to sign certificate requests. Valid values can be found in the [ACM PCA Documentation](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_CertificateAuthorityConfiguration.html).
+* `key_algorithm` - (Required) Type of the public key algorithm and size, in bits, of the key pair that your key pair creates when it issues a certificate. Valid values can be found in the [ACM PCA Documentation](https://docs.aws.amazon.com/privateca/latest/APIReference/API_CertificateAuthorityConfiguration.html).
+* `signing_algorithm` - (Required) Name of the algorithm your private CA uses to sign certificate requests. Valid values can be found in the [ACM PCA Documentation](https://docs.aws.amazon.com/privateca/latest/APIReference/API_CertificateAuthorityConfiguration.html).
 * `subject` - (Required) Nested argument that contains X.500 distinguished name information. At least one nested attribute must be specified.
 
 #### subject


### PR DESCRIPTION
### Description
Corrects documentation around assuming a role with a web identity to use the appropriate provider configuration.

### Relations
Closes #27015 
Relates #22907