### PR TITLE
Upgrade to `terraform-plugin-framework` v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.14.1
-	github.com/hashicorp/terraform-plugin-framework v0.11.1
+	github.com/hashicorp/terraform-plugin-framework v0.13.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjl
 github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
 github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
-github.com/hashicorp/terraform-plugin-framework v0.11.1 h1:rq8f+TLDO4tJu+n9mMYlDrcRoIdrg0gTUvV2Jr0Ya24=
-github.com/hashicorp/terraform-plugin-framework v0.11.1/go.mod h1:GENReHOz6GEt8Jk3UN94vk8BdC6irEHFgN3Z9HPhPUU=
+github.com/hashicorp/terraform-plugin-framework v0.13.0 h1:tGnqttzZwU3FKc+HasHr2Yi5L81FcQbdc8zQhbBD9jQ=
+github.com/hashicorp/terraform-plugin-framework v0.13.0/go.mod h1:wcZdk4+Uef6Ng+BiBJjGAcIPlIs5bhlEV/TA1k6Xkq8=
 github.com/hashicorp/terraform-plugin-framework-validators v0.5.0 h1:eD79idhnJOBajkUMEbm0c8dOyOb/F49STbUEVojT6F4=
 github.com/hashicorp/terraform-plugin-framework-validators v0.5.0/go.mod h1:NfGgclDM3FZqvNVppPKE2aHI1JAyT002ypPRya7ch3I=
 github.com/hashicorp/terraform-plugin-go v0.14.0 h1:ttnSlS8bz3ZPYbMb84DpcPhY4F5DsQtcAS7cHo8uvP4=

--- a/internal/experimental/intf/service.go
+++ b/internal/experimental/intf/service.go
@@ -3,11 +3,11 @@ package intf
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 )
 
 // ServiceData is data about a service.
 type ServiceData interface {
 	Configure(context.Context, ProviderData) error
-	DataSources(context.Context) (map[string]provider.DataSourceType, error)
+	DataSources(context.Context) []func(context.Context) (datasource.DataSource, error)
 }

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/experimental/intf"
 	"github.com/hashicorp/terraform-provider-aws/internal/fwtypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
