### PR TITLE
Use proper name for networking term Statmux

### DIFF
--- a/.changelog/27223.txt
+++ b/.changelog/27223.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_medialive_multiplex_program: Add ability to update `multiplex_program_settings` in place
+```
+
+```release-note:note
+resource/aws_medialive_multiplex_program: The `statemux_settings` argument has been deprecated. Use the `statmux_settings` argument instead
+```

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/experimental/intf"
 	"github.com/hashicorp/terraform-provider-aws/internal/fwtypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -349,6 +350,10 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 // the Metadata method. All resources must have unique names.
 func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	var resources []func() resource.Resource
+
+	resources = append(resources, func() resource.Resource {
+		return medialive.NewResourceMultiplexProgram(ctx)
+	})
 
 	for _, sp := range p.Primary.Meta().(*conns.AWSClient).ServicePackages {
 		for _, v := range sp.FrameworkResources(ctx) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2187,7 +2187,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 		// ServicePackageData is used before configuration to determine the provider's exported resources and data sources.
 		ServicePackages: []intf.ServicePackageData{
 			globalaccelerator.ServicePackageData,
-			medialive.ServicePackageData,
+			//medialive.ServicePackageData,
 			meta.ServicePackageData,
 			simpledb.ServicePackageData,
 			sts.ServicePackageData,

--- a/internal/service/medialive/medialive_test.go
+++ b/internal/service/medialive/medialive_test.go
@@ -15,6 +15,7 @@ func TestAccMediaLive_serial(t *testing.T) {
 		},
 		"MultiplexProgram": {
 			"basic":      testAccMultiplexProgram_basic,
+			"update":     testAccMultiplex_update,
 			"disappears": testAccMultiplexProgram_disappears,
 		},
 	}

--- a/internal/service/medialive/medialive_test.go
+++ b/internal/service/medialive/medialive_test.go
@@ -15,7 +15,7 @@ func TestAccMediaLive_serial(t *testing.T) {
 		},
 		"MultiplexProgram": {
 			"basic":      testAccMultiplexProgram_basic,
-			"update":     testAccMultiplex_update,
+			"update":     testAccMultiplexProgram_update,
 			"disappears": testAccMultiplexProgram_disappears,
 		},
 	}

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -116,7 +116,7 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 							},
 						},
 						Blocks: map[string]tfsdk.Block{
-							"statemux_settings": {
+							"statmux_settings": {
 								NestingMode: tfsdk.BlockNestingModeList,
 								MaxItems:    1,
 								Attributes: map[string]tfsdk.Attribute{

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -78,9 +78,6 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 				NestingMode: tfsdk.BlockNestingModeList,
 				MinItems:    1,
 				MaxItems:    1,
-				//PlanModifiers: tfsdk.AttributePlanModifiers{
-				//	resource.RequiresReplace(),
-				//},
 				Attributes: map[string]tfsdk.Attribute{
 					"program_number": {
 						Type:     types.Int64Type,

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -131,6 +131,16 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 										PlanModifiers: []tfsdk.AttributePlanModifier{
 											resource.UseStateForUnknown(),
 										},
+										//Validators: []tfsdk.AttributeValidator{
+										//	schemavalidator.ConflictsWith(
+										//		path.Expressions{path.MatchRelative().AtParent().
+										//			AtListIndex(0).AtName("video_settings").
+										//			AtListIndex(0).AtName("statmux_settings").AtListIndex(0).AtName("minimum_bitrate")}...),
+										//},
+										//Validators: []tfsdk.AttributeValidator{
+										//	schemavalidator.ConflictsWith(
+										//		path.Expressions{path.MatchRelative().AtParent().AtParent().AtParent().Resolve().AtName("statmux_settings")}...),
+										//},
 									},
 									"maximum_bitrate": {
 										Type:     types.Int64Type,
@@ -139,6 +149,12 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 										PlanModifiers: []tfsdk.AttributePlanModifier{
 											resource.UseStateForUnknown(),
 										},
+										//Validators: []tfsdk.AttributeValidator{
+										//	schemavalidator.ConflictsWith(
+										//		path.Expressions{path.MatchRoot("multiplex_program_settings").
+										//			AtListIndex(0).AtName("video_settings").
+										//			AtListIndex(0).AtName("statmux_settings").AtListIndex(0).AtName("maximum_bitrate")}...),
+										//},
 									},
 									"priority": {
 										Type:     types.Int64Type,
@@ -147,14 +163,14 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 										PlanModifiers: []tfsdk.AttributePlanModifier{
 											resource.UseStateForUnknown(),
 										},
+										//Validators: []tfsdk.AttributeValidator{
+										//	schemavalidator.ConflictsWith(
+										//		path.Expressions{path.MatchRoot("multiplex_program_settings").
+										//			AtListIndex(0).AtName("video_settings").
+										//			AtListIndex(0).AtName("statmux_settings").AtListIndex(0).AtName("priority_bitrate")}...),
+										//},
 									},
 								},
-								//Validators: []tfsdk.AttributeValidator{
-								//	schemavalidator.ConflictsWith(
-								//		path.Expressions{path.MatchRoot("multiplex_program_settings").
-								//			AtListIndex(0).AtName("video_settings").
-								//			AtListIndex(0).AtName("statmux_settings").Resolve()}...),
-								//},
 							},
 							"statmux_settings": {
 								NestingMode: tfsdk.BlockNestingModeList,
@@ -167,6 +183,12 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 										PlanModifiers: []tfsdk.AttributePlanModifier{
 											resource.UseStateForUnknown(),
 										},
+										//Validators: []tfsdk.AttributeValidator{
+										//	schemavalidator.ConflictsWith(
+										//		path.Expressions{path.MatchRoot("multiplex_program_settings").
+										//			AtAnyListIndex().AtName("video_settings").
+										//			AtAnyListIndex().AtName("statemux_settings").AtAnyListIndex().AtName("minimum_bitrate")}...),
+										//},
 									},
 									"maximum_bitrate": {
 										Type:     types.Int64Type,
@@ -643,6 +665,9 @@ func flattenVideoSettings(mps *mltypes.MultiplexVideoSettings, stateMuxIsNull bo
 		}
 		attrs["statemux_settings"] = flattenStatMuxSettings(mps.StatmuxSettings)
 	}
+
+	//attrs["statmux_settings"] = flattenStatMuxSettings(mps.StatmuxSettings)
+	//attrs["statemux_settings"] = flattenStatMuxSettings(mps.StatmuxSettings)
 
 	vals.Attrs = attrs
 

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -150,18 +150,15 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 									},
 								},
 								//Validators: []tfsdk.AttributeValidator{
-								//	schemavalidator.ExactlyOneOf(
+								//	schemavalidator.ConflictsWith(
 								//		path.Expressions{path.MatchRoot("multiplex_program_settings").
 								//			AtListIndex(0).AtName("video_settings").
-								//			AtListIndex(0).AtName("statmux_settings").AtListIndex(0)}...),
+								//			AtListIndex(0).AtName("statmux_settings").Resolve()}...),
 								//},
 							},
 							"statmux_settings": {
 								NestingMode: tfsdk.BlockNestingModeList,
 								MaxItems:    1,
-								PlanModifiers: []tfsdk.AttributePlanModifier{
-									resource.UseStateForUnknown(),
-								},
 								Attributes: map[string]tfsdk.Attribute{
 									"minimum_bitrate": {
 										Type:     types.Int64Type,

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -275,7 +275,7 @@ func (m *multiplexProgram) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	out, err := FindMultipleProgramByID(ctx, conn, multiplexId, programName)
+	out, err := FindMultiplexProgramByID(ctx, conn, multiplexId, programName)
 
 	if tfresource.NotFound(err) {
 		diag.NewWarningDiagnostic(
@@ -370,7 +370,7 @@ func (m *multiplexProgram) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	//Need to find multiplex program because output from update does not provide state data
-	out, errUpdate := FindMultipleProgramByID(ctx, conn, multiplexId, programName)
+	out, errUpdate := FindMultiplexProgramByID(ctx, conn, multiplexId, programName)
 
 	if errUpdate != nil {
 		resp.Diagnostics.AddError(
@@ -460,7 +460,7 @@ func (m *multiplexProgram) ValidateConfig(ctx context.Context, req resource.Vali
 	}
 }
 
-func FindMultipleProgramByID(ctx context.Context, conn *medialive.Client, multiplexId, programName string) (*medialive.DescribeMultiplexProgramOutput, error) {
+func FindMultiplexProgramByID(ctx context.Context, conn *medialive.Client, multiplexId, programName string) (*medialive.DescribeMultiplexProgramOutput, error) {
 	in := &medialive.DescribeMultiplexProgramInput{
 		MultiplexId: aws.String(multiplexId),
 		ProgramName: aws.String(programName),

--- a/internal/service/medialive/multiplex_program_test.go
+++ b/internal/service/medialive/multiplex_program_test.go
@@ -103,6 +103,50 @@ func testAccMultiplexProgram_basic(t *testing.T) {
 	})
 }
 
+func testAccMultiplexProgram_update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiplexprogram medialive.DescribeMultiplexProgramOutput
+	rName := fmt.Sprintf("tf_acc_%s", sdkacctest.RandString(8))
+	resourceName := "aws_medialive_multiplex_program.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiplexProgramDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiplexProgramConfig_update(rName, 100000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiplexProgramExists(resourceName, &multiplexprogram),
+					resource.TestCheckResourceAttr(resourceName, "program_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "multiplex_id"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.program_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.preferred_channel_pipeline", "CURRENTLY_ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.video_settings.0.statmux_settings.0.minimum_bitrate", "100000"),
+				),
+			},
+			{
+				Config: testAccMultiplexProgramConfig_update(rName, 100001),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiplexProgramExists(resourceName, &multiplexprogram),
+					resource.TestCheckResourceAttr(resourceName, "program_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "multiplex_id"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.program_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.preferred_channel_pipeline", "CURRENTLY_ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "multiplex_program_settings.0.video_settings.0.statmux_settings.0.minimum_bitrate", "100001"),
+				),
+			},
+		},
+	})
+}
+
 func testAccMultiplexProgram_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -210,6 +254,7 @@ resource "aws_medialive_multiplex" "test" {
 }
 `, rName))
 }
