### PR TITLE
r/aws_ssm_service_setting: fix panic on empty result

### DIFF
--- a/.changelog/27232.txt
+++ b/.changelog/27232.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_service_setting: Prevent panic during status read
+```

--- a/internal/service/ssm/find.go
+++ b/internal/service/ssm/find.go
@@ -87,9 +87,9 @@ func FindPatchGroup(conn *ssm.SSM, patchGroup, baselineId string) (*ssm.PatchGro
 	return result, err
 }
 
-func FindServiceSettingByARN(conn *ssm.SSM, arn string) (*ssm.ServiceSetting, error) {
+func FindServiceSettingByID(conn *ssm.SSM, id string) (*ssm.ServiceSetting, error) {
 	input := &ssm.GetServiceSettingInput{
-		SettingId: aws.String(arn),
+		SettingId: aws.String(id),
 	}
 
 	output, err := conn.GetServiceSetting(input)

--- a/internal/service/ssm/find.go
+++ b/internal/service/ssm/find.go
@@ -99,7 +99,7 @@ func FindServiceSettingByARN(conn *ssm.SSM, arn string) (*ssm.ServiceSetting, er
 	}
 
 	if output == nil || output.ServiceSetting == nil {
-		return nil, fmt.Errorf("finding %s: empty result", arn)
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.ServiceSetting, nil

--- a/internal/service/ssm/find.go
+++ b/internal/service/ssm/find.go
@@ -94,6 +94,13 @@ func FindServiceSettingByID(conn *ssm.SSM, id string) (*ssm.ServiceSetting, erro
 
 	output, err := conn.GetServiceSetting(input)
 
+	if tfawserr.ErrCodeContains(err, ssm.ErrCodeServiceSettingNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/ssm/service_setting.go
+++ b/internal/service/ssm/service_setting.go
@@ -74,7 +74,7 @@ func resourceServiceSettingRead(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Reading SSM Activation: %s", d.Id())
 
-	output, err := FindServiceSettingByARN(conn, d.Id())
+	output, err := FindServiceSettingByID(conn, d.Id())
 	if err != nil {
 		return create.Error(names.SSM, create.ErrActionReading, ResNameServiceSetting, d.Id(), err)
 	}

--- a/internal/service/ssm/service_setting_test.go
+++ b/internal/service/ssm/service_setting_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -57,26 +57,35 @@ func testAccServiceSettingDestroy(s *terraform.State) error {
 			continue
 		}
 
-		output, err := conn.GetServiceSetting(&ssm.GetServiceSettingInput{
-			SettingId: aws.String(rs.Primary.Attributes["setting_id"]),
-		})
-		_, ok := err.(awserr.Error)
-		if !ok {
+		output, err := tfssm.FindServiceSettingByID(conn, rs.Primary.Attributes["setting_id"])
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
 			return err
 		}
-		if output.ServiceSetting.Status != aws.String("default") {
-			return create.Error(names.SSM, create.ErrActionCheckingDestroyed, tfssm.ResNameServiceSetting, rs.Primary.Attributes["setting_id"], err)
+
+		if aws.StringValue(output.Status) == "Default" {
+			continue
 		}
+
+		return create.Error(names.SSM, create.ErrActionCheckingDestroyed, tfssm.ResNameServiceSetting, rs.Primary.Attributes["setting_id"], err)
 	}
 
 	return nil
 }
 
-func testAccServiceSettingExists(n string, res *ssm.ServiceSetting) resource.TestCheckFunc {
+func testAccServiceSettingExists(n string, v *ssm.ServiceSetting) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SSM Service Setting ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SSMConn
@@ -87,7 +96,7 @@ func testAccServiceSettingExists(n string, res *ssm.ServiceSetting) resource.Tes
 			return create.Error(names.SSM, create.ErrActionReading, tfssm.ResNameServiceSetting, rs.Primary.Attributes["setting_id"], err)
 		}
 
-		*res = *output
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/ssm/service_setting_test.go
+++ b/internal/service/ssm/service_setting_test.go
@@ -81,7 +81,7 @@ func testAccServiceSettingExists(n string, res *ssm.ServiceSetting) resource.Tes
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SSMConn
 
-		output, err := tfssm.FindServiceSettingByARN(conn, rs.Primary.Attributes["setting_id"])
+		output, err := tfssm.FindServiceSettingByID(conn, rs.Primary.Attributes["setting_id"])
 
 		if err != nil {
 			return create.Error(names.SSM, create.ErrActionReading, tfssm.ResNameServiceSetting, rs.Primary.Attributes["setting_id"], err)

--- a/internal/service/ssm/status.go
+++ b/internal/service/ssm/status.go
@@ -58,6 +58,10 @@ func statusServiceSetting(conn *ssm.SSM, arn string) resource.StateRefreshFunc {
 			return nil, "", nil
 		}
 
+		if err != nil {
+			return nil, "", err
+		}
+
 		return output, aws.StringValue(output.Status), nil
 	}
 }

--- a/internal/service/ssm/status.go
+++ b/internal/service/ssm/status.go
@@ -50,9 +50,9 @@ func statusDocument(conn *ssm.SSM, name string) resource.StateRefreshFunc {
 	}
 }
 
-func statusServiceSetting(conn *ssm.SSM, arn string) resource.StateRefreshFunc {
+func statusServiceSetting(conn *ssm.SSM, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindServiceSettingByARN(conn, arn)
+		output, err := FindServiceSettingByID(conn, id)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/ssm/wait.go
+++ b/internal/service/ssm/wait.go
@@ -71,11 +71,11 @@ func waitDocumentActive(conn *ssm.SSM, name string) (*ssm.DocumentDescription, e
 	return nil, err
 }
 
-func waitServiceSettingUpdated(conn *ssm.SSM, arn string, timeout time.Duration) (*ssm.ServiceSetting, error) {
+func waitServiceSettingUpdated(conn *ssm.SSM, id string, timeout time.Duration) (*ssm.ServiceSetting, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PendingUpdate", ""},
 		Target:  []string{"Customized", "Default"},
-		Refresh: statusServiceSetting(conn, arn),
+		Refresh: statusServiceSetting(conn, id),
 		Timeout: timeout,
 	}
 
@@ -88,11 +88,11 @@ func waitServiceSettingUpdated(conn *ssm.SSM, arn string, timeout time.Duration)
 	return nil, err
 }
 
-func waitServiceSettingReset(conn *ssm.SSM, arn string, timeout time.Duration) error {
+func waitServiceSettingReset(conn *ssm.SSM, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Customized", "PendingUpdate", ""},
 		Target:  []string{"Default"},
-		Refresh: statusServiceSetting(conn, arn),
+		Refresh: statusServiceSetting(conn, id),
 		Timeout: timeout,
 	}
 


### PR DESCRIPTION
### Description

This PR fixes a panic happening on an empty service setting status result.

### Relations
Closes #27225.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccSSMServiceSetting_' PKG=ssm 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMServiceSetting_ -timeout 180m
=== RUN   TestAccSSMServiceSetting_basic
=== PAUSE TestAccSSMServiceSetting_basic
=== CONT  TestAccSSMServiceSetting_basic
--- PASS: TestAccSSMServiceSetting_basic (51.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        52.976s
```