@@ -316,17 +317,18 @@ func (p *fwprovider) Configure(ctx context.Context, request provider.ConfigureRe
 func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	var dataSources []func() datasource.DataSource
 
-	// TODO Better error messages.
 	// TODO Wrap the returned type to add standard context, logging etc.
 	providerData := p.Primary.Meta().(intf.ProviderData)
-	for _, data := range providerData.Services(ctx) {
+	for serviceID, data := range providerData.Services(ctx) {
 		for _, v := range data.DataSources(ctx) {
 			v, err := v(ctx)
 
 			if err != nil {
-				// TODO (FW0.13)
-				// logging
-				// diags.AddError(fmt.Sprintf("data sources for service (%s)", serviceID), err.Error())
+				tflog.Warn(ctx, "creating data source", map[string]interface{}{
+					"service_id": serviceID,
+					"error":      err.Error(),
+				})
+
 				continue
 			}
 

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -303,10 +303,9 @@ func (p *fwprovider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnost
 // provider configuration block.
 func (p *fwprovider) Configure(ctx context.Context, request provider.ConfigureRequest, response *provider.ConfigureResponse) {
 	// Provider's parsed configuration (its instance state) is available through the primary provider's Meta() method.
-
-	// TODO (FW0.13)
-	// response.DataSourceData =
-	// response.ResourceData =
+	v := p.Primary.Meta()
+	response.DataSourceData = v
+	response.ResourceData = v
 }
 
 // DataSources returns a slice of functions to instantiate each DataSource
@@ -349,7 +348,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	var resources []func() resource.Resource
 
 	resources = append(resources, func() resource.Resource {
-		return medialive.NewResourceMultiplexProgram(ctx, p.Primary)
+		return medialive.NewResourceMultiplexProgram(ctx)
 	})
 
 	return resources

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -22,10 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func NewResourceMultiplexProgram(_ context.Context, meta interface{ Meta() interface{} }) resource.Resource {
-	return &multiplexProgram{
-		meta: meta,
-	}
+func NewResourceMultiplexProgram(_ context.Context) resource.Resource {
+	return &multiplexProgram{}
 }
 
 const (
@@ -33,7 +31,7 @@ const (
 )
 
 type multiplexProgram struct {
-	meta interface{ Meta() interface{} }
+	meta any
 }
 
 func (m *multiplexProgram) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
@@ -140,12 +138,11 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 }
 
 func (m *multiplexProgram) Configure(_ context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) { //nolint:unparam
-	// TODO (FW0.13)
-	// request.ProviderData
+	m.meta = request.ProviderData
 }
 
 func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	conn := m.meta.Meta().(*conns.AWSClient).MediaLiveConn
+	conn := m.meta.(*conns.AWSClient).MediaLiveConn
 
 	var plan resourceMultiplexProgramData
 	diags := req.Plan.Get(ctx, &plan)
@@ -190,7 +187,7 @@ func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateReques
 }
 
 func (m *multiplexProgram) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := m.meta.Meta().(*conns.AWSClient).MediaLiveConn
+	conn := m.meta.(*conns.AWSClient).MediaLiveConn
 
 	var state resourceMultiplexProgramData
 	diags := req.State.Get(ctx, &state)
@@ -252,7 +249,7 @@ func (m *multiplexProgram) Update(ctx context.Context, req resource.UpdateReques
 }
 
 func (m *multiplexProgram) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := m.meta.Meta().(*conns.AWSClient).MediaLiveConn
+	conn := m.meta.(*conns.AWSClient).MediaLiveConn
 
 	var state resourceMultiplexProgramData
 	diags := req.State.Get(ctx, &state)

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -137,7 +137,7 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 	return schema, nil
 }
 
-func (m *multiplexProgram) Configure(_ context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) { //nolint:unparam
+func (m *multiplexProgram) Configure(_ context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
 	m.meta = request.ProviderData
 }
 

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -23,17 +22,25 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func NewResourceMultiplexProgramType(_ context.Context, meta interface{ Meta() interface{} }) provider.ResourceType {
-	return &resourceMultiplexProgramType{
+func NewResourceMultiplexProgram(_ context.Context, meta interface{ Meta() interface{} }) resource.Resource {
+	return &multiplexProgram{
 		meta: meta,
 	}
 }
 
-type resourceMultiplexProgramType struct {
+const (
+	ResNameMultiplexProgram = "Multiplex Program"
+)
+
+type multiplexProgram struct {
 	meta interface{ Meta() interface{} }
 }
 
-func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (m *multiplexProgram) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_medialive_multiplex_program"
+}
+
+func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	schema := tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
@@ -132,18 +139,9 @@ func (t *resourceMultiplexProgramType) GetSchema(context.Context) (tfsdk.Schema,
 	return schema, nil
 }
 
-const (
-	ResNameMultiplexProgram = "Multiplex Program"
-)
-
-func (t *resourceMultiplexProgramType) NewResource(ctx context.Context, provider provider.Provider) (resource.Resource, diag.Diagnostics) {
-	return &multiplexProgram{
-		meta: t.meta,
-	}, nil
-}
-
-type multiplexProgram struct {
-	meta interface{ Meta() interface{} }
+func (m *multiplexProgram) Configure(_ context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) { //nolint:unparam
+	// TODO (FW0.13)
+	// request.ProviderData
 }
 
 func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/medialive/multiplex_program_test.go
+++ b/internal/service/medialive/multiplex_program_test.go
@@ -176,14 +176,12 @@ func testAccCheckMultiplexProgramExists(name string, multiplexprogram *medialive
 }
 
 func testAccMultiplexProgramBaseConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "test" {
-  state = "available"
-}
-
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
-  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {
     transport_stream_bitrate                = 1000000
@@ -196,7 +194,7 @@ resource "aws_medialive_multiplex" "test" {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName))
 }
 func testAccMultiplexProgramConfig_basic(rName string) string {
 	return acctest.ConfigCompose(

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -73,8 +73,6 @@ func (d *dataSourceARN) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnosti
 // provider-defined DataSource type. It is separately executed for each
 // ReadDataSource RPC.
 func (d *dataSourceARN) Configure(_ context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) { //nolint:unparam
-	// TODO (FW0.13)
-	// request.ProviderData
 }
 
 // Read is called when the provider must read data source values in order to update state.

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -7,29 +7,31 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/fwtypes"
 )
 
-// TODO: Remove
-var NewDataSourceARNType = newDataSourceARNType
-
 func init() {
-	registerDataSourceTypeFactory("aws_arn", newDataSourceARNType)
+	registerDataSourceFactory(newDataSourceARN)
 }
 
-// newDataSourceARNType instantiates a new DataSourceType for the aws_arn data source.
-func newDataSourceARNType(ctx context.Context) (provider.DataSourceType, error) {
-	return &dataSourceARNType{}, nil
+// newDataSourceARN instantiates a new DataSource for the aws_arn data source.
+func newDataSourceARN(ctx context.Context) (datasource.DataSource, error) {
+	return &dataSourceARN{}, nil
 }
 
-type dataSourceARNType struct{}
+type dataSourceARN struct{}
+
+// Metadata should return the full name of the data source, such as
+// examplecloud_thing.
+func (d *dataSourceARN) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = "aws_arn"
+}
 
 // GetSchema returns the schema for this data source.
-func (t *dataSourceARNType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (d *dataSourceARN) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	schema := tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"account": {
@@ -67,12 +69,13 @@ func (t *dataSourceARNType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagn
 	return schema, nil
 }
 
-// NewDataSource instantiates a new DataSource of this DataSourceType.
-func (t *dataSourceARNType) NewDataSource(ctx context.Context, provider provider.Provider) (datasource.DataSource, diag.Diagnostics) {
-	return &dataSourceARN{}, nil
+// Configure enables provider-level data or clients to be set in the
+// provider-defined DataSource type. It is separately executed for each
+// ReadDataSource RPC.
+func (d *dataSourceARN) Configure(_ context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) { //nolint:unparam
+	// TODO (FW0.13)
+	// request.ProviderData
 }
-
-type dataSourceARN struct{}
 
 // Read is called when the provider must read data source values in order to update state.
 // Config values should be read from the ReadRequest and new state values set on the ReadResponse.

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -26,7 +26,7 @@ type dataSourceARN struct{}
 
 // Metadata should return the full name of the data source, such as
 // examplecloud_thing.
-func (d *dataSourceARN) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+func (d *dataSourceARN) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
 	response.TypeName = "aws_arn"
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

* Combines `Resource` and `ResourceType` implementations
* Combines `DataSource` and `DataSourceType` implementations
* Adds `Metadata` method to `Resource` and `DataSource` implementations
* Adds `Configure` method to `Resource` and `DataSource` implementations which allows initialization simplifications
* Changes `Provider` `GetResources` and `GetDataSources` to `Resources` and `DataSources`, with change return types. This allows PoC self-registration mechanism simplification

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-awscc/pull/685.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/26832.

```console
% make testacc TESTARGS='-run=TestAccMetaARNDataSource_' PKG=meta
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/meta/... -v -count 1 -parallel 20  -run=TestAccMetaARNDataSource_ -timeout 180m
=== RUN   TestAccMetaARNDataSource_basic
=== PAUSE TestAccMetaARNDataSource_basic
=== RUN   TestAccMetaARNDataSource_s3Bucket
=== PAUSE TestAccMetaARNDataSource_s3Bucket
=== CONT  TestAccMetaARNDataSource_basic
=== CONT  TestAccMetaARNDataSource_s3Bucket
--- PASS: TestAccMetaARNDataSource_s3Bucket (12.09s)
--- PASS: TestAccMetaARNDataSource_basic (12.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	16.017s
% make testacc TESTARGS='-run=TestAccMediaLive_serial/MultiplexProgram' PKG=medialive ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 2  -run=TestAccMediaLive_serial/MultiplexProgram -timeout 180m
=== RUN   TestAccMediaLive_serial
=== RUN   TestAccMediaLive_serial/MultiplexProgram
=== RUN   TestAccMediaLive_serial/MultiplexProgram/basic
=== RUN   TestAccMediaLive_serial/MultiplexProgram/disappears
--- PASS: TestAccMediaLive_serial (123.08s)
    --- PASS: TestAccMediaLive_serial/MultiplexProgram (123.08s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/basic (66.66s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/disappears (56.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	126.988s
```
