### PR TITLE
Update S3 sweepers

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -78,6 +78,7 @@ gen:
 
 sweep:
 	# make sweep SWEEPARGS=-sweep-run=aws_example_thing
+	# set SWEEPARGS=-sweep-allow-failures to continue after first failure
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	$(GO_VER) test $(SWEEP_DIR) -v -tags=sweep -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1008,7 +1008,7 @@ func DeleteResource(resource *schema.Resource, d *schema.ResourceData, meta inte
 
 		for i := range diags {
 			if diags[i].Severity == diag.Error {
-				return fmt.Errorf("error deleting resource: %s", diags[i].Summary)
+				return fmt.Errorf("deleting resource: %s", diags[i].Summary)
 			}
 		}
 

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -995,7 +995,7 @@ func TestAccEMRCluster_Bootstrap_ordering(t *testing.T) {
 	var cluster emr.Cluster
 
 	resourceName := "aws_emr_cluster.test"
-	rName := sdkacctest.RandomWithPrefix("tf-emr-bootstrap")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, emr.EndpointsID),

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -768,7 +768,7 @@ func resourceBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := ValidBucketName(bucket, awsRegion); err != nil {
-		return fmt.Errorf("error validating S3 Bucket (%s) name: %w", bucket, err)
+		return fmt.Errorf("validating S3 Bucket (%s) name: %w", bucket, err)
 	}
 
 	// S3 Object Lock is not supported on all partitions.
@@ -819,7 +819,7 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 			return nil, terr
 		}, s3.ErrCodeNoSuchBucket)
 		if err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) tags: %s", d.Id(), err)
 		}
 	}
 
@@ -827,19 +827,19 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("policy") {
 		if err := resourceBucketInternalPolicyUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Policy: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Policy: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("cors_rule") {
 		if err := resourceBucketInternalCorsUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) CORS Rules: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) CORS Rules: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("website") {
 		if err := resourceBucketInternalWebsiteUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Website: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Website: %w", d.Id(), err)
 		}
 	}
 
