### PR TITLE
EKS Add-on resolve_conflicts with PRESERVE feature tests and docs updated

### DIFF
--- a/.changelog/27038.txt
+++ b/.changelog/27038.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_addon: Add `PRESERVE` option to `resolve_conflicts` argument.
+```

--- a/internal/service/eks/addon_test.go
+++ b/internal/service/eks/addon_test.go
@@ -173,7 +173,7 @@ func TestAccEKSAddon_preserve(t *testing.T) {
 }
 
 func TestAccEKSAddon_resolveConflicts(t *testing.T) {
-	var addon1, addon2 eks.Addon
+	var addon1, addon2, addon3 eks.Addon
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_eks_addon.test"
 	addonName := "vpc-cni"
@@ -203,6 +203,13 @@ func TestAccEKSAddon_resolveConflicts(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAddonExists(ctx, resourceName, &addon2),
 					resource.TestCheckResourceAttr(resourceName, "resolve_conflicts", eks.ResolveConflictsOverwrite),
+				),
+			},
+			{
+				Config: testAccAddonConfig_resolveConflicts(rName, addonName, eks.ResolveConflictsPreserve),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAddonExists(ctx, resourceName, &addon3),
+					resource.TestCheckResourceAttr(resourceName, "resolve_conflicts", eks.ResolveConflictsPreserve),
 				),
 			},
 		},

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -27,13 +27,13 @@ resource "aws_eks_addon" "example" {
 ## Example Update add-on usage with resolve_conflicts and PRESERVE
 `resolve_conflicts` with `PRESERVE` can be used to retain the config changes applied to the add-on with kubectl while upgrading to a newer version of the add-on.
 
-~> **Note:** `resolve_conflicts` with `PRESERVE` can only be used for upgrading the add-ons but not during the create add-on. 
+~> **Note:** `resolve_conflicts` with `PRESERVE` can only be used for upgrading the add-ons but not during the creation of add-on.
 
 ```terraform
 resource "aws_eks_addon" "example" {
   cluster_name      = aws_eks_cluster.example.name
   addon_name        = "coredns"
-  addon_version     = "v1.8.7-eksbuild.3"  #e.g., previous version v1.8.7-eksbuild.2 and the new version is v1.8.7-eksbuild.3
+  addon_version     = "v1.8.7-eksbuild.3" #e.g., previous version v1.8.7-eksbuild.2 and the new version is v1.8.7-eksbuild.3
   resolve_conflicts = "PRESERVE"
 }
 ```
@@ -98,7 +98,7 @@ The following arguments are optional:
   match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
 * `resolve_conflicts` - (Optional) Define how to resolve parameter value conflicts
   when migrating an existing add-on to an Amazon EKS add-on or when applying
-  version updates to the add-on. Valid values are `NONE`, `OVERWRITE` and `PRESERVE`. For more details check [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs. 
+  version updates to the add-on. Valid values are `NONE`, `OVERWRITE` and `PRESERVE`. For more details check [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `preserve` - (Optional) Indicates if you want to preserve the created resources when deleting the EKS add-on.
 * `service_account_role_arn` - (Optional) The Amazon Resource Name (ARN) of an

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -24,6 +24,20 @@ resource "aws_eks_addon" "example" {
 }
 ```
 
+## Example Update add-on usage with resolve_conflicts and PRESERVE
+`resolve_conflicts` with `PRESERVE` can be used to retain the config changes applied to the add-on with kubectl while upgrading to a newer version of the add-on.
+
+~> **Note:** `resolve_conflicts` with `PRESERVE` can only be used for upgrading the add-ons but not during the create add-on. 
+
+```terraform
+resource "aws_eks_addon" "example" {
+  cluster_name      = aws_eks_cluster.example.name
+  addon_name        = "coredns"
+  addon_version     = "v1.8.7-eksbuild.3"  #e.g., previous version v1.8.7-eksbuild.2 and the new version is v1.8.7-eksbuild.3
+  resolve_conflicts = "PRESERVE"
+}
+```
+
 ### Example IAM Role for EKS Addon "vpc-cni" with AWS managed policy
 
 ```terraform
@@ -84,7 +98,7 @@ The following arguments are optional:
   match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
 * `resolve_conflicts` - (Optional) Define how to resolve parameter value conflicts
   when migrating an existing add-on to an Amazon EKS add-on or when applying
-  version updates to the add-on. Valid values are `NONE` and `OVERWRITE`.
+  version updates to the add-on. Valid values are `NONE`, `OVERWRITE` and `PRESERVE`. For more details check [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs. 
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `preserve` - (Optional) Indicates if you want to preserve the created resources when deleting the EKS add-on.
 * `service_account_role_arn` - (Optional) The Amazon Resource Name (ARN) of an


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

### Description
EKS API now provides three options for `resolve_conflicts` which are NONE, OVERWRITE and PRESERVE. 

EKS Add-on currently supports a new feature to preserve user configuration during the upgrade of EKS Add-ons. Any changes applied to the managed add-ons using `kubectl` or through any other approach will be retained during the upgrade of managed add-on to the newer version. 

Current behaviour of the upgrade add-on version overwrites the custom changes applied to the previous version of add-on However, users can retain the custom configuration during the add-on upgrades by using `resolve_conflicts = "PRESERVE"`

This new `resolve_conflicts` with `PRESERVE` feature is already supported by the current version(4.32.0) of AWS provider since the option of pulling `resolve_conflicts` string is dynamic using `eks.ResolveConflicts_Values` hence the users can now pass the `resolve_conflicts = "PRESERVE"` during the upgrade of the add-on. 

I have added the tests and updates to the dcoumentation

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->



### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
➜  terraform-provider-aws git:(f-eks_addon-refactor) ✗ make testacc TESTARGS='-run=TestAccEKSAddon_resolveConflicts' PKG=eks TIMEOUT=300m
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 20  -run=TestAccEKSAddon_resolveConflicts -timeout 180m
=== RUN   TestAccEKSAddon_resolveConflicts
=== PAUSE TestAccEKSAddon_resolveConflicts
=== CONT  TestAccEKSAddon_resolveConflicts
--- PASS: TestAccEKSAddon_resolveConflicts (741.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        760.820s

——
```
