### PR TITLE
Document and test KMS `GENERATE_VERIFY_MAC` key usage value

### DIFF
--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -121,6 +121,29 @@ func TestAccKMSKey_asymmetricKey(t *testing.T) {
 	})
 }
 
+func TestAccKMSKey_hmacKey(t *testing.T) {
+	var key kms.KeyMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyConfig_hmac(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "customer_master_key_spec", "HMAC_256"),
+					resource.TestCheckResourceAttr(resourceName, "key_usage", "GENERATE_VERIFY_MAC"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKMSKey_Policy_basic(t *testing.T) {
 	var key kms.KeyMetadata
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -576,6 +599,18 @@ resource "aws_kms_key" "test" {
 
   key_usage                = "SIGN_VERIFY"
   customer_master_key_spec = "ECC_NIST_P384"
+}
+`, rName)
+}
+
+func testAccKeyConfig_hmac(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+
+  key_usage                = "GENERATE_VERIFY_MAC"
+  customer_master_key_spec = "HMAC_256"
 }
 `, rName)
 }

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -24,7 +24,7 @@ resource "aws_kms_key" "a" {
 The following arguments are supported:
 
 * `description` - (Optional) The description of the key as viewed in AWS console.
-* `key_usage` - (Optional) Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT` or `SIGN_VERIFY`.
+* `key_usage` - (Optional) Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT`, `SIGN_VERIFY`, or `GENERATE_VERIFY_MAC`.
 Defaults to `ENCRYPT_DECRYPT`.
 * `customer_master_key_spec` - (Optional) Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports.
 Valid values: `SYMMETRIC_DEFAULT`,  `RSA_2048`, `RSA_3072`, `RSA_4096`, `HMAC_256`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT`. For help with choosing a key spec, see the [AWS KMS Developer Guide](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Add documentation and tests for existing key usage parameter value `GENERATE_VERIFY_MAC`.


### Relations

 N/A

### References

[The newly documented value is present in the GO SDK](https://github.com/aws/aws-sdk-go/blob/427f0372a6a485ae717e9b2a0b8f94766966901a/service/kms/api.go#L19126-L19135) meaning that it will pass validation in actual usage, but the documentation doesn't list it. 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS='TestAccKMSKey_hmacKey' PKG=kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20 -run='TestAccKMSKey_hmacKey'  -timeout 180m
=== RUN   TestAccKMSKey_hmacKey
=== PAUSE TestAccKMSKey_hmacKey
=== CONT  TestAccKMSKey_hmacKey
--- PASS: TestAccKMSKey_hmacKey (22.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	28.128s
```
