### PR TITLE
resource/aws_acm_certificate: Add RFC 3339 duration support for `early_renewal_duration`

### DIFF
--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,63 @@
+package diag
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+const (
+	summaryInvalidValue     = "Invalid value"
+	summaryInvalidValueType = "Invalid value type"
+)
+
+func NewIncorrectValueTypeAttributeError(path cty.Path, expected string) diag.Diagnostic {
+	return NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidValueType,
+		fmt.Sprintf("Expected type to be %s", expected),
+	)
+}
+
+func NewInvalidValueAttributeErrorf(path cty.Path, format string, a ...any) diag.Diagnostic {
+	return NewInvalidValueAttributeError(
+		path,
+		fmt.Sprintf(format, a...),
+	)
+}
+
+func NewInvalidValueAttributeError(path cty.Path, detail string) diag.Diagnostic {
+	return NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidValue,
+		detail,
+	)
+}
+
+func NewAttributeErrorDiagnostic(path cty.Path, summary, detail string) diag.Diagnostic {
+	return withPath(
+		NewErrorDiagnostic(summary, detail),
+		path,
+	)
+}
+
+func NewErrorDiagnostic(summary, detail string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  summary,
+		Detail:   detail,
+	}
+}
+
+func FromAttributeError(path cty.Path, err error) diag.Diagnostic {
+	return withPath(
+		NewErrorDiagnostic(err.Error(), ""),
+		path,
+	)
+}
+
+func withPath(d diag.Diagnostic, path cty.Path) diag.Diagnostic {
+	d.AttributePath = path
+	return d
+}

--- a/internal/sdktypes/README.md
+++ b/internal/sdktypes/README.md
@@ -1,0 +1,3 @@
+# Terraform Plugin SDK Provider-Defined Types
+
+This package contains provider-defined types for Terraform Plugin SDK.

--- a/internal/sdktypes/duration.go
+++ b/internal/sdktypes/duration.go
@@ -1,0 +1,50 @@
+package sdktypes
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	awsdiag "github.com/hashicorp/terraform-provider-aws/internal/diag"
+)
+
+const (
+	TypeDuration = schema.TypeString
+)
+
+type Duration string
+
+func (d Duration) IsNull() bool {
+	return d == ""
+}
+
+func (d Duration) Value() (time.Duration, bool, error) {
+	if d.IsNull() {
+		return 0, true, nil
+	}
+
+	value, err := time.ParseDuration(string(d))
+	if err != nil {
+		return 0, false, err
+	}
+	return value, false, nil
+}
+
+func ValidateDuration(i any, path cty.Path) diag.Diagnostics {
+	v, ok := i.(string)
+	if !ok {
+		return diag.Diagnostics{awsdiag.NewIncorrectValueTypeAttributeError(path, "string")}
+	}
+
+	duration, err := time.ParseDuration(v)
+	if err != nil {
+		return diag.Diagnostics{awsdiag.NewInvalidValueAttributeErrorf(path, "Cannot be parsed as duration: %s", err)}
+	}
+
+	if duration < 0 {
+		return diag.Diagnostics{awsdiag.NewInvalidValueAttributeError(path, "Must be greater than zero")}
+	}
+
+	return nil
+}

