### PR TITLE
Private Registry Access for Lightsail container services

### DIFF
--- a/.changelog/27236.txt
+++ b/.changelog/27236.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lightsail_container_service: Add `private_registry_access` argument
+```

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -234,7 +234,7 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 	if err := d.Set("public_domain_names", flattenContainerServicePublicDomainNames(cs.PublicDomainNames)); err != nil {
 		return diag.Errorf("error setting public_domain_names for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
-	if err := d.Set("private_registry_access", flattenPrivateRegistryAccess(cs.PrivateRegistryAccess)); err != nil {
+	if err := d.Set("private_registry_access", []interface{}{flattenPrivateRegistryAccess(cs.PrivateRegistryAccess)}); err != nil {
 		return diag.Errorf("error setting private_registry_access for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 	d.Set("arn", cs.Arn)
@@ -389,7 +389,7 @@ func flattenPrivateRegistryAccess(apiObject *lightsail.PrivateRegistryAccess) ma
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.EcrImagePullerRole; v != nil {
-		tfMap["ecr_image_puller_role"] = flattenEcrImagePullerRole(v)
+		tfMap["ecr_image_puller_role"] = []interface{}{flattenEcrImagePullerRole(v)}
 	}
 
 	return tfMap

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -128,6 +128,10 @@ func ResourceContainerService() *schema.Resource {
 										Type:     schema.TypeBool,
 										Optional: true,
 									},
+									"principal_arn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 								},
 							},
 						},
@@ -407,6 +411,10 @@ func flattenECRImagePullerRole(apiObject *lightsail.ContainerServiceECRImagePull
 
 	if v := apiObject.IsActive; v != nil {
 		tfMap["is_active"] = aws.BoolValue(v)
+	}
+
+	if v := apiObject.PrincipalArn; v != nil {
+		tfMap["principal_arn"] = aws.StringValue(v)
 	}
 
 	return tfMap

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -364,13 +364,13 @@ func expandPrivateRegistryAccess(tfMap map[string]interface{}) *lightsail.Privat
 	apiObject := &lightsail.PrivateRegistryAccessRequest{}
 
 	if v, ok := tfMap["ecr_image_puller_role"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.EcrImagePullerRole = expandEcrImagePullerRole(v[0].(map[string]interface{}))
+		apiObject.EcrImagePullerRole = expandECRImagePullerRole(v[0].(map[string]interface{}))
 	}
 
 	return apiObject
 }
 
-func expandEcrImagePullerRole(tfMap map[string]interface{}) *lightsail.ContainerServiceECRImagePullerRoleRequest {
+func expandECRImagePullerRole(tfMap map[string]interface{}) *lightsail.ContainerServiceECRImagePullerRoleRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -392,13 +392,13 @@ func flattenPrivateRegistryAccess(apiObject *lightsail.PrivateRegistryAccess) ma
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.EcrImagePullerRole; v != nil {
-		tfMap["ecr_image_puller_role"] = []interface{}{flattenEcrImagePullerRole(v)}
+		tfMap["ecr_image_puller_role"] = []interface{}{flattenECRImagePullerRole(v)}
 	}
 
 	return tfMap
 }
 
-func flattenEcrImagePullerRole(apiObject *lightsail.ContainerServiceECRImagePullerRole) map[string]interface{} {
+func flattenECRImagePullerRole(apiObject *lightsail.ContainerServiceECRImagePullerRole) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -360,8 +360,8 @@ func expandPrivateRegistryAccess(tfMap map[string]interface{}) *lightsail.Privat
 
 	apiObject := &lightsail.PrivateRegistryAccessRequest{}
 
-	if v, ok := tfMap["ecr_image_puller_role"]; ok {
-		apiObject.EcrImagePullerRole = expandEcrImagePullerRole(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := tfMap["ecr_image_puller_role"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		apiObject.EcrImagePullerRole = expandEcrImagePullerRole(v[0].(map[string]interface{}))
 	}
 
 	return apiObject

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -113,17 +113,20 @@ func ResourceContainerService() *schema.Resource {
 			"private_registry_access": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ecr_image_puller_role": {
-							Type:     schema.TypeSet,
-							Required: true,
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"is_active": {
 										Type:     schema.TypeBool,
-										Required: true,
+										Optional: true,
 									},
 								},
 							},

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -110,6 +110,27 @@ func ResourceContainerService() *schema.Resource {
 					},
 				},
 			},
+			"private_registry_access": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ecr_image_puller_role": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"is_active": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"resource_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -147,6 +168,10 @@ func resourceContainerServiceCreate(ctx context.Context, d *schema.ResourceData,
 
 	if v, ok := d.GetOk("public_domain_names"); ok {
 		input.PublicDomainNames = expandContainerServicePublicDomainNames(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("private_registry_access"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.PrivateRegistryAccess = expandPrivateRegistryAccess(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if len(tags) > 0 {
@@ -208,6 +233,9 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 
 	if err := d.Set("public_domain_names", flattenContainerServicePublicDomainNames(cs.PublicDomainNames)); err != nil {
 		return diag.Errorf("error setting public_domain_names for Lightsail Container Service (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("private_registry_access", flattenPrivateRegistryAccess(cs.PrivateRegistryAccess)); err != nil {
+		return diag.Errorf("error setting private_registry_access for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 	d.Set("arn", cs.Arn)
 	d.Set("availability_zone", cs.Location.AvailabilityZone)
@@ -323,6 +351,62 @@ func expandContainerServicePublicDomainNames(rawPublicDomainNames []interface{})
 	}
 
 	return resultMap
+}
+
+func expandPrivateRegistryAccess(tfMap map[string]interface{}) *lightsail.PrivateRegistryAccessRequest {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &lightsail.PrivateRegistryAccessRequest{}
+
+	if v, ok := tfMap["ecr_image_puller_role"]; ok {
+		apiObject.EcrImagePullerRole = expandEcrImagePullerRole(v.([]interface{})[0].(map[string]interface{}))
+	}
+
+	return apiObject
+}
+
+func expandEcrImagePullerRole(tfMap map[string]interface{}) *lightsail.ContainerServiceECRImagePullerRoleRequest {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &lightsail.ContainerServiceECRImagePullerRoleRequest{}
+
+	if v, ok := tfMap["is_active"].(bool); ok {
+		apiObject.IsActive = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
+func flattenPrivateRegistryAccess(apiObject *lightsail.PrivateRegistryAccess) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.EcrImagePullerRole; v != nil {
+		tfMap["ecr_image_puller_role"] = flattenEcrImagePullerRole(v)
+	}
+
+	return tfMap
+}
+
+func flattenEcrImagePullerRole(apiObject *lightsail.ContainerServiceECRImagePullerRole) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.IsActive; v != nil {
+		tfMap["is_active"] = aws.BoolValue(v)
+	}
+
+	return tfMap
 }
 
 func flattenContainerServicePublicDomainNames(domainNames map[string][]*string) []interface{} {

--- a/internal/service/lightsail/container_service_test.go
+++ b/internal/service/lightsail/container_service_test.go
@@ -230,6 +230,7 @@ func TestAccLightsailContainerService_PrivateRegistryAccess(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "private_registry_access.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "private_registry_access.0.ecr_image_puller_role.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "private_registry_access.0.ecr_image_puller_role.0.is_active", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_registry_access.0.ecr_image_puller_role.0.principal_arn"),
 				),
 			},
 		},

--- a/internal/service/lightsail/container_service_test.go
+++ b/internal/service/lightsail/container_service_test.go
@@ -227,9 +227,9 @@ func TestAccLightsailContainerService_PrivateRegistryAccess(t *testing.T) {
 				Config: testAccContainerServiceConfig_privateRegistryAccess(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerServiceExists(resourceName),
-					resource.TestCheckResourceAttr(rName, "private_registry_access.#", "1"),
-					resource.TestCheckResourceAttr(rName, "private_registry_access.0.ecr_image_puller_role.#", "1"),
-					resource.TestCheckResourceAttr(rName, "private_registry_access.0.ecr_image_puller_role.0.is_active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "private_registry_access.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "private_registry_access.0.ecr_image_puller_role.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "private_registry_access.0.ecr_image_puller_role.0.is_active", "true"),
 				),
 			},
 		},

--- a/internal/service/lightsail/container_service_test.go
+++ b/internal/service/lightsail/container_service_test.go
@@ -189,7 +189,7 @@ func TestAccLightsailContainerService_Power(t *testing.T) {
 }
 
 func TestAccLightsailContainerService_PublicDomainNames(t *testing.T) {
-	resourceName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -202,7 +202,7 @@ func TestAccLightsailContainerService_PublicDomainNames(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerServiceConfig_publicDomainNames(resourceName),
+				Config:      testAccContainerServiceConfig_publicDomainNames(rName),
 				ExpectError: regexp.MustCompile(`do not exist`),
 			},
 		},
@@ -210,7 +210,8 @@ func TestAccLightsailContainerService_PublicDomainNames(t *testing.T) {
 }
 
 func TestAccLightsailContainerService_PrivateRegistryAccess(t *testing.T) {
-	resourceName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_container_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -223,14 +224,13 @@ func TestAccLightsailContainerService_PrivateRegistryAccess(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerServiceConfig_privateRegistryAccess(resourceName),
+				Config: testAccContainerServiceConfig_privateRegistryAccess(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "private_registry_access.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "private_registry_access.0.ecr_image_puller_role.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "private_registry_access.0.ecr_image_puller_role.0.is_active", "true"),
+					resource.TestCheckResourceAttr(rName, "private_registry_access.#", "1"),
+					resource.TestCheckResourceAttr(rName, "private_registry_access.0.ecr_image_puller_role.#", "1"),
+					resource.TestCheckResourceAttr(rName, "private_registry_access.0.ecr_image_puller_role.0.is_active", "true"),
 				),
-				ExpectError: regexp.MustCompile(`do not exist`),
 			},
 		},
 	})
@@ -395,7 +395,6 @@ resource "aws_lightsail_container_service" "test" {
   name  = %q
   power = "nano"
   scale = 1
-
   public_domain_names {
     certificate {
       certificate_name = "NonExsitingCertificate"
@@ -413,7 +412,7 @@ func testAccContainerServiceConfig_privateRegistryAccess(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lightsail_container_service" "test" {
   name  = %q
-  power = "nano"
+  power = "micro"
   scale = 1
 
   private_registry_access {
@@ -441,7 +440,6 @@ resource "aws_lightsail_container_service" "test" {
   name  = %[1]q
   power = "nano"
   scale = 1
-
   tags = {
     %[2]q = %[3]q
   }
@@ -455,7 +453,6 @@ resource "aws_lightsail_container_service" "test" {
   name  = %q
   power = "nano"
   scale = 1
-
   tags = {
     %[2]q = %[3]q
     %[4]q = %[5]q

--- a/website/docs/r/lightsail_container_service.html.markdown
+++ b/website/docs/r/lightsail_container_service.html.markdown
@@ -55,6 +55,20 @@ resource "aws_lightsail_container_service" "my_container_service" {
 }
 ```
 
