### PR TITLE
Refactor IPAM sweepers & remove SLR precheck

### DIFF
--- a/internal/service/ec2/ipam_byoip_test.go
+++ b/internal/service/ec2/ipam_byoip_test.go
@@ -48,7 +48,7 @@ func TestAccIPAM_byoipIPv6(t *testing.T) {
 	netmaskLength := 56
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVPCIPv6CIDRBlockAssociationDestroy,

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -22,7 +22,7 @@ func TestAccIPAMPoolAllocation_ipv4Basic(t *testing.T) {
 	cidr := "172.2.0.0/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMPoolAllocationDestroy,
@@ -52,7 +52,7 @@ func TestAccIPAMPoolAllocation_ipv4BasicNetmask(t *testing.T) {
 	netmask := "28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMPoolAllocationDestroy,
@@ -81,7 +81,7 @@ func TestAccIPAMPoolAllocation_ipv4DisallowedCIDR(t *testing.T) {
 	expectedCidr := "172.2.0.16/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -109,7 +109,7 @@ func TestAccIPAMPoolAllocation_multiple(t *testing.T) {
 	cidr2 := "10.1.0.0/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMPoolAllocationDestroy,

--- a/internal/service/ec2/ipam_pool_cidr_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_test.go
@@ -19,7 +19,7 @@ func TestAccIPAMPoolCIDR_basic(t *testing.T) {
 	cidr_range := "10.0.0.0/24"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMProvisionedPoolCIDRDestroy,

--- a/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source_test.go
@@ -12,7 +12,7 @@ func TestAccIPAMPoolCIDRsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_vpc_ipam_pool_cidrs.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/ipam_pool_data_source_test.go
+++ b/internal/service/ec2/ipam_pool_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccIPAMPoolDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/ipam_pool_test.go
+++ b/internal/service/ec2/ipam_pool_test.go
@@ -18,7 +18,7 @@ func TestAccIPAMPool_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMPoolDestroy,
@@ -60,7 +60,7 @@ func TestAccIPAMPool_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMPoolDestroy,
@@ -101,7 +101,7 @@ func TestAccIPAMPool_ipv6Basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMPoolDestroy,

--- a/internal/service/ec2/ipam_pools_data_source_test.go
+++ b/internal/service/ec2/ipam_pools_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccIPAMPoolsDataSource_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.testthree"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccIPAMPoolsDataSource_empty(t *testing.T) {
 	dataSourceName := "data.aws_vpc_ipam_pools.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/ipam_preview_next_cidr_data_source_test.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccIPAMPreviewNextCIDRDataSource_ipv4Basic(t *testing.T) {
 	netmaskLength := "28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -37,7 +37,7 @@ func TestAccIPAMPreviewNextCIDRDataSource_ipv4Allocated(t *testing.T) {
 	allocatedCidr := "172.2.0.0/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -70,7 +70,7 @@ func TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCIDR(t *testing.T) {
 	expectedCidr := "172.2.0.16/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,

--- a/internal/service/ec2/ipam_preview_next_cidr_test.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_test.go
@@ -14,7 +14,7 @@ func TestAccIPAMPreviewNextCIDR_ipv4Basic(t *testing.T) {
 	netmaskLength := "28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -38,7 +38,7 @@ func TestAccIPAMPreviewNextCIDR_ipv4Allocated(t *testing.T) {
 	allocatedCidr := "172.2.0.0/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -73,7 +73,7 @@ func TestAccIPAMPreviewNextCIDR_ipv4DisallowedCIDR(t *testing.T) {
 	expectedCidr := "172.2.0.16/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,

--- a/internal/service/ec2/ipam_scope_test.go
+++ b/internal/service/ec2/ipam_scope_test.go
@@ -19,7 +19,7 @@ func TestAccIPAMScope_basic(t *testing.T) {
 	ipamName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMScopeDestroy,
@@ -55,7 +55,7 @@ func TestAccIPAMScope_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam_scope.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMScopeDestroy,

--- a/internal/service/ec2/ipam_test.go
+++ b/internal/service/ec2/ipam_test.go
@@ -15,15 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccIPAMPreCheck(t *testing.T) {
-	acctest.PreCheckIAMServiceLinkedRole(t, "/aws-service-role/ipam.amazonaws.com")
-}
-
 func TestAccIPAM_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMDestroy,
@@ -54,7 +50,7 @@ func TestAccIPAM_modify(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			testAccIPAMPreCheck(t)
+
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -98,7 +94,7 @@ func TestAccIPAM_cascade(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMDestroy,
@@ -128,7 +124,7 @@ func TestAccIPAM_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIPAMDestroy,

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -355,21 +355,20 @@ func init() {
 
 	resource.AddTestSweepers("aws_vpc_ipam_pool_cidr_allocation", &resource.Sweeper{
 		Name: "aws_vpc_ipam_pool_cidr_allocation",
-		F:    sweepIPAMPoolCIDRAllocations,
+		F:    sweepIPAMs,
 	})
 
 	resource.AddTestSweepers("aws_vpc_ipam_pool_cidr", &resource.Sweeper{
 		Name: "aws_vpc_ipam_pool_cidr",
-		F:    sweepIPAMPoolCIDRs,
+		F:    sweepIPAMs,
 		Dependencies: []string{
 			"aws_vpc_ipam_pool_cidr_allocation",
-			"aws_vpc",
 		},
 	})
 
 	resource.AddTestSweepers("aws_vpc_ipam_pool", &resource.Sweeper{
 		Name: "aws_vpc_ipam_pool",
-		F:    sweepIPAMPools,
+		F:    sweepIPAMs,
 		Dependencies: []string{
 			"aws_vpc_ipam_pool_cidr",
 		},
@@ -377,7 +376,7 @@ func init() {
 
 	resource.AddTestSweepers("aws_vpc_ipam_scope", &resource.Sweeper{
 		Name: "aws_vpc_ipam_scope",
-		F:    sweepIPAMScopes,
+		F:    sweepIPAMs,
 		Dependencies: []string{
 			"aws_vpc_ipam_pool",
 		},
@@ -2401,236 +2400,6 @@ func sweepCustomerGateways(region string) error {
 	return nil
 }
 
-func sweepIPAMPoolCIDRAllocations(region string) error {
-	client, err := sweep.SharedRegionalSweepClient(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-	conn := client.(*conns.AWSClient).EC2Conn
-	input := &ec2.DescribeIpamPoolsInput{}
-	var sweeperErrs *multierror.Error
-	sweepResources := make([]sweep.Sweepable, 0)
-
-	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, v := range page.IpamPools {
-			poolID := aws.StringValue(v.IpamPoolId)
-			input := &ec2.GetIpamPoolAllocationsInput{
-				IpamPoolId: v.IpamPoolId,
-			}
-
-			err := conn.GetIpamPoolAllocationsPages(input, func(page *ec2.GetIpamPoolAllocationsOutput, lastPage bool) bool {
-				if page == nil {
-					return !lastPage
-				}
-
-				for _, v := range page.IpamPoolAllocations {
-					r := ResourceIPAMPoolCIDRAllocation()
-					d := r.Data(nil)
-					d.SetId(encodeIPAMPoolCIDRAllocationID(aws.StringValue(v.IpamPoolAllocationId), poolID))
-					d.Set("ipam_pool_id", poolID)
-					d.Set("ipam_pool_allocation_id", v.IpamPoolAllocationId)
-					d.Set("cidr", v.Cidr)
-
-					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-				}
-
-				return !lastPage
-			})
-
-			if sweep.SkipSweepError(err) {
-				continue
-			}
-
-			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IPAM Pool (%s) Allocations (%s): %w", poolID, region, err))
-			}
-		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IPAM Pool Allocations sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IPAM Pools (%s): %w", region, err))
-	}
-
-	err = sweep.SweepOrchestrator(sweepResources)
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping IPAM Pool Allocations (%s): %w", region, err))
-	}
-
-	return sweeperErrs.ErrorOrNil()
-}
-
-func sweepIPAMPoolCIDRs(region string) error {
-	client, err := sweep.SharedRegionalSweepClient(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-	conn := client.(*conns.AWSClient).EC2Conn
-	input := &ec2.DescribeIpamPoolsInput{}
-	var sweeperErrs *multierror.Error
-	sweepResources := make([]sweep.Sweepable, 0)
-
-	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, v := range page.IpamPools {
-			poolID := aws.StringValue(v.IpamPoolId)
-			input := &ec2.GetIpamPoolCidrsInput{
-				IpamPoolId: aws.String(poolID),
-			}
-
-			err := conn.GetIpamPoolCidrsPages(input, func(page *ec2.GetIpamPoolCidrsOutput, lastPage bool) bool {
-				if page == nil {
-					return !lastPage
-				}
-
-				for _, v := range page.IpamPoolCidrs {
-					r := ResourceIPAMPoolCIDR()
-					d := r.Data(nil)
-					d.SetId(encodeIPAMPoolCIDRId(aws.StringValue(v.Cidr), poolID))
-
-					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-				}
-
-				return !lastPage
-			})
-
-			if sweep.SkipSweepError(err) {
-				continue
-			}
-
-			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IPAM Pool (%s) CIDRs (%s): %w", poolID, region, err))
-			}
-		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IPAM Pool sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IPAM Pools (%s): %w", region, err))
-	}
-
-	err = sweep.SweepOrchestrator(sweepResources)
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping IPAM Pool CIDRs (%s): %w", region, err))
-	}
-
-	return sweeperErrs.ErrorOrNil()
-}
-
-func sweepIPAMPools(region string) error {
-	client, err := sweep.SharedRegionalSweepClient(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-	conn := client.(*conns.AWSClient).EC2Conn
-	input := &ec2.DescribeIpamPoolsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
-
-	err = conn.DescribeIpamPoolsPages(input, func(page *ec2.DescribeIpamPoolsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, v := range page.IpamPools {
-			r := ResourceIPAMPool()
-			d := r.Data(nil)
-			d.SetId(aws.StringValue(v.IpamPoolId))
-
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IPAM Pool sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing IPAM Pools (%s): %w", region, err)
-	}
-
-	err = sweep.SweepOrchestrator(sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping IPAM Pools (%s): %w", region, err)
-	}
-
-	return nil
-}
-
-func sweepIPAMScopes(region string) error {
-	client, err := sweep.SharedRegionalSweepClient(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-	conn := client.(*conns.AWSClient).EC2Conn
-	input := &ec2.DescribeIpamScopesInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
-
-	err = conn.DescribeIpamScopesPages(input, func(page *ec2.DescribeIpamScopesOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, v := range page.IpamScopes {
-			scopeID := aws.StringValue(v.IpamScopeId)
-
-			if aws.BoolValue(v.IsDefault) {
-				log.Printf("[DEBUG] Skipping default IPAM Scope (%s)", scopeID)
-				continue
-			}
-
-			r := ResourceIPAMScope()
-			d := r.Data(nil)
-			d.SetId(scopeID)
-
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IPAM Scope sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing IPAM Scopes (%s): %w", region, err)
-	}
-
-	err = sweep.SweepOrchestrator(sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping IPAM Scopes (%s): %w", region, err)
-	}
-
-	return nil
-}
-
 func sweepIPAMs(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
@@ -2638,19 +2407,27 @@ func sweepIPAMs(region string) error {
 	}
 	conn := client.(*conns.AWSClient).EC2Conn
 	input := &ec2.DescribeIpamsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = conn.DescribeIpamsPages(input, func(page *ec2.DescribeIpamsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, v := range page.Ipams {
-			r := ResourceIPAM()
-			d := r.Data(nil)
-			d.SetId(aws.StringValue(v.IpamId))
+		cascade := true
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		for _, ipam := range page.Ipams {
+			id := aws.StringValue(ipam.IpamId)
+			input := &ec2.DeleteIpamInput{
+				Cascade: aws.Bool(cascade),
+				IpamId:  aws.String(id),
+			}
+
+			log.Printf("[INFO] Cascade deleting EC2 IPAM: %s", id)
+			_, err := conn.DeleteIpam(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Error cascade deleting EC2 IPAM (%s): %s", id, err)
+			}
 		}
 
 		return !lastPage
@@ -2664,8 +2441,6 @@ func sweepIPAMs(region string) error {
 	if err != nil {
 		return fmt.Errorf("error listing IPAMs (%s): %w", region, err)
 	}
-
-	err = sweep.SweepOrchestrator(sweepResources)
 
 	if err != nil {
 		return fmt.Errorf("error sweeping IPAMs (%s): %w", region, err)

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -353,41 +353,9 @@ func init() {
 		},
 	})
 
-	resource.AddTestSweepers("aws_vpc_ipam_pool_cidr_allocation", &resource.Sweeper{
-		Name: "aws_vpc_ipam_pool_cidr_allocation",
-		F:    sweepIPAMs,
-	})
-
-	resource.AddTestSweepers("aws_vpc_ipam_pool_cidr", &resource.Sweeper{
-		Name: "aws_vpc_ipam_pool_cidr",
-		F:    sweepIPAMs,
-		Dependencies: []string{
-			"aws_vpc_ipam_pool_cidr_allocation",
-		},
-	})
-
-	resource.AddTestSweepers("aws_vpc_ipam_pool", &resource.Sweeper{
-		Name: "aws_vpc_ipam_pool",
-		F:    sweepIPAMs,
-		Dependencies: []string{
-			"aws_vpc_ipam_pool_cidr",
-		},
-	})
-
-	resource.AddTestSweepers("aws_vpc_ipam_scope", &resource.Sweeper{
-		Name: "aws_vpc_ipam_scope",
-		F:    sweepIPAMs,
-		Dependencies: []string{
-			"aws_vpc_ipam_pool",
-		},
-	})
-
 	resource.AddTestSweepers("aws_vpc_ipam", &resource.Sweeper{
 		Name: "aws_vpc_ipam",
 		F:    sweepIPAMs,
-		Dependencies: []string{
-			"aws_vpc_ipam_scope",
-		},
 	})
 
 	resource.AddTestSweepers("aws_ami", &resource.Sweeper{

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -2439,10 +2439,6 @@ func sweepIPAMs(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing IPAMs (%s): %w", region, err)
-	}
-
-	if err != nil {
 		return fmt.Errorf("error sweeping IPAMs (%s): %w", region, err)
 	}
 

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
@@ -85,7 +85,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_ipamBasic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVPCIPv4CIDRBlockAssociationDestroy,
@@ -111,7 +111,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_ipamBasicExplicitCIDR(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVPCIPv4CIDRBlockAssociationDestroy,

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -843,7 +843,7 @@ func TestAccVPC_IPAMIPv4BasicNetmask(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVPCDestroy,
@@ -870,7 +870,7 @@ func TestAccVPC_IPAMIPv4BasicExplicitCIDR(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVPCDestroy,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

3 Primary changes:

1. IPAM introduced the --cascade argument that allows you to delete ipam resources in summary from the root ipam. this will make the delete process simpler and remove the requirement to wait for allocations to be removed by the service (can take over 30m)
1. IPAM also removed the requirement to create SLR prior to deploying IPAM, instead its made when the `create-ipam` call is made.
1. had to update `ipam_pool.go` because _tags test was failing prior to changes

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccIPAM PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAM'  -timeout 180m
=== RUN   TestAccIPAM_byoipIPv6
    ipam_byoip_test.go:21: Environment variable IPAM_BYOIP_IPV6_MESSAGE, IPAM_BYOIP_IPV6_SIGNATURE, or IPAM_BYOIP_IPV6_PROVISIONED_CIDR is not set
--- SKIP: TestAccIPAM_byoipIPv6 (0.00s)
=== RUN   TestAccIPAMOrganizationAdminAccount_basic
    acctest.go:644: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccIPAMOrganizationAdminAccount_basic (0.41s)
=== RUN   TestAccIPAMPoolAllocation_ipv4Basic
=== PAUSE TestAccIPAMPoolAllocation_ipv4Basic
=== RUN   TestAccIPAMPoolAllocation_ipv4BasicNetmask
=== PAUSE TestAccIPAMPoolAllocation_ipv4BasicNetmask
=== RUN   TestAccIPAMPoolAllocation_ipv4DisallowedCIDR
=== PAUSE TestAccIPAMPoolAllocation_ipv4DisallowedCIDR
=== RUN   TestAccIPAMPoolAllocation_multiple
=== PAUSE TestAccIPAMPoolAllocation_multiple
=== RUN   TestAccIPAMPoolCIDR_basic
=== PAUSE TestAccIPAMPoolCIDR_basic
=== RUN   TestAccIPAMPoolCIDRsDataSource_basic
=== PAUSE TestAccIPAMPoolCIDRsDataSource_basic
=== RUN   TestAccIPAMPoolDataSource_basic
=== PAUSE TestAccIPAMPoolDataSource_basic
=== RUN   TestAccIPAMPool_basic
=== PAUSE TestAccIPAMPool_basic
=== RUN   TestAccIPAMPool_tags
=== PAUSE TestAccIPAMPool_tags
=== RUN   TestAccIPAMPool_ipv6Basic
=== PAUSE TestAccIPAMPool_ipv6Basic
=== RUN   TestAccIPAMPreviewNextCIDRDataSource_ipv4Basic
=== PAUSE TestAccIPAMPreviewNextCIDRDataSource_ipv4Basic
=== RUN   TestAccIPAMPreviewNextCIDRDataSource_ipv4Allocated
=== PAUSE TestAccIPAMPreviewNextCIDRDataSource_ipv4Allocated
=== RUN   TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCIDR
=== PAUSE TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCIDR
=== RUN   TestAccIPAMPreviewNextCIDR_ipv4Basic
=== PAUSE TestAccIPAMPreviewNextCIDR_ipv4Basic
=== RUN   TestAccIPAMPreviewNextCIDR_ipv4Allocated
=== PAUSE TestAccIPAMPreviewNextCIDR_ipv4Allocated
=== RUN   TestAccIPAMPreviewNextCIDR_ipv4DisallowedCIDR
=== PAUSE TestAccIPAMPreviewNextCIDR_ipv4DisallowedCIDR
=== RUN   TestAccIPAMScope_basic
=== PAUSE TestAccIPAMScope_basic
=== RUN   TestAccIPAMScope_tags
=== PAUSE TestAccIPAMScope_tags
=== RUN   TestAccIPAM_basic
=== PAUSE TestAccIPAM_basic
=== RUN   TestAccIPAM_modify
=== PAUSE TestAccIPAM_modify
=== RUN   TestAccIPAM_cascade
=== PAUSE TestAccIPAM_cascade
=== RUN   TestAccIPAM_tags
=== PAUSE TestAccIPAM_tags
=== CONT  TestAccIPAMPoolAllocation_ipv4Basic
=== CONT  TestAccIPAMPreviewNextCIDRDataSource_ipv4Allocated
=== CONT  TestAccIPAMPoolDataSource_basic
=== CONT  TestAccIPAMScope_tags
=== CONT  TestAccIPAMPreviewNextCIDR_ipv4Allocated
=== CONT  TestAccIPAMScope_basic
=== CONT  TestAccIPAMPreviewNextCIDR_ipv4Basic
=== CONT  TestAccIPAMPreviewNextCIDR_ipv4DisallowedCIDR
=== CONT  TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCIDR
=== CONT  TestAccIPAM_tags
=== CONT  TestAccIPAMPool_ipv6Basic
=== CONT  TestAccIPAMPoolCIDRsDataSource_basic
=== CONT  TestAccIPAMPool_tags
=== CONT  TestAccIPAMPoolAllocation_multiple
=== CONT  TestAccIPAM_cascade
=== CONT  TestAccIPAMPool_basic
=== CONT  TestAccIPAM_modify
=== CONT  TestAccIPAMPreviewNextCIDRDataSource_ipv4Basic
=== CONT  TestAccIPAM_basic
=== CONT  TestAccIPAMPoolAllocation_ipv4DisallowedCIDR
--- PASS: TestAccIPAMPoolDataSource_basic (130.09s)
=== CONT  TestAccIPAMPoolCIDR_basic
--- PASS: TestAccIPAM_cascade (138.66s)
=== CONT  TestAccIPAMPoolAllocation_ipv4BasicNetmask
--- PASS: TestAccIPAM_basic (144.41s)
--- PASS: TestAccIPAMPool_ipv6Basic (165.63s)
--- PASS: TestAccIPAMPreviewNextCIDR_ipv4DisallowedCIDR (179.31s)
--- PASS: TestAccIPAMPreviewNextCIDRDataSource_ipv4Basic (179.33s)
--- PASS: TestAccIPAMPreviewNextCIDRDataSource_ipv4DisallowedCIDR (189.37s)
--- PASS: TestAccIPAMPoolAllocation_ipv4DisallowedCIDR (189.38s)
--- PASS: TestAccIPAMPreviewNextCIDR_ipv4Basic (190.02s)
--- PASS: TestAccIPAMPoolAllocation_ipv4Basic (219.93s)
--- PASS: TestAccIPAMScope_basic (227.50s)
--- PASS: TestAccIPAMPoolAllocation_multiple (229.11s)
--- PASS: TestAccIPAMPool_basic (236.60s)
--- PASS: TestAccIPAMPreviewNextCIDR_ipv4Allocated (238.79s)
--- PASS: TestAccIPAM_tags (248.03s)
--- PASS: TestAccIPAMPreviewNextCIDRDataSource_ipv4Allocated (250.65s)
--- PASS: TestAccIPAMScope_tags (266.07s)
--- PASS: TestAccIPAMPoolCIDRsDataSource_basic (280.27s)
--- PASS: TestAccIPAMPoolAllocation_ipv4BasicNetmask (143.08s)
--- PASS: TestAccIPAMPoolCIDR_basic (155.11s)
--- PASS: TestAccIPAM_modify (288.15s)
--- PASS: TestAccIPAMPool_tags (289.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        293.558s
```

### Sweeper tests

I also ran tests locally to validate the new sweepers work:

run any ipam sweeper to delete the stack below:

example: `make sweep SWEEPARGS=-sweep-run=aws_vpc_ipam_pool` youll see ipam as `delete-in-progress` then shortly deleted everything

build:

```
module "basic" {
  source  = "aws-ia/ipam/aws"
#   source = "../.."

  top_cidr = ["10.0.0.0/8"]
  top_name = "basic ipam"

  pool_configurations = {
    corporate-us-west-2 = {
      description = "2nd level, locale us-west-2 pool"
      cidr        = ["10.0.0.0/16", "10.1.0.0/16"]

      sub_pools = {

        sandbox = {
          name                 = "mysandbox"
          cidr                 = ["10.0.0.0/20"]
        #   ram_share_principals = var.sandbox_ou_arn
          allocation_resource_tags = {
            env = "sandbox"
          }
        }
        dev = {
          cidr = ["10.1.0.0/20"]

          sub_pools = {
            team_a = {
              cidr                 = ["10.1.0.0/24"]
            #   ram_share_principals = var.prod_account # prod account
              locale               = "us-west-2"
            }

            team_b = {
              cidr                 = ["10.1.1.0/24"]
            #   ram_share_principals = var.prod_account # prod account
            }
          }
        }
        prod = {
          cidr   = ["10.1.16.0/20"]
          locale = "us-west-2"

          sub_pools = {
            team_a = {
              cidr                 = ["10.1.16.0/24"]
            #   ram_share_principals = var.prod_account # prod account
            }

            team_b = {
              cidr                 = ["10.1.17.0/24"]
            #   ram_share_principals = var.prod_account # prod account
            }
          }
        }
      }
    }
    us-east-1 = {
      cidr   = ["10.2.0.0/16"]
      locale = "us-east-1"

      sub_pools = {

        team_a = {
          cidr                 = ["10.2.0.0/20"]
        #   ram_share_principals = var.prod_ou_arn
        }

        team_b = {
          cidr                 = ["10.2.16.0/20"]
        #   ram_share_principals = var.prod_ou_arn
        }
      }
    }
  }
}

resource "aws_vpc" "name" {
  ipv4_ipam_pool_id = module.basic.pools_level_2["us-east-1/team_b"].id
  ipv4_netmask_length = 28
}

```