--- a/internal/sdktypes/duration_test.go
+++ b/internal/sdktypes/duration_test.go
@@ -1,0 +1,76 @@
+package sdktypes
+
+import (
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestDuration(t *testing.T) {
+	cases := []struct {
+		val           string
+		expectNull    bool
+		expectedValue time.Duration
+		expectErr     bool
+	}{
+		{
+			val:           "1h2m3s",
+			expectNull:    false,
+			expectedValue: 1*time.Hour + 2*time.Minute + 3*time.Second,
+		},
+		{
+			val:           "",
+			expectNull:    true,
+			expectedValue: 0,
+		},
+		{
+			val:           "A",
+			expectNull:    false,
+			expectedValue: 0,
+			expectErr:     true,
+		},
+	}
+
+	for i, tc := range cases {
+		v := Duration(tc.val)
+
+		if null := v.IsNull(); null != tc.expectNull {
+			t.Fatalf("expected test case %d IsNull to return %t, got %t", i, null, tc.expectNull)
+		}
+
+		value, null, err := v.Value()
+		if value != tc.expectedValue {
+			t.Fatalf("expected test case %d Value to be %s, got %s", i, tc.expectedValue, value)
+		}
+		if null != tc.expectNull {
+			t.Fatalf("expected test case %d Value null flag to be %t, got %t", i, tc.expectNull, null)
+		}
+		if tc.expectErr == false && err != nil {
+			t.Fatalf("expected test case %d to succeed, got error %s", i, err)
+		}
+		if tc.expectErr && err == nil {
+			t.Fatalf("expected test case %d to have error but had none", i)
+		}
+	}
+}
+
+func TestValidationDuration(t *testing.T) {
+	runTestCases(t, map[string]testCase{
+		"valid": {
+			val: "1h2m3s",
+			f:   ValidateDuration,
+		},
+		"invalid": {
+			val:             "A",
+			f:               ValidateDuration,
+			expectedSummary: regexp.MustCompile(`^Invalid value$`),
+			expectedDetail:  regexp.MustCompile(`time: invalid duration "A"`),
+		},
+		"wrong type": {
+			val:             1,
+			f:               ValidateDuration,
+			expectedSummary: regexp.MustCompile(`^Invalid value type$`),
+			expectedDetail:  regexp.MustCompile(`Expected type to be string`),
+		},
+	})
+}

--- a/internal/sdktypes/rfc3339_duration.go
+++ b/internal/sdktypes/rfc3339_duration.go
@@ -1,0 +1,45 @@
+package sdktypes
+
+import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	awsdiag "github.com/hashicorp/terraform-provider-aws/internal/diag"
+	"github.com/hashicorp/terraform-provider-aws/internal/types/duration"
+)
+
+const (
+	TypeRFC3339Duration = schema.TypeString
+)
+
+type RFC3339Duration string
+
+func (d RFC3339Duration) IsNull() bool {
+	return d == ""
+}
+
+func (d RFC3339Duration) Value() (duration.Duration, bool, error) {
+	if d.IsNull() {
+		return duration.Duration{}, true, nil
+	}
+
+	value, err := duration.Parse(string(d))
+	if err != nil {
+		return duration.Duration{}, false, err
+	}
+	return value, false, nil
+}
+
+func ValidateRFC3339Duration(i any, path cty.Path) diag.Diagnostics {
+	v, ok := i.(string)
+	if !ok {
+		return diag.Diagnostics{awsdiag.NewIncorrectValueTypeAttributeError(path, "string")}
+	}
+
+	_, err := duration.Parse(v)
+	if err != nil {
+		return diag.Diagnostics{awsdiag.NewInvalidValueAttributeErrorf(path, "Cannot be parsed as an RFC 3339 duration: %s", err)}
+	}
+
+	return nil
+}

--- a/internal/sdktypes/testing_test.go
+++ b/internal/sdktypes/testing_test.go
@@ -1,0 +1,48 @@
+package sdktypes
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type testCase struct {
+	val             interface{}
+	f               schema.SchemaValidateDiagFunc
+	expectedSummary *regexp.Regexp
+	expectedDetail  *regexp.Regexp
+}
+
+func runTestCases(t *testing.T, cases map[string]testCase) {
+	t.Helper()
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			diags := tc.f(tc.val, cty.Path{cty.GetAttrStep{Name: "test_property"}})
+
+			if !diags.HasError() && tc.expectedSummary == nil && tc.expectedDetail == nil {
+				return
+			}
+
+			if diags.HasError() && tc.expectedSummary == nil && tc.expectedDetail == nil {
+				t.Fatalf("expected no errors, got %v", diags)
+			}
+
+			for _, d := range diags {
+				if d.Severity != diag.Error {
+					continue
+				}
+				if tc.expectedSummary != nil && !tc.expectedSummary.MatchString(d.Summary) {
+					t.Errorf("expected error with summary matching \"%s\", got %#v", tc.expectedSummary, diags)
+				}
+				if tc.expectedDetail != nil && !tc.expectedDetail.MatchString(d.Detail) {
+					t.Errorf("expected error with detail matching \"%s\", got %#v", tc.expectedDetail, diags)
+				}
+			}
+		})
+	}
+}