@@ -850,67 +850,67 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 			if versioning := expandVersioningWhenIsNewResource(v); versioning != nil {
 				err := resourceBucketInternalVersioningUpdate(conn, d.Id(), versioning, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
-					return fmt.Errorf("error updating (new) S3 Bucket (%s) Versioning: %w", d.Id(), err)
+					return fmt.Errorf("updating (new) S3 Bucket (%s) Versioning: %w", d.Id(), err)
 				}
 			}
 		} else {
 			if err := resourceBucketInternalVersioningUpdate(conn, d.Id(), expandVersioning(v), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return fmt.Errorf("error updating S3 Bucket (%s) Versioning: %w", d.Id(), err)
+				return fmt.Errorf("updating S3 Bucket (%s) Versioning: %w", d.Id(), err)
 			}
 		}
 	}
 
 	if d.HasChange("acl") && !d.IsNewResource() {
 		if err := resourceBucketInternalACLUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) ACL: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) ACL: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("grant") {
 		if err := resourceBucketInternalGrantsUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Grants: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Grants: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("logging") {
 		if err := resourceBucketInternalLoggingUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Logging: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Logging: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("lifecycle_rule") {
 		if err := resourceBucketInternalLifecycleUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Lifecycle Rules: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Lifecycle Rules: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("acceleration_status") {
 		if err := resourceBucketInternalAccelerationUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Acceleration Status: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Acceleration Status: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("request_payer") {
 		if err := resourceBucketInternalRequestPayerUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Request Payer: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Request Payer: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("replication_configuration") {
 		if err := resourceBucketInternalReplicationConfigurationUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Replication configuration: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Replication configuration: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("server_side_encryption_configuration") {
 		if err := resourceBucketInternalServerSideEncryptionConfigurationUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Server-side Encryption configuration: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Server-side Encryption configuration: %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("object_lock_configuration") {
 		if err := resourceBucketInternalObjectLockConfigurationUpdate(conn, d); err != nil {
-			return fmt.Errorf("error updating S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
+			return fmt.Errorf("updating S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
 		}
 	}
 
@@ -985,7 +985,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchBucketPolicy, ErrCodeNotImplemented) {
-		return fmt.Errorf("error getting S3 bucket (%s) policy: %w", d.Id(), err)
+		return fmt.Errorf("getting S3 bucket (%s) policy: %w", d.Id(), err)
 	}
 
 	if output, ok := pol.(*s3.GetBucketPolicyOutput); ok {
@@ -1012,12 +1012,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error getting S3 Bucket (%s) ACL: %w", d.Id(), err)
+		return fmt.Errorf("getting S3 Bucket (%s) ACL: %w", d.Id(), err)
 	}
 
 	if aclOutput, ok := apResponse.(*s3.GetBucketAclOutput); ok {
 		if err := d.Set("grant", flattenGrants(aclOutput)); err != nil {
-			return fmt.Errorf("error setting grant %s", err)
+			return fmt.Errorf("setting grant %s", err)
 		}
 	} else {
 		d.Set("grant", nil)
@@ -1040,12 +1040,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchCORSConfiguration, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
-		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
+		return fmt.Errorf("getting S3 Bucket CORS configuration: %s", err)
 	}
 
 	if output, ok := corsResponse.(*s3.GetBucketCorsOutput); ok {
 		if err := d.Set("cors_rule", flattenBucketCorsRules(output.CORSRules)); err != nil {
-			return fmt.Errorf("error setting cors_rule: %w", err)
+			return fmt.Errorf("setting cors_rule: %w", err)
 		}
 	} else {
 		d.Set("cors_rule", nil)
@@ -1073,7 +1073,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		ErrCodeNoSuchWebsiteConfiguration,
 		ErrCodeXNotImplemented,
 	) {
-		return fmt.Errorf("error getting S3 Bucket website configuration: %w", err)
+		return fmt.Errorf("getting S3 Bucket website configuration: %w", err)
 	}
 
 	if ws, ok := wsResponse.(*s3.GetBucketWebsiteOutput); ok {
@@ -1082,7 +1082,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := d.Set("website", website); err != nil {
-			return fmt.Errorf("error setting website: %w", err)
+			return fmt.Errorf("setting website: %w", err)
 		}
 	} else {
 		d.Set("website", nil)
@@ -1106,12 +1106,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
+		return fmt.Errorf("getting S3 Bucket versioning (%s): %w", d.Id(), err)
 	}
 
 	if versioning, ok := versioningResponse.(*s3.GetBucketVersioningOutput); ok {
 		if err := d.Set("versioning", flattenVersioning(versioning)); err != nil {
-			return fmt.Errorf("error setting versioning: %w", err)
+			return fmt.Errorf("setting versioning: %w", err)
 		}
 	}
 
@@ -1134,7 +1134,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Amazon S3 Transfer Acceleration might not be supported in the region
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument, ErrCodeNotImplemented) {
-		return fmt.Errorf("error getting S3 Bucket (%s) accelerate configuration: %w", d.Id(), err)
+		return fmt.Errorf("getting S3 Bucket (%s) accelerate configuration: %w", d.Id(), err)
 	}
 
 	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {
@@ -1159,7 +1159,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented) {
-		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
+		return fmt.Errorf("getting S3 Bucket request payment: %s", err)
 	}
 
 	if payer, ok := payerResponse.(*s3.GetBucketRequestPaymentOutput); ok {
@@ -1183,12 +1183,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented) {
-		return fmt.Errorf("error getting S3 Bucket logging: %s", err)
+		return fmt.Errorf("getting S3 Bucket logging: %s", err)
 	}
 
 	if logging, ok := loggingResponse.(*s3.GetBucketLoggingOutput); ok {
 		if err := d.Set("logging", flattenBucketLoggingEnabled(logging.LoggingEnabled)); err != nil {
-			return fmt.Errorf("error setting logging: %s", err)
+			return fmt.Errorf("setting logging: %s", err)
 		}
 	} else {
 		d.Set("logging", nil)
@@ -1212,12 +1212,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration) {
-		return fmt.Errorf("error getting S3 Bucket (%s) Lifecycle Configuration: %w", d.Id(), err)
+		return fmt.Errorf("getting S3 Bucket (%s) Lifecycle Configuration: %w", d.Id(), err)
 	}
 
 	if lifecycle, ok := lifecycleResponse.(*s3.GetBucketLifecycleConfigurationOutput); ok {
 		if err := d.Set("lifecycle_rule", flattenBucketLifecycleRules(lifecycle.Rules)); err != nil {
-			return fmt.Errorf("error setting lifecycle_rule: %s", err)
+			return fmt.Errorf("setting lifecycle_rule: %s", err)
 		}
 	} else {
 		d.Set("lifecycle_rule", nil)
@@ -1241,12 +1241,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeReplicationConfigurationNotFound) {
-		return fmt.Errorf("error getting S3 Bucket replication: %w", err)
+		return fmt.Errorf("getting S3 Bucket replication: %w", err)
 	}
 
 	if replication, ok := replicationResponse.(*s3.GetBucketReplicationOutput); ok {
 		if err := d.Set("replication_configuration", flattenBucketReplicationConfiguration(replication.ReplicationConfiguration)); err != nil {
-			return fmt.Errorf("error setting replication_configuration: %w", err)
+			return fmt.Errorf("setting replication_configuration: %w", err)
 		}
 	} else {
 		// Still need to set for the non-existent case
@@ -1271,12 +1271,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil && !tfawserr.ErrMessageContains(err, ErrCodeServerSideEncryptionConfigurationNotFound, "encryption configuration was not found") {
-		return fmt.Errorf("error getting S3 Bucket encryption: %w", err)
+		return fmt.Errorf("getting S3 Bucket encryption: %w", err)
 	}
 
 	if encryption, ok := encryptionResponse.(*s3.GetBucketEncryptionOutput); ok {
 		if err := d.Set("server_side_encryption_configuration", flattenServerSideEncryptionConfiguration(encryption.ServerSideEncryptionConfiguration)); err != nil {
-			return fmt.Errorf("error setting server_side_encryption_configuration: %w", err)
+			return fmt.Errorf("setting server_side_encryption_configuration: %w", err)
 		}
 	} else {
 		d.Set("server_side_encryption_configuration", nil)
@@ -1301,7 +1301,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	// Object lock not supported in all partitions (extra guard, also guards in read func)
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeNotImplemented, ErrCodeObjectLockConfigurationNotFound) {
 		if meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID {
-			return fmt.Errorf("error getting S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
+			return fmt.Errorf("getting S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
 		}
 	}
 
@@ -1312,7 +1312,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	if output, ok := resp.(*s3.GetObjectLockConfigurationOutput); ok && output.ObjectLockConfiguration != nil {
 		d.Set("object_lock_enabled", aws.StringValue(output.ObjectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled)
 		if err := d.Set("object_lock_configuration", flattenObjectLockConfiguration(output.ObjectLockConfiguration)); err != nil {
-			return fmt.Errorf("error setting object_lock_configuration: %w", err)
+			return fmt.Errorf("setting object_lock_configuration: %w", err)
 		}
 	} else {
 		d.Set("object_lock_enabled", nil)
@@ -1346,7 +1346,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error getting S3 Bucket location: %s", err)
+		return fmt.Errorf("getting S3 Bucket location: %s", err)
 	}
 
 	region := discoveredRegion.(string)
@@ -1408,24 +1408,24 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)
+		return fmt.Errorf("listing tags for S3 Bucket (%s): %s", d.Id(), err)
 	}
 
 	tags, ok := tagsRaw.(tftags.KeyValueTags)
 
 	if !ok {
-		return fmt.Errorf("error listing tags for S3 Bucket (%s): unable to convert tags", d.Id())
+		return fmt.Errorf("listing tags for S3 Bucket (%s): unable to convert tags", d.Id())
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	arn := arn.ARN{
@@ -1441,7 +1441,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).S3Conn
 
-	log.Printf("[DEBUG] Deleting S3 Bucket: %s", d.Id())
+	log.Printf("[INFO] Deleting S3 Bucket: %s", d.Id())
 	_, err := conn.DeleteBucketWithContext(ctx, &s3.DeleteBucketInput{
 		Bucket: aws.String(d.Id()),
 	})
@@ -1629,7 +1629,7 @@ func resourceBucketInternalCorsUpdate(conn *s3.S3, d *schema.ResourceData) error
 		}, s3.ErrCodeNoSuchBucket)
 
 		if err != nil {
-			return fmt.Errorf("error deleting S3 Bucket (%s) CORS: %w", d.Id(), err)
+			return fmt.Errorf("deleting S3 Bucket (%s) CORS: %w", d.Id(), err)
 		}
 
 		return nil
@@ -1690,7 +1690,7 @@ func resourceBucketInternalGrantsUpdate(conn *s3.S3, d *schema.ResourceData) err
 		log.Printf("[DEBUG] S3 bucket: %s, Grants fallback to canned ACL", d.Id())
 
 		if err := resourceBucketInternalACLUpdate(conn, d); err != nil {
-			return fmt.Errorf("error fallback to canned ACL, %s", err)
+			return fmt.Errorf("fallback to canned ACL, %s", err)
 		}
 
 		return nil
@@ -1703,13 +1703,13 @@ func resourceBucketInternalGrantsUpdate(conn *s3.S3, d *schema.ResourceData) err
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return fmt.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
+		return fmt.Errorf("getting S3 Bucket (%s) ACL: %s", d.Id(), err)
 	}
 
 	output := resp.(*s3.GetBucketAclOutput)
 
 	if output == nil {
-		return fmt.Errorf("error getting S3 Bucket (%s) ACL: empty output", d.Id())
+		return fmt.Errorf("getting S3 Bucket (%s) ACL: empty output", d.Id())
 	}
 
 	input := &s3.PutBucketAclInput{
@@ -1738,7 +1738,7 @@ func resourceBucketInternalLifecycleUpdate(conn *s3.S3, d *schema.ResourceData) 
 		_, err := conn.DeleteBucketLifecycle(input)
 
 		if err != nil {
-			return fmt.Errorf("error removing S3 Bucket (%s) lifecycle: %w", d.Id(), err)
+			return fmt.Errorf("removing S3 Bucket (%s) lifecycle: %w", d.Id(), err)
 		}
 
 		return nil
@@ -1793,7 +1793,7 @@ func resourceBucketInternalLifecycleUpdate(conn *s3.S3, d *schema.ResourceData) 
 			if val, ok := e["date"].(string); ok && val != "" {
 				t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", val))
 				if err != nil {
-					return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
+					return fmt.Errorf("parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
 				}
 				i.Date = aws.Time(t)
 			} else if val, ok := e["days"].(int); ok && val > 0 {
@@ -1826,7 +1826,7 @@ func resourceBucketInternalLifecycleUpdate(conn *s3.S3, d *schema.ResourceData) 
 				if val, ok := transition["date"].(string); ok && val != "" {
 					t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", val))
 					if err != nil {
-						return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
+						return fmt.Errorf("parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
 					}
 					i.Date = aws.Time(t)
 				} else if val, ok := transition["days"].(int); ok && val >= 0 {
@@ -1942,7 +1942,7 @@ func resourceBucketInternalPolicyUpdate(conn *s3.S3, d *schema.ResourceData) err
 		}, s3.ErrCodeNoSuchBucket)
 
 		if err != nil {
-			return fmt.Errorf("error deleting S3 Bucket (%s) policy: %w", d.Id(), err)
+			return fmt.Errorf("deleting S3 Bucket (%s) policy: %w", d.Id(), err)
 		}
 
 		return nil
@@ -1982,7 +1982,7 @@ func resourceBucketInternalReplicationConfigurationUpdate(conn *s3.S3, d *schema
 		_, err := conn.DeleteBucketReplication(input)
 
 		if err != nil {
-			return fmt.Errorf("error removing S3 Bucket (%s) Replication: %w", d.Id(), err)
+			return fmt.Errorf("removing S3 Bucket (%s) Replication: %w", d.Id(), err)
 		}
 
 		return nil
@@ -2053,7 +2053,7 @@ func resourceBucketInternalServerSideEncryptionConfigurationUpdate(conn *s3.S3, 
 		_, err := conn.DeleteBucketEncryption(input)
 
 		if err != nil {
-			return fmt.Errorf("error removing S3 Bucket (%s) Server-side Encryption: %w", d.Id(), err)
+			return fmt.Errorf("removing S3 Bucket (%s) Server-side Encryption: %w", d.Id(), err)
 		}
 
 		return nil
@@ -2132,7 +2132,7 @@ func resourceBucketInternalWebsiteUpdate(conn *s3.S3, d *schema.ResourceData) er
 		}, s3.ErrCodeNoSuchBucket)
 
 		if err != nil {
-			return fmt.Errorf("error deleting S3 Bucket (%s) Website: %w", d.Id(), err)
+			return fmt.Errorf("deleting S3 Bucket (%s) Website: %w", d.Id(), err)
 		}
 
 		d.Set("website_endpoint", "")
@@ -2143,7 +2143,7 @@ func resourceBucketInternalWebsiteUpdate(conn *s3.S3, d *schema.ResourceData) er
 
 	websiteConfig, err := expandWebsiteConfiguration(ws)
 	if err != nil {
-		return fmt.Errorf("error expanding S3 Bucket (%s) website configuration: %w", d.Id(), err)
+		return fmt.Errorf("expanding S3 Bucket (%s) website configuration: %w", d.Id(), err)
 	}
 
 	input := &s3.PutBucketWebsiteInput{
@@ -3117,7 +3117,7 @@ func flattenBucketWebsite(ws *s3.GetBucketWebsiteOutput) ([]interface{}, error) 
 	if v := ws.RoutingRules; v != nil {
 		rr, err := normalizeRoutingRules(v)
 		if err != nil {
-			return nil, fmt.Errorf("error while marshaling routing rules: %w", err)
+			return nil, fmt.Errorf("while marshaling routing rules: %w", err)
 		}
 		m["routing_rules"] = rr
 	}

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -232,7 +232,7 @@ func resourceObjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading S3 Object (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading S3 Object (%s): %w", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Reading S3 Object meta: %s", resp)
@@ -252,7 +252,7 @@ func resourceObjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("metadata", metadata); err != nil {
-		return fmt.Errorf("error setting metadata: %s", err)
+		return fmt.Errorf("setting metadata: %s", err)
 	}
 	d.Set("version_id", resp.VersionId)
 	d.Set("server_side_encryption", resp.ServerSideEncryption)
@@ -281,24 +281,24 @@ func resourceObjectRead(d *schema.ResourceData, meta interface{}) error {
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for S3 Bucket (%s) Object (%s): %s", bucket, key, err)
+		return fmt.Errorf("listing tags for S3 Bucket (%s) Object (%s): %s", bucket, key, err)
 	}
 
 	tags, ok := tagsRaw.(tftags.KeyValueTags)
 
 	if !ok {
-		return fmt.Errorf("error listing tags for S3 Bucket (%s) Object (%s): unable to convert tags", bucket, key)
+		return fmt.Errorf("listing tags for S3 Bucket (%s) Object (%s): unable to convert tags", bucket, key)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	return nil
@@ -321,7 +321,7 @@ func resourceObjectUpdate(d *schema.ResourceData, meta interface{}) error {
 			ACL:    aws.String(d.Get("acl").(string)),
 		})
 		if err != nil {
-			return fmt.Errorf("error putting S3 object ACL: %s", err)
+			return fmt.Errorf("putting S3 object ACL: %s", err)
 		}
 	}
 
@@ -334,7 +334,7 @@ func resourceObjectUpdate(d *schema.ResourceData, meta interface{}) error {
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("error putting S3 object lock legal hold: %s", err)
+			return fmt.Errorf("putting S3 object lock legal hold: %s", err)
 		}
 	}
 
@@ -360,7 +360,7 @@ func resourceObjectUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := conn.PutObjectRetention(req)
 		if err != nil {
-			return fmt.Errorf("error putting S3 object lock retention: %s", err)
+			return fmt.Errorf("putting S3 object lock retention: %s", err)
 		}
 	}
 
@@ -368,7 +368,7 @@ func resourceObjectUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 
 		if err := ObjectUpdateTags(conn, bucket, key, o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("updating tags: %s", err)
 		}
 	}
 
@@ -393,7 +393,7 @@ func resourceObjectDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting S3 Bucket (%s) Object (%s): %s", bucket, key, err)
+		return fmt.Errorf("deleting S3 Bucket (%s) Object (%s): %s", bucket, key, err)
 	}
 
 	return nil
@@ -430,11 +430,11 @@ func resourceObjectUpload(d *schema.ResourceData, meta interface{}) error {
 		source := v.(string)
 		path, err := homedir.Expand(source)
 		if err != nil {
-			return fmt.Errorf("Error expanding homedir in source (%s): %s", source, err)
+			return fmt.Errorf("expanding homedir in source (%s): %s", source, err)
 		}
 		file, err := os.Open(path)
 		if err != nil {
-			return fmt.Errorf("Error opening S3 object source (%s): %s", path, err)
+			return fmt.Errorf("opening S3 object source (%s): %s", path, err)
 		}
 
 		body = file
@@ -453,7 +453,7 @@ func resourceObjectUpload(d *schema.ResourceData, meta interface{}) error {
 		// the AWS SDK requires an io.ReadSeeker but a base64 decoder can't seek.
 		contentRaw, err := base64.StdEncoding.DecodeString(content)
 		if err != nil {
-			return fmt.Errorf("error decoding content_base64: %s", err)
+			return fmt.Errorf("decoding content_base64: %s", err)
 		}
 		body = bytes.NewReader(contentRaw)
 	} else {
@@ -533,7 +533,7 @@ func resourceObjectUpload(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, err := uploader.Upload(input); err != nil {
-		return fmt.Errorf("Error uploading object to S3 bucket (%s): %s", bucket, err)
+		return fmt.Errorf("uploading object to S3 bucket (%s): %s", bucket, err)
 	}
 
 	d.SetId(key)
@@ -710,7 +710,7 @@ func DeleteAllObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreO
 
 	if lastErr != nil {
 		if !ignoreObjectErrors {
-			return nObjects, fmt.Errorf("error deleting at least one object version, last error: %s", lastErr)
+			return nObjects, fmt.Errorf("deleting at least one object version, last error: %s", lastErr)
 		}
 
 		lastErr = nil
@@ -752,7 +752,7 @@ func DeleteAllObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreO
 
 	if lastErr != nil {
 		if !ignoreObjectErrors {
-			return nObjects, fmt.Errorf("error deleting at least one object delete marker, last error: %s", lastErr)
+			return nObjects, fmt.Errorf("deleting at least one object delete marker, last error: %s", lastErr)
 		}
 
 		lastErr = nil

--- a/internal/service/s3/sweep.go
+++ b/internal/service/s3/sweep.go
@@ -9,13 +9,13 @@ import (
 	"log"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -41,21 +41,19 @@ func init() {
 func sweepObjects(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("getting client: %s", err)
 	}
 
 	conn := client.(*conns.AWSClient).S3ConnURICleaningDisabled
 	input := &s3.ListBucketsInput{}
 
 	output, err := conn.ListBuckets(input)
-
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping S3 Objects sweep for %s: %s", region, err)
 		return nil
 	}
-
 	if err != nil {
-		return fmt.Errorf("error listing S3 Objects: %s", err)
+		return fmt.Errorf("listing S3 Buckets: %w", err)
 	}
 
 	if len(output.Buckets) == 0 {
@@ -63,58 +61,61 @@ func sweepObjects(region string) error {
 		return nil
 	}
 
-	for _, bucket := range output.Buckets {
-		bucketName := aws.StringValue(bucket.Name)
+	sweepables := make([]sweep.Sweepable, 0)
+	var errs *multierror.Error
 
-		hasPrefix := false
-		prefixes := []string{"tf-acc", "tf-object-test", "tf-test", "tf-emr-bootstrap"}
-
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(bucketName, prefix) {
-				hasPrefix = true
-				break
-			}
-		}
-
-		if !hasPrefix {
-			log.Printf("[INFO] Skipping S3 Bucket: %s", bucketName)
-			continue
-		}
-
-		bucketRegion, err := bucketRegion(conn, bucketName)
-
-		if err != nil {
-			log.Printf("[ERROR] Error getting S3 Bucket (%s) Location: %s", bucketName, err)
-			continue
-		}
-
-		if bucketRegion != region {
-			log.Printf("[INFO] Skipping S3 Bucket (%s) in different region: %s", bucketName, bucketRegion)
-			continue
-		}
-
-		objectLockEnabled, err := objectLockEnabled(conn, bucketName)
-
-		if err != nil {
-			log.Printf("[ERROR] Error getting S3 Bucket (%s) Object Lock: %s", bucketName, err)
-			continue
-		}
-
-		// Delete everything including locked objects. Ignore any object errors.
-		_, err = DeleteAllObjectVersions(conn, bucketName, "", objectLockEnabled, true)
-
-		if err != nil {
-			return fmt.Errorf("error deleting S3 Bucket (%s) Objects: %s", bucketName, err)
-		}
+	buckets, err := filterBuckets(output.Buckets, bucketRegionFilter(conn, region))
+	if err != nil {
+		errs = multierror.Append(errs, err)
 	}
 
+	buckets, err = filterBuckets(buckets, bucketNameFilter)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	for _, bucket := range buckets {
+		bucketName := aws.StringValue(bucket.Name)
+
+		objectLockEnabled, err := objectLockEnabled(conn, bucketName)
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("reading S3 Bucket (%s) object lock: %w", bucketName, err))
+			continue
+		}
+
+		sweepables = append(sweepables, objectSweeper{
+			conn:   conn,
+			name:   bucketName,
+			locked: objectLockEnabled,
+		})
+	}
+
+	if err := sweep.SweepOrchestrator(sweepables); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping DynamoDB Backups for %s: %w", region, err))
+	}
+
+	return errs.ErrorOrNil()
+}
+
+type objectSweeper struct {
+	conn   *s3.S3
+	name   string
+	locked bool
+}
+
+func (os objectSweeper) Delete(ctx context.Context, rc sweep.RetryConfig) error {
+	// Delete everything including locked objects
+	_, err := DeleteAllObjectVersions(os.conn, os.name, "", os.locked, true)
+	if err != nil {
+		return fmt.Errorf("deleting S3 Bucket (%s) contents: %w", os.name, err)
+	}
 	return nil
 }
 
 func sweepBuckets(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("getting client: %s", err)
 	}
 
 	conn := client.(*conns.AWSClient).S3Conn
@@ -128,7 +129,7 @@ func sweepBuckets(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing S3 Buckets: %s", err)
+		return fmt.Errorf("listing S3 Buckets: %w", err)
 	}
 
 	if len(output.Buckets) == 0 {
@@ -136,89 +137,34 @@ func sweepBuckets(region string) error {
 		return nil
 	}
 
-	defaultNameRegexp := regexp.MustCompile(`^terraform-\d+$`)
-	for _, bucket := range output.Buckets {
-		name := aws.StringValue(bucket.Name)
+	var errs *multierror.Error
+	sweepResources := make([]sweep.Sweepable, 0)
 
-		sweepable := false
-		prefixes := []string{
-			"aws-elastictranscoder-pipeline-tf-test",
-			"danieldreier",
-			"deletemebucket",
-			"images-2021",
-			"klaemmity-",
-			"msk-broker-logs-test",
-			"terraform-remote-s3-test",
-			"tf-acc",
-			"tf-emr-bootstrap",
-			"tf-object-test",
-			"tf-objects-test-bucket",
-			"tf-redshift-logging",
-			"tf-s3",
-			"tf-spot-datafeed",
-			"tf-test",
-			"tftest.applicationversion",
-			"unique-destination-bucket",
-			"unique-source-bucket",
-		}
-
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(name, prefix) {
-				sweepable = true
-				break
-			}
-		}
-
-		if defaultNameRegexp.MatchString(name) {
-			sweepable = true
-		}
-
-		if !sweepable {
-			log.Printf("[INFO] Skipping S3 Bucket: %s", name)
-			continue
-		}
-
-		bucketRegion, err := bucketRegion(conn, name)
-
-		if err != nil {
-			log.Printf("[ERROR] Error getting S3 Bucket (%s) Location: %s", name, err)
-			continue
-		}
-
-		if bucketRegion != region {
-			log.Printf("[INFO] Skipping S3 Bucket (%s) in different Region: %s", name, bucketRegion)
-			continue
-		}
-
-		input := &s3.DeleteBucketInput{
-			Bucket: bucket.Name,
-		}
-
-		log.Printf("[INFO] Deleting S3 Bucket: %s", name)
-		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-			_, err := conn.DeleteBucket(input)
-
-			if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
-				return nil
-			}
-
-			if tfawserr.ErrCodeEquals(err, "BucketNotEmpty") {
-				return resource.RetryableError(err)
-			}
-
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			return fmt.Errorf("error deleting S3 Bucket (%s): %s", name, err)
-		}
+	buckets, err := filterBuckets(output.Buckets, bucketRegionFilter(conn, region))
+	if err != nil {
+		errs = multierror.Append(errs, err)
 	}
 
-	return nil
+	buckets, err = filterBuckets(buckets, bucketNameFilter)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	for _, bucket := range buckets {
+		name := aws.StringValue(bucket.Name)
+
+		r := ResourceBucket()
+		d := r.Data(nil)
+		d.SetId(name)
+
+		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping S3 Buckets for %s: %w", region, err))
+	}
+
+	return errs.ErrorOrNil()
 }
 
 func bucketRegion(conn *s3.S3, bucket string) (string, error) {
@@ -252,4 +198,65 @@ func objectLockEnabled(conn *s3.S3, bucket string) (bool, error) {
 	}
 
 	return aws.StringValue(output.ObjectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled, nil
+}
+
+type bucketFilter func(*s3.Bucket) (bool, error)
+
+func filterBuckets(in []*s3.Bucket, f bucketFilter) ([]*s3.Bucket, error) {
+	var errs *multierror.Error
+	var out []*s3.Bucket
+
+	for _, b := range in {
+		if ok, err := f(b); err != nil {
+			errs = multierror.Append(errs, err)
+		} else if ok {
+			out = append(out, b)
+		}
+	}
+
+	return out, errs.ErrorOrNil()
+}
+
+func bucketNameFilter(bucket *s3.Bucket) (bool, error) {
+	name := aws.StringValue(bucket.Name)
+
+	prefixes := []string{
+		"tf-acc",
+		"tf-object-test",
+		"tf-test",
+		"tftest.applicationversion",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true, nil
+		}
+	}
+
+	if defaultNameRegexp.MatchString(name) {
+		return true, nil
+	}
+
+	log.Printf("[INFO] Skipping S3 Bucket (%s): not in prefix list", name)
+	return false, nil
+}
+
+var (
+	defaultNameRegexp = regexp.MustCompile(fmt.Sprintf(`^%s\d+$`, resource.UniqueIdPrefix))
+)
+
+func bucketRegionFilter(conn *s3.S3, region string) bucketFilter {
+	return func(bucket *s3.Bucket) (bool, error) {
+		name := aws.StringValue(bucket.Name)
+
+		bucketRegion, err := bucketRegion(conn, name)
+		if err != nil {
+			return false, err
+		}
+		if bucketRegion != region {
+			log.Printf("[INFO] Skipping S3 Bucket (%s): not in %s", name, region)
+			return false, nil
+		}
+
+		return true, nil
+	}
 }

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -88,7 +88,7 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 	client, diags := conf.ConfigureProvider(ctx, &conns.AWSClient{})
 
 	if diags.HasError() {
-		return nil, fmt.Errorf("error getting AWS client: %#v", diags)
+		return nil, fmt.Errorf("getting AWS client: %#v", diags)
 	}
 
 	SweeperClients[region] = client
@@ -248,7 +248,7 @@ func DeleteResource(resource *schema.Resource, d *schema.ResourceData, meta inte
 
 		for i := range diags {
 			if diags[i].Severity == diag.Error {
-				return fmt.Errorf("error deleting resource: %s", diags[i].Summary)
+				return fmt.Errorf("deleting resource: %s", diags[i].Summary)
 			}
 		}
 


### PR DESCRIPTION
Updates S3 sweepers to:

* use same filtering for Buckets and Objects
* not fail silently for some failures
* not return on first failure for some failures
* run concurrently

Also renames resources in `TestAccEMRCluster_Bootstrap_ordering` to remove an S3 bucket name prefix