### PR TITLE
data/aws_iam_policy_document - additional json validation

### DIFF
--- a/.changelog/27055.txt
+++ b/.changelog/27055.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data/aws_iam_policy_document: Better handling when invalid JSON passed to `override_policy_documents`
+```

--- a/.changelog/27055.txt
+++ b/.changelog/27055.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data/aws_iam_policy_document: Better handling when invalid JSON passed to `override_policy_documents`
+data-source/aws_iam_policy_document: Better handling when invalid JSON passed to `override_policy_documents`
 ```

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -33,23 +33,28 @@ func DataSourcePolicyDocument() *schema.Resource {
 				Computed: true,
 			},
 			"override_json": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Deprecated: "Use the attribute \"override_policy_documents\" instead.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Deprecated:   "Use the attribute \"override_policy_documents\" instead.",
 			},
 			"override_policy_documents": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsJSON,
+				},
 			},
 			"policy_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"source_json": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Deprecated: "Use the attribute \"source_policy_documents\" instead.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Deprecated:   "Use the attribute \"source_policy_documents\" instead.",
 			},
 			"source_policy_documents": {
 				Type:     schema.TypeList,
@@ -256,6 +261,9 @@ func dataSourcePolicyDocumentRead(d *schema.ResourceData, meta interface{}) erro
 	// merge override_policy_documents policies into mergedDoc in order specified
 	if v, ok := d.GetOk("override_policy_documents"); ok && len(v.([]interface{})) > 0 {
 		for _, overrideJSON := range v.([]interface{}) {
+			if overrideJSON == nil {
+				continue
+			}
 			overrideDoc := &IAMPolicyDoc{}
 			if err := json.Unmarshal([]byte(overrideJSON.(string)), overrideDoc); err != nil {
 				return err

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -263,6 +263,72 @@ func TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON(t *testing.T) {
 	})
 }
 
+func TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPolicyDocumentDataSourceConfig_overridePolicyDocument_invalidJSON,
+				ExpectError: regexp.MustCompile(`"override_policy_documents.0" contains an invalid JSON: unexpected end of JSON input`),
+			},
+			{
+				Config: testAccPolicyDocumentDataSourceConfig_overridePolicyDocument_emptyString,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json",
+						testAccPolicyDocumentExpectedJSONNoStatement,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPolicyDocumentDataSourceConfig_overrideJSON_invalidJSON,
+				ExpectError: regexp.MustCompile(`"override_json" contains an invalid JSON: unexpected end of JSON input`),
+			},
+			{
+				Config: testAccPolicyDocumentDataSourceConfig_overrideJSON_emptyString,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json",
+						testAccPolicyDocumentExpectedJSONNoStatement,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPolicyDocumentDataSourceConfig_sourceJSON_invalidJSON,
+				ExpectError: regexp.MustCompile(`"source_json" contains an invalid JSON: unexpected end of JSON input`),
+			},
+			{
+				Config: testAccPolicyDocumentDataSourceConfig_sourceJSON_emptyString,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json",
+						testAccPolicyDocumentExpectedJSONNoStatement,
+					),
+				),
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/10777
 func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice(t *testing.T) {
 	dataSourceName := "data.aws_iam_policy_document.test"
@@ -1441,3 +1507,39 @@ func testAccPolicyDocumentExpectedJSONStatementPrincipalIdentifiersMultiplePrinc
   ]
 }`, acctest.Partition())
 }
+
+var testAccPolicyDocumentDataSourceConfig_overridePolicyDocument_emptyString = `
+data "aws_iam_policy_document" "test" {
+  override_policy_documents = [""]
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_overridePolicyDocument_invalidJSON = `
+data "aws_iam_policy_document" "test" {
+  override_policy_documents = ["{"]
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_overrideJSON_emptyString = `
+data "aws_iam_policy_document" "test" {
+  override_json = ""
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_overrideJSON_invalidJSON = `
+data "aws_iam_policy_document" "test" {
+  override_json = "{"
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_sourceJSON_emptyString = `
+data "aws_iam_policy_document" "test" {
+  source_json = ""
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_sourceJSON_invalidJSON = `
+data "aws_iam_policy_document" "test" {
+  source_json = "{"
+}
+`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds additional validation to user supplied JSON attributes on `override_policy_documents`.

Note that this change introduces additional validation on deprecated attributes (`override_json`, `source_json`). Supplying invalid JSON to these fields did not cause a 'panic' or crash and this validation + additional tests exists for completeness and to prevent against future regressions. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27022.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/26640.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON'  -timeout 180m
=== RUN   TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== CONT  TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
--- PASS: TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON (14.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        15.030s

 make testacc TESTS=TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON'  -timeout 180m
=== RUN   TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON
=== CONT  TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON (14.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        14.697s

make testacc TESTS=TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON'  -timeout 180m
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON (16.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        16.841s


...
```