--- a/internal/types/duration/duration.go
+++ b/internal/types/duration/duration.go
@@ -1,0 +1,91 @@
+package duration
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrSyntax = errors.New("invalid syntax")
+
+const (
+	pattern = `^(?i)P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?$`
+)
+
+// Durations supports the year-month-day subset of an RFC 3339 duration
+// https://www.rfc-editor.org/rfc/rfc3339
+type Duration struct {
+	years  int
+	months int
+	days   int
+}
+
+func Parse(s string) (Duration, error) {
+	if s == "" || s == "P" {
+		return Duration{}, ErrSyntax
+	}
+
+	re := regexp.MustCompile(pattern)
+	match := re.FindStringSubmatch(s)
+	if match == nil {
+		return Duration{}, ErrSyntax
+	}
+
+	var duration Duration
+
+	for i, name := range re.SubexpNames() {
+		value := match[i]
+		if i == 0 || name == "" || value == "" {
+			continue
+		}
+
+		v, err := strconv.Atoi(value)
+		if err != nil {
+			return Duration{}, err
+		}
+
+		switch name {
+		case "years":
+			duration.years = v
+		case "months":
+			duration.months = v
+		case "days":
+			duration.days = v
+		}
+	}
+
+	return duration, nil
+}
+
+func (d Duration) String() string {
+	var b strings.Builder
+	b.WriteString("P")
+	if d.years > 0 {
+		fmt.Fprintf(&b, "%dY", d.years)
+	}
+	if d.months > 0 {
+		fmt.Fprintf(&b, "%dM", d.months)
+	}
+	if d.days > 0 {
+		fmt.Fprintf(&b, "%dD", d.days)
+	}
+	return b.String()
+}
+
+func (d Duration) IsZero() bool {
+	return d.years == 0 && d.months == 0 && d.days == 0
+}
+
+func (d Duration) equal(o Duration) bool {
+	if d.years != o.years || d.months != o.months || d.days != o.days {
+		return false
+	}
+	return true
+}
+
+func Sub(t time.Time, d Duration) time.Time {
+	return t.AddDate(-d.years, -d.months, -d.days)
+}

--- a/internal/types/duration/duration_test.go
+++ b/internal/types/duration/duration_test.go
@@ -1,0 +1,160 @@
+package duration
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	testcases := map[string]struct {
+		input       string
+		expected    Duration
+		expectedErr error
+	}{
+		// Invalid
+		"empty": {
+			input:       "",
+			expectedErr: ErrSyntax,
+		},
+		"P only": {
+			input:       "P",
+			expectedErr: ErrSyntax,
+		},
+
+		// Single
+		"years only": {
+			input:       "P1Y",
+			expected:    Duration{years: 1},
+			expectedErr: nil,
+		},
+		"months only": {
+			input:       "P3M",
+			expected:    Duration{months: 3},
+			expectedErr: nil,
+		},
+		"days only": {
+			input:       "P30D",
+			expected:    Duration{days: 30},
+			expectedErr: nil,
+		},
+
+		// Multiple
+		"years months": {
+			input:       "P1Y2M",
+			expected:    Duration{years: 1, months: 2},
+			expectedErr: nil,
+		},
+		"years days": {
+			input:       "P2Y15D",
+			expected:    Duration{years: 2, days: 15},
+			expectedErr: nil,
+		},
+		"years months days": {
+			input:       "P2Y1M10D",
+			expected:    Duration{years: 2, months: 1, days: 10},
+			expectedErr: nil,
+		},
+
+		"zero years": {
+			input:       "P0Y1M10D",
+			expected:    Duration{months: 1, days: 10},
+			expectedErr: nil,
+		},
+
+		"insensitive": {
+			input:       "p2y1M10d",
+			expected:    Duration{years: 2, months: 1, days: 10},
+			expectedErr: nil,
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			duration, err := Parse(tc.input)
+
+			if tc.expectedErr == nil && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if tc.expectedErr != nil {
+				if !errors.Is(err, tc.expectedErr) {
+					t.Fatalf("expected error matching \"%s\", got %s", tc.expectedErr, err)
+				}
+			}
+
+			if !duration.equal(tc.expected) {
+				t.Errorf("expected %q, got %q", tc.expected, duration)
+			}
+		})
+	}
+}
+
+func TestSub(t *testing.T) {
+	now := time.Now()
+	tz, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	testcases := map[string]struct {
+		startTime time.Time
+		duration  Duration
+		expected  time.Time
+		hoursDiff int
+	}{
+		"zero": {
+			startTime: now,
+			duration:  Duration{},
+			expected:  now,
+		},
+		"regular": {
+			startTime: now,
+			duration:  Duration{years: 1, months: 2, days: 3},
+			expected:  now.AddDate(-1, -2, -3),
+		},
+
+		"month": {
+			startTime: time.Date(2022, 3, 29, 0, 0, 0, 0, tz),
+			duration:  Duration{months: 1},
+			expected:  time.Date(2022, 3, 1, 0, 0, 0, 0, tz),
+		},
+		"leap year month": {
+			startTime: time.Date(2020, 3, 29, 0, 0, 0, 0, tz),
+			duration:  Duration{months: 1},
+			expected:  time.Date(2020, 2, 29, 0, 0, 0, 0, tz),
+		},
+
+		"day": {
+			startTime: time.Date(2022, 4, 14, 12, 0, 0, 0, tz),
+			duration:  Duration{days: 3},
+			expected:  time.Date(2022, 4, 11, 12, 0, 0, 0, tz),
+			hoursDiff: 3 * 24,
+		},
+		"daylight saving day": {
+			startTime: time.Date(2022, 3, 14, 12, 0, 0, 0, tz),
+			duration:  Duration{days: 3},
+			expected:  time.Date(2022, 3, 11, 12, 0, 0, 0, tz),
+			hoursDiff: 3*24 - 1,
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			actual := Sub(tc.startTime, tc.duration)
+
+			if !actual.Equal(tc.expected) {
+				t.Fatalf("expected %s, got %s", tc.expected, actual)
+			}
+
+			if tc.hoursDiff != 0 {
+				diff := tc.startTime.Sub(tc.expected)
+				if diff.Hours() != float64(tc.hoursDiff) {
+					t.Fatalf("diff expected %d, got %f", tc.hoursDiff, diff.Hours())
+				}
+			}
+		})
+	}
+
+}

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -378,5 +380,31 @@ func FloatGreaterThan(threshold float64) schema.SchemaValidateFunc {
 		}
 
 		return