+### Private Registry Access
+
+```terraform
+resource "aws_lightsail_container_service" "my_container_service" {
+  # ... other configuration ...
+
+  private_registry_access {
+    ecr_image_puller_role {
+      is_active = true
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 ~> **NOTE:** You must create and validate an SSL/TLS certificate before you can use `public_domain_names` with your
@@ -76,10 +90,24 @@ The following arguments are supported:
   specify are used when you create a deployment with a container configured as the public endpoint of your container
   service. If you don't specify public domain names, then you can use the default domain of the container service.
   Defined below.
+* `private_registry_access` - (Optional) An object to describe the configuration for the container service to access private container image repositories, such as Amazon Elastic Container Registry (Amazon ECR) private repositories. See [Private Registry Access](#private-registry-access) below for more details.
 * `tags` - (Optional) Map of container service tags. To tag at launch, specify the tags in the Launch Template. If
   configured with a provider
   [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block)
   present, tags with matching keys will overwrite those defined at the provider-level.
+
+
+### Private Registry Access
+
+The `private_registry_access` block supports the following arguments:
+
+* `ecr_image_puller_role` - (Optional) Describes a request to configure an Amazon Lightsail container service to access private container image repositories, such as Amazon Elastic Container Registry (Amazon ECR) private repositories. See [ECR Image Puller Role](#ecr-image-puller-role) below for more details.
+
+### ECR Image Puller Role
+
+The `ecr_image_puller_role` blocks supports the following arguments:
+
+* `is_active` - (Optional) A Boolean value that indicates whether to activate the role. The default is `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/lightsail_container_service.html.markdown
+++ b/website/docs/r/lightsail_container_service.html.markdown
@@ -96,7 +96,6 @@ The following arguments are supported:
   [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block)
   present, tags with matching keys will overwrite those defined at the provider-level.
 
