### PR TITLE
Prevent panic from nil SES active receipt rule set

### DIFF
--- a/.changelog/27073.txt
+++ b/.changelog/27073.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ses_active_receipt_rule_set: Prevent crash when no receipt rule set is active
+```

--- a/internal/service/ses/active_receipt_rule_set_data_source.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func DataSourceActiveReceiptRuleSet() *schema.Resource {
@@ -34,6 +35,9 @@ func dataSourceActiveReceiptRuleSetRead(d *schema.ResourceData, meta interface{}
 
 	if err != nil {
 		return fmt.Errorf("reading SES Active Receipt Rule Set: %s", err)
+	}
+	if data == nil || data.Metadata == nil {
+		return tfresource.NewEmptyResultError(nil)
 	}
 
 	name := aws.StringValue(data.Metadata.Name)

--- a/internal/service/ses/active_receipt_rule_set_data_source_test.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source_test.go
@@ -2,7 +2,6 @@ package ses_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -39,12 +38,6 @@ func testAccActiveReceiptRuleSetDataSource_basic(t *testing.T) {
 }
 
 func testAccActiveReceiptRuleSetDataSource_noActiveRuleSet(t *testing.T) {
-	// Gate this test so active SES receipt rule sets are not de-activated unless
-	// explicitly intended
-	if os.Getenv("UNSET_ACTIVE_SES_RECEIPT_RULE_SET") == "" {
-		t.Skip("UNSET_ACTIVE_SES_RECEIPT_RULE_SET environment variable not set")
-	}
-
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)

--- a/internal/service/ses/active_receipt_rule_set_data_source_test.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source_test.go
@@ -107,6 +107,4 @@ func testAccPreCheckUnsetActiveRuleSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
-
-	return
 }

--- a/internal/service/ses/active_receipt_rule_set_data_source_test.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source_test.go
@@ -2,12 +2,15 @@ package ses_test
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ses"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 func testAccActiveReceiptRuleSetDataSource_basic(t *testing.T) {
@@ -35,6 +38,30 @@ func testAccActiveReceiptRuleSetDataSource_basic(t *testing.T) {
 	})
 }
 
+func testAccActiveReceiptRuleSetDataSource_noActiveRuleSet(t *testing.T) {
+	// Gate this test so active SES receipt rule sets are not de-activated unless
+	// explicitly intended
+	if os.Getenv("UNSET_ACTIVE_SES_RECEIPT_RULE_SET") == "" {
+		t.Skip("UNSET_ACTIVE_SES_RECEIPT_RULE_SET environment variable not set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			testAccPreCheckUnsetActiveRuleSet(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ses.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccActiveReceiptRuleSetDataSourceConfig_noActiveRuleSet(),
+				ExpectError: regexp.MustCompile("empty result"),
+			},
+		},
+	})
+}
+
 func testAccActiveReceiptRuleSetDataSourceConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
@@ -49,4 +76,37 @@ data "aws_ses_active_receipt_rule_set" "test" {
   depends_on = [aws_ses_active_receipt_rule_set.test]
 }
 `, name)
+}
+
+func testAccActiveReceiptRuleSetDataSourceConfig_noActiveRuleSet() string {
+	return `
+data "aws_ses_active_receipt_rule_set" "test" {}
+`
+}
+
+func testAccPreCheckUnsetActiveRuleSet(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SESConn
+
+	output, err := conn.DescribeActiveReceiptRuleSet(&ses.DescribeActiveReceiptRuleSetInput{})
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if output == nil || output.Metadata == nil {
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	_, err = conn.SetActiveReceiptRuleSet(&ses.SetActiveReceiptRuleSetInput{
+		RuleSetName: nil,
+	})
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	return
 }

--- a/internal/service/ses/active_receipt_rule_set_test.go
+++ b/internal/service/ses/active_receipt_rule_set_test.go
@@ -23,7 +23,8 @@ func TestAccSESActiveReceiptRuleSet_serial(t *testing.T) {
 			"disappears": testAccActiveReceiptRuleSet_disappears,
 		},
 		"DataSource": {
-			"basic": testAccActiveReceiptRuleSetDataSource_basic,
+			"basic":           testAccActiveReceiptRuleSetDataSource_basic,
+			"noActiveRuleSet": testAccActiveReceiptRuleSetDataSource_noActiveRuleSet,
 		},
 	}
 


### PR DESCRIPTION
### Description
Handles cases where there is no SES receipt rule set as active. An empty result error is now returned in this scenario:

```
data.aws_ses_active_receipt_rule_set.active_receipt_rule_set: Reading...
╷
│ Error: empty result
│
│   with data.aws_ses_active_receipt_rule_set.active_receipt_rule_set,
│   on main.tf line 15, in data "aws_ses_active_receipt_rule_set" "active_receipt_rule_set":
│   15: data "aws_ses_active_receipt_rule_set" "active_receipt_rule_set" {}
│
╵
```

### Relations
Closes #26936

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccSESActiveReceiptRuleSet_serial' PKG=ses
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ses/... -v -count 1 -parallel 20 -run='TestAccSESActiveReceiptRuleSet_serial'  -timeout 180m
=== RUN   TestAccSESActiveReceiptRuleSet_serial
=== RUN   TestAccSESActiveReceiptRuleSet_serial/Resource
=== RUN   TestAccSESActiveReceiptRuleSet_serial/Resource/disappears
=== RUN   TestAccSESActiveReceiptRuleSet_serial/Resource/basic
=== RUN   TestAccSESActiveReceiptRuleSet_serial/DataSource
=== RUN   TestAccSESActiveReceiptRuleSet_serial/DataSource/basic
=== RUN   TestAccSESActiveReceiptRuleSet_serial/DataSource/noActiveRuleSet
--- PASS: TestAccSESActiveReceiptRuleSet_serial (45.07s)
    --- PASS: TestAccSESActiveReceiptRuleSet_serial/Resource (28.15s)
        --- PASS: TestAccSESActiveReceiptRuleSet_serial/Resource/disappears (14.75s)
        --- PASS: TestAccSESActiveReceiptRuleSet_serial/Resource/basic (13.40s)
    --- PASS: TestAccSESActiveReceiptRuleSet_serial/DataSource (16.92s)
        --- PASS: TestAccSESActiveReceiptRuleSet_serial/DataSource/basic (14.81s)
        --- PASS: TestAccSESActiveReceiptRuleSet_serial/DataSource/noActiveRuleSet (2.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        47.569s
```
