### PR TITLE
Example update: In `http` module - `body` is deprecated.

### DIFF
--- a/examples/eks-getting-started/workstation-external-ip.tf
+++ b/examples/eks-getting-started/workstation-external-ip.tf
@@ -14,5 +14,5 @@ data "http" "workstation-external-ip" {
 
 # Override with variable or hardcoded value if necessary
 locals {
-  workstation-external-cidr = "${chomp(data.http.workstation-external-ip.body)}/32"
+  workstation-external-cidr = "${chomp(data.http.workstation-external-ip.response_body)}/32"
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As per the Terraform `http` module docs for [`body`](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http#body) - it is deprecated. 

In a particular example, the minor update is: `body` -> [`response_body`](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http#response_body).