### PR TITLE
fix: migrate first interaction action from v1 to v1.1.1

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add comment to add helpful context for new contributors
-        uses: actions/first-interaction@v1
+        uses: actions/first-interaction@v1.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: |-


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request aims to migrate the action `first-interaction` from `v1` to `v1.1.1`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27209

### References
[https://github.com/actions/first-interaction/issues/101](https://github.com/actions/first-interaction/issues/101)


### Output from Acceptance Testing
