### PR TITLE
Remove use of `element()` function with `aws_ses_domain_dkim` documentation example

### DIFF
--- a/website/docs/r/ses_domain_dkim.html.markdown
+++ b/website/docs/r/ses_domain_dkim.html.markdown
@@ -43,10 +43,10 @@ resource "aws_ses_domain_dkim" "example" {
 resource "aws_route53_record" "example_amazonses_dkim_record" {
   count   = 3
   zone_id = "ABCDEFGHIJ123"
-  name    = "${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}._domainkey"
+  name    = "${aws_ses_domain_dkim.example.dkim_tokens[count.index]}._domainkey"
   type    = "CNAME"
   ttl     = "600"
-  records = ["${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  records = ["${aws_ses_domain_dkim.example.dkim_tokens[count.index]}.dkim.amazonses.com"]
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Dropping use of [`element()` function](https://www.terraform.io/language/functions/element) with `aws_ses_domain_dkim` example of setup of Route53 DKIM records, in place of just the built-in index syntax.

Provides a simpler example to reason with.

`element()` provides "wrap around" - but that won't help here - as you'd end up with conflicting `CNAME` DNS names anyway - which would fail the AWS API on `terraform apply`.
