### PR TITLE
Add log group arn to aws prometheus workspace 26444

### DIFF
--- a/.changelog/27213.txt
+++ b/.changelog/27213.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_prometheus_workspace: Add `cloudwatch_log_group_arn` argument
+resource/aws_prometheus_workspace: Add `logging_configuration` argument
 ```

--- a/.changelog/27213.txt
+++ b/.changelog/27213.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_prometheus_workspace: Add `cloudwatch_log_group_arn` argument ([#26444](https://github.com/hashicorp/terraform-provider-aws/issues/26444))
+resource/aws_prometheus_workspace: Add `cloudwatch_log_group_arn` argument
 ```

--- a/.changelog/27213.txt
+++ b/.changelog/27213.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_prometheus_workspace: Add `cloudwatch_log_group_arn` argument ([#26444](https://github.com/hashicorp/terraform-provider-aws/issues/26444))
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ ENHANCEMENTS:
 * resource/aws_dx_connection: Add `vlan_id` attribute ([#27148](https://github.com/hashicorp/terraform-provider-aws/issues/27148))
 * resource/aws_opsworks_custom_layer: Add `load_based_auto_scaling` argument ([#10962](https://github.com/hashicorp/terraform-provider-aws/issues/10962))
 * resource/aws_vpc: Add `enable_network_address_usage_metrics` argument ([#27165](https://github.com/hashicorp/terraform-provider-aws/issues/27165))
-* resource/aws_prometheus_workspace: Add `cloudwatch_log_group_arn` argument ([#26444](https://github.com/hashicorp/terraform-provider-aws/issues/26444))
 
 ## 4.34.0 (October  6, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ ENHANCEMENTS:
 * resource/aws_dx_connection: Add `vlan_id` attribute ([#27148](https://github.com/hashicorp/terraform-provider-aws/issues/27148))
 * resource/aws_opsworks_custom_layer: Add `load_based_auto_scaling` argument ([#10962](https://github.com/hashicorp/terraform-provider-aws/issues/10962))
 * resource/aws_vpc: Add `enable_network_address_usage_metrics` argument ([#27165](https://github.com/hashicorp/terraform-provider-aws/issues/27165))
+* resource/aws_prometheus_workspace: Add `cloudwatch_log_group_arn` argument ([#26444](https://github.com/hashicorp/terraform-provider-aws/issues/26444))
 
 ## 4.34.0 (October  6, 2022)
 

--- a/internal/service/amp/alert_manager_definition.go
+++ b/internal/service/amp/alert_manager_definition.go
@@ -16,10 +16,11 @@ import (
 
 func ResourceAlertManagerDefinition() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAlertManagerDefinitionCreate,
-		ReadContext:   resourceAlertManagerDefinitionRead,
-		UpdateContext: resourceAlertManagerDefinitionUpdate,
-		DeleteContext: resourceAlertManagerDefinitionDelete,
+		CreateWithoutTimeout: resourceAlertManagerDefinitionCreate,
+		ReadWithoutTimeout:   resourceAlertManagerDefinitionRead,
+		UpdateWithoutTimeout: resourceAlertManagerDefinitionUpdate,
+		DeleteWithoutTimeout: resourceAlertManagerDefinitionDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/internal/service/amp/alert_manager_definition.go
+++ b/internal/service/amp/alert_manager_definition.go
@@ -2,7 +2,6 @@ package amp
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,39 +47,16 @@ func resourceAlertManagerDefinitionCreate(ctx context.Context, d *schema.Resourc
 		WorkspaceId: aws.String(workspaceID),
 	}
 
-	log.Printf("[DEBUG] Creating Prometheus Alert Manager Definition: %s", input)
 	_, err := conn.CreateAlertManagerDefinitionWithContext(ctx, input)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Prometheus Alert Manager Definition (%s): %w", workspaceID, err))
+		return diag.Errorf("creating Prometheus Alert Manager Definition (%s): %s", workspaceID, err)
 	}
 
 	d.SetId(workspaceID)
 
 	if _, err := waitAlertManagerDefinitionCreated(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Alert Manager Definition (%s) create: %w", d.Id(), err))
-	}
-
-	return resourceAlertManagerDefinitionRead(ctx, d, meta)
-}
-
-func resourceAlertManagerDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AMPConn
-
-	input := &prometheusservice.PutAlertManagerDefinitionInput{
-		Data:        []byte(d.Get("definition").(string)),
-		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
-	}
-
-	log.Printf("[DEBUG] Updating Prometheus Alert Manager Definition: %s", input)
-	_, err := conn.PutAlertManagerDefinitionWithContext(ctx, input)
-
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Prometheus Alert Manager Definition (%s): %w", d.Id(), err))
-	}
-
-	if _, err := waitAlertManagerDefinitionUpdated(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Alert Manager Definition (%s) update: %w", d.Id(), err))
+		return diag.Errorf("waiting for Prometheus Alert Manager Definition (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceAlertManagerDefinitionRead(ctx, d, meta)
@@ -98,13 +74,34 @@ func resourceAlertManagerDefinitionRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error reading Prometheus Alert Manager Definition (%s): %w", d.Id(), err))
+		return diag.Errorf("reading Prometheus Alert Manager Definition (%s): %s", d.Id(), err)
 	}
 
 	d.Set("definition", string(amd.Data))
 	d.Set("workspace_id", d.Id())
 
 	return nil
+}
+
+func resourceAlertManagerDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AMPConn
+
+	input := &prometheusservice.PutAlertManagerDefinitionInput{
+		Data:        []byte(d.Get("definition").(string)),
+		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
+	}
+
+	_, err := conn.PutAlertManagerDefinitionWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("updating Prometheus Alert Manager Definition (%s): %s", d.Id(), err)
+	}
+
+	if _, err := waitAlertManagerDefinitionUpdated(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for Prometheus Alert Manager Definition (%s) update: %s", d.Id(), err)
+	}
+
+	return resourceAlertManagerDefinitionRead(ctx, d, meta)
 }
 
 func resourceAlertManagerDefinitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -120,11 +117,11 @@ func resourceAlertManagerDefinitionDelete(ctx context.Context, d *schema.Resourc
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Prometheus Alert Manager Definition (%s): %w", d.Id(), err))
+		return diag.Errorf("deleting Prometheus Alert Manager Definition (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitAlertManagerDefinitionDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Alert Manager Definition (%s) delete: %w", d.Id(), err))
+		return diag.Errorf("waiting for Prometheus Alert Manager Definition (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/amp/alert_manager_definition_test.go
+++ b/internal/service/amp/alert_manager_definition_test.go
@@ -138,8 +138,8 @@ alertmanager_config: |
 
 func testAccAlertManagerDefinitionConfig_basic(definition string) string {
 	return fmt.Sprintf(`
-resource "aws_prometheus_workspace" "test" {
-}
+resource "aws_prometheus_workspace" "test" {}
+
 resource "aws_prometheus_alert_manager_definition" "test" {
   workspace_id = aws_prometheus_workspace.test.id
   definition   = %[1]q

--- a/internal/service/amp/find.go
+++ b/internal/service/amp/find.go
@@ -100,3 +100,28 @@ func FindWorkspaceByID(conn *prometheusservice.PrometheusService, id string) (*p
 
 	return output.Workspace, nil
 }
+
+func FindLoggingConfigurationByWorkspaceID(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.LoggingConfigurationMetadata, error) {
+	input := &prometheusservice.DescribeLoggingConfigurationInput{
+		WorkspaceId: aws.String(id),
+	}
+
+	output, err := conn.DescribeLoggingConfigurationWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.LoggingConfiguration == nil || output.LoggingConfiguration.Status == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.LoggingConfiguration, nil
+}

--- a/internal/service/amp/find.go
+++ b/internal/service/amp/find.go
@@ -76,12 +76,12 @@ func FindRuleGroupNamespaceByARN(ctx context.Context, conn *prometheusservice.Pr
 	return output.RuleGroupsNamespace, nil
 }
 
-func FindWorkspaceByID(conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceDescription, error) {
+func FindWorkspaceByID(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceDescription, error) {
 	input := &prometheusservice.DescribeWorkspaceInput{
 		WorkspaceId: aws.String(id),
 	}
 
-	output, err := conn.DescribeWorkspace(input)
+	output, err := conn.DescribeWorkspaceWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) {
 		return nil, &resource.NotFoundError{

--- a/internal/service/amp/find.go
+++ b/internal/service/amp/find.go
@@ -94,7 +94,7 @@ func FindWorkspaceByID(conn *prometheusservice.PrometheusService, id string) (*p
 		return nil, err
 	}
 
-	if output == nil || output.Workspace == nil {
+	if output == nil || output.Workspace == nil || output.Workspace.Status == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 

--- a/internal/service/amp/rule_group_namespace.go
+++ b/internal/service/amp/rule_group_namespace.go
@@ -2,7 +2,6 @@ package amp
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -50,45 +49,21 @@ func resourceRuleGroupNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 	workspaceID := d.Get("workspace_id").(string)
 	name := d.Get("name").(string)
 	input := &prometheusservice.CreateRuleGroupsNamespaceInput{
-		Name:        aws.String(name),
 		Data:        []byte(d.Get("data").(string)),
+		Name:        aws.String(name),
 		WorkspaceId: aws.String(workspaceID),
 	}
 
-	log.Printf("[DEBUG] Creating Prometheus Rule Group Namespace: %s", input)
 	output, err := conn.CreateRuleGroupsNamespaceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Prometheus Rule Group Namespace (%s) for workspace (%s): %w", name, workspaceID, err))
+		return diag.Errorf("creating Prometheus Rule Group Namespace (%s) for Workspace (%s): %s", name, workspaceID, err)
 	}
 
 	d.SetId(aws.StringValue(output.Arn))
 
 	if _, err := waitRuleGroupNamespaceCreated(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Rule Group Namespace (%s) create: %w", d.Id(), err))
-	}
-
-	return resourceRuleGroupNamespaceRead(ctx, d, meta)
-}
-
-func resourceRuleGroupNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AMPConn
-
-	input := &prometheusservice.PutRuleGroupsNamespaceInput{
-		Name:        aws.String(d.Get("name").(string)),
-		Data:        []byte(d.Get("data").(string)),
-		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
-	}
-
-	log.Printf("[DEBUG] Updating Prometheus Rule Group Namespace: %s", input)
-	_, err := conn.PutRuleGroupsNamespaceWithContext(ctx, input)
-
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Prometheus Rule Group Namespace (%s): %w", d.Id(), err))
-	}
-
-	if _, err := waitRuleGroupNamespaceUpdated(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Rule Group Namespace (%s) update: %w", d.Id(), err))
+		return diag.Errorf("waiting for Prometheus Rule Group Namespace (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceRuleGroupNamespaceRead(ctx, d, meta)
@@ -106,7 +81,7 @@ func resourceRuleGroupNamespaceRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error reading Prometheus Rule Group Namespace (%s): %w", d.Id(), err))
+		return diag.Errorf("reading Prometheus Rule Group Namespace (%s): %s", d.Id(), err)
 	}
 
 	d.Set("data", string(rgn.Data))
@@ -118,6 +93,28 @@ func resourceRuleGroupNamespaceRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("workspace_id", workspaceID)
 
 	return nil
+}
+
+func resourceRuleGroupNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AMPConn
+
+	input := &prometheusservice.PutRuleGroupsNamespaceInput{
+		Data:        []byte(d.Get("data").(string)),
+		Name:        aws.String(d.Get("name").(string)),
+		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
+	}
+
+	_, err := conn.PutRuleGroupsNamespaceWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("updating Prometheus Rule Group Namespace (%s): %s", d.Id(), err)
+	}
+
+	if _, err := waitRuleGroupNamespaceUpdated(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for Prometheus Rule Group Namespace (%s) update: %s", d.Id(), err)
+	}
+
+	return resourceRuleGroupNamespaceRead(ctx, d, meta)
 }
 
 func resourceRuleGroupNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -134,11 +131,11 @@ func resourceRuleGroupNamespaceDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Prometheus Rule Group Namespace (%s): %w", d.Id(), err))
+		return diag.Errorf("deleting Prometheus Rule Group Namespace (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitRuleGroupNamespaceDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Rule Group Namespace (%s) delete: %w", d.Id(), err))
+		return diag.Errorf("waiting for Prometheus Rule Group Namespace (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/amp/rule_group_namespace.go
+++ b/internal/service/amp/rule_group_namespace.go
@@ -16,10 +16,11 @@ import (
 
 func ResourceRuleGroupNamespace() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRuleGroupNamespaceCreate,
-		ReadContext:   resourceRuleGroupNamespaceRead,
-		UpdateContext: resourceRuleGroupNamespaceUpdate,
-		DeleteContext: resourceRuleGroupNamespaceDelete,
+		CreateWithoutTimeout: resourceRuleGroupNamespaceCreate,
+		ReadWithoutTimeout:   resourceRuleGroupNamespaceRead,
+		UpdateWithoutTimeout: resourceRuleGroupNamespaceUpdate,
+		DeleteWithoutTimeout: resourceRuleGroupNamespaceDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/internal/service/amp/rule_group_namespace_test.go
+++ b/internal/service/amp/rule_group_namespace_test.go
@@ -143,8 +143,8 @@ groups:
 
 func testAccRuleGroupNamespaceConfig_basic(data string) string {
 	return fmt.Sprintf(`
-resource "aws_prometheus_workspace" "test" {
-}
+resource "aws_prometheus_workspace" "test" {}
+
 resource "aws_prometheus_rule_group_namespace" "test" {
   workspace_id = aws_prometheus_workspace.test.id
   name         = "rules"

--- a/internal/service/amp/status.go
+++ b/internal/service/amp/status.go
@@ -56,3 +56,19 @@ func statusWorkspace(ctx context.Context, conn *prometheusservice.PrometheusServ
 		return output, aws.StringValue(output.Status.StatusCode), nil
 	}
 }
+
+func statusLoggingConfiguration(ctx context.Context, conn *prometheusservice.PrometheusService, workspaceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindLoggingConfigurationByWorkspaceID(ctx, conn, workspaceID)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status.StatusCode), nil
+	}
+}

--- a/internal/service/amp/status.go
+++ b/internal/service/amp/status.go
@@ -43,7 +43,7 @@ func statusRuleGroupNamespace(ctx context.Context, conn *prometheusservice.Prome
 
 func statusWorkspace(ctx context.Context, conn *prometheusservice.PrometheusService, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindWorkspaceByID(conn, id)
+		output, err := FindWorkspaceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/amp/status.go
+++ b/internal/service/amp/status.go
@@ -5,15 +5,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/prometheusservice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-)
-
-const (
-	resourceStatusFailed  = "Failed"
-	resourceStatusUnknown = "Unknown"
-	resourceStatusDeleted = "Deleted"
 )
 
 func statusAlertManagerDefinition(ctx context.Context, conn *prometheusservice.PrometheusService, id string) resource.StateRefreshFunc {
@@ -48,48 +41,18 @@ func statusRuleGroupNamespace(ctx context.Context, conn *prometheusservice.Prome
 	}
 }
 
-// statusWorkspaceCreated fetches the Workspace and its Status.
-func statusWorkspaceCreated(ctx context.Context, conn *prometheusservice.PrometheusService, id string) resource.StateRefreshFunc {
+func statusWorkspace(ctx context.Context, conn *prometheusservice.PrometheusService, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &prometheusservice.DescribeWorkspaceInput{
-			WorkspaceId: aws.String(id),
-		}
+		output, err := FindWorkspaceByID(conn, id)
 
-		output, err := conn.DescribeWorkspaceWithContext(ctx, input)
-
-		if err != nil {
-			return output, resourceStatusFailed, err
-		}
-
-		if output == nil || output.Workspace == nil {
-			return output, resourceStatusUnknown, nil
-		}
-
-		return output.Workspace, aws.StringValue(output.Workspace.Status.StatusCode), nil
-	}
-}
-
-// statusWorkspaceDeleted fetches the Workspace and its Status
-func statusWorkspaceDeleted(ctx context.Context, conn *prometheusservice.PrometheusService, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		input := &prometheusservice.DescribeWorkspaceInput{
-			WorkspaceId: aws.String(id),
-		}
-
-		output, err := conn.DescribeWorkspaceWithContext(ctx, input)
-
-		if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) {
-			return output, resourceStatusDeleted, nil
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
 		if err != nil {
-			return output, resourceStatusUnknown, err
+			return nil, "", err
 		}
 
-		if output == nil || output.Workspace == nil {
-			return output, resourceStatusUnknown, nil
-		}
-
-		return output.Workspace, aws.StringValue(output.Workspace.Status.StatusCode), nil
+		return output, aws.StringValue(output.Status.StatusCode), nil
 	}
 }

--- a/internal/service/amp/wait.go
+++ b/internal/service/amp/wait.go
@@ -176,3 +176,62 @@ func waitWorkspaceUpdated(ctx context.Context, conn *prometheusservice.Prometheu
 
 	return nil, err
 }
+
+func waitLoggingConfigurationCreated(ctx context.Context, conn *prometheusservice.PrometheusService, workspaceID string) (*prometheusservice.LoggingConfigurationMetadata, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{prometheusservice.LoggingConfigurationStatusCodeCreating},
+		Target:  []string{prometheusservice.LoggingConfigurationStatusCodeActive},
+		Refresh: statusLoggingConfiguration(ctx, conn, workspaceID),
+		Timeout: workspaceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*prometheusservice.LoggingConfigurationMetadata); ok {
+		if statusCode := aws.StringValue(output.Status.StatusCode); statusCode == prometheusservice.LoggingConfigurationStatusCodeCreationFailed {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Status.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitLoggingConfigurationDeleted(ctx context.Context, conn *prometheusservice.PrometheusService, workspaceID string) (*prometheusservice.LoggingConfigurationMetadata, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{prometheusservice.LoggingConfigurationStatusCodeDeleting},
+		Target:  []string{},
+		Refresh: statusLoggingConfiguration(ctx, conn, workspaceID),
+		Timeout: workspaceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*prometheusservice.LoggingConfigurationMetadata); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitLoggingConfigurationUpdated(ctx context.Context, conn *prometheusservice.PrometheusService, workspaceID string) (*prometheusservice.LoggingConfigurationMetadata, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{prometheusservice.LoggingConfigurationStatusCodeUpdating},
+		Target:  []string{prometheusservice.LoggingConfigurationStatusCodeActive},
+		Refresh: statusLoggingConfiguration(ctx, conn, workspaceID),
+		Timeout: workspaceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*prometheusservice.LoggingConfigurationMetadata); ok {
+		if statusCode := aws.StringValue(output.Status.StatusCode); statusCode == prometheusservice.LoggingConfigurationStatusCodeUpdateFailed {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Status.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/amp/wait.go
+++ b/internal/service/amp/wait.go
@@ -24,7 +24,7 @@ func waitAlertManagerDefinitionCreated(ctx context.Context, conn *prometheusserv
 		Timeout: workspaceTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*prometheusservice.AlertManagerDefinitionDescription); ok {
 		if statusCode := aws.StringValue(output.Status.StatusCode); statusCode == prometheusservice.AlertManagerDefinitionStatusCodeCreationFailed {
@@ -45,7 +45,7 @@ func waitAlertManagerDefinitionUpdated(ctx context.Context, conn *prometheusserv
 		Timeout: workspaceTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*prometheusservice.AlertManagerDefinitionDescription); ok {
 		if statusCode := aws.StringValue(output.Status.StatusCode); statusCode == prometheusservice.AlertManagerDefinitionStatusCodeUpdateFailed {
@@ -66,7 +66,7 @@ func waitAlertManagerDefinitionDeleted(ctx context.Context, conn *prometheusserv
 		Timeout: workspaceTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*prometheusservice.AlertManagerDefinitionDescription); ok {
 		return output, err
@@ -83,7 +83,7 @@ func waitRuleGroupNamespaceDeleted(ctx context.Context, conn *prometheusservice.
 		Timeout: workspaceTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*prometheusservice.RuleGroupsNamespaceDescription); ok {
 		return output, err
@@ -100,7 +100,7 @@ func waitRuleGroupNamespaceCreated(ctx context.Context, conn *prometheusservice.
 		Timeout: workspaceTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*prometheusservice.RuleGroupsNamespaceDescription); ok {
 		return output, err
@@ -117,7 +117,7 @@ func waitRuleGroupNamespaceUpdated(ctx context.Context, conn *prometheusservice.
 		Timeout: workspaceTimeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*prometheusservice.RuleGroupsNamespaceDescription); ok {
 		return output, err

--- a/internal/service/amp/wait.go
+++ b/internal/service/amp/wait.go
@@ -75,42 +75,6 @@ func waitAlertManagerDefinitionDeleted(ctx context.Context, conn *prometheusserv
 	return nil, err
 }
 
-// waitWorkspaceCreated waits for a Workspace to return "Active"
-func waitWorkspaceCreated(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceSummary, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{prometheusservice.WorkspaceStatusCodeCreating},
-		Target:  []string{prometheusservice.WorkspaceStatusCodeActive},
-		Refresh: statusWorkspaceCreated(ctx, conn, id),
-		Timeout: workspaceTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if v, ok := outputRaw.(*prometheusservice.WorkspaceSummary); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-// waitWorkspaceDeleted waits for a Workspace to return "Deleted"
-func waitWorkspaceDeleted(ctx context.Context, conn *prometheusservice.PrometheusService, arn string) (*prometheusservice.WorkspaceSummary, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{prometheusservice.WorkspaceStatusCodeDeleting},
-		Target:  []string{resourceStatusDeleted},
-		Refresh: statusWorkspaceDeleted(ctx, conn, arn),
-		Timeout: workspaceTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if v, ok := outputRaw.(*prometheusservice.WorkspaceSummary); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
 func waitRuleGroupNamespaceDeleted(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.RuleGroupsNamespaceDescription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{prometheusservice.RuleGroupsNamespaceStatusCodeDeleting},
@@ -156,6 +120,57 @@ func waitRuleGroupNamespaceUpdated(ctx context.Context, conn *prometheusservice.
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*prometheusservice.RuleGroupsNamespaceDescription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitWorkspaceCreated(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{prometheusservice.WorkspaceStatusCodeCreating},
+		Target:  []string{prometheusservice.WorkspaceStatusCodeActive},
+		Refresh: statusWorkspace(ctx, conn, id),
+		Timeout: workspaceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*prometheusservice.WorkspaceDescription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitWorkspaceDeleted(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{prometheusservice.WorkspaceStatusCodeDeleting},
+		Target:  []string{},
+		Refresh: statusWorkspace(ctx, conn, id),
+		Timeout: workspaceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*prometheusservice.WorkspaceDescription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitWorkspaceUpdated(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{prometheusservice.WorkspaceStatusCodeUpdating},
+		Target:  []string{prometheusservice.WorkspaceStatusCodeActive},
+		Refresh: statusWorkspace(ctx, conn, id),
+		Timeout: workspaceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*prometheusservice.WorkspaceDescription); ok {
 		return output, err
 	}
 

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -17,10 +17,11 @@ import (
 
 func ResourceWorkspace() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceWorkspaceCreate,
-		ReadContext:   resourceWorkspaceRead,
-		UpdateContext: resourceWorkspaceUpdate,
-		DeleteContext: resourceWorkspaceDelete,
+		CreateWithoutTimeout: resourceWorkspaceCreate,
+		ReadWithoutTimeout:   resourceWorkspaceRead,
+		UpdateWithoutTimeout: resourceWorkspaceUpdate,
+		DeleteWithoutTimeout: resourceWorkspaceDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -33,18 +34,27 @@ func ResourceWorkspace() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"prometheus_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"cloudwatch_log_group_arn": {
-				Type:         schema.TypeString,
-				ValidateFunc: verify.ValidARN,
-				Optional:     true,
+			"logging_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log_group_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
+			"prometheus_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
@@ -52,36 +62,67 @@ func ResourceWorkspace() *schema.Resource {
 	}
 }
 
-func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[INFO] Reading AMP workspace %s", d.Id())
+func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AMPConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
+	input := &prometheusservice.CreateWorkspaceInput{}
+
+	if v, ok := d.GetOk("alias"); ok {
+		input.Alias = aws.String(v.(string))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	result, err := conn.CreateWorkspaceWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("creating Prometheus Workspace: %s", err)
+	}
+
+	d.SetId(aws.StringValue(result.WorkspaceId))
+
+	if _, err := waitWorkspaceCreated(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for Prometheus Workspace (%s) create: %w", d.Id(), err)
+	}
+
+	// TODO
+	if v, ok := d.GetOk("cloudwatch_log_group_arn"); ok {
+		_, err := conn.CreateLoggingConfigurationWithContext(ctx, &prometheusservice.CreateLoggingConfigurationInput{WorkspaceId: aws.String(d.Id()), LogGroupArn: aws.String(v.(string))})
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error creating Logging Configuration (log group arn: %s) for Workspace (%s): %w", v.(string), d.Id(), err))
+		}
+	}
+
+	return resourceWorkspaceRead(ctx, d, meta)
+}
+
+func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AMPConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	details, err := conn.DescribeWorkspaceWithContext(ctx, &prometheusservice.DescribeWorkspaceInput{
-		WorkspaceId: aws.String(d.Id()),
-	})
-	if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) && !d.IsNewResource() {
+	ws, err := FindWorkspaceByID(conn, d.Id())
+
+	if tfresource.NotFound(err) && !d.IsNewResource() {
 		log.Printf("[WARN] Prometheus Workspace (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error reading Prometheus Workspace (%s): %w", d.Id(), err))
+		return diag.Errorf("reading Prometheus Workspace (%s): %s", d.Id(), err)
 	}
-
-	if details == nil || details.Workspace == nil {
-		return diag.FromErr(fmt.Errorf("error reading Prometheus Workspace (%s): empty response", d.Id()))
-	}
-
-	ws := details.Workspace
 
 	d.Set("alias", ws.Alias)
-	d.Set("arn", ws.Arn)
+	arn := aws.StringValue(ws.Arn)
+	d.Set("arn", arn)
 	d.Set("prometheus_endpoint", ws.PrometheusEndpoint)
 
+	// TODO
 	loggingConfig, err := conn.DescribeLoggingConfigurationWithContext(ctx, &prometheusservice.DescribeLoggingConfigurationInput{WorkspaceId: aws.String(d.Id())})
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) {
@@ -93,48 +134,55 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set("cloudwatch_log_group_arn", loggingConfig.LoggingConfiguration.LogGroupArn)
 	}
 
-	tags, err := ListTags(conn, *ws.Arn)
+	tags, err := ListTagsWithContext(ctx, conn, arn)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing tags for Prometheus Workspace (%s): %s", d.Id(), err))
+		return diag.Errorf("listing tags for Prometheus Workspace (%s): %s", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+		return diag.Errorf("setting tags_all: %s", err)
 	}
 	return nil
 }
 
 func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[INFO] Updating AMP workspace %s", d.Id())
-
-	req := &prometheusservice.UpdateWorkspaceAliasInput{
-		WorkspaceId: aws.String(d.Id()),
-	}
-	if v, ok := d.GetOk("alias"); ok {
-		req.Alias = aws.String(v.(string))
-	}
 	conn := meta.(*conns.AWSClient).AMPConn
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	if d.HasChange("alias") {
+		input := &prometheusservice.UpdateWorkspaceAliasInput{
+			Alias:       aws.String(d.Get("alias").(string)),
+			WorkspaceId: aws.String(d.Id()),
+		}
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Prometheus WorkSpace (%s) tags: %s", d.Id(), err))
+		_, err := conn.UpdateWorkspaceAliasWithContext(ctx, input)
+
+		if err != nil {
+			return diag.Errorf("updating Prometheus Workspace alias (%s): %s", d.Id(), err)
+		}
+
+		if _, err := waitWorkspaceUpdated(ctx, conn, d.Id()); err != nil {
+			return diag.Errorf("waiting for Prometheus Workspace (%s) update: %w", d.Id(), err)
 		}
 	}
 
-	if _, err := conn.UpdateWorkspaceAliasWithContext(ctx, req); err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Prometheus WorkSpace (%s): %w", d.Id(), err))
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		arn := d.Get("arn").(string)
+
+		if err := UpdateTagsWithContext(ctx, conn, arn, o, n); err != nil {
+			return diag.FromErr(fmt.Errorf("updating Prometheus Workspace (%s) tags: %s", arn, err))
+		}
 	}
 
+	// TODO
 	if d.HasChange("cloudwatch_log_group_arn") {
 		_, n := d.GetChange("cloudwatch_log_group_arn")
 		_, err := conn.UpdateLoggingConfigurationWithContext(ctx, &prometheusservice.UpdateLoggingConfigurationInput{WorkspaceId: aws.String(d.Id()), LogGroupArn: aws.String(n.(string))})
@@ -146,45 +194,10 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return resourceWorkspaceRead(ctx, d, meta)
 }
 
-func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[INFO] Creating AMP workspace %s", d.Id())
-	conn := meta.(*conns.AWSClient).AMPConn
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
-
-	req := &prometheusservice.CreateWorkspaceInput{}
-	if v, ok := d.GetOk("alias"); ok {
-		req.Alias = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		req.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	result, err := conn.CreateWorkspaceWithContext(ctx, req)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Prometheus WorkSpace (%s): %w", d.Id(), err))
-	}
-	d.SetId(aws.StringValue(result.WorkspaceId))
-
-	if _, err := waitWorkspaceCreated(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Workspace (%s) to be created: %w", d.Id(), err))
-	}
-
-	if v, ok := d.GetOk("cloudwatch_log_group_arn"); ok {
-		_, err := conn.CreateLoggingConfigurationWithContext(ctx, &prometheusservice.CreateLoggingConfigurationInput{WorkspaceId: aws.String(d.Id()), LogGroupArn: aws.String(v.(string))})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("error creating Logging Configuration (log group arn: %s) for Workspace (%s): %w", v.(string), d.Id(), err))
-		}
-	}
-
-	return resourceWorkspaceRead(ctx, d, meta)
-}
-
 func resourceWorkspaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[INFO] Deleting AMP workspace %s", d.Id())
 	conn := meta.(*conns.AWSClient).AMPConn
 
+	log.Printf("[INFO] Deleting Prometheus Workspace: %s", d.Id())
 	_, err := conn.DeleteWorkspaceWithContext(ctx, &prometheusservice.DeleteWorkspaceInput{
 		WorkspaceId: aws.String(d.Id()),
 	})
@@ -194,11 +207,11 @@ func resourceWorkspaceDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Prometheus Workspace (%s): %w", d.Id(), err))
+		return diag.Errorf("deleting Prometheus Workspace (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitWorkspaceDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for Prometheus Workspace (%s) to be deleted: %w", d.Id(), err))
+		return diag.Errorf("waiting for Prometheus Workspace (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -114,7 +114,7 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	ws, err := FindWorkspaceByID(conn, d.Id())
+	ws, err := FindWorkspaceByID(ctx, conn, d.Id())
 
 	if tfresource.NotFound(err) && !d.IsNewResource() {
 		log.Printf("[WARN] Prometheus Workspace (%s) not found, removing from state", d.Id())

--- a/internal/service/amp/workspace_data_source.go
+++ b/internal/service/amp/workspace_data_source.go
@@ -1,9 +1,10 @@
 package amp
 
 import (
-	"fmt"
+	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -11,7 +12,7 @@ import (
 
 func DataSourceWorkspace() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceWorkspaceRead,
+		ReadWithoutTimeout: dataSourceWorkspaceRead,
 
 		Schema: map[string]*schema.Schema{
 			"alias": {
@@ -43,7 +44,7 @@ func DataSourceWorkspace() *schema.Resource {
 	}
 }
 
-func dataSourceWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AMPConn
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -51,7 +52,7 @@ func dataSourceWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	workspace, err := FindWorkspaceByID(conn, workspaceID)
 
 	if err != nil {
-		return fmt.Errorf("reading AMP Workspace (%s): %w", workspaceID, err)
+		return diag.Errorf("reading AMP Workspace (%s): %s", workspaceID, err)
 	}
 
 	d.SetId(workspaceID)
@@ -63,7 +64,7 @@ func dataSourceWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", workspace.Status.StatusCode)
 
 	if err := d.Set("tags", KeyValueTags(workspace.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("setting tags: %w", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/amp/workspace_data_source.go
+++ b/internal/service/amp/workspace_data_source.go
@@ -49,7 +49,7 @@ func dataSourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta i
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	workspaceID := d.Get("workspace_id").(string)
-	workspace, err := FindWorkspaceByID(conn, workspaceID)
+	workspace, err := FindWorkspaceByID(ctx, conn, workspaceID)
 
 	if err != nil {
 		return diag.Errorf("reading AMP Workspace (%s): %s", workspaceID, err)

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -1,24 +1,23 @@
 package amp_test
 
 import (
+	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/prometheusservice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfamp "github.com/hashicorp/terraform-provider-aws/internal/service/amp"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccAMPWorkspace_basic(t *testing.T) {
-	workspaceAlias := sdkacctest.RandomWithPrefix("tf_amp_workspace")
+	var v prometheusservice.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -28,10 +27,14 @@ func TestAccAMPWorkspace_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig_alias(workspaceAlias),
+				Config: testAccWorkspaceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "alias", workspaceAlias),
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "alias", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -39,25 +42,14 @@ func TestAccAMPWorkspace_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccWorkspaceConfig_noAlias(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "alias", ""),
-				),
-			},
-			{
-				Config: testAccWorkspaceConfig_alias(workspaceAlias),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "alias", workspaceAlias),
-				),
-			},
 		},
 	})
 }
 
 func TestAccAMPWorkspace_disappears(t *testing.T) {
+	var v prometheusservice.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(prometheusservice.EndpointsID, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
@@ -65,9 +57,9 @@ func TestAccAMPWorkspace_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig_noAlias(),
+				Config: testAccWorkspaceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
+					testAccCheckWorkspaceExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfamp.ResourceWorkspace(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -77,22 +69,21 @@ func TestAccAMPWorkspace_disappears(t *testing.T) {
 }
 
 func TestAccAMPWorkspace_tags(t *testing.T) {
-	rInt := sdkacctest.RandInt()
+	var v prometheusservice.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchlogs.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig_tags(rInt),
+				Config: testAccWorkspaceConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "production"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Owner", "mh9"),
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
@@ -101,32 +92,72 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkspaceConfig_tagsAdded(rInt),
+				Config: testAccWorkspaceConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "production"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Owner", "mh9"),
-					resource.TestCheckResourceAttr(resourceName, "tags.App", "foo42"),
-				),
-			},
-			{
-				Config: testAccWorkspaceConfig_tagsUpdated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "production"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Owner", "abhi"),
-					resource.TestCheckResourceAttr(resourceName, "tags.App", "foo42"),
-				),
-			},
-			{
-				Config: testAccWorkspaceConfig_tags(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
+					testAccCheckWorkspaceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "production"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Owner", "mh9"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_tags1("key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAMPWorkspace_alias(t *testing.T) {
+	var v1, v2, v3, v4 prometheusservice.WorkspaceDescription
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_prometheus_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(prometheusservice.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_alias(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "alias", rName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspaceConfig_alias(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v2),
+					testAccCheckVPNConnectionNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "alias", rName2),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v3),
+					testAccCheckVPNConnectionRecreated(&v2, &v3),
+					resource.TestCheckResourceAttr(resourceName, "alias", ""),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_alias(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v4),
+					testAccCheckVPNConnectionNotRecreated(&v3, &v4),
+					resource.TestCheckResourceAttr(resourceName, "alias", rName1),
 				),
 			},
 		},
@@ -134,20 +165,22 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 }
 
 func TestAccAMPWorkspace_loggingConfiguration(t *testing.T) {
+	var v prometheusservice.WorkspaceDescription
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_prometheus_workspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchlogs.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig_loggingConfig("somelogname"),
+				Config: testAccWorkspaceConfig_loggingConfiguration(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch_log_group_arn"),
-					testAccCheckLogGrouparnInLoggingConfig(resourceName, "somelogname"),
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "logging_configuration.0.log_group_arn"),
 				),
 			},
 			{
@@ -156,48 +189,25 @@ func TestAccAMPWorkspace_loggingConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkspaceConfig_loggingConfig("otherlogname"),
+				Config: testAccWorkspaceConfig_loggingConfiguration(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch_log_group_arn"),
-					testAccCheckLogGrouparnInLoggingConfig(resourceName, "otherlogname"),
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "logging_configuration.0.log_group_arn"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckLogGrouparnInLoggingConfig(resource string, logGroupName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resource]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resource)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No AMP Workspace ID is set")
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn
-
-		req := &prometheusservice.DescribeLoggingConfigurationInput{
-			WorkspaceId: aws.String(rs.Primary.ID),
-		}
-		loggingConfig, err := conn.DescribeLoggingConfiguration(req)
-		if err != nil {
-			return err
-		}
-		if loggingConfig == nil {
-			return fmt.Errorf("Got nil account ?!")
-		}
-		if !strings.Contains(*loggingConfig.LoggingConfiguration.LogGroupArn, logGroupName) {
-			return fmt.Errorf("used logGroupArn %s does not contain configured logGroupArn: %s", *loggingConfig.LoggingConfiguration.LogGroupArn, logGroupName)
-		}
-		return nil
-	}
-}
-
-func testAccCheckWorkspaceExists(n string) resource.TestCheckFunc {
+func testAccCheckWorkspaceExists(n string, v *prometheusservice.WorkspaceDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -205,21 +215,18 @@ func testAccCheckWorkspaceExists(n string) resource.TestCheckFunc {
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No AMP Workspace ID is set")
+			return fmt.Errorf("No Prometheus Workspace ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn
 
-		req := &prometheusservice.DescribeWorkspaceInput{
-			WorkspaceId: aws.String(rs.Primary.ID),
-		}
-		describe, err := conn.DescribeWorkspace(req)
+		output, err := tfamp.FindWorkspaceByID(context.Background(), conn, rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
-		if describe == nil {
-			return fmt.Errorf("Got nil account ?!")
-		}
+
+		*v = *output
 
 		return nil
 	}
@@ -233,84 +240,89 @@ func testAccCheckWorkspaceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := conn.DescribeWorkspace(&prometheusservice.DescribeWorkspaceInput{
-			WorkspaceId: aws.String(rs.Primary.ID),
-		})
-		if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) {
+		_, err := tfamp.FindWorkspaceByID(context.Background(), conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
 			continue
 		}
 
 		if err != nil {
-			return fmt.Errorf("error reading Prometheus WorkSpace (%s): %w", rs.Primary.ID, err)
+			return err
 		}
+
+		return fmt.Errorf("Prometheus Workspace %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccWorkspaceConfig_loggingConfig(logGroupName string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
-  name = "%s"
-}
-resource "aws_prometheus_workspace" "test" {
-  cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
-}
-`, logGroupName)
+func testAccCheckVPNConnectionRecreated(before, after *prometheusservice.WorkspaceDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.StringValue(before.WorkspaceId), aws.StringValue(after.WorkspaceId); before == after {
+			return fmt.Errorf("Expected Prometheus Workspace IDs to change, %s", before)
+		}
+
+		return nil
+	}
 }
 
-func testAccWorkspaceConfig_alias(randName string) string {
-	return fmt.Sprintf(`
-resource "aws_prometheus_workspace" "test" {
-  alias = %q
-}
-`, randName)
+func testAccCheckVPNConnectionNotRecreated(before, after *prometheusservice.WorkspaceDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.StringValue(before.WorkspaceId), aws.StringValue(after.WorkspaceId); before != after {
+			return fmt.Errorf("Expected Prometheus Workspace IDs not to change, but got before: %s, after: %s", before, after)
+		}
+
+		return nil
+	}
 }
 
-func testAccWorkspaceConfig_noAlias() string {
+func testAccWorkspaceConfig_basic() string {
 	return `
-resource "aws_prometheus_workspace" "test" {
-}
+resource "aws_prometheus_workspace" "test" {}
 `
 }
 
-func testAccWorkspaceConfig_tags(randInt int) string {
+func testAccWorkspaceConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_prometheus_workspace" "test" {
-  alias = "test-%d"
-
   tags = {
-    Environment = "production"
-    Owner       = "mh9"
+    %[1]q = %[2]q
   }
 }
-`, randInt)
+`, tagKey1, tagValue1)
 }
 
-func testAccWorkspaceConfig_tagsAdded(randInt int) string {
+func testAccWorkspaceConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_prometheus_workspace" "test" {
-  alias = "test-%d"
-
   tags = {
-    Environment = "production"
-    Owner       = "mh9"
-    App         = "foo42"
+    %[1]q = %[2]q
+    %[3]q = %[4]q
   }
 }
-`, randInt)
+`, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccWorkspaceConfig_tagsUpdated(randInt int) string {
+func testAccWorkspaceConfig_alias(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_prometheus_workspace" "test" {
-  alias = "test-%d"
+  alias = %[1]q
+}
+`, rName)
+}
 
-  tags = {
-    Environment = "production"
-    Owner       = "abhi"
-    App         = "foo42"
+func testAccWorkspaceConfig_loggingConfiguration(rName string, idx int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  count = 2
+
+  name = "%[1]s-${count.index}"
+}
+
+resource "aws_prometheus_workspace" "test" {
+  logging_configuration {
+    log_group_arn = "${aws_cloudwatch_log_group.test[%[2]d].arn}:*"
   }
 }
-`, randInt)
+`, rName, idx)
 }

--- a/website/docs/r/prometheus_workspace.html.markdown
+++ b/website/docs/r/prometheus_workspace.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages an Amazon Managed Service for Prometheus (AMP) Workspace.
 
-~> **NOTE:** This AWS functionality is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```terraform
@@ -27,10 +25,17 @@ resource "aws_prometheus_workspace" "demo" {
 
 ## Argument Reference
 
-The following argument is supported:
+The following arguments are supported:
 
 * `alias` - (Optional) The alias of the prometheus workspace. See more [in AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html).
+* `logging_configuration` - (Optional) Logging configuration for the workspace. See [Logging Configuration](#logging-configuration) below for details.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Logging Configuration
+
+The `logging_configuration` block supports the following arguments:
+
+* `log_group_arn` - (Required) The ARN of the CloudWatch log group to which the vended log data will be published. This log group must exist.
 
 ## Attributes Reference
 

--- a/website/docs/r/prometheus_workspace.html.markdown
+++ b/website/docs/r/prometheus_workspace.html.markdown
@@ -13,12 +13,25 @@ Manages an Amazon Managed Service for Prometheus (AMP) Workspace.
 ## Example Usage
 
 ```terraform
-resource "aws_prometheus_workspace" "demo" {
-  alias = "prometheus-test"
+resource "aws_prometheus_workspace" "example" {
+  alias = "example"
 
   tags = {
     Environment = "production"
-    Owner       = "abhi"
+  }
+}
+```
+
+### CloudWatch Logging
+
+```terraform
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example"
+}
+
+resource "aws_prometheus_workspace" "example" {
+  logging_configuration {
+    log_group_arn = "${aws_cloudwatch_log_group.example.arn}:*"
   }
 }
 ```


### PR DESCRIPTION
### Description
Add cloudwatch_log_group_arn to aws_prometheus_workspace resource.

I did not add log_level as an extra property as it does not exist in the API and it only indicates whether the logging configuration is enabled or not. In my opinion it is clearer to leave it out for now.

For the log_group_arn configuration I use the same contract as the API call, which requires users to add ':*' to the log_group_arn (see tests for more details). I did not want to abstract this away by adding extra logic to the terraform provider. 

### Relations

Closes #26444.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```
$ make testacc TESTS='TestAccAMPWorkspace_' PKG=amp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amp/... -v -count 1 -parallel 20 -run='TestAccAMPWorkspace_'  -timeout 180m
=== RUN   TestAccAMPWorkspace_basic
=== PAUSE TestAccAMPWorkspace_basic
=== RUN   TestAccAMPWorkspace_disappears
=== PAUSE TestAccAMPWorkspace_disappears
=== RUN   TestAccAMPWorkspace_tags
=== PAUSE TestAccAMPWorkspace_tags
=== RUN   TestAccAMPWorkspace_loggingConfiguration
=== PAUSE TestAccAMPWorkspace_loggingConfiguration
=== CONT  TestAccAMPWorkspace_basic
=== CONT  TestAccAMPWorkspace_tags
=== CONT  TestAccAMPWorkspace_disappears
=== CONT  TestAccAMPWorkspace_loggingConfiguration
--- PASS: TestAccAMPWorkspace_disappears (32.82s)
--- PASS: TestAccAMPWorkspace_loggingConfiguration (78.29s)
--- PASS: TestAccAMPWorkspace_basic (99.32s)
--- PASS: TestAccAMPWorkspace_tags (130.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	130.844s

```
