### PR TITLE
sweepers/aws_evidently_project

### DIFF
--- a/internal/service/evidently/sweep.go
+++ b/internal/service/evidently/sweep.go
@@ -1,0 +1,65 @@
+//go:build sweep
+// +build sweep
+
+package evidently
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_evidently_project", &resource.Sweeper{
+		Name: "aws_evidently_project",
+		F:    sweepProject,
+	})
+}
+
+func sweepProject(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %w", err)
+	}
+	conn := client.(*conns.AWSClient).EvidentlyConn
+	input := &cloudwatchevidently.ListProjectsInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.ListProjectsPages(input, func(page *cloudwatchevidently.ListProjectsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, project := range page.Projects {
+			r := ResourceProject()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(project.Name))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Evidently Project sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Evidently Projects for %s: %w", region, err))
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Evidently Projects for %s: %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -68,6 +68,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/emrcontainers"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/events"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/firehose"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/fis"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/fsx"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Sweepers for Evidently Project.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #22624

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make sweep SWEEPARGS=-sweep-run=aws_evidently SWEEP=us-west-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_evidently -timeout 60m
2022/10/11 15:19:23 [DEBUG] Running Sweepers for region (us-west-2):
2022/10/11 15:19:23 [DEBUG] Running Sweeper (aws_evidently_project) in region (us-west-2)
2022/10/11 15:19:23 [INFO] Retrieved credentials from "EC2RoleProvider"
2022/10/11 15:19:23 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/10/11 15:19:24 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/10/11 15:19:25 [DEBUG] Completed Sweeper (aws_evidently_project) in region (us-west-2) in 2.072274992s
2022/10/11 15:19:25 Completed Sweepers for region (us-west-2) in 2.072366218s
2022/10/11 15:19:25 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_evidently_project
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      2.093s


...
```
