### PR TITLE
Update document example of aws_identitystore_group resource creation

### DIFF
--- a/website/docs/r/identitystore_group.html.markdown
+++ b/website/docs/r/identitystore_group.html.markdown
@@ -18,7 +18,7 @@ Terraform resource for managing an AWS IdentityStore Group.
 resource "aws_identitystore_group" "this" {
   display_name      = "Example group"
   description       = "Example description"
-  identity_store_id = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  identity_store_id = tolist(data.aws_ssoadmin_instances.example.identity_store_ids)[0]
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
To update example of **aws_identitystore_group** creation. Should be **aws_ssoadmin_instances**'s `identity_store_ids` instead of `arns`



### Original example
```
resource "aws_identitystore_group" "this" {
  display_name      = "Example group"
  description       = "Example description"
  identity_store_id = tolist(data.aws_ssoadmin_instances.example.arns)[0]
}
```

### Expected example
```
resource "aws_identitystore_group" "this" {
  display_name      = "Example group"
  description       = "Example description"
  identity_store_id = tolist(data.aws_ssoadmin_instances.example.identity_store_ids)[0]
}
```

