### PR TITLE
refactor: Move environment variable functions and constants to package

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
@@ -202,10 +203,10 @@ func PreCheck(t *testing.T) {
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderConfigure.Do(func() {
-		conns.FailIfAllEnvVarEmpty(t, []string{conns.EnvVarProfile, conns.EnvVarAccessKeyId, conns.EnvVarContainerCredentialsFullURI}, "credentials for running acceptance testing")
+		envvar.FailIfAllEnvVarEmpty(t, []string{envvar.EnvVarProfile, envvar.EnvVarAccessKeyId, envvar.EnvVarContainerCredentialsFullURI}, "credentials for running acceptance testing")
 
-		if os.Getenv(conns.EnvVarAccessKeyId) != "" {
-			conns.FailIfEnvVarEmpty(t, conns.EnvVarSecretAccessKey, "static credentials value when using "+conns.EnvVarAccessKeyId)
+		if os.Getenv(envvar.EnvVarAccessKeyId) != "" {
+			envvar.FailIfEnvVarEmpty(t, envvar.EnvVarSecretAccessKey, "static credentials value when using "+envvar.EnvVarAccessKeyId)
 		}
 
 		// Setting the AWS_DEFAULT_REGION environment variable here allows all tests to omit
@@ -216,7 +217,7 @@ func PreCheck(t *testing.T) {
 		//   * AWS_DEFAULT_REGION is required and checked above (should mention us-west-2 default)
 		//   * Region is automatically handled via shared AWS configuration file and still verified
 		region := Region()
-		os.Setenv(conns.EnvVarDefaultRegion, region)
+		os.Setenv(envvar.EnvVarDefaultRegion, region)
 
 		err := Provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 		if err != nil {
@@ -593,15 +594,15 @@ func AccountID() string {
 }
 
 func Region() string {
-	return conns.GetEnvVarWithDefault(conns.EnvVarDefaultRegion, endpoints.UsWest2RegionID)
+	return envvar.GetEnvVarWithDefault(envvar.EnvVarDefaultRegion, endpoints.UsWest2RegionID)
 }
 
 func AlternateRegion() string {
-	return conns.GetEnvVarWithDefault(conns.EnvVarAlternateRegion, endpoints.UsEast1RegionID)
+	return envvar.GetEnvVarWithDefault(envvar.EnvVarAlternateRegion, endpoints.UsEast1RegionID)
 }
 
 func ThirdRegion() string {
-	return conns.GetEnvVarWithDefault(conns.EnvVarThirdRegion, endpoints.UsEast2RegionID)
+	return envvar.GetEnvVarWithDefault(envvar.EnvVarThirdRegion, endpoints.UsEast2RegionID)
 }
 
 func Partition() string {
@@ -641,10 +642,10 @@ func thirdRegionPartition() string {
 }
 
 func PreCheckAlternateAccount(t *testing.T) {
-	conns.SkipIfAllEnvVarEmpty(t, []string{conns.EnvVarAlternateProfile, conns.EnvVarAlternateAccessKeyId}, "credentials for running acceptance testing in alternate AWS account")
+	envvar.SkipIfAllEnvVarEmpty(t, []string{envvar.EnvVarAlternateProfile, envvar.EnvVarAlternateAccessKeyId}, "credentials for running acceptance testing in alternate AWS account")
 
-	if os.Getenv(conns.EnvVarAlternateAccessKeyId) != "" {
-		conns.SkipIfEnvVarEmpty(t, conns.EnvVarAlternateSecretAccessKey, "static credentials value when using "+conns.EnvVarAlternateAccessKeyId)
+	if os.Getenv(envvar.EnvVarAlternateAccessKeyId) != "" {
+		envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarAlternateSecretAccessKey, "static credentials value when using "+envvar.EnvVarAlternateAccessKeyId)
 	}
 }
 
@@ -658,11 +659,11 @@ func PreCheckPartitionHasService(serviceId string, t *testing.T) {
 
 func PreCheckMultipleRegion(t *testing.T, regions int) {
 	if Region() == AlternateRegion() {
-		t.Fatalf("%s and %s must be set to different values for acceptance tests", conns.EnvVarDefaultRegion, conns.EnvVarAlternateRegion)
+		t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.EnvVarDefaultRegion, envvar.EnvVarAlternateRegion)
 	}
 
 	if Partition() != alternateRegionPartition() {
-		t.Fatalf("%s partition (%s) does not match %s partition (%s)", conns.EnvVarAlternateRegion, alternateRegionPartition(), conns.EnvVarDefaultRegion, Partition())
+		t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.EnvVarAlternateRegion, alternateRegionPartition(), envvar.EnvVarDefaultRegion, Partition())
 	}
 
 	if regions >= 3 {
@@ -671,15 +672,15 @@ func PreCheckMultipleRegion(t *testing.T, regions int) {
 		}
 
 		if Region() == ThirdRegion() {
-			t.Fatalf("%s and %s must be set to different values for acceptance tests", conns.EnvVarDefaultRegion, conns.EnvVarThirdRegion)
+			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.EnvVarDefaultRegion, envvar.EnvVarThirdRegion)
 		}
 
 		if AlternateRegion() == ThirdRegion() {
-			t.Fatalf("%s and %s must be set to different values for acceptance tests", conns.EnvVarAlternateRegion, conns.EnvVarThirdRegion)
+			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.EnvVarAlternateRegion, envvar.EnvVarThirdRegion)
 		}
 
 		if Partition() != thirdRegionPartition() {
-			t.Fatalf("%s partition (%s) does not match %s partition (%s)", conns.EnvVarThirdRegion, thirdRegionPartition(), conns.EnvVarDefaultRegion, Partition())
+			t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.EnvVarThirdRegion, thirdRegionPartition(), envvar.EnvVarDefaultRegion, Partition())
 		}
 	}
 
@@ -693,7 +694,7 @@ func PreCheckMultipleRegion(t *testing.T, regions int) {
 // PreCheckRegion checks that the test region is the specified region.
 func PreCheckRegion(t *testing.T, region string) {
 	if curr := Region(); curr != region {
-		t.Skipf("skipping tests; %s (%s) does not equal %s", conns.EnvVarDefaultRegion, curr, region)
+		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.EnvVarDefaultRegion, curr, region)
 	}
 }
 
@@ -701,7 +702,7 @@ func PreCheckRegion(t *testing.T, region string) {
 func PreCheckRegionNot(t *testing.T, regions ...string) {
 	for _, region := range regions {
 		if curr := Region(); curr == region {
-			t.Skipf("skipping tests; %s (%s) not supported", conns.EnvVarDefaultRegion, curr)
+			t.Skipf("skipping tests; %s (%s) not supported", envvar.EnvVarDefaultRegion, curr)
 		}
 	}
 }
@@ -709,7 +710,7 @@ func PreCheckRegionNot(t *testing.T, regions ...string) {
 // PreCheckAlternateRegionIs checks that the alternate test region is the specified region.
 func PreCheckAlternateRegionIs(t *testing.T, region string) {
 	if curr := AlternateRegion(); curr != region {
-		t.Skipf("skipping tests; %s (%s) does not equal %s", conns.EnvVarAlternateRegion, curr, region)
+		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.EnvVarAlternateRegion, curr, region)
 	}
 }
 
@@ -858,7 +859,7 @@ provider %[1]q {
   profile    = %[3]q
   secret_key = %[4]q
 }
-`, ProviderNameAlternate, os.Getenv(conns.EnvVarAlternateAccessKeyId), os.Getenv(conns.EnvVarAlternateProfile), os.Getenv(conns.EnvVarAlternateSecretAccessKey))
+`, ProviderNameAlternate, os.Getenv(envvar.EnvVarAlternateAccessKeyId), os.Getenv(envvar.EnvVarAlternateProfile), os.Getenv(envvar.EnvVarAlternateSecretAccessKey))
 }
 
 // Deprecated: Use ConfigMultipleRegionProvider instead
@@ -1230,7 +1231,7 @@ provider "aws" {
 }
 
 func PreCheckAssumeRoleARN(t *testing.T) {
-	conns.SkipIfEnvVarEmpty(t, conns.EnvVarAccAssumeRoleARN, "Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions")
+	envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarAccAssumeRoleARN, "Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions")
 }
 
 func ConfigAssumeRolePolicy(policy string) string {
@@ -1242,7 +1243,7 @@ provider "aws" {
     policy   = %q
   }
 }
-`, os.Getenv(conns.EnvVarAccAssumeRoleARN), policy)
+`, os.Getenv(envvar.EnvVarAccAssumeRoleARN), policy)
 }
 
 const testAccProviderConfigBase = `

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -203,10 +203,10 @@ func PreCheck(t *testing.T) {
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderConfigure.Do(func() {
-		envvar.FailIfAllEnvVarEmpty(t, []string{envvar.EnvVarProfile, envvar.EnvVarAccessKeyId, envvar.EnvVarContainerCredentialsFullURI}, "credentials for running acceptance testing")
+		envvar.FailIfAllEmpty(t, []string{envvar.Profile, envvar.AccessKeyId, envvar.ContainerCredentialsFullURI}, "credentials for running acceptance testing")
 
-		if os.Getenv(envvar.EnvVarAccessKeyId) != "" {
-			envvar.FailIfEnvVarEmpty(t, envvar.EnvVarSecretAccessKey, "static credentials value when using "+envvar.EnvVarAccessKeyId)
+		if os.Getenv(envvar.AccessKeyId) != "" {
+			envvar.FailIfEmpty(t, envvar.SecretAccessKey, "static credentials value when using "+envvar.AccessKeyId)
 		}
 
 		// Setting the AWS_DEFAULT_REGION environment variable here allows all tests to omit
@@ -217,7 +217,7 @@ func PreCheck(t *testing.T) {
 		//   * AWS_DEFAULT_REGION is required and checked above (should mention us-west-2 default)
 		//   * Region is automatically handled via shared AWS configuration file and still verified
 		region := Region()
-		os.Setenv(envvar.EnvVarDefaultRegion, region)
+		os.Setenv(envvar.DefaultRegion, region)
 
 		err := Provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 		if err != nil {
@@ -594,15 +594,15 @@ func AccountID() string {
 }
 
 func Region() string {
-	return envvar.GetEnvVarWithDefault(envvar.EnvVarDefaultRegion, endpoints.UsWest2RegionID)
+	return envvar.GetWithDefault(envvar.DefaultRegion, endpoints.UsWest2RegionID)
 }
 
 func AlternateRegion() string {
-	return envvar.GetEnvVarWithDefault(envvar.EnvVarAlternateRegion, endpoints.UsEast1RegionID)
+	return envvar.GetWithDefault(envvar.AlternateRegion, endpoints.UsEast1RegionID)
 }
 
 func ThirdRegion() string {
-	return envvar.GetEnvVarWithDefault(envvar.EnvVarThirdRegion, endpoints.UsEast2RegionID)
+	return envvar.GetWithDefault(envvar.ThirdRegion, endpoints.UsEast2RegionID)
 }
 
 func Partition() string {
@@ -642,10 +642,10 @@ func thirdRegionPartition() string {
 }
 
 func PreCheckAlternateAccount(t *testing.T) {
-	envvar.SkipIfAllEnvVarEmpty(t, []string{envvar.EnvVarAlternateProfile, envvar.EnvVarAlternateAccessKeyId}, "credentials for running acceptance testing in alternate AWS account")
+	envvar.SkipIfAllEmpty(t, []string{envvar.AlternateProfile, envvar.AlternateAccessKeyId}, "credentials for running acceptance testing in alternate AWS account")
 
-	if os.Getenv(envvar.EnvVarAlternateAccessKeyId) != "" {
-		envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarAlternateSecretAccessKey, "static credentials value when using "+envvar.EnvVarAlternateAccessKeyId)
+	if os.Getenv(envvar.AlternateAccessKeyId) != "" {
+		envvar.SkipIfEmpty(t, envvar.AlternateSecretAccessKey, "static credentials value when using "+envvar.AlternateAccessKeyId)
 	}
 }
 
@@ -659,11 +659,11 @@ func PreCheckPartitionHasService(serviceId string, t *testing.T) {
 
 func PreCheckMultipleRegion(t *testing.T, regions int) {
 	if Region() == AlternateRegion() {
-		t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.EnvVarDefaultRegion, envvar.EnvVarAlternateRegion)
+		t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.DefaultRegion, envvar.AlternateRegion)
 	}
 
 	if Partition() != alternateRegionPartition() {
-		t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.EnvVarAlternateRegion, alternateRegionPartition(), envvar.EnvVarDefaultRegion, Partition())
+		t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.AlternateRegion, alternateRegionPartition(), envvar.DefaultRegion, Partition())
 	}
 
 	if regions >= 3 {
@@ -672,15 +672,15 @@ func PreCheckMultipleRegion(t *testing.T, regions int) {
 		}
 
 		if Region() == ThirdRegion() {
-			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.EnvVarDefaultRegion, envvar.EnvVarThirdRegion)
+			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.DefaultRegion, envvar.ThirdRegion)
 		}
 
 		if AlternateRegion() == ThirdRegion() {
-			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.EnvVarAlternateRegion, envvar.EnvVarThirdRegion)
+			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.AlternateRegion, envvar.ThirdRegion)
 		}
 
 		if Partition() != thirdRegionPartition() {
-			t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.EnvVarThirdRegion, thirdRegionPartition(), envvar.EnvVarDefaultRegion, Partition())
+			t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.ThirdRegion, thirdRegionPartition(), envvar.DefaultRegion, Partition())
 		}
 	}
 
@@ -694,7 +694,7 @@ func PreCheckMultipleRegion(t *testing.T, regions int) {
 // PreCheckRegion checks that the test region is the specified region.
 func PreCheckRegion(t *testing.T, region string) {
 	if curr := Region(); curr != region {
-		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.EnvVarDefaultRegion, curr, region)
+		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.DefaultRegion, curr, region)
 	}
 }
 
@@ -702,7 +702,7 @@ func PreCheckRegion(t *testing.T, region string) {
 func PreCheckRegionNot(t *testing.T, regions ...string) {
 	for _, region := range regions {
 		if curr := Region(); curr == region {
-			t.Skipf("skipping tests; %s (%s) not supported", envvar.EnvVarDefaultRegion, curr)
+			t.Skipf("skipping tests; %s (%s) not supported", envvar.DefaultRegion, curr)
 		}
 	}
 }
@@ -710,7 +710,7 @@ func PreCheckRegionNot(t *testing.T, regions ...string) {
 // PreCheckAlternateRegionIs checks that the alternate test region is the specified region.
 func PreCheckAlternateRegionIs(t *testing.T, region string) {
 	if curr := AlternateRegion(); curr != region {
-		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.EnvVarAlternateRegion, curr, region)
+		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.AlternateRegion, curr, region)
 	}
 }
 
@@ -859,7 +859,7 @@ provider %[1]q {
   profile    = %[3]q
   secret_key = %[4]q
 }
-`, ProviderNameAlternate, os.Getenv(envvar.EnvVarAlternateAccessKeyId), os.Getenv(envvar.EnvVarAlternateProfile), os.Getenv(envvar.EnvVarAlternateSecretAccessKey))
+`, ProviderNameAlternate, os.Getenv(envvar.AlternateAccessKeyId), os.Getenv(envvar.AlternateProfile), os.Getenv(envvar.AlternateSecretAccessKey))
 }
 
 // Deprecated: Use ConfigMultipleRegionProvider instead
@@ -1231,7 +1231,7 @@ provider "aws" {
 }
 
 func PreCheckAssumeRoleARN(t *testing.T) {
-	envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarAccAssumeRoleARN, "Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions")
+	envvar.SkipIfEmpty(t, envvar.AccAssumeRoleARN, "Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions")
 }
 
 func ConfigAssumeRolePolicy(policy string) string {
@@ -1243,7 +1243,7 @@ provider "aws" {
     policy   = %q
   }
 }
-`, os.Getenv(envvar.EnvVarAccAssumeRoleARN), policy)
+`, os.Getenv(envvar.AccAssumeRoleARN), policy)
 }
 
 const testAccProviderConfigBase = `

