### PR TITLE
Update CloudFront documentation to implement use of preferred `aws_cloudfront_origin_access_control` for S3 access.

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -252,7 +252,7 @@ of several sub-resources - these resources are laid out below.
     one).
 
 * `web_acl_id` (Optional) - A unique identifier that specifies the AWS WAF web ACL,
-    if any, to associate with this distribution.  
+    if any, to associate with this distribution.
     To specify a web ACL created using the latest version of AWS WAF (WAFv2), use the ACL ARN,
     for example `aws_wafv2_web_acl.example.arn`. To specify a web
     ACL created using AWS WAF Classic, use the ACL ID, for example `aws_waf_web_acl.example.id`.
@@ -315,7 +315,7 @@ of several sub-resources - these resources are laid out below.
 
 * `realtime_log_config_arn` (Optional) - The ARN of the [real-time log configuration](cloudfront_realtime_log_config.html)
     that is attached to this cache behavior.
-  
+
 * `response_headers_policy_id` (Optional) - The identifier for a response headers policy.
 
 * `smooth_streaming` (Optional) - Indicates whether you want to distribute
@@ -464,7 +464,7 @@ argument should not be specified.
 
 * `custom_origin_config` - The [CloudFront custom
     origin](#custom-origin-config-arguments) configuration information. If an S3
-    origin is required, use `s3_origin_config` instead.
+    origin is required, use `origin_access_control_id` or `s3_origin_config` instead.
 
 * `domain_name` (Required) - The DNS domain name of either the S3 bucket, or
     web site of your custom origin.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -473,7 +473,7 @@ argument should not be specified.
     `value` parameters that specify header data that will be sent to the origin
     (multiples allowed).
 
-* `origin_access_control_id` (Optional) - The unique identifier of an origin access control for this origin.
+* `origin_access_control_id` (Optional) - The unique identifier of a [CloudFront origin access control][8] for this origin.
 
 * `origin_id` (Required) - A unique identifier for the origin.
 
@@ -513,8 +513,7 @@ argument should not be specified.
 
 ##### S3 Origin Config Arguments
 
-* `origin_access_identity` (Optional) - The [CloudFront origin access
-  identity][5] to associate with the origin.
+* `origin_access_identity` (Required) - The [CloudFront origin access identity][5] to associate with the origin.
 
 #### Origin Group Arguments
 
@@ -631,6 +630,7 @@ In addition to all arguments above, the following attributes are exported:
 [5]: /docs/providers/aws/r/cloudfront_origin_access_identity.html
 [6]: https://aws.amazon.com/certificate-manager/
 [7]: http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html
+[8]: /docs/providers/aws/r/cloudfront_origin_access_control.html
 
 ## Import
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -44,12 +44,9 @@ locals {
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
-    origin_id   = locals.s3_origin_id
-
-    s3_origin_config {
-      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
-    }
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = locals.s3_origin_id
   }
 
   enabled             = true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

AWS have updated CloudFront with [Origin Access Controls (OAC)](https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/) which now are considered a better option vs the previous origin access identity (OAI) method.

This PR updates the documentation/example for CloudFront to better reflect this use.

It also makes it clear that an `origin {}` block can contain one of `origin_access_control_id`, `s3_origin_config` (legacy OAI) or `custom_origin_config`.
