### PR TITLE
sweeper/aws_acmpca_certificate_authority: skip already deleted certificate authorities

### DIFF
--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -354,7 +354,7 @@ func resourceCertificateAuthorityCreate(d *schema.ResourceData, meta interface{}
 		output, err = conn.CreateCertificateAuthority(input)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating ACM PCA Certificate Authority: %s", err)
+		return fmt.Errorf("creating ACM PCA Certificate Authority: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.CertificateAuthorityArn))
@@ -362,7 +362,7 @@ func resourceCertificateAuthorityCreate(d *schema.ResourceData, meta interface{}
 	_, err = waitCertificateAuthorityCreated(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		return fmt.Errorf("error waiting for ACM PCA Certificate Authority %q to be active or pending certificate: %s", d.Id(), err)
+		return fmt.Errorf("waiting for ACM PCA Certificate Authority %q to be active or pending certificate: %s", d.Id(), err)
 	}
 
 	return resourceCertificateAuthorityRead(d, meta)
@@ -382,12 +382,12 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading ACM PCA Certificate Authority (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading ACM PCA Certificate Authority (%s): %w", d.Id(), err)
 	}
 
 	if certificateAuthority == nil || aws.StringValue(certificateAuthority.Status) == acmpca.CertificateAuthorityStatusDeleted {
 		if d.IsNewResource() {
-			return fmt.Errorf("error reading ACM PCA Certificate Authority (%s): not found or deleted", d.Id())
+			return fmt.Errorf("reading ACM PCA Certificate Authority (%s): not found or deleted", d.Id())
 		}
 
 		log.Printf("[WARN] ACM PCA Certificate Authority (%s) not found, removing from state", d.Id())
@@ -398,7 +398,7 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("arn", certificateAuthority.Arn)
 
 	if err := d.Set("certificate_authority_configuration", flattenCertificateAuthorityConfiguration(certificateAuthority.CertificateAuthorityConfiguration)); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("setting tags: %s", err)
 	}
 
 	d.Set("enabled", (aws.StringValue(certificateAuthority.Status) != acmpca.CertificateAuthorityStatusDisabled))
@@ -406,7 +406,7 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("not_before", aws.TimeValue(certificateAuthority.NotBefore).Format(time.RFC3339))
 
 	if err := d.Set("revocation_configuration", flattenRevocationConfiguration(certificateAuthority.RevocationConfiguration)); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("setting tags: %s", err)
 	}
 
 	d.Set("serial", certificateAuthority.Serial)
@@ -430,7 +430,7 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	// Returned when in PENDING_CERTIFICATE status
 	// InvalidStateException: The certificate authority XXXXX is not in the correct state to have a certificate signing request.
 	if err != nil && !tfawserr.ErrCodeEquals(err, acmpca.ErrCodeInvalidStateException) {
-		return fmt.Errorf("error reading ACM PCA Certificate Authority (%s) Certificate: %w", d.Id(), err)
+		return fmt.Errorf("reading ACM PCA Certificate Authority (%s) Certificate: %w", d.Id(), err)
 	}
 
 	d.Set("certificate", "")
@@ -457,7 +457,7 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	// Returned when in PENDING_CERTIFICATE status
 	// InvalidStateException: The certificate authority XXXXX is not in the correct state to have a certificate signing request.
 	if err != nil && !tfawserr.ErrCodeEquals(err, acmpca.ErrCodeInvalidStateException) {
-		return fmt.Errorf("error reading ACM PCA Certificate Authority (%s) Certificate Signing Request: %w", d.Id(), err)
+		return fmt.Errorf("reading ACM PCA Certificate Authority (%s) Certificate Signing Request: %w", d.Id(), err)
 	}
 
 	d.Set("certificate_signing_request", "")
@@ -468,18 +468,18 @@ func resourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) 
 	tags, err := ListTags(conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for ACM PCA Certificate Authority (%s): %s", d.Id(), err)
+		return fmt.Errorf("listing tags for ACM PCA Certificate Authority (%s): %s", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	return nil
@@ -510,7 +510,7 @@ func resourceCertificateAuthorityUpdate(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Updating ACM PCA Certificate Authority: %s", input)
 		_, err := conn.UpdateCertificateAuthority(input)
 		if err != nil {
-			return fmt.Errorf("error updating ACM PCA Certificate Authority: %s", err)
+			return fmt.Errorf("updating ACM PCA Certificate Authority: %s", err)
 		}
 	}
 
@@ -518,7 +518,7 @@ func resourceCertificateAuthorityUpdate(d *schema.ResourceData, meta interface{}
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating ACM PCA Certificate Authority (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("updating ACM PCA Certificate Authority (%s) tags: %s", d.Id(), err)
 		}
 	}
 
@@ -538,7 +538,7 @@ func resourceCertificateAuthorityDelete(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 	if err != nil && !tfawserr.ErrMessageContains(err, acmpca.ErrCodeInvalidStateException, "The certificate authority must be in the ACTIVE or DISABLED state to be updated") {
-		return fmt.Errorf("error setting ACM PCA Certificate Authority (%s) to DISABLED status before deleting: %w", d.Id(), err)
+		return fmt.Errorf("setting ACM PCA Certificate Authority (%s) to DISABLED status before deleting: %w", d.Id(), err)
 	}
 
 	deleteInput := &acmpca.DeleteCertificateAuthorityInput{
@@ -549,13 +549,13 @@ func resourceCertificateAuthorityDelete(d *schema.ResourceData, meta interface{}
 		deleteInput.PermanentDeletionTimeInDays = aws.Int64(int64(v.(int)))
 	}
 
-	log.Printf("[DEBUG] Deleting ACM PCA Certificate Authority: %s", deleteInput)
+	log.Printf("[INFO] Deleting ACM PCA Certificate Authority: %s", d.Id())
 	_, err = conn.DeleteCertificateAuthority(deleteInput)
 	if tfawserr.ErrCodeEquals(err, acmpca.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting ACM PCA Certificate Authority (%s): %w", d.Id(), err)
+		return fmt.Errorf("deleting ACM PCA Certificate Authority (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/acmpca/sweep.go
+++ b/internal/service/acmpca/sweep.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acmpca"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -28,77 +27,52 @@ func sweepCertificateAuthorities(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-	conn := client.(*conns.AWSClient).ACMPCAConn
 
-	certificateAuthorities, err := listCertificateAuthorities(conn)
-	if err != nil {
-		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping ACM PCA Certificate Authorities sweep for %s: %s", region, err)
-			return nil
+	conn := client.(*conns.AWSClient).ACMPCAConn
+	sweepResources := make([]sweep.Sweepable, 0)
+	var errs *multierror.Error
+
+	input := &acmpca.ListCertificateAuthoritiesInput{}
+
+	err = conn.ListCertificateAuthoritiesPages(input, func(page *acmpca.ListCertificateAuthoritiesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
-		return fmt.Errorf("retrieving ACM PCA Certificate Authorities: %w", err)
+
+		for _, item := range page.CertificateAuthorities {
+			if item == nil {
+				continue
+			}
+
+			if aws.StringValue(item.Status) == acmpca.CertificateAuthorityStatusDeleted {
+				continue
+			}
+
+			arn := aws.StringValue(item.Arn)
+
+			r := ResourceCertificateAuthority()
+			d := r.Data(nil)
+			d.SetId(arn)
+			d.Set("permanent_deletion_time_in_days", 7)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("listing ACM PCA Certificate Authorities: %w", err))
 	}
-	if len(certificateAuthorities) == 0 {
-		log.Print("[DEBUG] No ACM PCA Certificate Authorities to sweep")
+
+	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping ACM PCA Certificate Authorities for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping ACM PCA Certificate Authorities sweep for %s: %s", region, errs)
 		return nil
 	}
 
-	var sweeperErrs *multierror.Error
-
-	for _, certificateAuthority := range certificateAuthorities {
-		arn := aws.StringValue(certificateAuthority.Arn)
-
-		if aws.StringValue(certificateAuthority.Status) == acmpca.CertificateAuthorityStatusActive {
-			log.Printf("[INFO] Disabling ACM PCA Certificate Authority: %s", arn)
-			_, err := conn.UpdateCertificateAuthority(&acmpca.UpdateCertificateAuthorityInput{
-				CertificateAuthorityArn: aws.String(arn),
-				Status:                  aws.String(acmpca.CertificateAuthorityStatusDisabled),
-			})
-			if tfawserr.ErrCodeEquals(err, acmpca.ErrCodeResourceNotFoundException) {
-				continue
-			}
-			if err != nil {
-				sweeperErr := fmt.Errorf("error disabling ACM PCA Certificate Authority (%s): %w", arn, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
-			}
-		}
-
-		log.Printf("[INFO] Deleting ACM PCA Certificate Authority: %s", arn)
-		_, err := conn.DeleteCertificateAuthority(&acmpca.DeleteCertificateAuthorityInput{
-			CertificateAuthorityArn:     aws.String(arn),
-			PermanentDeletionTimeInDays: aws.Int64(7),
-		})
-		if tfawserr.ErrCodeEquals(err, acmpca.ErrCodeResourceNotFoundException) {
-			continue
-		}
-		if err != nil {
-			sweeperErr := fmt.Errorf("error deleting ACM PCA Certificate Authority (%s): %w", arn, err)
-			log.Printf("[ERROR] %s", sweeperErr)
-			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-			continue
-		}
-	}
-
-	return sweeperErrs.ErrorOrNil()
-}
-
-func listCertificateAuthorities(conn *acmpca.ACMPCA) ([]*acmpca.CertificateAuthority, error) {
-	certificateAuthorities := []*acmpca.CertificateAuthority{}
-	input := &acmpca.ListCertificateAuthoritiesInput{}
-
-	for {
-		output, err := conn.ListCertificateAuthorities(input)
-		if err != nil {
-			return certificateAuthorities, err
-		}
-		certificateAuthorities = append(certificateAuthorities, output.CertificateAuthorities...)
-		if output.NextToken == nil {
-			break
-		}
-		input.NextToken = output.NextToken
-	}
-
-	return certificateAuthorities, nil
+	return errs.ErrorOrNil()
 }


### PR DESCRIPTION
ACM PCA certificate authorities are preserved for a minimum of seven days, in the state `DELETED`. The `aws_acmpca_certificate_authority` sweeper currently tries to delete the deleted CAs. Skip if already in `DELETED`.