### PR TITLE
Add support for AWS GlobalAccelerator BYOIP.

### DIFF
--- a/.changelog/27181.txt
+++ b/.changelog/27181.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_globalaccelerator_accelerator: Support `ip_addresses` for BYOIP accelerator
+```

--- a/.changelog/27181.txt
+++ b/.changelog/27181.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_globalaccelerator_accelerator: Support `ip_addresses` for BYOIP accelerator
+resource/aws_globalaccelerator_accelerator: Add `ip_addresses` argument in support of [BYOIP addresses](https://docs.aws.amazon.com/global-accelerator/latest/dg/using-byoip.html)
 ```

--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -64,6 +64,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME` | Amazon EventBridge partner event source name. |
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
+| `GLOBALACCERATOR_BYOIP_IPV4_ADDRESS` | IPv4 address from a BYOIP CIDR of AWS Account used for testing Global Accelerator's BYOIP accelerator. |
 | `GRAFANA_SSO_GROUP_ID` | AWS SSO group ID for Grafana testing. |
 | `GRAFANA_SSO_USER_ID` | AWS SSO user ID for Grafana testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |

--- a/internal/service/globalaccelerator/accelerator.go
+++ b/internal/service/globalaccelerator/accelerator.go
@@ -143,7 +143,7 @@ func resourceAcceleratorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("ip_addresses"); ok {
-		input.IpAddresses = expandIpAddresses(v.([]interface{}))
+		input.IpAddresses = expandIPAddresses(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating Global Accelerator Accelerator: %s", input)
@@ -347,7 +347,7 @@ func resourceAcceleratorDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandIpAddresses(ipAddresses []interface{}) []*string {
+func expandIPAddresses(ipAddresses []interface{}) []*string {
 	out := make([]*string, len(ipAddresses))
 	for i, raw := range ipAddresses {
 		out[i] = aws.String(raw.(string))

--- a/internal/service/globalaccelerator/accelerator.go
+++ b/internal/service/globalaccelerator/accelerator.go
@@ -414,26 +414,6 @@ func flattenIPSets(apiObjects []*globalaccelerator.IpSet) []interface{} {
 	return tfList
 }
 
-func flattenIPSetsToStringList(apiObjects []*globalaccelerator.IpSet) []string {
-	if len(apiObjects) == 0 {
-		return nil
-	}
-
-	tfList := make([]string, 0)
-
-	for _, apiObject := range apiObjects {
-		if apiObject == nil {
-			continue
-		}
-
-		for _, ipAddress := range apiObject.IpAddresses {
-			tfList = append(tfList, *ipAddress)
-		}
-	}
-
-	return tfList
-}
-
 func flattenAcceleratorAttributes(apiObject *globalaccelerator.AcceleratorAttributes) map[string]interface{} {
 	if apiObject == nil {
 		return nil

--- a/internal/service/globalaccelerator/accelerator.go
+++ b/internal/service/globalaccelerator/accelerator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -143,7 +144,7 @@ func resourceAcceleratorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("ip_addresses"); ok {
-		input.IpAddresses = expandIPAddresses(v.([]interface{}))
+		input.IpAddresses = flex.ExpandStringList(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating Global Accelerator Accelerator: %s", input)
@@ -345,15 +346,6 @@ func resourceAcceleratorDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func expandIPAddresses(ipAddresses []interface{}) []*string {
-	out := make([]*string, len(ipAddresses))
-	for i, raw := range ipAddresses {
-		out[i] = aws.String(raw.(string))
-	}
-
-	return out
 }
 
 func expandUpdateAcceleratorAttributesInput(tfMap map[string]interface{}) *globalaccelerator.UpdateAcceleratorAttributesInput {

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -58,6 +58,12 @@ func DataSourceAccelerator() *schema.Resource {
 					},
 				},
 			},
+			"ip_addresses": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"attributes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -131,6 +137,7 @@ func dataSourceAcceleratorRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", accelerator.Name)
 	d.Set("ip_address_type", accelerator.IpAddressType)
 	d.Set("ip_sets", flattenIPSets(accelerator.IpSets))
+	d.Set("ip_addresses", flattenIPSetsToStringList(accelerator.IpSets))
 
 	acceleratorAttributes, err := FindAcceleratorAttributesByARN(conn, d.Id())
 	if err != nil {

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -58,12 +58,6 @@ func DataSourceAccelerator() *schema.Resource {
 					},
 				},
 			},
-			"ip_addresses": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 			"attributes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -137,7 +131,6 @@ func dataSourceAcceleratorRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", accelerator.Name)
 	d.Set("ip_address_type", accelerator.IpAddressType)
 	d.Set("ip_sets", flattenIPSets(accelerator.IpSets))
-	d.Set("ip_addresses", flattenIPSetsToStringList(accelerator.IpSets))
 
 	acceleratorAttributes, err := FindAcceleratorAttributesByARN(conn, d.Id())
 	if err != nil {

--- a/internal/service/globalaccelerator/accelerator_test.go
+++ b/internal/service/globalaccelerator/accelerator_test.go
@@ -2,6 +2,8 @@ package globalaccelerator_test
 
 import (
 	"fmt"
+	"net"
+	"os"
 	"regexp"
 	"testing"
 
@@ -84,6 +86,54 @@ func TestAccGlobalAcceleratorAccelerator_ipAddressType_dualStack(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGlobalAcceleratorAccelerator_byoip(t *testing.T) {
+	resourceName := "aws_globalaccelerator_accelerator.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	requestedAddr := os.Getenv("GLOBALACCELERATOR_BYOIP_IPV4_ADDRESS")
+	matches := 0
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t); testAccCheckByoipExists(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, globalaccelerator.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAcceleratorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAcceleratorConfig_byoip(rName, requestedAddr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAcceleratorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ip_sets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_sets.0.ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ip_sets.0.ip_family", "IPv4"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					// requested address may be index 0 or index 1 in ip_sets.0.ip_addresses. Test framework
+					// does not have a mechanism to test against a list directly. We collect the number of
+					// matches individually and then validate that there is only one match.
+					resource.TestCheckResourceAttrWith(resourceName, "ip_sets.0.ip_addresses.0", func(value string) error {
+						if requestedAddr == value {
+							matches += 1
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith(resourceName, "ip_sets.0.ip_addresses.1", func(value string) error {
+						if requestedAddr == value {
+							matches += 1
+						}
+						return nil
+					}),
+					func(_ *terraform.State) error {
+						if matches == 1 {
+							return nil
+						}
+						return fmt.Errorf("Requested address %s should be present exactly once in %s", requestedAddr, resourceName)
+					},
+				),
 			},
 		},
 	})
@@ -280,6 +330,53 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccCheckByoipExists(t *testing.T) {
+	requestedAddr := os.Getenv("GLOBALACCELERATOR_BYOIP_IPV4_ADDRESS")
+
+	if requestedAddr == "" {
+		t.Skip("Environment variable GLOBALACCELERATOR_BYOIP_IPV4_ADDRESS not set")
+	}
+
+	parsedAddr := net.ParseIP(requestedAddr)
+
+	conn := acctest.Provider.Meta().(*conns.AWSClient).GlobalAcceleratorConn
+
+	input := &globalaccelerator.ListByoipCidrsInput{}
+	cidrs := make([]*globalaccelerator.ByoipCidr, 0)
+
+	err := conn.ListByoipCidrsPages(input,
+		func(page *globalaccelerator.ListByoipCidrsOutput, lastPage bool) bool {
+			cidrs = append(cidrs, page.ByoipCidrs...)
+			return !lastPage
+		})
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if len(cidrs) == 0 {
+		t.Skip("skipping acceptance testing: no BYOIP Global Accelerator CIDR found")
+	}
+
+	matches := false
+
+	for _, cidr := range cidrs {
+		_, network, _ := net.ParseCIDR(*cidr.Cidr)
+		if network.Contains(parsedAddr) {
+			matches = true
+			break
+		}
+	}
+
+	if !matches {
+		t.Skipf("skipping acceptance testing: requested address %s not available via BYOIP", requestedAddr)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
 func testAccCheckAcceleratorExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GlobalAcceleratorConn
@@ -328,6 +425,15 @@ resource "aws_globalaccelerator_accelerator" "test" {
   name = %[1]q
 }
 `, rName)
