### PR TITLE
Docs: Fix typo in efs_file_system_policy reference

### DIFF
--- a/website/docs/r/efs_file_system_policy.html.markdown
+++ b/website/docs/r/efs_file_system_policy.html.markdown
@@ -33,7 +33,7 @@ resource "aws_efs_file_system_policy" "policy" {
             "Principal": {
                 "AWS": "*"
             },
-            "Resource": "${aws_efs_file_system.test.arn}",
+            "Resource": "${aws_efs_file_system.fs.arn}",
             "Action": [
                 "elasticfilesystem:ClientMount",
                 "elasticfilesystem:ClientWrite"


### PR DESCRIPTION
### Description

Fixes a typo in the reference documentation for `efs_file_system_policy`. The example inconsistently uses the name `fs` and `test` for the `aws_efs_file_system`.