### PR TITLE
Adding VLAN_ID to Direct Connect datasource

### DIFF
--- a/.changelog/27148.txt
+++ b/.changelog/27148.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 data-source/aws_dx_connection: Add `vlan_id` attribute
 ```
+
+```release-note:enhancement
+resource/aws_dx_connection: Add `vlan_id` attribute
+```

--- a/.changelog/27148.txt
+++ b/.changelog/27148.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_dx_connection: Add `vlan_id` attribute
+```

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -70,6 +70,10 @@ func ResourceConnection() *schema.Resource {
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
+			"vlan_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -141,6 +145,7 @@ func resourceConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", connection.ConnectionName)
 	d.Set("owner_account_id", connection.OwnerAccount)
 	d.Set("provider_name", connection.ProviderName)
+	d.Set("vlan_id", connection.Vlan)
 
 	tags, err := ListTags(conn, arn)
 

--- a/internal/service/directconnect/connection_data_source.go
+++ b/internal/service/directconnect/connection_data_source.go
@@ -44,11 +44,11 @@ func DataSourceConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tftags.TagsSchemaComputed(),
 			"vlan_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
 }

--- a/internal/service/directconnect/connection_data_source.go
+++ b/internal/service/directconnect/connection_data_source.go
@@ -44,6 +44,10 @@ func DataSourceConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"vlan_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
@@ -96,6 +100,7 @@ func dataSourceConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", connection.ConnectionName)
 	d.Set("owner_account_id", connection.OwnerAccount)
 	d.Set("provider_name", connection.ProviderName)
+	d.Set("vlan_id", connection.Vlan)
 
 	tags, err := ListTags(conn, arn)
 

--- a/internal/service/directconnect/connection_data_source_test.go
+++ b/internal/service/directconnect/connection_data_source_test.go
@@ -31,6 +31,7 @@ func TestAccDirectConnectConnectionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "owner_account_id", resourceName, "owner_account_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "provider_name", resourceName, "provider_name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "vlan_id", resourceName, "vlan_id"),
 				),
 			},
 		},

--- a/internal/service/directconnect/connection_test.go
+++ b/internal/service/directconnect/connection_test.go
@@ -28,7 +28,7 @@ func TestAccDirectConnectConnection_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConnectionConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectionExists(resourceName, &connection),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "directconnect", regexp.MustCompile(`dxcon/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth", "1Gbps"),
@@ -37,6 +37,7 @@ func TestAccDirectConnectConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vlan_id", ""),
 				),
 			},
 			// Test import.

--- a/website/docs/d/dx_connection.html.markdown
+++ b/website/docs/d/dx_connection.html.markdown
@@ -33,4 +33,5 @@ In addition to all arguments above, the following attributes are exported:
 * `location` - AWS Direct Connect location where the connection is located.
 * `owner_account_id` - ID of the AWS account that owns the connection.
 * `provider_name` - Name of the service provider associated with the connection.
+* `vlan_id` - The VLAN ID.
 * `tags` - Map of tags for the resource.

--- a/website/docs/d/dx_connection.html.markdown
+++ b/website/docs/d/dx_connection.html.markdown
@@ -33,5 +33,5 @@ In addition to all arguments above, the following attributes are exported:
 * `location` - AWS Direct Connect location where the connection is located.
 * `owner_account_id` - ID of the AWS account that owns the connection.
 * `provider_name` - Name of the service provider associated with the connection.
-* `vlan_id` - The VLAN ID.
 * `tags` - Map of tags for the resource.
+* `vlan_id` - The VLAN ID.

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -41,6 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
 * `owner_account_id` - The ID of the AWS account that owns the connection.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `vlan_id` - The VLAN ID.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adding VLAN ID parameter to Direct Connect datasource
<!---
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #26461
--->

Closes #26461

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccDirectConnectConnectionDataSource_basic PKG=directconnect

...
```
