### PR TITLE
aws_appconfig data sources

### DIFF
--- a/.changelog/27054.txt
+++ b/.changelog/27054.txt
@@ -1,0 +1,15 @@
+```release-note:new-data-source
+aws_appconfig_environment
+```
+
+```release-note:new-data-source
+aws_appconfig_environments
+```
+
+```release-note:new-data-source
+aws_appconfig_configuration_profile
+```
+
+```release-note:new-data-source
+aws_appconfig_configuration_profiles
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -92,7 +92,7 @@ testacc: fmtcheck
 		echo "For example if updating internal/service/acm/certificate.go, use the test names in internal/service/acm/certificate_test.go starting with TestAcc and up to the underscore:"; \
 		echo "make testacc TESTS=TestAccACMCertificate_ PKG=acm"; \
 		echo ""; \
-		echo "See the contributing guide for more information: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md"; \
+		echo "See the contributing guide for more information: https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests"; \
 		exit 1; \
 	fi
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -432,6 +432,11 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_apigatewayv2_apis":   apigatewayv2.DataSourceAPIs(),
 			"aws_apigatewayv2_export": apigatewayv2.DataSourceExport(),
 
+			"aws_appconfig_configuration_profile":  appconfig.DataSourceConfigurationProfile(),
+			"aws_appconfig_configuration_profiles": appconfig.DataSourceConfigurationProfiles(),
+			"aws_appconfig_environment":            appconfig.DataSourceEnvironment(),
+			"aws_appconfig_environments":           appconfig.DataSourceEnvironments(),
+
 			"aws_appmesh_mesh":            appmesh.DataSourceMesh(),
 			"aws_appmesh_virtual_service": appmesh.DataSourceVirtualService(),
 

--- a/internal/service/appconfig/configuration_profile_data_source.go
+++ b/internal/service/appconfig/configuration_profile_data_source.go
@@ -1,0 +1,146 @@
+package appconfig
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceConfigurationProfile() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceConfigurationProfileRead,
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z\d]{4,7}`), ""),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"configuration_profile_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z\d]{4,7}`), ""),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"location_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"retrieval_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"validator": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+const (
+	DSNameConfigurationProfile = "Configuration Profile Data Source"
+)
+
+func dataSourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+
+	appId := d.Get("application_id").(string)
+	profileId := d.Get("configuration_profile_id").(string)
+	ID := fmt.Sprintf("%s:%s", profileId, appId)
+
+	out, err := findConfigurationProfileByApplicationAndProfile(ctx, conn, appId, profileId)
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameConfigurationProfile, ID, err)
+	}
+
+	d.SetId(ID)
+
+	d.Set("application_id", appId)
+
+	arn := arn.ARN{
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Partition: meta.(*conns.AWSClient).Partition,
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("application/%s/configurationprofile/%s", appId, profileId),
+		Service:   "appconfig",
+	}.String()
+
+	d.Set("arn", arn)
+	d.Set("configuration_profile_id", profileId)
+	d.Set("description", out.Description)
+	d.Set("location_uri", out.LocationUri)
+	d.Set("name", out.Name)
+	d.Set("retrieval_role_arn", out.RetrievalRoleArn)
+	d.Set("type", out.Type)
+
+	if err := d.Set("validator", flattenValidators(out.Validators)); err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionSetting, DSNameConfigurationProfile, ID, err)
+	}
+
+	tags, err := ListTags(conn, arn)
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameConfigurationProfile, ID, err)
+	}
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.Map()); err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionSetting, DSNameConfigurationProfile, ID, err)
+	}
+
+	return nil
+}
+
+func findConfigurationProfileByApplicationAndProfile(ctx context.Context, conn *appconfig.AppConfig, appId string, cpId string) (*appconfig.GetConfigurationProfileOutput, error) {
+	res, err := conn.GetConfigurationProfileWithContext(ctx, &appconfig.GetConfigurationProfileInput{
+		ApplicationId:          aws.String(appId),
+		ConfigurationProfileId: aws.String(cpId),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/internal/service/appconfig/configuration_profile_data_source_test.go
+++ b/internal/service/appconfig/configuration_profile_data_source_test.go
@@ -1,0 +1,80 @@
+package appconfig_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccAppConfigConfigurationProfileDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	appName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	appResourceName := "aws_appconfig_application.test"
+	dataSourceName := "data.aws_appconfig_configuration_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(appconfig.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationProfileDataSourceConfig_basic(appName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_id", appResourceName, "id"),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "appconfig", regexp.MustCompile(`application/([a-z\d]{4,7})/configurationprofile/+.`)),
+					resource.TestMatchResourceAttr(dataSourceName, "configuration_profile_id", regexp.MustCompile(`[a-z\d]{4,7}`)),
+					resource.TestCheckResourceAttr(dataSourceName, "location_uri", "hosted"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "retrieval_role_arn", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "AWS.Freeform"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "validator.*", map[string]string{
+						"content": "{\"$schema\":\"http://json-schema.org/draft-05/schema#\",\"description\":\"BasicFeatureToggle-1\",\"title\":\"$id$\"}",
+						"type":    appconfig.ValidatorTypeJsonSchema,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigurationProfileDataSourceConfig_basic(appName, rName string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_name(appName),
+		fmt.Sprintf(`
+resource "aws_appconfig_configuration_profile" "test" {
+  application_id = aws_appconfig_application.test.id
+  name           = %[1]q
+  location_uri   = "hosted"
+
+  validator {
+    content = jsonencode({
+      "$schema"   = "http://json-schema.org/draft-05/schema#"
+      title       = "$id$"
+      description = "BasicFeatureToggle-1"
+    })
+
+    type = "JSON_SCHEMA"
+  }
+
+  tags = {
+    key1 = "value1"
+  }
+}
+
+data "aws_appconfig_configuration_profile" "test" {
+  application_id 		   = aws_appconfig_application.test.id
+  configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
+}
+`, rName))
+}

--- a/internal/service/appconfig/configuration_profiles_data_source.go
+++ b/internal/service/appconfig/configuration_profiles_data_source.go
@@ -1,0 +1,71 @@
+package appconfig
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceConfigurationProfiles() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceConfigurationProfilesRead,
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"configuration_profile_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+const (
+	DSNameConfigurationProfiles = "Configuration Profiles Data Source"
+)
+
+func dataSourceConfigurationProfilesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+	appId := d.Get("application_id").(string)
+
+	out, err := findConfigurationProfileSummariesByApplication(ctx, conn, appId)
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameConfigurationProfiles, appId, err)
+	}
+
+	d.SetId(appId)
+
+	var configIds []*string
+	for _, v := range out {
+		configIds = append(configIds, v.Id)
+	}
+
+	d.Set("configuration_profile_ids", aws.StringValueSlice(configIds))
+
+	return nil
+}
+
+func findConfigurationProfileSummariesByApplication(ctx context.Context, conn *appconfig.AppConfig, applicationId string) ([]*appconfig.ConfigurationProfileSummary, error) {
+	var outputs []*appconfig.ConfigurationProfileSummary
+	err := conn.ListConfigurationProfilesPagesWithContext(ctx, &appconfig.ListConfigurationProfilesInput{
+		ApplicationId: aws.String(applicationId),
+	}, func(output *appconfig.ListConfigurationProfilesOutput, lastPage bool) bool {
+		outputs = append(outputs, output.Items...)
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return outputs, nil
+}

--- a/internal/service/appconfig/configuration_profiles_data_source_test.go
+++ b/internal/service/appconfig/configuration_profiles_data_source_test.go
@@ -1,0 +1,61 @@
+package appconfig_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccAppConfigConfigurationProfilesDataSource_basic(t *testing.T) {
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	appName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_appconfig_configuration_profiles.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(appconfig.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationProfilesDataSourceConfig_basic(appName, rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "configuration_profile_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "configuration_profile_ids.*", "aws_appconfig_configuration_profile.test_1", "configuration_profile_id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "configuration_profile_ids.*", "aws_appconfig_configuration_profile.test_2", "configuration_profile_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigurationProfilesDataSourceConfig_basic(appName, rName1, rName2 string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_name(appName),
+		fmt.Sprintf(`
+resource "aws_appconfig_configuration_profile" "test_1" {
+  application_id = aws_appconfig_application.test.id
+  name           = %[1]q
+  location_uri   = "hosted"
+}
+
+resource "aws_appconfig_configuration_profile" "test_2" {
+  application_id = aws_appconfig_application.test.id
+  name           = %[2]q
+  location_uri   = "hosted"
+}
+
+data "aws_appconfig_configuration_profiles" "test" {
+  application_id	= aws_appconfig_application.test.id
+  depends_on 		= [aws_appconfig_configuration_profile.test_1, aws_appconfig_configuration_profile.test_2]
+}
+`, rName1, rName2))
+}

--- a/internal/service/appconfig/environment_data_source.go
+++ b/internal/service/appconfig/environment_data_source.go
@@ -1,0 +1,137 @@
+package appconfig
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceEnvironment() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceEnvironmentRead,
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z\d]{4,7}`), ""),
+			},
+			"environment_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z\d]{4,7}`), ""),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"monitor": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_arn": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"alarm_role_arn": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+					},
+				},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameEnvironment = "Environment Data Source"
+)
+
+func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+
+	appID := d.Get("application_id").(string)
+	envID := d.Get("environment_id").(string)
+	ID := fmt.Sprintf("%s:%s", envID, appID)
+
+	out, err := findEnvironmentByApplicationAndEnvironment(ctx, conn, appID, envID)
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameEnvironment, ID, err)
+	}
+
+	d.SetId(ID)
+
+	d.Set("application_id", appID)
+	d.Set("environment_id", envID)
+	d.Set("description", out.Description)
+	d.Set("name", out.Name)
+	d.Set("state", out.State)
+
+	if err := d.Set("monitor", flattenEnvironmentMonitors(out.Monitors)); err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameEnvironment, ID, err)
+	}
+
+	arn := arn.ARN{
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Partition: meta.(*conns.AWSClient).Partition,
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("application/%s/environment/%s", appID, envID),
+		Service:   "appconfig",
+	}.String()
+
+	d.Set("arn", arn)
+
+	tags, err := ListTags(conn, arn)
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameEnvironment, ID, err)
+	}
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.Map()); err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionSetting, DSNameEnvironment, ID, err)
+	}
+
+	return nil
+}
+
+func findEnvironmentByApplicationAndEnvironment(ctx context.Context, conn *appconfig.AppConfig, appId string, envId string) (*appconfig.GetEnvironmentOutput, error) {
+	res, err := conn.GetEnvironmentWithContext(ctx, &appconfig.GetEnvironmentInput{
+		ApplicationId: aws.String(appId),
+		EnvironmentId: aws.String(envId),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/internal/service/appconfig/environment_data_source_test.go
+++ b/internal/service/appconfig/environment_data_source_test.go
@@ -1,0 +1,130 @@
+package appconfig_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccAppConfigEnvironmentDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	appName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	appResourceName := "aws_appconfig_application.test"
+	dataSourceName := "data.aws_appconfig_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(appconfig.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentDataSourceConfig_basic(appName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "appconfig", regexp.MustCompile(`application/([a-z\d]{4,7})/environment/+.`)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_id", appResourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "Example AppConfig Environment"),
+					resource.TestMatchResourceAttr(dataSourceName, "environment_id", regexp.MustCompile(`[a-z\d]{4,7}`)),
+					resource.TestCheckResourceAttr(dataSourceName, "monitor.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "monitor.*.alarm_arn", "aws_cloudwatch_metric_alarm.test", "arn"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "monitor.*.alarm_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEnvironmentDataSourceConfig_basic(appName, rName string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_name(appName),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "appconfig.${data.aws_partition.current.dns_suffix}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.name
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:DescribeAlarms"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name                = "%[1]s"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/EC2"
+  period                    = "120"
+  statistic                 = "Average"
+  threshold                 = "80"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_appconfig_environment" "test" {
+  application_id = aws_appconfig_application.test.id
+  name           = %[1]q
+  description    = "Example AppConfig Environment"
+
+  monitor {
+	alarm_arn      = aws_cloudwatch_metric_alarm.test.arn
+	alarm_role_arn = aws_iam_role.test.arn
+  }
+
+  tags = {
+    key1 = "value1"
+  }
+}
+
+data "aws_appconfig_environment" "test" {
+  application_id = aws_appconfig_application.test.id
+  environment_id = aws_appconfig_environment.test.environment_id
+}
+`, rName))
+}

--- a/internal/service/appconfig/environments_data_source.go
+++ b/internal/service/appconfig/environments_data_source.go
@@ -1,0 +1,74 @@
+package appconfig
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceEnvironments() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceEnvironmentsRead,
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z\d]{4,7}`), ""),
+			},
+			"environment_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+const (
+	DSNameEnvironments = "Environments Data Source"
+)
+
+func dataSourceEnvironmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+	appID := d.Get("application_id").(string)
+
+	out, err := findEnvironmentsByApplication(ctx, conn, appID)
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, DSNameEnvironments, appID, err)
+	}
+
+	d.SetId(appID)
+
+	var environmentIds []*string
+	for _, v := range out {
+		environmentIds = append(environmentIds, v.Id)
+	}
+	d.Set("environment_ids", aws.StringValueSlice(environmentIds))
+
+	return nil
+}
+
+func findEnvironmentsByApplication(ctx context.Context, conn *appconfig.AppConfig, appId string) ([]*appconfig.Environment, error) {
+	var outputs []*appconfig.Environment
+	err := conn.ListEnvironmentsPagesWithContext(ctx, &appconfig.ListEnvironmentsInput{
+		ApplicationId: aws.String(appId),
+	}, func(output *appconfig.ListEnvironmentsOutput, lastPage bool) bool {
+		outputs = append(outputs, output.Items...)
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return outputs, nil
+}

--- a/internal/service/appconfig/environments_data_source_test.go
+++ b/internal/service/appconfig/environments_data_source_test.go
@@ -1,0 +1,59 @@
+package appconfig_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccAppConfigEnvironmentsDataSource_basic(t *testing.T) {
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	appName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_appconfig_environments.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(appconfig.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentsDataSourceConfig_basic(appName, rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "environment_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "environment_ids.*", "aws_appconfig_environment.test_1", "environment_id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "environment_ids.*", "aws_appconfig_environment.test_2", "environment_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEnvironmentsDataSourceConfig_basic(appName, rName1, rName2 string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_name(appName),
+		fmt.Sprintf(`
+resource "aws_appconfig_environment" "test_1" {
+  application_id = aws_appconfig_application.test.id
+  name           = %[1]q
+}
+
+resource "aws_appconfig_environment" "test_2" {
+  application_id = aws_appconfig_application.test.id
+  name           = %[2]q
+}
+
+data "aws_appconfig_environments" "test" {
+  application_id	= aws_appconfig_application.test.id
+  depends_on 		= [aws_appconfig_environment.test_1, aws_appconfig_environment.test_2]
+}
+`, rName1, rName2))
+}

--- a/website/docs/d/appconfig_configuration_profile.html.markdown
+++ b/website/docs/d/appconfig_configuration_profile.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "AppConfig"
+layout: "aws"
+page_title: "AWS: aws_appconfig_configuration_profile"
+description: |-
+Terraform data source for managing an AWS AppConfig Configuration Profile.
+---
+
+# Data Source: aws_appconfig_configuration_profile
+
+Provides access to an AppConfig Configuration Profile.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_appconfig_configuration_profile" "example" {
+  application_id           = "b5d5gpj"
+  configuration_profile_id = "qrbb1c1"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_id` - (Required) ID of the AppConfig application to which this configuration profile belongs.
+* `configuration_profile_id` - (Required) ID of the Configuration Profile.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Configuration Profile.
+* `description` - Description of the Configuration Profile.
+* `id` - AppConfig Configuration Profile ID and Application ID separated by a colon `(:)`.
+* `location_uri` - Location URI of the Configuration Profile.
+* `name` - Name of the Configuration Profile.
+* `retrieval_role_arn` - ARN of an IAM role with permission to access the configuration at the specified location_uri.
+* `tags` - Map of tags for the resource.
+* `validator` - Nested list of methods for validating the configuration.
+    * `content` - Either the JSON Schema content or the ARN of an AWS Lambda function.
+    * `type` - Type of validator. Valid values: JSON_SCHEMA and LAMBDA.

--- a/website/docs/d/appconfig_configuration_profiles.html.markdown
+++ b/website/docs/d/appconfig_configuration_profiles.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "AppConfig"
+layout: "aws"
+page_title: "AWS: aws_appconfig_configuration_profiles"
+description: |-
+Terraform data source for managing an AWS AppConfig Configuration Profiles.
+---
+
+# Data Source: aws_appconfig_configuration_profiles
+
+Provides access to all Configuration Properties for an AppConfig Application. This will allow you to pass Configuration
+Profile IDs to another resource.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_appconfig_configuration_profiles" "example" {
+  application_id = "a1d3rpe"
+}
+
+data "aws_appconfig_configuration_profile" "example" {
+  for_each                 = data.aws_appconfig_configuration_profiles.example.configuration_profile_ids
+  configuration_profile_id = each.value
+  application_id           = aws_appconfig_application.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_id` - (Required) ID of the AppConfig Application.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `configuration_profile_ids` - Set of Configuration Profile IDs associated with the AppConfig Application.

--- a/website/docs/d/appconfig_environment.html.markdown
+++ b/website/docs/d/appconfig_environment.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "AppConfig"
+layout: "aws"
+page_title: "AWS: aws_appconfig_environment"
+description: |-
+Terraform data source for managing an AWS AppConfig Environment.
+---
+
+# Data Source: aws_appconfig_environment
+
+Provides access to an AppConfig Environment.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_appconfig_environment" "example" {
+  application_id = "b5d5gpj"
+  environment_id = "qrbb1c1"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_id` - (Required) ID of the AppConfig Application to which this Environment belongs.
+* `environment_id` - (Required) ID of the AppConfig Environment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the environment.
+* `name` - Name of the environment.
+* `description` - Name of the environment.
+* `monitor` - Set of Amazon CloudWatch alarms to monitor during the deployment process.
+    * `alarm_arn` - ARN of the Amazon CloudWatch alarm.
+    * `alarm_role_arn` - ARN of an IAM role for AWS AppConfig to monitor.
+* `state` - State of the environment. Possible values are `READY_FOR_DEPLOYMENT`, `DEPLOYING`, `ROLLING_BACK`
+  or `ROLLED_BACK`.
+* `tags` - Map of tags for the resource.

--- a/website/docs/d/appconfig_environments.html.markdown
+++ b/website/docs/d/appconfig_environments.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "AppConfig"
+layout: "aws"
+page_title: "AWS: aws_appconfig_environments"
+description: |-
+Terraform data source for managing an AWS AppConfig Environments.
+---
+
+# Data Source: aws_appconfig_environments
+
+Provides access to all Environments for an AppConfig Application. This will allow you to pass Environment IDs to another
+resource.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_appconfig_environments" "example" {
+  application_id = "a1d3rpe"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_id` - (Required) ID of the AppConfig Application.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `environment_ids` - Set of Environment IDs associated with this AppConfig Application.

--- a/website/docs/r/appconfig_environment.html.markdown
+++ b/website/docs/r/appconfig_environment.html.markdown
@@ -62,6 +62,8 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - ARN of the AppConfig Environment.
 * `id` - AppConfig environment ID and application ID separated by a colon (`:`).
 * `environment_id` - AppConfig environment ID.
+* `state` - State of the environment. Possible values are `READY_FOR_DEPLOYMENT`, `DEPLOYING`, `ROLLING_BACK`
+  or `ROLLED_BACK`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
- Add data source for appconfig_configuration_profile 
- Add data source for appconfig_configuration_profiles 
- Add data source for appconfig_environment
- Add data source for appconfig_environments

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26119

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccAppConfigConfigurationProfileDataSource PKG=appconfig
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appconfig/... -v -count 1 -parallel 20 -run='TestAccAppConfigConfigurationProfileDataSource'  -timeout 180m
=== RUN   TestAccAppConfigConfigurationProfileDataSource_basic
=== PAUSE TestAccAppConfigConfigurationProfileDataSource_basic
=== CONT  TestAccAppConfigConfigurationProfileDataSource_basic
--- PASS: TestAccAppConfigConfigurationProfileDataSource_basic (26.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  26.660s

make testacc TESTS=TestAccAppConfigEnvironmentDataSource PKG=appconfig
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appconfig/... -v -count 1 -parallel 20 -run='TestAccAppConfigEnvironmentDataSource'  -timeout 180m
=== RUN   TestAccAppConfigEnvironmentDataSource_basic
=== PAUSE TestAccAppConfigEnvironmentDataSource_basic
=== CONT  TestAccAppConfigEnvironmentDataSource_basic
--- PASS: TestAccAppConfigEnvironmentDataSource_basic (33.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  33.291s

make testacc TESTS=TestAccAppConfigConfigurationProfilesDataSource PKG=appconfig
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appconfig/... -v -count 1 -parallel 20 -run='TestAccAppConfigConfigurationProfilesDataSource'  -timeout 180m
=== RUN   TestAccAppConfigConfigurationProfilesDataSource_basic
=== PAUSE TestAccAppConfigConfigurationProfilesDataSource_basic
=== CONT  TestAccAppConfigConfigurationProfilesDataSource_basic
--- PASS: TestAccAppConfigConfigurationProfilesDataSource_basic (25.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  25.278s

make testacc TESTS=TestAccAppConfigEnvironmentsDataSource PKG=appconfig
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appconfig/... -v -count 1 -parallel 20 -run='TestAccAppConfigEnvironmentsDataSource'  -timeout 180m
=== RUN   TestAccAppConfigEnvironmentsDataSource_basic
=== PAUSE TestAccAppConfigEnvironmentsDataSource_basic
=== CONT  TestAccAppConfigEnvironmentsDataSource_basic
--- PASS: TestAccAppConfigEnvironmentsDataSource_basic (25.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  25.085s


...
```