+	}
+}
+
+// https://github.com/hashicorp/terraform-plugin-sdk/issues/1071
+func ValidAllDiag(validators ...schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
+	return func(i any, path cty.Path) diag.Diagnostics {
+		var results diag.Diagnostics
+		for _, validator := range validators {
+			results = append(results, validator(i, path)...)
+		}
+		return results
+	}
+}
+
+// https://github.com/hashicorp/terraform-plugin-sdk/issues/1071
+func ValidAnyDiag(validators ...schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
+	return func(i any, path cty.Path) diag.Diagnostics {
+		var results diag.Diagnostics
+		for _, validator := range validators {
+			diags := validator(i, path)
+			if len(diags) == 0 {
+				return diag.Diagnostics{}
+			}
+			results = append(results, diags...)
+		}
+		return results
 	}
 }

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -155,7 +155,9 @@ The following arguments are supported:
     * `domain_name` - (Required) Domain name for which the certificate should be issued.
     * `early_renewal_duration` - (Optional) Amount of time to start automatic renewal process before expiration.
       Has no effect if less than 60 days.
-      Represented by a string such as `2160h`.
+      Represented by either
+      a subset of [RFC 3339 duration](https://www.rfc-editor.org/rfc/rfc3339) supporting years, months, and days (e.g., `P90D`),
+      or a string such as `2160h`.
 * `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate.
   To remove all elements of a previously configured list, set this value equal to an empty list (`[]`)
   or use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html) to trigger recreation.


### PR DESCRIPTION
Adds support for a subset of RFC 3339 duration to `early_renewal_duration`. Supports year, month, and day values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #26784

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=acm TESTS=TestAccACMCertificate_

--- PASS: TestAccACMCertificate_SubjectAlternativeNames_emptyString (4.73s)
--- PASS: TestAccACMCertificate_Root_trailingPeriod (5.25s)
--- PASS: TestAccACMCertificate_Imported_ipAddress (30.44s)
--- PASS: TestAccACMCertificate_Imported_validityDates (38.98s)
--- PASS: TestAccACMCertificate_San_trailingPeriod (51.48s)
--- PASS: TestAccACMCertificate_root (58.98s)
--- PASS: TestAccACMCertificate_wildcard (69.37s)
--- PASS: TestAccACMCertificate_wildcardAndRootSan (70.31s)
--- PASS: TestAccACMCertificate_emailValidation (71.63s)
--- PASS: TestAccACMCertificate_San_single (72.21s)
--- PASS: TestAccACMCertificate_San_matches_domain (85.50s)
--- PASS: TestAccACMCertificate_rootAndWildcardSan (86.34s)
--- PASS: TestAccACMCertificate_disableCTLogging (86.46s)
--- PASS: TestAccACMCertificate_San_multiple (89.34s)
--- PASS: TestAccACMCertificate_dnsValidation (69.59s)
--- PASS: TestAccACMCertificate_Imported_domainName (125.01s)
--- PASS: TestAccACMCertificate_validationOptions (64.02s)
--- PASS: TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture (132.82s)
--- PASS: TestAccACMCertificate_privateCertificate_removeEarlyRenewal (129.42s)
--- PASS: TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible (107.92s)
--- PASS: TestAccACMCertificate_PrivateKey_tags (140.41s)
--- PASS: TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration (153.13s)
--- PASS: TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration (154.16s)
--- PASS: TestAccACMCertificate_privateCertificate_renewable (201.58s)
--- PASS: TestAccACMCertificate_privateCertificate_addEarlyRenewalPast (182.20s)
--- PASS: TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture (162.74s)
--- PASS: TestAccACMCertificate_privateCertificate_noRenewalPermission (281.13s)
```
