### PR TITLE
[Docs]: Change import help-text from 'id' to 'arn'

### DIFF
--- a/website/docs/r/ram_resource_share.markdown
+++ b/website/docs/r/ram_resource_share.markdown
@@ -42,7 +42,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Resource shares can be imported using the `id`, e.g.,
+Resource shares can be imported using the `arn` of the resource share, e.g.,
 
 ```
 $ terraform import aws_ram_resource_share.example arn:aws:ram:eu-west-1:123456789012:resource-share/73da1ab9-b94a-4ba3-8eb4-45917f7f4b12


### PR DESCRIPTION
### Description
Minor change to documentation of resource aws_ram_resource_share - The import help-text stated that `id` of the resource share should be used when importing, but the example code below clearly uses the complete `arn` instead.
Verified that `arn` is in fact the correct value to use when importing these resources.