-
 ### Private Registry Access
 
 The `private_registry_access` block supports the following arguments:

--- a/website/docs/r/lightsail_container_service.html.markdown
+++ b/website/docs/r/lightsail_container_service.html.markdown
@@ -58,7 +58,7 @@ resource "aws_lightsail_container_service" "my_container_service" {
 ### Private Registry Access
 
 ```terraform
-resource "aws_lightsail_container_service" "my_container_service" {
+resource "aws_lightsail_container_service" "default" {
   # ... other configuration ...
 
   private_registry_access {
@@ -66,6 +66,29 @@ resource "aws_lightsail_container_service" "my_container_service" {
       is_active = true
     }
   }
+}
+
+resource "aws_ecr_repository_policy" "default" {
+  repository = aws_ecr_repository.default.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowLightsailPull",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_lightsail_container_service.default.private_registry_access[0].ecr_image_puller_role[0].principal_arn}"
+      },
+      "Action": [
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ]
+    }
+  ]
+}
+EOF
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds Private Registry Access, see tagged issue for more information.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27201

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccLightsailContainerService_ PKG=lightsail 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailContainerService_'  -timeout 180m
=== RUN   TestAccLightsailContainerService_basic
=== PAUSE TestAccLightsailContainerService_basic
=== RUN   TestAccLightsailContainerService_disappears
=== PAUSE TestAccLightsailContainerService_disappears
=== RUN   TestAccLightsailContainerService_Name
=== PAUSE TestAccLightsailContainerService_Name
=== RUN   TestAccLightsailContainerService_IsDisabled
=== PAUSE TestAccLightsailContainerService_IsDisabled
=== RUN   TestAccLightsailContainerService_Power
=== PAUSE TestAccLightsailContainerService_Power
=== RUN   TestAccLightsailContainerService_PublicDomainNames
=== PAUSE TestAccLightsailContainerService_PublicDomainNames
=== RUN   TestAccLightsailContainerService_PrivateRegistryAccess
=== PAUSE TestAccLightsailContainerService_PrivateRegistryAccess
=== RUN   TestAccLightsailContainerService_Scale
=== PAUSE TestAccLightsailContainerService_Scale
=== RUN   TestAccLightsailContainerService_tags
=== PAUSE TestAccLightsailContainerService_tags
=== CONT  TestAccLightsailContainerService_basic
=== CONT  TestAccLightsailContainerService_PublicDomainNames
=== CONT  TestAccLightsailContainerService_Scale
=== CONT  TestAccLightsailContainerService_tags
=== CONT  TestAccLightsailContainerService_PrivateRegistryAccess
=== CONT  TestAccLightsailContainerService_IsDisabled
=== CONT  TestAccLightsailContainerService_Power
=== CONT  TestAccLightsailContainerService_Name
=== CONT  TestAccLightsailContainerService_disappears
--- PASS: TestAccLightsailContainerService_PublicDomainNames (13.47s)
--- PASS: TestAccLightsailContainerService_PrivateRegistryAccess (79.05s)
--- PASS: TestAccLightsailContainerService_disappears (94.44s)
--- PASS: TestAccLightsailContainerService_Scale (120.85s)
--- PASS: TestAccLightsailContainerService_basic (135.28s)
--- PASS: TestAccLightsailContainerService_tags (141.43s)
--- PASS: TestAccLightsailContainerService_Power (171.34s)
--- PASS: TestAccLightsailContainerService_IsDisabled (229.41s)
--- PASS: TestAccLightsailContainerService_Name (245.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  247.315s
```
