### PR TITLE
Organizations Bugfix, handle missing policy when reading policy attachment

### DIFF
--- a/.changelog/27238.txt
+++ b/.changelog/27238.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_organizations_policy_attachment: Handle missing policy when reading policy attachment
+```

--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -61,7 +61,7 @@ func TestAccOrganizations_serial(t *testing.T) {
 			"Account":            testAccPolicyAttachment_Account,
 			"OrganizationalUnit": testAccPolicyAttachment_OrganizationalUnit,
 			"Root":               testAccPolicyAttachment_Root,
-			"BUG27231":           testAccPolicyAttachment_BUG27231,
+			"disappears":         testAccPolicyAttachment_disappears,
 		},
 		"DelegatedAdministrator": {
 			"basic":      testAccDelegatedAdministrator_basic,

--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -61,6 +61,7 @@ func TestAccOrganizations_serial(t *testing.T) {
 			"Account":            testAccPolicyAttachment_Account,
 			"OrganizationalUnit": testAccPolicyAttachment_OrganizationalUnit,
 			"Root":               testAccPolicyAttachment_Root,
+			"BUG27231":           testAccPolicyAttachment_BUG27231,
 		},
 		"DelegatedAdministrator": {
 			"basic":      testAccDelegatedAdministrator_basic,

--- a/internal/service/organizations/policy_attachment.go
+++ b/internal/service/organizations/policy_attachment.go
@@ -110,6 +110,11 @@ func resourcePolicyAttachmentRead(d *schema.ResourceData, meta interface{}) erro
 			d.SetId("")
 			return nil
 		}
+		if tfawserr.ErrCodeEquals(err, organizations.ErrCodePolicyNotFoundException) {
+			log.Printf("[WARN] Policy does not exist, removing from state: %s", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/internal/service/organizations/policy_attachment.go
+++ b/internal/service/organizations/policy_attachment.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -20,6 +19,7 @@ func ResourcePolicyAttachment() *schema.Resource {
 		Create: resourcePolicyAttachmentCreate,
 		Read:   resourcePolicyAttachmentRead,
 		Delete: resourcePolicyAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -44,37 +44,21 @@ func resourcePolicyAttachmentCreate(d *schema.ResourceData, meta interface{}) er
 
 	policyID := d.Get("policy_id").(string)
 	targetID := d.Get("target_id").(string)
-
+	id := fmt.Sprintf("%s:%s", targetID, policyID)
 	input := &organizations.AttachPolicyInput{
 		PolicyId: aws.String(policyID),
 		TargetId: aws.String(targetID),
 	}
 
-	log.Printf("[DEBUG] Creating Organizations Policy Attachment: %s", input)
-
-	err := resource.Retry(4*time.Minute, func() *resource.RetryError {
-		_, err := conn.AttachPolicy(input)
-
-		if err != nil {
-			if tfawserr.ErrCodeEquals(err, organizations.ErrCodeFinalizingOrganizationException) {
-				log.Printf("[DEBUG] Trying to create policy attachment again: %q", err.Error())
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		_, err = conn.AttachPolicy(input)
-	}
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(4*time.Minute, func() (interface{}, error) {
+		return conn.AttachPolicy(input)
+	}, organizations.ErrCodeFinalizingOrganizationException)
 
 	if err != nil {
-		return fmt.Errorf("error creating Organizations Policy Attachment: %s", err)
+		return fmt.Errorf("creating Organizations Policy Attachment (%s): %w", id, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s:%s", targetID, policyID))
+	d.SetId(id)
 
 	return resourcePolicyAttachmentRead(d, meta)
 }
@@ -87,45 +71,21 @@ func resourcePolicyAttachmentRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	input := &organizations.ListTargetsForPolicyInput{
-		PolicyId: aws.String(policyID),
-	}
+	_, err = FindPolicyAttachmentByTwoPartKey(conn, targetID, policyID)
 
-	log.Printf("[DEBUG] Listing Organizations Policies for Target: %s", input)
-	var output *organizations.PolicyTargetSummary
-
-	err = conn.ListTargetsForPolicyPages(input, func(page *organizations.ListTargetsForPolicyOutput, lastPage bool) bool {
-		for _, policySummary := range page.Targets {
-			if aws.StringValue(policySummary.TargetId) == targetID {
-				output = policySummary
-				return true
-			}
-		}
-		return !lastPage
-	})
-
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, organizations.ErrCodeTargetNotFoundException) {
-			log.Printf("[WARN] Target does not exist, removing from state: %s", d.Id())
-			d.SetId("")
-			return nil
-		}
-		if tfawserr.ErrCodeEquals(err, organizations.ErrCodePolicyNotFoundException) {
-			log.Printf("[WARN] Policy does not exist, removing from state: %s", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
-	}
-
-	if output == nil {
-		log.Printf("[WARN] Attachment does not exist, removing from state: %s", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Organizations Policy Attachment %s not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
+	if err != nil {
+		return fmt.Errorf("reading Organizations Policy Attachment (%s): %w", d.Id(), err)
+	}
+
 	d.Set("policy_id", policyID)
 	d.Set("target_id", targetID)
+
 	return nil
 }
 
@@ -137,22 +97,20 @@ func resourcePolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	input := &organizations.DetachPolicyInput{
+	log.Printf("[DEBUG] Deleting Organizations Policy Attachment: %s", d.Id())
+	_, err = conn.DetachPolicy(&organizations.DetachPolicyInput{
 		PolicyId: aws.String(policyID),
 		TargetId: aws.String(targetID),
+	})
+
+	if tfawserr.ErrCodeEquals(err, organizations.ErrCodeTargetNotFoundException, organizations.ErrCodePolicyNotFoundException) {
+		return nil
 	}
 
-	log.Printf("[DEBUG] Detaching Organizations Policy %q from %q", policyID, targetID)
-	_, err = conn.DetachPolicy(input)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, organizations.ErrCodePolicyNotFoundException) {
-			return nil
-		}
-		if tfawserr.ErrCodeEquals(err, organizations.ErrCodeTargetNotFoundException) {
-			return nil
-		}
-		return err
+		return fmt.Errorf("deleting Organizations Policy Attachment (%s): %w", d.Id(), err)
 	}
+
 	return nil
 }
 

--- a/internal/service/organizations/policy_attachment_test.go
+++ b/internal/service/organizations/policy_attachment_test.go
@@ -218,10 +218,7 @@ func testAccCheckPolicyAttachmentPolicyRemoved(resourceName string) resource.Tes
 		}
 		log.Printf("[DEBUG] Delete policy outside of TF %s", deleteInput)
 		_, err = conn.DeletePolicy(deleteInput)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	}
 }
 

--- a/internal/service/organizations/policy_attachment_test.go
+++ b/internal/service/organizations/policy_attachment_test.go
@@ -281,30 +281,3 @@ resource "aws_organizations_policy_attachment" "test" {
 }
 `, rName)
 }
