### PR TITLE
[Enhancement] dynamodb import table from S3

### DIFF
--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1982,6 +1982,42 @@ func TestAccDynamoDBTable_backup_overrideEncryption(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_importTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf dynamodb.DescribeTableOutput
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_import(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "read_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "write_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "hash_key", rName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "attribute.*", map[string]string{
+						"name": rName,
+						"type": "S",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "table_class", ""),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckTableDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn
 
@@ -3510,6 +3546,43 @@ resource "aws_dynamodb_table" "test" {
   name                   = "%[1]s-target"
   restore_source_name    = aws_dynamodb_table.source.name
   restore_to_latest_time = true
+}
+`, rName)
+}
+
+func testAccTableConfig_import(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = %[1]q
+
+  attribute {
+    name = %[1]q
+    type = "S"
+  }
+
+  import_table {
+    client_token = %[1]q
+    input_compression_type = "NONE"
+    input_format = "DYNAMODB_JSON"
+
+    s3_bucket_source {
+      s3_bucket = aws_s3_bucket.test.bucket
+      s3_key_prefix = "data"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_object" "test" {
+  bucket = aws_s3_bucket.test.id
+  key    = "data/somedoc.json"
+  content = "{\"Item\":{\"%[1]s\":{\"S\":\"test\"},\"field\":{\"S\":\"test\"}}}"
 }
 `, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add the possibility to create an `aws_dynamodb_table` from an S3 export by adding an `import_table` block:

```terraform
  import_table {
    client_token = "some_random_string"
    input_compression_type = "GZIP"
    input_format = "DYNAMODB_JSON"

    s3_bucket_source {
      s3_bucket = "my_s3_bucket"
      s3_key_prefix = "some_prefix/"
      s3_bucket_owner = "some_account"
    }
  }
```


### Relations
Closes #26944

### References
[API Reference](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ImportTable.html)
[AWS Blog Article](https://aws.amazon.com/blogs/database/amazon-dynamodb-can-now-import-amazon-s3-data-into-a-new-table/)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccDynamoDBTable_importTable PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_importTable'  -timeout 180m
=== RUN   TestAccDynamoDBTable_importTable
=== PAUSE TestAccDynamoDBTable_importTable
=== CONT  TestAccDynamoDBTable_importTable
--- PASS: TestAccDynamoDBTable_importTable (225.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	229.018s
...
```
