### PR TITLE
resource/aws_elasticache_global_replication_group: Update node type and automatic failover setting

### DIFF
--- a/.changelog/27134.txt
+++ b/.changelog/27134.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ resource/aws_elasticache_global_replication_group: Add support for updating `cache_node_type` and `automatic_failover_enabled`.
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -515,7 +515,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		log.Printf("[WARN] error listing tags for Elasticache Cache Cluster (%s): %s", d.Id(), err)
+		log.Printf("[WARN] error listing tags for ElastiCache Cache Cluster (%s): %s", d.Id(), err)
 	}
 
 	if tags != nil {
@@ -802,7 +802,7 @@ func createCacheCluster(conn *elasticache.ElastiCache, input *elasticache.Create
 	if output == nil || output.CacheCluster == nil {
 		return "", "", errors.New("missing cluster ID after creation")
 	}
-	// Elasticache always retains the id in lower case, so we have to
+	// ElastiCache always retains the id in lower case, so we have to
 	// mimic that or else we won't be able to refresh a resource whose
 	// name contained uppercase characters.
 	return strings.ToLower(aws.StringValue(output.CacheCluster.CacheClusterId)), aws.StringValue(output.CacheCluster.ARN), nil

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -234,11 +234,11 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, aws.StringValue(cluster.ARN))
 
 	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
-		return fmt.Errorf("error listing tags for Elasticache Cluster (%s): %w", d.Id(), err)
+		return fmt.Errorf("error listing tags for ElastiCache Cluster (%s): %w", d.Id(), err)
 	}
 
 	if err != nil {
-		log.Printf("[WARN] error listing tags for Elasticache Cluster (%s): %s", d.Id(), err)
+		log.Printf("[WARN] error listing tags for ElastiCache Cluster (%s): %s", d.Id(), err)
 	}
 
 	if tags != nil {

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -261,11 +261,13 @@ func resourceGlobalReplicationGroupCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("waiting for ElastiCache Global Replication Group (%s) creation: %w", d.Id(), err)
 	}
 