+}
+
+func testAccAcceleratorConfig_byoip(rName string, ipAddress string) string {
+	return fmt.Sprintf(`
+resource "aws_globalaccelerator_accelerator" "test" {
+  name            = %[1]q
+  ip_addresses    = [%[2]q]
+}
+`, rName, ipAddress)
 }
 
 func testAccAcceleratorConfig_ipAddressTypeDualStack(rName string) string {

--- a/internal/service/globalaccelerator/accelerator_test.go
+++ b/internal/service/globalaccelerator/accelerator_test.go
@@ -98,7 +98,7 @@ func TestAccGlobalAcceleratorAccelerator_byoip(t *testing.T) {
 	matches := 0
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t); testAccCheckByoipExists(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t); testAccCheckBYOIPExists(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, globalaccelerator.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAcceleratorDestroy,
@@ -330,7 +330,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccCheckByoipExists(t *testing.T) {
+func testAccCheckBYOIPExists(t *testing.T) {
 	requestedAddr := os.Getenv("GLOBALACCELERATOR_BYOIP_IPV4_ADDRESS")
 
 	if requestedAddr == "" {
@@ -430,8 +430,8 @@ resource "aws_globalaccelerator_accelerator" "test" {
 func testAccAcceleratorConfig_byoip(rName string, ipAddress string) string {
 	return fmt.Sprintf(`
 resource "aws_globalaccelerator_accelerator" "test" {
-  name            = %[1]q
-  ip_addresses    = [%[2]q]
+  name         = %[1]q
+  ip_addresses = [%[2]q]
 }
 `, rName, ipAddress)
 }

--- a/internal/service/globalaccelerator/accelerator_test.go
+++ b/internal/service/globalaccelerator/accelerator_test.go
@@ -41,6 +41,7 @@ func TestAccGlobalAcceleratorAccelerator_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "hosted_zone_id", "Z2BJ6XQ5FK7U4H"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_addresses.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "ip_sets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ip_sets.0.ip_addresses.#", "2"),
 					resource.TestMatchResourceAttr(resourceName, "ip_sets.0.ip_addresses.0", ipRegex),

--- a/internal/service/globalaccelerator/find.go
+++ b/internal/service/globalaccelerator/find.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/globalaccelerator"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // FindAcceleratorByARN returns the accelerator corresponding to the specified ARN.
@@ -34,10 +35,7 @@ func FindAccelerator(conn *globalaccelerator.GlobalAccelerator, input *globalacc
 	}
 
 	if output == nil || output.Accelerator == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.Accelerator, nil
@@ -70,10 +68,7 @@ func FindAcceleratorAttributes(conn *globalaccelerator.GlobalAccelerator, input 
 	}
 
 	if output == nil || output.AcceleratorAttributes == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.AcceleratorAttributes, nil
@@ -106,10 +101,7 @@ func FindEndpointGroup(conn *globalaccelerator.GlobalAccelerator, input *globala
 	}
 
 	if output == nil || output.EndpointGroup == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.EndpointGroup, nil
@@ -142,10 +134,7 @@ func FindListener(conn *globalaccelerator.GlobalAccelerator, input *globalaccele
 	}
 
 	if output == nil || output.Listener == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.Listener, nil

--- a/website/docs/r/globalaccelerator_accelerator.html.markdown
+++ b/website/docs/r/globalaccelerator_accelerator.html.markdown
@@ -16,6 +16,7 @@ Creates a Global Accelerator accelerator.
 resource "aws_globalaccelerator_accelerator" "example" {
   name            = "Example"
   ip_address_type = "IPV4"
+  ip_addresses    = [ "1.2.3.4" ]
   enabled         = true
 
   attributes {
@@ -32,6 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the accelerator.
 * `ip_address_type` - (Optional) The value for the address type. Defaults to `IPV4`. Valid values: `IPV4`, `DUAL_STACK`.
+* `ip_addresses` - (Optional) The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses.
 * `enabled` - (Optional) Indicates whether the accelerator is enabled. Defaults to `true`. Valid values: `true`, `false`.
 * `attributes` - (Optional) The attributes of the accelerator. Fields documented below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/globalaccelerator_accelerator.html.markdown
+++ b/website/docs/r/globalaccelerator_accelerator.html.markdown
@@ -16,7 +16,7 @@ Creates a Global Accelerator accelerator.
 resource "aws_globalaccelerator_accelerator" "example" {
   name            = "Example"
   ip_address_type = "IPV4"
-  ip_addresses    = [ "1.2.3.4" ]
+  ip_addresses    = ["1.2.3.4"]
   enabled         = true
 
   attributes {


### PR DESCRIPTION
### Description
This PR adds support for BYOIP IP addresses for creating AWS GlobalAccelerator accelerators

### References
[API reference](https://docs.aws.amazon.com/global-accelerator/latest/api/API_CreateAccelerator.html#API_CreateAccelerator_RequestSyntax)

### Relations
Closes #14002


### Output from Acceptance Testing
(Changed IP address because of security reasons)

```
$ GLOBALACCELERATOR_BYOIP_IPV4_ADDRESS=127.0.0.1 make testacc TESTS=TestAccGlobalAcceleratorAccelerator_byoip PKG=globalaccelerator
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorAccelerator_byoip'  -timeout 180m
=== RUN   TestAccGlobalAcceleratorAccelerator_byoip
=== PAUSE TestAccGlobalAcceleratorAccelerator_byoip
=== CONT  TestAccGlobalAcceleratorAccelerator_byoip
--- PASS: TestAccGlobalAcceleratorAccelerator_byoip (59.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	59.571s

$ make testacc TESTS=TestAccGlobalAcceleratorAccelerator_byoip PKG=globalaccelerator
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorAccelerator_byoip'  -timeout 180m
=== RUN   TestAccGlobalAcceleratorAccelerator_byoip
=== PAUSE TestAccGlobalAcceleratorAccelerator_byoip
=== CONT  TestAccGlobalAcceleratorAccelerator_byoip
    accelerator_test.go:337: Environment variable GLOBALACCELERATOR_BYOIP_IPV4_ADDRESS not set
--- SKIP: TestAccGlobalAcceleratorAccelerator_byoip (0.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	0.604s
```

I am a member of AWS Global Accelerator engineering team.