+
 func testAccMultiplexProgramConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccMultiplexProgramBaseConfig(rName),
@@ -228,4 +273,26 @@ resource "aws_medialive_multiplex_program" "test" {
   }
 }
 `, rName))
+}
+
+func testAccMultiplexProgramConfig_update(rName string, minBitrate int) string {
+	return acctest.ConfigCompose(
+		testAccMultiplexProgramBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_medialive_multiplex_program" "test" {
+  program_name = %[1]q
+  multiplex_id = aws_medialive_multiplex.test.id
+
+  multiplex_program_settings {
+    program_number             = 1
+    preferred_channel_pipeline = "CURRENTLY_ACTIVE"
+
+    video_settings {
+      statmux_settings {
+        minimum_bitrate = %[2]d
+      }
+    }
+  }
+}
+`, rName, minBitrate))
 }

--- a/internal/service/medialive/multiplex_program_test.go
+++ b/internal/service/medialive/multiplex_program_test.go
@@ -188,7 +188,7 @@ func testAccCheckMultiplexProgramDestroy(s *terraform.State) error {
 
 		attributes := rs.Primary.Attributes
 
-		_, err := tfmedialive.FindMultipleProgramByID(ctx, conn, attributes["multiplex_id"], attributes["program_name"])
+		_, err := tfmedialive.FindMultiplexProgramByID(ctx, conn, attributes["multiplex_id"], attributes["program_name"])
 
 		if tfresource.NotFound(err) {
 			continue
@@ -221,7 +221,7 @@ func testAccCheckMultiplexProgramExists(name string, multiplexprogram *medialive
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveConn
 		ctx := context.Background()
-		resp, err := tfmedialive.FindMultipleProgramByID(ctx, conn, multiplexId, programName)
+		resp, err := tfmedialive.FindMultiplexProgramByID(ctx, conn, multiplexId, programName)
 
 		if err != nil {
 			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameMultiplexProgram, rs.Primary.ID, err)

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -77,9 +77,14 @@ The following arguments are optional:
 ### Video Settings
 
 `constant_bitrate` - (Optional) Constant bitrate value.
-`statemux_settings` - (Optional) Statemux settings. See [Statemux Settings](#statemux-settings) for more details.
+`statmux_settings` - (Optional) Statmux settings. See [Statmux Settings](#statmux-settings) for more details.
 
+<<<<<<< HEAD
 ### Statemux Settings
+=======
+
+### Statmux Settings
+>>>>>>> 2e089fee39 (Use proper name for networking term Statmux)
 
 * `minimum_bitrate` - (Optional) Minimum bitrate.
 * `maximum_bitrate` - (Optional) Maximum bitrate.

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform resource for managing an AWS MediaLive MultiplexProgram.
 
+~> **Note** Attribute `statemux_settings` has been deprecated and will be removed in a future major release. Please use `statmux_settings` instead.
+
 ## Example Usage
 
 ### Basic Usage
@@ -77,18 +79,21 @@ The following arguments are optional:
 ### Video Settings
 
 `constant_bitrate` - (Optional) Constant bitrate value.
-`statmux_settings` - (Optional) Statmux settings. See [Statmux Settings](#statmux-settings) for more details.
-
-<<<<<<< HEAD
-### Statemux Settings
-=======
+`statemux_settings` - (Optional, **Deprecated**) Statemux settings. See [Statmux Settings](#statemux-settings) for more details. Conflicts with `statmux_settings`.
+`statmux_settings` - (Optional) Statmux settings. See [Statmux Settings](#statmux-settings) for more details Conflicts with `statemux_settings`.
 
 ### Statmux Settings
->>>>>>> 2e089fee39 (Use proper name for networking term Statmux)
 
 * `minimum_bitrate` - (Optional) Minimum bitrate.
 * `maximum_bitrate` - (Optional) Maximum bitrate.
 * `priority` - (Optional) Priority value.
+
+### Statemux Settings
+
+* `minimum_bitrate` - (Optional) Minimum bitrate.
+* `maximum_bitrate` - (Optional) Maximum bitrate.
+* `priority` - (Optional) Priority value.
+
 
 ## Attributes Reference
 

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -79,7 +79,7 @@ The following arguments are optional:
 ### Video Settings
 
 `constant_bitrate` - (Optional) Constant bitrate value.
-`statemux_settings` - (Optional, **Deprecated**) Statemux settings. See [Statmux Settings](#statemux-settings) for more details. Conflicts with `statmux_settings`.
+`statemux_settings` - (Optional, **Deprecated**) Statemux settings. See [Statmux Settings](#statemux-settings) for more details. Settings from this attribute will apply to `statmux_settings`. Conflicts with `statmux_settings`.
 `statmux_settings` - (Optional) Statmux settings. See [Statmux Settings](#statmux-settings) for more details Conflicts with `statemux_settings`.
 
 ### Statmux Settings

--- a/website/docs/r/medialive_multiplex_program.html.markdown
+++ b/website/docs/r/medialive_multiplex_program.html.markdown
@@ -94,7 +94,6 @@ The following arguments are optional:
 * `maximum_bitrate` - (Optional) Maximum bitrate.
 * `priority` - (Optional) Priority value.
 
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Statmux is a shortened name for Statistical Multiplexing


<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Rename code references from `statemux` and `Statemux` to `statmux` and `Statmux` respectively.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #4936

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
See: 
- https://en.wikipedia.org/wiki/Statistical_time-division_multiplexing
- https://aws.amazon.com/medialive/features/statmux/
### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccMediaLive_serial PKG=medialive

...
```