-	if v := d.Get("automatic_failover_enabled").(bool); v == flattenGlobalReplicationGroupAutomaticFailoverEnabled(globalReplicationGroup.Members) {
-		log.Printf("[DEBUG] Not updating ElastiCache Global Replication Group (%s) automatic failover: no change from %t", d.Id(), v)
-	} else {
-		if err := updateGlobalReplicationGroup(conn, d.Id(), globalReplicationAutomaticFailoverUpdater(v)); err != nil {
-			return fmt.Errorf("updating ElastiCache Global Replication Group (%s) automatic failover on creation: %w", d.Id(), err)
+	if v, ok := d.GetOk("automatic_failover_enabled"); ok {
+		if v := v.(bool); v == flattenGlobalReplicationGroupAutomaticFailoverEnabled(globalReplicationGroup.Members) {
+			log.Printf("[DEBUG] Not updating ElastiCache Global Replication Group (%s) automatic failover: no change from %t", d.Id(), v)
+		} else {
+			if err := updateGlobalReplicationGroup(conn, d.Id(), globalReplicationAutomaticFailoverUpdater(v)); err != nil {
+				return fmt.Errorf("updating ElastiCache Global Replication Group (%s) automatic failover on creation: %w", d.Id(), err)
+			}
 		}
 	}
 

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -184,7 +184,7 @@ func customizeDiffGlobalReplicationGroupEngineVersionErrorOnDowngrade(_ context.
 		return nil
 	}
 
-	return fmt.Errorf(`Downgrading Elasticache Global Replication Group (%s) engine version requires replacement
+	return fmt.Errorf(`Downgrading ElastiCache Global Replication Group (%s) engine version requires replacement
 of the Global Replication Group and all Replication Group members. The AWS provider cannot handle this internally.
 
 Please use the "-replace" option on the terraform plan and apply commands (see https://www.terraform.io/cli/commands/plan#replace-address).`, diff.Id())

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -934,7 +934,7 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDown
 			},
 			{
 				Config:      testAccGlobalReplicationGroupConfig_engineVersion(rName, primaryReplicationGroupId, "6.2", "6.0"),
-				ExpectError: regexp.MustCompile(`Downgrading Elasticache Global Replication Group \(.*\) engine version requires replacement`),
+				ExpectError: regexp.MustCompile(`Downgrading ElastiCache Global Replication Group \(.*\) engine version requires replacement`),
 			},
 			// This step fails with: Error running pre-apply refresh
 			// {

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -50,6 +50,7 @@ func TestAccElastiCacheGlobalReplicationGroup_basic(t *testing.T) {
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "elasticache", regexp.MustCompile(`globalreplicationgroup:`+tfelasticache.GlobalReplicationGroupRegionPrefixFormat+rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "at_rest_encryption_enabled", primaryReplicationGroupResourceName, "at_rest_encryption_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "auth_token_enabled", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryReplicationGroupResourceName, "automatic_failover_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "cache_node_type", primaryReplicationGroupResourceName, "node_type"),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_enabled", primaryReplicationGroupResourceName, "cluster_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "engine", primaryReplicationGroupResourceName, "engine"),
@@ -288,6 +289,155 @@ func TestAccElastiCacheGlobalReplicationGroup_nodeType_update(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createNoChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	enabled := "true"
+	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_global_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, enabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", enabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createWithChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	enabled := "false"
+	globalEnabled := "true"
+	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_global_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createWithChange(rName, primaryReplicationGroupId, enabled, globalEnabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", globalEnabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_setNoChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	enabled := "false"
+	resourceName := "aws_elasticache_global_replication_group.test"
+	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_basic_automaticFailover(rName, primaryReplicationGroupId, enabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryReplicationGroupResourceName, "automatic_failover_enabled"),
+				),
+			},
+			{
+				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, enabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", enabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	enabled := "true"
+	updatedEnabled := "false"
+	resourceName := "aws_elasticache_global_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, enabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", enabled),
+				),
+			},
+			{
+				Config: testAccGlobalReplicationGroupConfig_automaticFailover_update(rName, primaryReplicationGroupId, updatedEnabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", updatedEnabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -374,6 +524,7 @@ func TestAccElastiCacheGlobalReplicationGroup_clusterMode(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
 					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryReplicationGroupResourceName, "automatic_failover_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
 				),
 			},
@@ -1106,6 +1257,28 @@ resource "aws_elasticache_replication_group" "test" {
 `, rName, primaryReplicationGroupId, nodeType)
 }
 
+func testAccGlobalReplicationGroupConfig_basic_automaticFailover(rName, primaryReplicationGroupId, automaticFailover string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[2]q
+  replication_group_description = "test"
+
+  node_type = "cache.m5.large"
+
+  engine                = "redis"
+  engine_version        = "5.0.6"
+  number_cache_clusters = 2
+
+  automatic_failover_enabled = %[3]s
+}
+`, rName, primaryReplicationGroupId, automaticFailover)
+}
+
 func testAccGlobalReplicationGroupConfig_description(rName, primaryReplicationGroupId, description string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_global_replication_group" "test" {
@@ -1188,6 +1361,82 @@ resource "aws_elasticache_replication_group" "test" {
   number_cache_clusters = 1
 }
 `, rName, primaryReplicationGroupId, nodeType)
+}
+
+func testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, automaticFailover string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+
+  automatic_failover_enabled = %[3]s
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[2]q
+  replication_group_description = "test"
+
+  node_type = "cache.m5.large"
+
+  engine                = "redis"
+  engine_version        = "5.0.6"
+  number_cache_clusters = 2
+
+  automatic_failover_enabled = %[3]s
+}
+`, rName, primaryReplicationGroupId, automaticFailover)
+}
+
+func testAccGlobalReplicationGroupConfig_automaticFailover_createWithChange(rName, primaryReplicationGroupId, automaticFailover, globalAutomaticFailover string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+
+  automatic_failover_enabled = %[4]s
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[2]q
+  replication_group_description = "test"
+
+  node_type = "cache.m5.large"
+
+  engine                = "redis"
+  engine_version        = "5.0.6"
+  number_cache_clusters = 2
+
+  automatic_failover_enabled = %[3]s
+
+  lifecycle {
+    ignore_changes = [automatic_failover_enabled]
+  }
+}
+`, rName, primaryReplicationGroupId, automaticFailover, globalAutomaticFailover)
+}
+
+func testAccGlobalReplicationGroupConfig_automaticFailover_update(rName, primaryReplicationGroupId, globalAutomaticFailover string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+
+  automatic_failover_enabled = %[3]s
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[2]q
+  replication_group_description = "test"
+
+  engine                = "redis"
+  engine_version        = "5.0.6"
+  number_cache_clusters = 2
+
+  lifecycle {
+    ignore_changes = [automatic_failover_enabled]
+  }
+}
+`, rName, primaryReplicationGroupId, globalAutomaticFailover)
 }
 
 func testAccGlobalReplicationGroupConfig_multipleSecondaries(rName string) string {

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -148,7 +148,7 @@ func resourceParameterGroupRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if err != nil {
-		log.Printf("[WARN] failed listing tags for Elasticache Parameter Group (%s): %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for ElastiCache Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if tags != nil {

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2088,7 +2088,7 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing
 }
 
 // Test for out-of-band deletion
-// Naming to allow grouping all TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_* tests
+// Naming to allow grouping all TestAccAWSElastiCacheReplicationGroup_GlobalReplicationGroupID_* tests
 func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears(t *testing.T) { // nosemgrep:ci.acceptance-test-naming-parent-disappears
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -41,7 +41,7 @@ func ResourceSubnetGroup() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				StateFunc: func(val interface{}) string {
-					// Elasticache normalizes subnet names to lowercase,
+					// ElastiCache normalizes subnet names to lowercase,
 					// so we have to do this too or else we can end up
 					// with non-converging diffs.
 					return strings.ToLower(val.(string))
@@ -115,7 +115,7 @@ func resourceSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Assign the group name as the resource ID
-	// Elasticache always retains the name in lower case, so we have to
+	// ElastiCache always retains the name in lower case, so we have to
 	// mimic that or else we won't be able to refresh a resource whose
 	// name contained uppercase characters.
 	d.SetId(strings.ToLower(name))
@@ -150,7 +150,7 @@ func resourceSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "CacheSubnetGroupNotFoundFault" {
 			// Update state to indicate the db subnet no longer exists.
-			log.Printf("[WARN] Elasticache Subnet Group (%s) not found, removing from state", d.Id())
+			log.Printf("[WARN] ElastiCache Subnet Group (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -189,7 +189,7 @@ func resourceSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	// tags not supported in all partitions
 	if err != nil {
-		log.Printf("[WARN] failed listing tags for Elasticache Subnet Group (%s): %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for ElastiCache Subnet Group (%s): %s", d.Id(), err)
 	}
 
 	if tags != nil {

--- a/internal/service/elasticache/sweep.go
+++ b/internal/service/elasticache/sweep.go
@@ -186,7 +186,7 @@ func sweepParameterGroups(region string) error {
 
 	err = conn.DescribeCacheParameterGroupsPages(&elasticache.DescribeCacheParameterGroupsInput{}, func(page *elasticache.DescribeCacheParameterGroupsOutput, lastPage bool) bool {
 		if len(page.CacheParameterGroups) == 0 {
-			log.Print("[DEBUG] No Elasticache Parameter Groups to sweep")
+			log.Print("[DEBUG] No ElastiCache Parameter Groups to sweep")
 			return false
 		}
 
@@ -194,26 +194,26 @@ func sweepParameterGroups(region string) error {
 			name := aws.StringValue(parameterGroup.CacheParameterGroupName)
 
 			if strings.HasPrefix(name, "default.") {
-				log.Printf("[INFO] Skipping Elasticache Cache Parameter Group: %s", name)
+				log.Printf("[INFO] Skipping ElastiCache Cache Parameter Group: %s", name)
 				continue
 			}
 
-			log.Printf("[INFO] Deleting Elasticache Parameter Group: %s", name)
+			log.Printf("[INFO] Deleting ElastiCache Parameter Group: %s", name)
 			_, err := conn.DeleteCacheParameterGroup(&elasticache.DeleteCacheParameterGroupInput{
 				CacheParameterGroupName: aws.String(name),
 			})
 			if err != nil {
-				log.Printf("[ERROR] Failed to delete Elasticache Parameter Group (%s): %s", name, err)
+				log.Printf("[ERROR] Failed to delete ElastiCache Parameter Group (%s): %s", name, err)
 			}
 		}
 		return !lastPage
 	})
 	if err != nil {
 		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Elasticache Parameter Group sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping ElastiCache Parameter Group sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Elasticache Parameter Group: %w", err)
+		return fmt.Errorf("Error retrieving ElastiCache Parameter Group: %w", err)
 	}
 	return nil
 }
@@ -252,17 +252,17 @@ func sweepReplicationGroups(region string) error {
 	})
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error describing Elasticache Replication Groups: %w", err))
+		errs = multierror.Append(errs, fmt.Errorf("error describing ElastiCache Replication Groups: %w", err))
 	}
 
 	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Elasticache Replication Groups for %s: %w", region, err))
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping ElastiCache Replication Groups for %s: %w", region, err))
 	}
 
 	// waiting for deletion is not necessary in the sweeper since the resource's delete waits
 
 	if sweep.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Elasticache Replication Group sweep for %s: %s", region, errs)
+		log.Printf("[WARN] Skipping ElastiCache Replication Group sweep for %s: %s", region, errs)
 		return nil
 	}
 
@@ -278,7 +278,7 @@ func sweepCacheSecurityGroups(region string) error {
 
 	err = conn.DescribeCacheSecurityGroupsPages(&elasticache.DescribeCacheSecurityGroupsInput{}, func(page *elasticache.DescribeCacheSecurityGroupsOutput, lastPage bool) bool {
 		if len(page.CacheSecurityGroups) == 0 {
-			log.Print("[DEBUG] No Elasticache Cache Security Groups to sweep")
+			log.Print("[DEBUG] No ElastiCache Cache Security Groups to sweep")
 			return false
 		}
 
@@ -286,26 +286,26 @@ func sweepCacheSecurityGroups(region string) error {
 			name := aws.StringValue(securityGroup.CacheSecurityGroupName)
 
 			if name == "default" {
-				log.Printf("[INFO] Skipping Elasticache Cache Security Group: %s", name)
+				log.Printf("[INFO] Skipping ElastiCache Cache Security Group: %s", name)
 				continue
 			}
 
-			log.Printf("[INFO] Deleting Elasticache Cache Security Group: %s", name)
+			log.Printf("[INFO] Deleting ElastiCache Cache Security Group: %s", name)
 			_, err := conn.DeleteCacheSecurityGroup(&elasticache.DeleteCacheSecurityGroupInput{
 				CacheSecurityGroupName: aws.String(name),
 			})
 			if err != nil {
-				log.Printf("[ERROR] Failed to delete Elasticache Cache Security Group (%s): %s", name, err)
+				log.Printf("[ERROR] Failed to delete ElastiCache Cache Security Group (%s): %s", name, err)
 			}
 		}
 		return !lastPage
 	})
 	if err != nil {
 		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Elasticache Cache Security Group sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping ElastiCache Cache Security Group sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Elasticache Cache Security Groups: %s", err)
+		return fmt.Errorf("Error retrieving ElastiCache Cache Security Groups: %s", err)
 	}
 	return nil
 }
@@ -319,29 +319,29 @@ func sweepSubnetGroups(region string) error {
 
 	err = conn.DescribeCacheSubnetGroupsPages(&elasticache.DescribeCacheSubnetGroupsInput{}, func(page *elasticache.DescribeCacheSubnetGroupsOutput, lastPage bool) bool {
 		if len(page.CacheSubnetGroups) == 0 {
-			log.Print("[DEBUG] No Elasticache Subnet Groups to sweep")
+			log.Print("[DEBUG] No ElastiCache Subnet Groups to sweep")
 			return false
 		}
 
 		for _, subnetGroup := range page.CacheSubnetGroups {
 			name := aws.StringValue(subnetGroup.CacheSubnetGroupName)
 
-			log.Printf("[INFO] Deleting Elasticache Subnet Group: %s", name)
+			log.Printf("[INFO] Deleting ElastiCache Subnet Group: %s", name)
 			_, err := conn.DeleteCacheSubnetGroup(&elasticache.DeleteCacheSubnetGroupInput{
 				CacheSubnetGroupName: aws.String(name),
 			})
 			if err != nil {
-				log.Printf("[ERROR] Failed to delete Elasticache Subnet Group (%s): %s", name, err)
+				log.Printf("[ERROR] Failed to delete ElastiCache Subnet Group (%s): %s", name, err)
 			}
 		}
 		return !lastPage
 	})
 	if err != nil {
 		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Elasticache Subnet Group sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping ElastiCache Subnet Group sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Elasticache Subnet Groups: %w", err)
+		return fmt.Errorf("Error retrieving ElastiCache Subnet Groups: %w", err)
 	}
 	return nil
 }

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -160,7 +160,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	// tags not supported in all partitions
 	if err != nil {
-		log.Printf("[WARN] failed listing tags for Elasticache User (%s): %s", aws.StringValue(resp.ARN), err)
+		log.Printf("[WARN] failed listing tags for ElastiCache User (%s): %s", aws.StringValue(resp.ARN), err)
 	}
 
 	if tags != nil {

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -159,7 +159,7 @@ func resourceUserGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	// tags not supported in all partitions
 	if err != nil {
-		log.Printf("[WARN] failed listing tags for Elasticache User Group (%s): %s", aws.StringValue(resp.ARN), err)
+		log.Printf("[WARN] failed listing tags for ElastiCache User Group (%s): %s", aws.StringValue(resp.ARN), err)
 	}
 
 	if tags != nil {

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -183,7 +183,7 @@ func testAccCheckUserDestroyWithProvider(s *terraform.State, provider *schema.Pr
 		}
 
 		if user != nil {
-			return fmt.Errorf("Elasticache User (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("ElastiCache User (%s) still exists", rs.Primary.ID)
 		}
 	}
 

--- a/website/docs/d/elasticache_cluster.html.markdown
+++ b/website/docs/d/elasticache_cluster.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_elasticache_cluster
 
-Use this data source to get information about an Elasticache Cluster
+Use this data source to get information about an ElastiCache Cluster
 
 ## Example Usage
 

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_elasticache_replication_group
 
-Use this data source to get information about an Elasticache Replication Group.
+Use this data source to get information about an ElastiCache Replication Group.
 
 ## Example Usage
 

--- a/website/docs/d/elasticache_user.html.markdown
+++ b/website/docs/d/elasticache_user.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_elasticache_user
 
-Use this data source to get information about an Elasticache User.
+Use this data source to get information about an ElastiCache User.
 
 ## Example Usage
 

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -100,6 +100,8 @@ resource "aws_elasticache_replication_group" "secondary" {
 
 The following arguments are supported:
 
+* `automatic_failover_enabled` - (Optional) Specifies whether read-only replicas will be automatically promoted to read/write primary if the existing primary fails.
+  When creating, by default the Global Replication Group inherits the automatic failover setting of the primary replication group.
 * `cache_node_type` - (Optional) The instance class used.
   See AWS documentation for information on [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html)
   and [guidance on selecting node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html).

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -100,6 +100,10 @@ resource "aws_elasticache_replication_group" "secondary" {
 
 The following arguments are supported:
 
+* `cache_node_type` - (Optional) The instance class used.
+  See AWS documentation for information on [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html)
+  and [guidance on selecting node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html).
+  When creating, by default the Global Replication Group inherits the node type of the primary replication group.
 * `engine_version` - (Optional) Redis version to use for the Global Replication Group.
   When creating, by default the Global Replication Group inherits the version of the primary replication group.
   If a version is specified, the Global Replication Group and all member replication groups will be upgraded to this version.
@@ -124,7 +128,6 @@ In addition to all arguments above, the following attributes are exported:
 * `engine_version_actual` - The full version number of the cache engine running on the members of this global replication group.
 * `at_rest_encryption_enabled` - A flag that indicate whether the encryption at rest is enabled.
 * `auth_token_enabled` - A flag that indicate whether AuthToken (password) is enabled.
-* `cache_node_type` - The instance class used. See AWS documentation for information on [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html).
 * `cluster_enabled` - Indicates whether the Global Datastore is cluster enabled.
 * `engine` - The name of the cache engine to be used for the clusters in this global replication group.
 * `global_replication_group_id` - The full ID of the global replication group.

--- a/website/docs/r/elasticache_parameter_group.html.markdown
+++ b/website/docs/r/elasticache_parameter_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an ElastiCache parameter group resource.
 
-~> **NOTE:** Attempting to remove the `reserved-memory` parameter when `family` is set to `redis2.6` or `redis2.8` may show a perpetual difference in Terraform due to an Elasticache API limitation. Leave that parameter configured with any value to workaround the issue.
+~> **NOTE:** Attempting to remove the `reserved-memory` parameter when `family` is set to `redis2.6` or `redis2.8` may show a perpetual difference in Terraform due to an ElastiCache API limitation. Leave that parameter configured with any value to workaround the issue.
 
 ## Example Usage
 

--- a/website/docs/r/elasticache_subnet_group.html.markdown
+++ b/website/docs/r/elasticache_subnet_group.html.markdown
@@ -45,7 +45,7 @@ resource "aws_elasticache_subnet_group" "bar" {
 
 The following arguments are supported:
 
-* `name` – (Required) Name for the cache subnet group. Elasticache converts this name to lowercase.
+* `name` – (Required) Name for the cache subnet group. ElastiCache converts this name to lowercase.
 * `description` – (Optional) Description for the cache subnet group. Defaults to "Managed by Terraform".
 * `subnet_ids` – (Required) List of VPC Subnet IDs for the cache subnet group
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
Add support for updating `cache_node_type` and `automatic_failover_enabled` on an `aws_elasticache_global_replication_group`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #17696
Closes #22528

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=elasticache TESTS=TestAccElastiCacheGlobalReplicationGroup_

--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6x (906.81s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion (927.24s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v5 (934.59s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createNoChange (1055.25s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode (1145.08s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade (1173.15s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x (1303.30s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createWithChange (1325.56s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_basic (1401.62s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion (28.61s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade (1561.15s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_setNoChange (1712.48s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6 (1868.19s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x (1873.41s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade (1892.01s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x (1144.26s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x (900.80s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_update (2260.85s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade (1180.72s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade (947.85s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange (1493.68s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange (1364.33s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_description (1506.82s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_disappears (942.15s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade (1334.52s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange (2765.48s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade (1607.40s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName (2987.27s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_update (2987.33s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade (1337.03s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries (3092.91s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion (4278.61s)
```
