### PR TITLE
aws_ami: Support setting the imds_support attribute at creation time

### DIFF
--- a/.changelog/27084.txt
+++ b/.changelog/27084.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/aws_ami: Add `imds_support` argument
+```
+
+```release-note:enhancement
+resource/aws_ami_copy: Add `imds_support` argument
+```
+
+```release-note:enhancement
+resource/aws_ami_from_instance: Add `imds_support` argument
+```
+
+```release-note:enhancement
+data-source/aws_ami: Add `imds_support` attribute
+```

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -198,6 +198,12 @@ func ResourceAMI() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"imds_support": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true, // this attribute can only be set at registration time
+				ValidateFunc: validation.StringInSlice([]string{"v2.0"}, false),
+			},
 			"kernel_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -342,6 +348,10 @@ func resourceAMICreate(d *schema.ResourceData, meta interface{}) error {
 		input.BlockDeviceMappings = append(input.BlockDeviceMappings, expandBlockDeviceMappingsForAMIEphemeralBlockDevice(v.(*schema.Set).List())...)
 	}
 
+	if v := d.Get("imds_support").(string); v != "" {
+		input.ImdsSupport = aws.String(v)
+	}
+
 	output, err := conn.RegisterImage(input)
 
 	if err != nil {
@@ -419,6 +429,7 @@ func resourceAMIRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("image_location", image.ImageLocation)
 	d.Set("image_owner_alias", image.ImageOwnerAlias)
 	d.Set("image_type", image.ImageType)
+	d.Set("imds_support", image.ImdsSupport)
 	d.Set("kernel_id", image.KernelId)
 	d.Set("name", image.Name)
 	d.Set("owner_id", image.OwnerId)

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -304,6 +304,10 @@ func resourceAMICreate(d *schema.ResourceData, meta interface{}) error {
 		input.BootMode = aws.String(v)
 	}
 
+	if v := d.Get("imds_support").(string); v != "" {
+		input.ImdsSupport = aws.String(v)
+	}
+
 	if kernelId := d.Get("kernel_id").(string); kernelId != "" {
 		input.KernelId = aws.String(kernelId)
 	}
@@ -346,10 +350,6 @@ func resourceAMICreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("ephemeral_block_device"); ok && v.(*schema.Set).Len() > 0 {
 		input.BlockDeviceMappings = append(input.BlockDeviceMappings, expandBlockDeviceMappingsForAMIEphemeralBlockDevice(v.(*schema.Set).List())...)
-	}
-
-	if v := d.Get("imds_support").(string); v != "" {
-		input.ImdsSupport = aws.String(v)
 	}
 
 	output, err := conn.RegisterImage(input)

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -108,6 +108,11 @@ func DataSourceAMI() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"imds_support": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"v2.0"}, false),
+			},
 			"include_deprecated": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -302,6 +307,7 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta int
 	d.Set("image_location", image.ImageLocation)
 	d.Set("image_owner_alias", image.ImageOwnerAlias)
 	d.Set("image_type", image.ImageType)
+	d.Set("imds_support", image.ImdsSupport)
 	d.Set("kernel_id", image.KernelId)
 	d.Set("name", image.Name)
 	d.Set("owner_id", image.OwnerId)

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -109,9 +109,8 @@ func DataSourceAMI() *schema.Resource {
 				Computed: true,
 			},
 			"imds_support": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"v2.0"}, false),
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"include_deprecated": {
 				Type:     schema.TypeBool,

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -42,6 +42,7 @@ func TestAccEC2AMIDataSource_natInstance(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "image_location", regexp.MustCompile("^amazon/")),
 					resource.TestCheckResourceAttr(resourceName, "image_owner_alias", "amazon"),
 					resource.TestCheckResourceAttr(resourceName, "image_type", "machine"),
+					resource.TestCheckResourceAttr(resourceName, "imds_support", ""),
 					resource.TestCheckResourceAttr(resourceName, "most_recent", "true"),
 					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^amzn-ami-vpc-nat")),
 					acctest.MatchResourceAttrAccountID(resourceName, "owner_id"),

--- a/internal/service/ec2/ec2_ami_test.go
+++ b/internal/service/ec2/ec2_ami_test.go
@@ -51,6 +51,7 @@ func TestAccEC2AMI_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "hypervisor", "xen"),
 					resource.TestCheckResourceAttr(resourceName, "image_type", "machine"),
+					resource.TestCheckResourceAttr(resourceName, "imds_support", ""),
 					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
@@ -549,6 +550,36 @@ func TestAccEC2AMI_tpmSupport(t *testing.T) {
 	})
 }
 
+func TestAccEC2AMI_imdsSupport(t *testing.T) {
+	var ami ec2.Image
+	resourceName := "aws_ami.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAMIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAMIConfig_imdsSupport(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAMIExists(resourceName, &ami),
+					resource.TestCheckResourceAttr(resourceName, "imds_support", "v2.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manage_ebs_snapshots",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckAMIDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 
@@ -840,6 +871,25 @@ resource "aws_ami" "test" {
   virtualization_type = "hvm"
   boot_mode           = "uefi"
   tpm_support         = "v2.0"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    snapshot_id = aws_ebs_snapshot.test.id
+  }
+}
+`, rName))
+}
+
+func testAccAMIConfig_imdsSupport(rName string) string {
+	return acctest.ConfigCompose(
+		testAccAMIConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_ami" "test" {
+  name                = %[1]q
+  root_device_name    = "/dev/xvda"
+  virtualization_type = "hvm"
+  boot_mode           = "uefi"
+  imds_support        = "v2.0"
 
   ebs_block_device {
     device_name = "/dev/xvda"

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -97,6 +97,7 @@ interpolation.
 * `image_owner_alias` - AWS account alias (for example, `amazon`, `self`) or
   the AWS account ID of the AMI owner.
 * `image_type` - Type of image.
+* `imds_support` - Instance Metadata Service (IMDS) support mode for the image. Set to `v2.0` if instances ran from this image enforce IMDSv2.
 * `kernel_id` - Kernel associated with the image, if any. Only applicable
   for machine images.
 * `name` - Name of the AMI that was provided during image creation.

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -27,7 +27,7 @@ resource "aws_ami" "example" {
   name                = "terraform-example"
   virtualization_type = "hvm"
   root_device_name    = "/dev/xvda"
-
+  imds_support        = "v2.0" # Enforce usage of IMDSv2. You can safely remove this line if your application explicitly doesn't support it.
   ebs_block_device {
     device_name = "/dev/xvda"
     snapshot_id = "snap-xxxxxxxx"
@@ -56,6 +56,7 @@ The following arguments are supported:
   should be attached to created instances. The structure of this block is described below.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tpm_support` - (Optional) If the image is configured for NitroTPM support, the value is `v2.0`. For more information, see [NitroTPM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nitrotpm.html) in the Amazon Elastic Compute Cloud User Guide.
+* `imds_support` - (Optional) If EC2 instances started from this image should require the use of the Instance Metadata Service V2 (IMDSv2), set this argument to `v2.0`. For more information, see [Configure instance metadata options for new instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ami-configuration).
 
 When `virtualization_type` is "paravirtual" the following additional arguments apply:
 


### PR DESCRIPTION
# Description

This pull request adds support for setting the `imds_support` attribute when creating `aws_ami` resources. It also adds support for this attribute in the `aws_ami` data source.

Note: Setting this attribute is currently only supported in the AWS API at registration time (i.e. `ec2:RegisterImage`). It is not available in `ec2:ModifyImageAttributes`.

### Relations

closes #27083

### References

https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-machine-images-support-instance-metadata-service-version-2-default/


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccEC2AMI_imdsSupport PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2AMI_imdsSupport'  -timeout 180m
=== RUN   TestAccEC2AMI_imdsSupport
=== PAUSE TestAccEC2AMI_imdsSupport
=== CONT  TestAccEC2AMI_imdsSupport
--- PASS: TestAccEC2AMI_imdsSupport (76.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	79.165s
```

Note: Due to https://github.com/hashicorp/terraform-provider-aws/issues/27049, I had to use Terraform v1.2.9 to run acceptance tests (did not work with v1.3.1)