### PR TITLE
Change aws_cloudfront_origin_request_policy wording to match other policy docs

### DIFF
--- a/website/docs/d/cloudfront_origin_request_policy.html.markdown
+++ b/website/docs/d/cloudfront_origin_request_policy.html.markdown
@@ -28,6 +28,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
+In addition to all arguments above, the following attributes are exported:
+
 * `comment` - Comment to describe the origin request policy.
 * `cookies_config` - Object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
 * `etag` - Current version of the origin request policy.


### PR DESCRIPTION

### Description
Updates wording for [aws_cloudfront_cache_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_request_policy) to match other policies ([aws_cloudfront_cache_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) and [aws_cloudfront_response_headers_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_response_headers_policy)).


### Relations

Closes #27217 

