### PR TITLE
wafv2_web_acl: Remove broken link in docs breaking CI

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -549,7 +549,7 @@ The `field_to_match` block supports the following arguments:
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
-* `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [Body](#body) below for details.
+* `body` - (Optional) Inspect the request body, which immediately follows the request headers.
 * `cookies` - (Optional) Inspect the cookies in the web request. See [Cookies](#cookies) below for details.
 * `headers` - (Optional) Inspect the request headers. See [Headers](#headers) below for details.
 * `json_body` - (Optional) Inspect the request body as JSON. See [JSON Body](#json-body) for details.


### PR DESCRIPTION
Heading was removed in https://github.com/hashicorp/terraform-provider-aws/commit/7a292ba5ebfa288c242f5238d4d584384b7bb4d9#diff-abb481e03fb308d7193a38448a81e378d5f3a25076d08a9fc4e0f1a3ea06aafd but one link remains, breaking the CI pipeline e.g. https://github.com/hashicorp/terraform-provider-aws/actions/runs/3181284850/jobs/5185856649

```
FILE: website/docs/r/wafv2_web_acl.html.markdown
  [✖] #body → Status: 404

  52 links checked.

  ERROR: 1 dead links found!
  [✖] #body → Status: 404
```