### PR TITLE
[New Data Source] d/aws_vpc_ipam_pool_cidrs

### DIFF
--- a/.changelog/27051.txt
+++ b/.changelog/27051.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_vpc_ipam_pool_cidrs
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -592,6 +592,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_vpc_endpoint_service":                       ec2.DataSourceVPCEndpointService(),
 			"aws_vpc_endpoint":                               ec2.DataSourceVPCEndpoint(),
 			"aws_vpc_ipam_pool":                              ec2.DataSourceIPAMPool(),
+			"aws_vpc_ipam_pool_cidrs":                        ec2.DataSourceIPAMPoolCidrs(),
 			"aws_vpc_ipam_preview_next_cidr":                 ec2.DataSourceIPAMPreviewNextCIDR(),
 			"aws_vpc_peering_connection":                     ec2.DataSourceVPCPeeringConnection(),
 			"aws_vpc_peering_connections":                    ec2.DataSourceVPCPeeringConnections(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -592,7 +592,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_vpc_endpoint_service":                       ec2.DataSourceVPCEndpointService(),
 			"aws_vpc_endpoint":                               ec2.DataSourceVPCEndpoint(),
 			"aws_vpc_ipam_pool":                              ec2.DataSourceIPAMPool(),
-			"aws_vpc_ipam_pool_cidrs":                        ec2.DataSourceIPAMPoolCidrs(),
+			"aws_vpc_ipam_pool_cidrs":                        ec2.DataSourceIPAMPoolCIDRs(),
 			"aws_vpc_ipam_preview_next_cidr":                 ec2.DataSourceIPAMPreviewNextCIDR(),
 			"aws_vpc_peering_connection":                     ec2.DataSourceVPCPeeringConnection(),
 			"aws_vpc_peering_connections":                    ec2.DataSourceVPCPeeringConnections(),

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4937,6 +4937,37 @@ func FindInternetGatewayAttachment(conn *ec2.EC2, internetGatewayID, vpcID strin
 	return attachment, nil
 }
 
+func FindIPAMPoolCIDRs(conn *ec2.EC2, input *ec2.GetIpamPoolCidrsInput) ([]*ec2.IpamPoolCidr, error) {
+	var output []*ec2.IpamPoolCidr
+
+	err := conn.GetIpamPoolCidrsPages(input, func(page *ec2.GetIpamPoolCidrsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.IpamPoolCidrs {
+			if v != nil {
+				output = append(output, v)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, InvalidIPAMPoolIDNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
 func FindKeyPair(conn *ec2.EC2, input *ec2.DescribeKeyPairsInput) (*ec2.KeyPairInfo, error) {
 	output, err := FindKeyPairs(conn, input)
 

--- a/internal/service/ec2/ipam_pool_cidrs_data_source.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source.go
@@ -1,0 +1,94 @@
+package ec2
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func DataSourceIPAMPoolCidrs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIPAMPoolCidrsRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(1 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"filter": DataSourceFiltersSchema(),
+			"ipam_pool_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// computed
+			"ipam_pool_cidrs": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIPAMPoolCidrsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	input := &ec2.GetIpamPoolCidrsInput{}
+
+	if v, ok := d.GetOk("ipam_pool_id"); ok {
+		input.IpamPoolId = aws.String(v.(string))
+	}
+
+	filters, filtersOk := d.GetOk("filter")
+	if filtersOk {
+		input.Filters = BuildFiltersDataSource(filters.(*schema.Set))
+	}
+
+	output, err := conn.GetIpamPoolCidrs(input)
+	var cidrs []*ec2.IpamPoolCidr
+
+	if err != nil {
+		return err
+	}
+
+	if len(output.IpamPoolCidrs) == 0 || output.IpamPoolCidrs[0] == nil {
+		return tfresource.SingularDataSourceFindError("EC2 VPC IPAM POOL CIDRS", tfresource.NewEmptyResultError(input))
+	}
+
+	cidrs = output.IpamPoolCidrs
+
+	d.SetId(d.Get("ipam_pool_id").(string))
+	d.Set("ipam_pool_cidrs", flattenIPAMPoolCidrs(cidrs))
+
+	return nil
+}
+
+func flattenIPAMPoolCidrs(c []*ec2.IpamPoolCidr) []interface{} {
+	cidrs := []interface{}{}
+	for _, cidr := range c {
+		cidrs = append(cidrs, flattenIPAMPoolCidr(cidr))
+	}
+	return cidrs
+}
+
+func flattenIPAMPoolCidr(c *ec2.IpamPoolCidr) map[string]interface{} {
+	cidr := make(map[string]interface{})
+	cidr["cidr"] = aws.StringValue(c.Cidr)
+	cidr["state"] = aws.StringValue(c.State)
+	return cidr
+}

--- a/internal/service/ec2/ipam_pool_cidrs_data_source.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source.go
@@ -58,21 +58,18 @@ func dataSourceIPAMPoolCIDRsRead(d *schema.ResourceData, meta interface{}) error
 		input.Filters = BuildFiltersDataSource(filters.(*schema.Set))
 	}
 
-	output, err := conn.GetIpamPoolCidrs(input)
-	var cidrs []*ec2.IpamPoolCidr
+	output, err := FindIPAMPoolCIDRs(conn, input)
 
 	if err != nil {
 		return err
 	}
 
-	if len(output.IpamPoolCidrs) == 0 || output.IpamPoolCidrs[0] == nil {
-		return tfresource.SingularDataSourceFindError("EC2 VPC IPAM POOL CIDRS", tfresource.NewEmptyResultError(input))
+	if len(output) == 0 || output[0] == nil {
+		return tfresource.SingularDataSourceFindError("CIDRS IN EC2 VPC IPAM POOL", tfresource.NewEmptyResultError(input))
 	}
 
-	cidrs = output.IpamPoolCidrs
-
 	d.SetId(d.Get("ipam_pool_id").(string))
-	d.Set("ipam_pool_cidrs", flattenIPAMPoolCIDRs(cidrs))
+	d.Set("ipam_pool_cidrs", flattenIPAMPoolCIDRs(output))
 
 	return nil
 }

--- a/internal/service/ec2/ipam_pool_cidrs_data_source.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func DataSourceIPAMPoolCidrs() *schema.Resource {
+func DataSourceIPAMPoolCIDRs() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceIPAMPoolCidrsRead,
+		Read: dataSourceIPAMPoolCIDRsRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(1 * time.Minute),
@@ -45,7 +45,7 @@ func DataSourceIPAMPoolCidrs() *schema.Resource {
 	}
 }
 
-func dataSourceIPAMPoolCidrsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIPAMPoolCIDRsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	input := &ec2.GetIpamPoolCidrsInput{}
@@ -73,20 +73,20 @@ func dataSourceIPAMPoolCidrsRead(d *schema.ResourceData, meta interface{}) error
 	cidrs = output.IpamPoolCidrs
 
 	d.SetId(d.Get("ipam_pool_id").(string))
-	d.Set("ipam_pool_cidrs", flattenIPAMPoolCidrs(cidrs))
+	d.Set("ipam_pool_cidrs", flattenIPAMPoolCIDRs(cidrs))
 
 	return nil
 }
 
-func flattenIPAMPoolCidrs(c []*ec2.IpamPoolCidr) []interface{} {
+func flattenIPAMPoolCIDRs(c []*ec2.IpamPoolCidr) []interface{} {
 	cidrs := []interface{}{}
 	for _, cidr := range c {
-		cidrs = append(cidrs, flattenIPAMPoolCidr(cidr))
+		cidrs = append(cidrs, flattenIPAMPoolCIDR(cidr))
 	}
 	return cidrs
 }
 
-func flattenIPAMPoolCidr(c *ec2.IpamPoolCidr) map[string]interface{} {
+func flattenIPAMPoolCIDR(c *ec2.IpamPoolCidr) map[string]interface{} {
 	cidr := make(map[string]interface{})
 	cidr["cidr"] = aws.StringValue(c.Cidr)
 	cidr["state"] = aws.StringValue(c.State)

--- a/internal/service/ec2/ipam_pool_cidrs_data_source.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source.go
@@ -24,7 +24,6 @@ func DataSourceIPAMPoolCIDRs() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			// computed
 			"ipam_pool_cidrs": {
 				Type:     schema.TypeSet,
 				Computed: true,

--- a/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
@@ -1,0 +1,102 @@
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccIPAMPoolCidrsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_vpc_ipam_pool_cidrs.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMPoolCidrsDataSourceConfig_BasicOneCidrs,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "1"),
+				),
+			},
+			{
+				Config: testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrs,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "2"),
+				),
+			},
+			{
+				Config: testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrsFiltered,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+var testAccIPAMPoolCidrsDataSourceConfig_BasicOneCidrs = acctest.ConfigCompose(
+	testAccIPAMPoolConfig_basic, `
+resource "aws_vpc_ipam_pool_cidr" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = "172.2.0.0/16"
+}
+
+data "aws_vpc_ipam_pool_cidrs" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test
+  ]
+}
+`)
+
+var testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrs = acctest.ConfigCompose(
+	testAccIPAMPoolConfig_basic, `
+
+
+resource "aws_vpc_ipam_pool_cidr" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = "172.2.0.0/16"
+}
+resource "aws_vpc_ipam_pool_cidr" "testtwo" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = "10.2.0.0/16"
+}
+
+data "aws_vpc_ipam_pool_cidrs" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test,
+    aws_vpc_ipam_pool_cidr.testtwo,
+  ]
+}
+`)
+
+var testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrsFiltered = acctest.ConfigCompose(
+	testAccIPAMPoolConfig_basic, `
+resource "aws_vpc_ipam_pool_cidr" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = "172.2.0.0/16"
+}
+resource "aws_vpc_ipam_pool_cidr" "testtwo" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = "10.2.0.0/16"
+}
+
+data "aws_vpc_ipam_pool_cidrs" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+
+  filter {
+    name   = "cidr"
+    values = ["10.*"]
+  }
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test,
+    aws_vpc_ipam_pool_cidr.testtwo,
+  ]
+}
+`)

--- a/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
@@ -17,19 +17,19 @@ func TestAccIPAMPoolCIDRsDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolCIDRsDataSourceConfig_BasicOneCIDRs,
+				Config: testAccIPAMPoolCIDRsDataSourceConfig_basicOneCIDRs,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "1"),
 				),
 			},
 			{
-				Config: testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRs,
+				Config: testAccIPAMPoolCIDRsDataSourceConfig_basicTwoCIDRs,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "2"),
 				),
 			},
 			{
-				Config: testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRsFiltered,
+				Config: testAccIPAMPoolCIDRsDataSourceConfig_basicTwoCIDRsFiltered,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "1"),
 				),