--- a/internal/envvar/envvar.go
+++ b/internal/envvar/envvar.go
@@ -12,21 +12,21 @@ import (
 const (
 	// Default static credential identifier for tests (AWS Go SDK does not provide this as constant)
 	// See also AWS_SECRET_ACCESS_KEY and AWS_PROFILE
-	EnvVarAccessKeyId = "AWS_ACCESS_KEY_ID"
+	AccessKeyId = "AWS_ACCESS_KEY_ID"
 
 	// Container credentials endpoint
 	// See also AWS_ACCESS_KEY_ID and AWS_PROFILE
-	EnvVarContainerCredentialsFullURI = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
+	ContainerCredentialsFullURI = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
 
 	// Default AWS region for tests (AWS Go SDK does not provide this as constant)
-	EnvVarDefaultRegion = "AWS_DEFAULT_REGION"
+	DefaultRegion = "AWS_DEFAULT_REGION"
 
 	// Default AWS shared configuration profile for tests (AWS Go SDK does not provide this as constant)
-	EnvVarProfile = "AWS_PROFILE"
+	Profile = "AWS_PROFILE"
 
 	// Default static credential value for tests (AWS Go SDK does not provide this as constant)
 	// See also AWS_ACCESS_KEY_ID and AWS_PROFILE
-	EnvVarSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+	SecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 )
 
 // Custom environment variables used in the Terraform AWS Provider testing.
@@ -34,46 +34,46 @@ const (
 // of the Maintainers Guide: docs/MAINTAINING.md
 const (
 	// For tests using an alternate AWS account, the equivalent of AWS_ACCESS_KEY_ID for that account
-	EnvVarAlternateAccessKeyId = "AWS_ALTERNATE_ACCESS_KEY_ID"
+	AlternateAccessKeyId = "AWS_ALTERNATE_ACCESS_KEY_ID"
 
 	// For tests using an alternate AWS account, the equivalent of AWS_PROFILE for that account
-	EnvVarAlternateProfile = "AWS_ALTERNATE_PROFILE"
+	AlternateProfile = "AWS_ALTERNATE_PROFILE"
 
 	// For tests using an alternate AWS region, the equivalent of AWS_DEFAULT_REGION for that account
-	EnvVarAlternateRegion = "AWS_ALTERNATE_REGION"
+	AlternateRegion = "AWS_ALTERNATE_REGION"
 
 	// For tests using an alternate AWS account, the equivalent of AWS_SECRET_ACCESS_KEY for that account
-	EnvVarAlternateSecretAccessKey = "AWS_ALTERNATE_SECRET_ACCESS_KEY"
+	AlternateSecretAccessKey = "AWS_ALTERNATE_SECRET_ACCESS_KEY"
 
 	// For tests using a third AWS region, the equivalent of AWS_DEFAULT_REGION for that region
-	EnvVarThirdRegion = "AWS_THIRD_REGION"
+	ThirdRegion = "AWS_THIRD_REGION"
 
 	// For tests requiring GitHub permissions
-	EnvVarGithubToken = "GITHUB_TOKEN"
+	GithubToken = "GITHUB_TOKEN"
 
 	// For tests requiring restricted IAM permissions, an existing IAM Role to assume
 	// An inline assume role policy is then used to deny actions for the test
-	EnvVarAccAssumeRoleARN = "TF_ACC_ASSUME_ROLE_ARN"
+	AccAssumeRoleARN = "TF_ACC_ASSUME_ROLE_ARN"
 )
 
 // Custom environment variables used for assuming a role with resource sweepers
 const (
 	// The ARN of the IAM Role to assume
-	EnvVarAssumeRoleARN = "TF_AWS_ASSUME_ROLE_ARN"
+	AssumeRoleARN = "TF_AWS_ASSUME_ROLE_ARN"
 
 	// The duration in seconds the IAM role will be assumed.
 	// Defaults to 1 hour (3600) instead of the SDK default of 15 minutes.
-	EnvVarAssumeRoleDuration = "TF_AWS_ASSUME_ROLE_DURATION"
+	AssumeRoleDuration = "TF_AWS_ASSUME_ROLE_DURATION"
 
 	// An External ID to pass to the assumed role
-	EnvVarAssumeRoleExternalID = "TF_AWS_ASSUME_ROLE_EXTERNAL_ID"
+	AssumeRoleExternalID = "TF_AWS_ASSUME_ROLE_EXTERNAL_ID"
 
 	// A session name for the assumed role
-	EnvVarAssumeRoleSessionName = "TF_AWS_ASSUME_ROLE_SESSION_NAME"
+	AssumeRoleSessionName = "TF_AWS_ASSUME_ROLE_SESSION_NAME"
 )
 
-// GetEnvVarWithDefault gets an environment variable value if non-empty or returns the default.
-func GetEnvVarWithDefault(variable string, defaultValue string) string {
+// GetWithDefault gets an environment variable value if non-empty or returns the default.
+func GetWithDefault(variable string, defaultValue string) string {
 	value := os.Getenv(variable)
 
 	if value == "" {
@@ -83,10 +83,10 @@ func GetEnvVarWithDefault(variable string, defaultValue string) string {
 	return value
 }
 
-// RequireOneOfEnvVar verifies that at least one environment variable is non-empty or returns an error.
+// RequireOneOf verifies that at least one environment variable is non-empty or returns an error.
 //
 // If at least one environment variable is non-empty, returns the first name and value.
-func RequireOneOfEnvVar(names []string, usageMessage string) (string, string, error) {
+func RequireOneOf(names []string, usageMessage string) (string, string, error) {
 	for _, variable := range names {
 		value := os.Getenv(variable)
 
@@ -98,8 +98,8 @@ func RequireOneOfEnvVar(names []string, usageMessage string) (string, string, er
 	return "", "", fmt.Errorf("at least one environment variable of %v must be set. Usage: %s", names, usageMessage)
 }
 
-// RequireEnvVar verifies that an environment variable is non-empty or returns an error.
-func RequireEnvVar(name string, usageMessage string) (string, error) {
+// Require verifies that an environment variable is non-empty or returns an error.
+func Require(name string, usageMessage string) (string, error) {
 	value := os.Getenv(name)
 
 	if value == "" {
@@ -109,13 +109,13 @@ func RequireEnvVar(name string, usageMessage string) (string, error) {
 	return value, nil
 }
 
-// FailIfAllEnvVarEmpty verifies that at least one environment variable is non-empty or fails the test.
+// FailIfAllEmpty verifies that at least one environment variable is non-empty or fails the test.
 //
 // If at least one environment variable is non-empty, returns the first name and value.
-func FailIfAllEnvVarEmpty(t testing.T, names []string, usageMessage string) (string, string) {
+func FailIfAllEmpty(t testing.T, names []string, usageMessage string) (string, string) {
 	t.Helper()
 
-	name, value, err := RequireOneOfEnvVar(names, usageMessage)
+	name, value, err := RequireOneOf(names, usageMessage)
 	if err != nil {
 		t.Fatal(err)
 		return "", ""
@@ -124,10 +124,10 @@ func FailIfAllEnvVarEmpty(t testing.T, names []string, usageMessage string) (str
 	return name, value
 }
 
-// FailIfEnvVarEmpty verifies that an environment variable is non-empty or fails the test.
+// FailIfEmpty verifies that an environment variable is non-empty or fails the test.
 //
 // For acceptance tests, this function must be used outside PreCheck functions to set values for configurations.
-func FailIfEnvVarEmpty(t testing.T, name string, usageMessage string) string {
+func FailIfEmpty(t testing.T, name string, usageMessage string) string {
 	t.Helper()
 
 	value := os.Getenv(name)
@@ -139,10 +139,10 @@ func FailIfEnvVarEmpty(t testing.T, name string, usageMessage string) string {
 	return value
 }
 
-// SkipIfEnvVarEmpty verifies that an environment variable is non-empty or skips the test.
+// SkipIfEmpty verifies that an environment variable is non-empty or skips the test.
 //
 // For acceptance tests, this function must be used outside PreCheck functions to set values for configurations.
-func SkipIfEnvVarEmpty(t testing.T, name string, usageMessage string) string {
+func SkipIfEmpty(t testing.T, name string, usageMessage string) string {
 	t.Helper()
 
 	value := os.Getenv(name)
@@ -154,13 +154,13 @@ func SkipIfEnvVarEmpty(t testing.T, name string, usageMessage string) string {
 	return value
 }
 
-// SkipIfAllEnvVarEmpty verifies that at least one environment variable is non-empty or skips the test.
+// SkipIfAllEmpty verifies that at least one environment variable is non-empty or skips the test.
 //
 // If at least one environment variable is non-empty, returns the first name and value.
-func SkipIfAllEnvVarEmpty(t testing.T, names []string, usageMessage string) (string, string) {
+func SkipIfAllEmpty(t testing.T, names []string, usageMessage string) (string, string) {
 	t.Helper()
 
-	name, value, err := RequireOneOfEnvVar(names, usageMessage)
+	name, value, err := RequireOneOf(names, usageMessage)
 	if err != nil {
 		t.Skipf("skipping test because %s.", err)
 		return "", ""

--- a/internal/envvar/envvar.go
+++ b/internal/envvar/envvar.go
@@ -1,4 +1,4 @@
-package conns
+package envvar
 
 import (
 	"fmt"

--- a/internal/envvar/envvar_test.go
+++ b/internal/envvar/envvar_test.go
@@ -1,4 +1,4 @@
-package conns
+package envvar
 
 import (
 	"os"

--- a/internal/envvar/envvar_test.go
+++ b/internal/envvar/envvar_test.go
@@ -15,7 +15,7 @@ func TestGetWithDefault(t *testing.T) {
 
 		os.Unsetenv(envVar)
 
-		got := GetEnvVarWithDefault(envVar, want)
+		got := GetWithDefault(envVar, want)
 
 		if got != want {
 			t.Fatalf("expected %s, got %s", want, got)
@@ -28,7 +28,7 @@ func TestGetWithDefault(t *testing.T) {
 		os.Setenv(envVar, "")
 		defer os.Unsetenv(envVar)
 
-		got := GetEnvVarWithDefault(envVar, want)
+		got := GetWithDefault(envVar, want)
 
 		if got != want {
 			t.Fatalf("expected %s, got %s", want, got)
@@ -41,7 +41,7 @@ func TestGetWithDefault(t *testing.T) {
 		os.Setenv(envVar, want)
 		defer os.Unsetenv(envVar)
 
-		got := GetEnvVarWithDefault(envVar, "default")
+		got := GetWithDefault(envVar, "default")
 
 		if got != want {
 			t.Fatalf("expected %s, got %s", want, got)
@@ -59,7 +59,7 @@ func TestRequireOneOf(t *testing.T) {
 			os.Unsetenv(envVar)
 		}
 
-		_, _, err := RequireOneOfEnvVar(envVars, "usage")
+		_, _, err := RequireOneOf(envVars, "usage")
 
 		if err == nil {
 			t.Fatal("expected error")
@@ -71,7 +71,7 @@ func TestRequireOneOf(t *testing.T) {
 		os.Setenv(envVar2, "")
 		defer unsetEnvVars(envVars)
 
-		_, _, err := RequireOneOfEnvVar(envVars, "usage")
+		_, _, err := RequireOneOf(envVars, "usage")
 
 		if err == nil {
 			t.Fatal("expected error")
@@ -85,7 +85,7 @@ func TestRequireOneOf(t *testing.T) {
 		os.Setenv(envVar2, wantValue)
 		defer unsetEnvVars(envVars)
 
-		gotName, gotValue, err := RequireOneOfEnvVar(envVars, "usage")
+		gotName, gotValue, err := RequireOneOf(envVars, "usage")
 
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -107,7 +107,7 @@ func TestRequireOneOf(t *testing.T) {
 		os.Setenv(envVar2, "other")
 		defer unsetEnvVars(envVars)
 
-		gotName, gotValue, err := RequireOneOfEnvVar(envVars, "usage")
+		gotName, gotValue, err := RequireOneOf(envVars, "usage")
 
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -129,7 +129,7 @@ func TestRequire(t *testing.T) {
 	t.Run("missing", func(t *testing.T) {
 		os.Unsetenv(envVar)
 
-		_, err := RequireEnvVar(envVar, "usage")
+		_, err := Require(envVar, "usage")
 
 		if err == nil {
 			t.Fatal("expected error")
@@ -140,7 +140,7 @@ func TestRequire(t *testing.T) {
 		os.Setenv(envVar, "")
 		defer os.Unsetenv(envVar)
 
-		_, err := RequireEnvVar(envVar, "usage")
+		_, err := Require(envVar, "usage")
 
 		if err == nil {
 			t.Fatal("expected error")
@@ -153,7 +153,7 @@ func TestRequire(t *testing.T) {
 		os.Setenv(envVar, want)
 		defer os.Unsetenv(envVar)
 
-		got, err := RequireEnvVar(envVar, "usage")
+		got, err := Require(envVar, "usage")
 
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -177,7 +177,7 @@ func TestTestFailIfAllEmpty(t *testing.T) {
 			os.Unsetenv(envVar)
 		}
 
-		FailIfAllEnvVarEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+		FailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
 
 		t.Fatal("expected to fail previously")
 	})
@@ -189,7 +189,7 @@ func TestTestFailIfAllEmpty(t *testing.T) {
 		os.Setenv(envVar2, "")
 		defer unsetEnvVars(envVars)
 
-		FailIfAllEnvVarEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+		FailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
 
 		t.Fatal("expected to fail previously")
 	})
@@ -201,7 +201,7 @@ func TestTestFailIfAllEmpty(t *testing.T) {
 		os.Setenv(envVar2, wantValue)
 		defer unsetEnvVars(envVars)
 
-		gotName, gotValue := FailIfAllEnvVarEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+		gotName, gotValue := FailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
 
 		if gotName != envVar2 {
 			t.Fatalf("expected name: %s, got: %s", envVar2, gotName)
@@ -219,7 +219,7 @@ func TestTestFailIfAllEmpty(t *testing.T) {
 		os.Setenv(envVar2, "other")
 		defer unsetEnvVars(envVars)
 
-		gotName, gotValue := FailIfAllEnvVarEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+		gotName, gotValue := FailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
 
 		if gotName != envVar1 {
 			t.Fatalf("expected name: %s, got: %s", envVar1, gotName)
@@ -239,7 +239,7 @@ func TestTestFailIfEmpty(t *testing.T) {
 
 		os.Unsetenv(envVar)
 
-		FailIfEnvVarEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+		FailIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
 
 		t.Fatal("expected to fail previously")
 	})
@@ -250,7 +250,7 @@ func TestTestFailIfEmpty(t *testing.T) {
 		os.Setenv(envVar, "")
 		defer os.Unsetenv(envVar)
 
-		FailIfEnvVarEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+		FailIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
 
 		t.Fatal("expected to fail previously")
 	})
@@ -261,7 +261,7 @@ func TestTestFailIfEmpty(t *testing.T) {
 		os.Setenv(envVar, want)
 		defer os.Unsetenv(envVar)
 
-		got := FailIfEnvVarEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+		got := FailIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
 
 		if got != want {
 			t.Fatalf("expected value: %s, got: %s", want, got)
@@ -277,7 +277,7 @@ func TestTestSkipIfEmpty(t *testing.T) {
 
 		os.Unsetenv(envVar)
 
-		SkipIfEnvVarEmpty(mockT, envVar, "usage")
+		SkipIfEmpty(mockT, envVar, "usage")
 
 		if !mockT.Skipped() {
 			t.Fatal("expected to skip previously")
@@ -290,7 +290,7 @@ func TestTestSkipIfEmpty(t *testing.T) {
 		os.Setenv(envVar, "")
 		defer os.Unsetenv(envVar)
 
-		SkipIfEnvVarEmpty(mockT, envVar, "usage")
+		SkipIfEmpty(mockT, envVar, "usage")
 
 		if !mockT.Skipped() {
 			t.Fatal("expected to skip previously")
@@ -303,7 +303,7 @@ func TestTestSkipIfEmpty(t *testing.T) {
 		os.Setenv(envVar, want)
 		defer os.Unsetenv(envVar)
 
-		got := SkipIfEnvVarEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+		got := SkipIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
 
 		if got != want {
 			t.Fatalf("expected value: %s, got: %s", want, got)

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -476,7 +476,7 @@ func TestAccCodePipeline_withNamespace(t *testing.T) {
 }
 
 func TestAccCodePipeline_withGitHubV1SourceAction(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, "token with GitHub permissions to repository for CodePipeline source configuration")
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, "token with GitHub permissions to repository for CodePipeline source configuration")
 
 	var v codepipeline.PipelineDeclaration
 	name := sdkacctest.RandString(10)

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	tfcodepipeline "github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -475,7 +476,7 @@ func TestAccCodePipeline_withNamespace(t *testing.T) {
 }
 
 func TestAccCodePipeline_withGitHubV1SourceAction(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, "token with GitHub permissions to repository for CodePipeline source configuration")
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, "token with GitHub permissions to repository for CodePipeline source configuration")
 
 	var v codepipeline.PipelineDeclaration
 	name := sdkacctest.RandString(10)

--- a/internal/service/codepipeline/webhook_test.go
+++ b/internal/service/codepipeline/webhook_test.go
@@ -12,13 +12,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	tfcodepipeline "github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline"
 )
 
 const envVarGithubTokenUsageWebhook = "token with GitHub permissions to repository for CodePipeline webhook creation"
 
 func TestAccCodePipelineWebhook_basic(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -88,7 +89,7 @@ func TestAccCodePipelineWebhook_basic(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_ipAuth(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -123,7 +124,7 @@ func TestAccCodePipelineWebhook_ipAuth(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_unauthenticated(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -156,7 +157,7 @@ func TestAccCodePipelineWebhook_unauthenticated(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_tags(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
 
 	var v1, v2, v3 codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -220,7 +221,7 @@ func TestAccCodePipelineWebhook_tags(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_disappears(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -249,7 +250,7 @@ func TestAccCodePipelineWebhook_disappears(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_UpdateAuthentication_secretToken(t *testing.T) {
-	githubToken := conns.SkipIfEnvVarEmpty(t, conns.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
 
 	var v1, v2 codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/codepipeline/webhook_test.go
+++ b/internal/service/codepipeline/webhook_test.go
@@ -19,7 +19,7 @@ import (
 const envVarGithubTokenUsageWebhook = "token with GitHub permissions to repository for CodePipeline webhook creation"
 
 func TestAccCodePipelineWebhook_basic(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -89,7 +89,7 @@ func TestAccCodePipelineWebhook_basic(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_ipAuth(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -124,7 +124,7 @@ func TestAccCodePipelineWebhook_ipAuth(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_unauthenticated(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -157,7 +157,7 @@ func TestAccCodePipelineWebhook_unauthenticated(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_tags(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageWebhook)
 
 	var v1, v2, v3 codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -221,7 +221,7 @@ func TestAccCodePipelineWebhook_tags(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_disappears(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -250,7 +250,7 @@ func TestAccCodePipelineWebhook_disappears(t *testing.T) {
 }
 
 func TestAccCodePipelineWebhook_UpdateAuthentication_secretToken(t *testing.T) {
-	githubToken := envvar.SkipIfEnvVarEmpty(t, envvar.EnvVarGithubToken, envVarGithubTokenUsageWebhook)
+	githubToken := envvar.SkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageWebhook)
 
 	var v1, v2 codepipeline.ListWebhookItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
@@ -9,7 +9,7 @@ import (
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 )
 
 func testAccTransitGatewayPeeringAttachmentAccepter_basic(t *testing.T) {
@@ -152,7 +152,7 @@ provider %[1]q {
   region     = %[4]q
   secret_key = %[5]q
 }
-`, acctest.ProviderNameAlternate, os.Getenv(conns.EnvVarAlternateAccessKeyId), os.Getenv(conns.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(conns.EnvVarAlternateSecretAccessKey))
+`, acctest.ProviderNameAlternate, os.Getenv(envvar.EnvVarAlternateAccessKeyId), os.Getenv(envvar.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.EnvVarAlternateSecretAccessKey))
 }
 
 func testAccTransitGatewayPeeringAttachmentAccepterConfig_base(rName string) string {

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
@@ -152,7 +152,7 @@ provider %[1]q {
   region     = %[4]q
   secret_key = %[5]q
 }
-`, acctest.ProviderNameAlternate, os.Getenv(envvar.EnvVarAlternateAccessKeyId), os.Getenv(envvar.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.EnvVarAlternateSecretAccessKey))
+`, acctest.ProviderNameAlternate, os.Getenv(envvar.AlternateAccessKeyId), os.Getenv(envvar.AlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.AlternateSecretAccessKey))
 }
 
 func testAccTransitGatewayPeeringAttachmentAccepterConfig_base(rName string) string {

--- a/internal/service/macie2/invitation_accepter_test.go
+++ b/internal/service/macie2/invitation_accepter_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 )
 
 func testAccInvitationAccepter_basic(t *testing.T) {
 	resourceName := "aws_macie2_invitation_accepter.member"
-	email := conns.SkipIfEnvVarEmpty(t, EnvVarPrincipalEmail, EnvVarPrincipalEmailMessageError)
+	email := envvar.SkipIfEnvVarEmpty(t, envVarPrincipalEmail, envVarPrincipalEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/macie2/invitation_accepter_test.go
+++ b/internal/service/macie2/invitation_accepter_test.go
@@ -16,7 +16,7 @@ import (
 
 func testAccInvitationAccepter_basic(t *testing.T) {
 	resourceName := "aws_macie2_invitation_accepter.member"
-	email := envvar.SkipIfEnvVarEmpty(t, envVarPrincipalEmail, envVarPrincipalEmailMessageError)
+	email := envvar.SkipIfEmpty(t, envVarPrincipalEmail, envVarPrincipalEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/macie2/member_test.go
+++ b/internal/service/macie2/member_test.go
@@ -89,7 +89,7 @@ func testAccMember_disappears(t *testing.T) {
 func testAccMember_invitationDisableEmailNotification(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
-	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
+	email := envvar.SkipIfEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -130,7 +130,7 @@ func testAccMember_invite(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
+	email := envvar.SkipIfEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -184,7 +184,7 @@ func testAccMember_inviteRemoved(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
+	email := envvar.SkipIfEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -238,7 +238,7 @@ func testAccMember_status(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
+	email := envvar.SkipIfEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/macie2/member_test.go
+++ b/internal/service/macie2/member_test.go
@@ -11,15 +11,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	tfmacie2 "github.com/hashicorp/terraform-provider-aws/internal/service/macie2"
 )
 
 const (
-	EnvVarPrincipalEmail             = "AWS_MACIE2_ACCOUNT_EMAIL"
-	EnvVarAlternateEmail             = "AWS_MACIE2_ALTERNATE_ACCOUNT_EMAIL"
-	EnvVarPrincipalEmailMessageError = "Environment variable AWS_MACIE2_ACCOUNT_EMAIL is not set. " +
+	envVarPrincipalEmail             = "AWS_MACIE2_ACCOUNT_EMAIL"
+	envVarAlternateEmail             = "AWS_MACIE2_ALTERNATE_ACCOUNT_EMAIL"
+	envVarPrincipalEmailMessageError = "Environment variable AWS_MACIE2_ACCOUNT_EMAIL is not set. " +
 		"To properly test inviting Macie member account must be provided."
-	EnvVarAlternateEmailMessageError = "Environment variable AWS_MACIE2_ALTERNATE_ACCOUNT_EMAIL is not set. " +
+	envVarAlternateEmailMessageError = "Environment variable AWS_MACIE2_ALTERNATE_ACCOUNT_EMAIL is not set. " +
 		"To properly test inviting Macie member account must be provided."
 )
 
@@ -88,7 +89,7 @@ func testAccMember_disappears(t *testing.T) {
 func testAccMember_invitationDisableEmailNotification(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
-	email := conns.SkipIfEnvVarEmpty(t, EnvVarAlternateEmail, EnvVarAlternateEmailMessageError)
+	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -129,7 +130,7 @@ func testAccMember_invite(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := conns.SkipIfEnvVarEmpty(t, EnvVarAlternateEmail, EnvVarAlternateEmailMessageError)
+	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -183,7 +184,7 @@ func testAccMember_inviteRemoved(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := conns.SkipIfEnvVarEmpty(t, EnvVarAlternateEmail, EnvVarAlternateEmailMessageError)
+	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -237,7 +238,7 @@ func testAccMember_status(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := conns.SkipIfEnvVarEmpty(t, EnvVarAlternateEmail, EnvVarAlternateEmailMessageError)
+	email := envvar.SkipIfEnvVarEmpty(t, envVarAlternateEmail, envVarAlternateEmailMessageError)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -6674,7 +6674,7 @@ provider "awsalternateaccountsameregion" {
 provider "awssameaccountalternateregion" {
   region = %[3]q
 }
-`, os.Getenv(envvar.EnvVarAlternateAccessKeyId), os.Getenv(envvar.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.EnvVarAlternateSecretAccessKey))
+`, os.Getenv(envvar.AlternateAccessKeyId), os.Getenv(envvar.AlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.AlternateSecretAccessKey))
 }
 
 func testAccInstanceConfig_ReplicateSourceDB_DBSubnetGroupName_ramShared(rName string) string {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	tfrds "github.com/hashicorp/terraform-provider-aws/internal/service/rds"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -6673,7 +6674,7 @@ provider "awsalternateaccountsameregion" {
 provider "awssameaccountalternateregion" {
   region = %[3]q
 }
-`, os.Getenv(conns.EnvVarAlternateAccessKeyId), os.Getenv(conns.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(conns.EnvVarAlternateSecretAccessKey))
+`, os.Getenv(envvar.EnvVarAlternateAccessKeyId), os.Getenv(envvar.EnvVarAlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.EnvVarAlternateSecretAccessKey))
 }
 
 func testAccInstanceConfig_ReplicateSourceDB_DBSubnetGroupName_ramShared(rName string) string {

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -45,13 +46,13 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 		return client, nil
 	}
 
-	_, _, err := conns.RequireOneOfEnvVar([]string{conns.EnvVarProfile, conns.EnvVarAccessKeyId, conns.EnvVarContainerCredentialsFullURI}, "credentials for running sweepers")
+	_, _, err := envvar.RequireOneOfEnvVar([]string{envvar.EnvVarProfile, envvar.EnvVarAccessKeyId, envvar.EnvVarContainerCredentialsFullURI}, "credentials for running sweepers")
 	if err != nil {
 		return nil, err
 	}
 
-	if os.Getenv(conns.EnvVarAccessKeyId) != "" {
-		_, err := conns.RequireEnvVar(conns.EnvVarSecretAccessKey, "static credentials value when using "+conns.EnvVarAccessKeyId)
+	if os.Getenv(envvar.EnvVarAccessKeyId) != "" {
+		_, err := envvar.RequireEnvVar(envvar.EnvVarSecretAccessKey, "static credentials value when using "+envvar.EnvVarAccessKeyId)
 		if err != nil {
 			return nil, err
 		}
@@ -63,23 +64,23 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 		SuppressDebugLog: true,
 	}
 
-	if role := os.Getenv(conns.EnvVarAssumeRoleARN); role != "" {
+	if role := os.Getenv(envvar.EnvVarAssumeRoleARN); role != "" {
 		conf.AssumeRole.RoleARN = role
 
 		conf.AssumeRole.Duration = time.Duration(defaultSweeperAssumeRoleDurationSeconds) * time.Second
-		if v := os.Getenv(conns.EnvVarAssumeRoleDuration); v != "" {
+		if v := os.Getenv(envvar.EnvVarAssumeRoleDuration); v != "" {
 			d, err := strconv.Atoi(v)
 			if err != nil {
-				return nil, fmt.Errorf("environment variable %s: %w", conns.EnvVarAssumeRoleDuration, err)
+				return nil, fmt.Errorf("environment variable %s: %w", envvar.EnvVarAssumeRoleDuration, err)
 			}
 			conf.AssumeRole.Duration = time.Duration(d) * time.Second
 		}
 
-		if v := os.Getenv(conns.EnvVarAssumeRoleExternalID); v != "" {
+		if v := os.Getenv(envvar.EnvVarAssumeRoleExternalID); v != "" {
 			conf.AssumeRole.ExternalID = v
 		}
 
-		if v := os.Getenv(conns.EnvVarAssumeRoleSessionName); v != "" {
+		if v := os.Getenv(envvar.EnvVarAssumeRoleSessionName); v != "" {
 			conf.AssumeRole.SessionName = v
 		}
 	}

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -46,13 +46,13 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 		return client, nil
 	}
 
-	_, _, err := envvar.RequireOneOfEnvVar([]string{envvar.EnvVarProfile, envvar.EnvVarAccessKeyId, envvar.EnvVarContainerCredentialsFullURI}, "credentials for running sweepers")
+	_, _, err := envvar.RequireOneOf([]string{envvar.Profile, envvar.AccessKeyId, envvar.ContainerCredentialsFullURI}, "credentials for running sweepers")
 	if err != nil {
 		return nil, err
 	}
 
-	if os.Getenv(envvar.EnvVarAccessKeyId) != "" {
-		_, err := envvar.RequireEnvVar(envvar.EnvVarSecretAccessKey, "static credentials value when using "+envvar.EnvVarAccessKeyId)
+	if os.Getenv(envvar.AccessKeyId) != "" {
+		_, err := envvar.Require(envvar.SecretAccessKey, "static credentials value when using "+envvar.AccessKeyId)
 		if err != nil {
 			return nil, err
 		}
@@ -64,23 +64,23 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 		SuppressDebugLog: true,
 	}
 
-	if role := os.Getenv(envvar.EnvVarAssumeRoleARN); role != "" {
+	if role := os.Getenv(envvar.AssumeRoleARN); role != "" {
 		conf.AssumeRole.RoleARN = role
 
 		conf.AssumeRole.Duration = time.Duration(defaultSweeperAssumeRoleDurationSeconds) * time.Second
-		if v := os.Getenv(envvar.EnvVarAssumeRoleDuration); v != "" {
+		if v := os.Getenv(envvar.AssumeRoleDuration); v != "" {
 			d, err := strconv.Atoi(v)
 			if err != nil {
-				return nil, fmt.Errorf("environment variable %s: %w", envvar.EnvVarAssumeRoleDuration, err)
+				return nil, fmt.Errorf("environment variable %s: %w", envvar.AssumeRoleDuration, err)
 			}
 			conf.AssumeRole.Duration = time.Duration(d) * time.Second
 		}
 
-		if v := os.Getenv(envvar.EnvVarAssumeRoleExternalID); v != "" {
+		if v := os.Getenv(envvar.AssumeRoleExternalID); v != "" {
 			conf.AssumeRole.ExternalID = v
 		}
 
-		if v := os.Getenv(envvar.EnvVarAssumeRoleSessionName); v != "" {
+		if v := os.Getenv(envvar.AssumeRoleSessionName); v != "" {
 			conf.AssumeRole.SessionName = v
 		}
 	}


### PR DESCRIPTION
Since the environment variable handling code is only used in acceptance tests and sweeping, they should not be in the `conns` package.

This is one step in breaking the dependency of all acceptance tests on the entire non-test codebase.