-
-func testAccPolicyAttachmentConfig_bug27231(rName string) string {
-	return fmt.Sprintf(`
-data "aws_organizations_organization" "test" {}
-
-resource "aws_organizations_policy" "test" {
-
-  content = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-EOF
-
-  name = %[1]q
-}
-
-resource "aws_organizations_policy_attachment" "test" {
-  policy_id = aws_organizations_policy.test.id
-  target_id = data.aws_organizations_organization.test.roots[0].id
-}
-`, rName)
-}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Properly handle missing policy when reading policy attachment.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27231

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccOrganizations_serial/PolicyAttachment/BUG27231 PKG=organizations
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/organizations/... -v -count 1 -parallel 20 -run='TestAccOrganizations_serial/PolicyAttachment/BUG27231'  -timeout 180m
=== RUN   TestAccOrganizations_serial
=== RUN   TestAccOrganizations_serial/PolicyAttachment
=== RUN   TestAccOrganizations_serial/PolicyAttachment/BUG27231
--- PASS: TestAccOrganizations_serial (20.04s)
    --- PASS: TestAccOrganizations_serial/PolicyAttachment (20.04s)
        --- PASS: TestAccOrganizations_serial/PolicyAttachment/BUG27231 (20.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/organizations      23.785s
...
```