@@ -38,7 +38,7 @@ func TestAccIPAMPoolCIDRsDataSource_basic(t *testing.T) {
 	})
 }
 
-var testAccIPAMPoolCIDRsDataSourceConfig_BasicOneCIDRs = acctest.ConfigCompose(
+var testAccIPAMPoolCIDRsDataSourceConfig_basicOneCIDRs = acctest.ConfigCompose(
 	testAccIPAMPoolConfig_basic, `
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id
@@ -53,7 +53,7 @@ data "aws_vpc_ipam_pool_cidrs" "test" {
 }
 `)
 
-var testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRs = acctest.ConfigCompose(
+var testAccIPAMPoolCIDRsDataSourceConfig_basicTwoCIDRs = acctest.ConfigCompose(
 	testAccIPAMPoolConfig_basic, `
 
 
@@ -75,7 +75,7 @@ data "aws_vpc_ipam_pool_cidrs" "test" {
 }
 `)
 
-var testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRsFiltered = acctest.ConfigCompose(
+var testAccIPAMPoolCIDRsDataSourceConfig_basicTwoCIDRsFiltered = acctest.ConfigCompose(
 	testAccIPAMPoolConfig_basic, `
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id

--- a/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccIPAMPoolCidrsDataSource_basic(t *testing.T) {
+func TestAccIPAMPoolCIDRsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_vpc_ipam_pool_cidrs.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -17,19 +17,19 @@ func TestAccIPAMPoolCidrsDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolCidrsDataSourceConfig_BasicOneCidrs,
+				Config: testAccIPAMPoolCIDRsDataSourceConfig_BasicOneCIDRs,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "1"),
 				),
 			},
 			{
-				Config: testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrs,
+				Config: testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRs,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "2"),
 				),
 			},
 			{
-				Config: testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrsFiltered,
+				Config: testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRsFiltered,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ipam_pool_cidrs.#", "1"),
 				),
@@ -38,7 +38,7 @@ func TestAccIPAMPoolCidrsDataSource_basic(t *testing.T) {
 	})
 }
 
-var testAccIPAMPoolCidrsDataSourceConfig_BasicOneCidrs = acctest.ConfigCompose(
+var testAccIPAMPoolCIDRsDataSourceConfig_BasicOneCIDRs = acctest.ConfigCompose(
 	testAccIPAMPoolConfig_basic, `
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id
@@ -53,7 +53,7 @@ data "aws_vpc_ipam_pool_cidrs" "test" {
 }
 `)
 
-var testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrs = acctest.ConfigCompose(
+var testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRs = acctest.ConfigCompose(
 	testAccIPAMPoolConfig_basic, `
 
 
@@ -75,7 +75,7 @@ data "aws_vpc_ipam_pool_cidrs" "test" {
 }
 `)
 
-var testAccIPAMPoolCidrsDataSourceConfig_BasicTwoCidrsFiltered = acctest.ConfigCompose(
+var testAccIPAMPoolCIDRsDataSourceConfig_BasicTwoCIDRsFiltered = acctest.ConfigCompose(
 	testAccIPAMPoolConfig_basic, `
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id

--- a/website/docs/d/vpc_ipam_pool_cidrs.html.markdown
+++ b/website/docs/d/vpc_ipam_pool_cidrs.html.markdown
@@ -1,0 +1,86 @@
+---
+subcategory: "VPC IPAM (IP Address Manager)"
+layout: "aws"
+page_title: "AWS: aws_vpc_ipam_pool_cidrs"
+description: |-
+    Returns cidrs provisioned into an IPAM pool.
+---
+
+# Data Source: aws_vpc_ipam_pool_cidrs
+
+`aws_vpc_ipam_pool_cidrs` provides details about an IPAM pool.
+
+This resource can prove useful when an ipam pool was shared to your account and you want to know all (or a filtered list) of the CIDRs that are provisioned into the pool.
+
+## Example Usage
+
+Basic usage:
+
+```terraform
+data "aws_vpc_ipam_pool_cidrs" "c" {
+  ipam_pool_id = "ipam-pool-123"
+}
+```
+
+Filtering:
+
+```terraform
+data "aws_vpc_ipam_pool_cidrs" "c" {
+  ipam_pool_id = "ipam-pool-123"
+  filter {
+    name   = "cidr"
+    values = ["10.*"]
+  }
+}
+
+locals {
+  mycidrs = [for cidr in data.aws_vpc_ipam_pool_cidrs.c.ipam_pool_cidrs :
+    cidr.cidr if
+  cidr.state == "provisioned"]
+}
+
+resource "aws_ec2_managed_prefix_list" "pls" {
+  name           = "IPAM Pool (${aws_vpc_ipam_pool.test.id}) Cidrs"
+  address_family = "IPv4"
+  max_entries    = length(local.mycidrs)
+
+  dynamic "entry" {
+    for_each = local.mycidrs
+    content {
+      cidr        = entry.value
+      description = entry.value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available
+VPCs in the current region. The given filters must match exactly one
+VPC whose data will be exported as attributes.
+
+* `ipam_pool_id` - ID of the IPAM pool you would like the list of provisioned CIDRs.
+* `filter` - Custom filter block as described below.
+
+## Attributes Reference
+
+All of the argument attributes except `filter` blocks are also exported as
+result attributes. This data source will complete the data by populating
+any fields that are not included in the configuration with the data for
+the selected IPAM Pool CIDRs.
+
+The following attribute is additionally exported:
+
+* `ipam_pool_cidrs` - The CIDRs provisioned into the IPAM pool, described below.
+
+### ipam_pool_cidrs
+
+* `cidr` - A network CIDR.
+* `state` - The provisioning state of that CIDR.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+- `read` - (Default `1m`)

--- a/website/docs/d/vpc_ipam_pool_cidrs.html.markdown
+++ b/website/docs/d/vpc_ipam_pool_cidrs.html.markdown
@@ -18,7 +18,19 @@ Basic usage:
 
 ```terraform
 data "aws_vpc_ipam_pool_cidrs" "c" {
-  ipam_pool_id = "ipam-pool-123"
+  ipam_pool_id = data.aws_vpc_ipam_pool.p.id
+}
+
+data "aws_vpc_ipam_pool" "p" {
+  filter {
+    name   = "description"
+    values = ["*mypool*"]
+  }
+
+  filter {
+    name   = "address-family"
+    values = ["ipv4"]
+  }
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds a new data source to list all cidrs provisioned into a pool. This is especially helpful for those who receive a pool via ram sharing and want to add all CIDRs from a pool to route tables.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #27040
--->

Closes #27040

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccIPAMPoolCidrsDataSource_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAMPoolCidrsDataSource_basic'  -timeout 180m
=== RUN   TestAccIPAMPoolCidrsDataSource_basic
=== PAUSE TestAccIPAMPoolCidrsDataSource_basic
=== CONT  TestAccIPAMPoolCidrsDataSource_basic
--- PASS: TestAccIPAMPoolCidrsDataSource_basic (123.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        127.394s
```
