### PR TITLE
resource/aws_appstream_stack: Fix panic on read

### DIFF
--- a/.changelog/27257.txt
+++ b/.changelog/27257.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_appstream_stack: Fix panic with `application_settings`.
+```
+
+```release-note:enhancement
+resource/aws_appstream_stack: Add validation for `application_settings`.
+```

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -3,6 +3,7 @@ package appstream
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -10,7 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appstream"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -19,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 var (
@@ -71,7 +75,7 @@ func ResourceStack() *schema.Resource {
 						"settings_group": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 100),
+							ValidateFunc: validation.StringLenBetween(0, 100),
 						},
 					},
 				},
@@ -184,7 +188,52 @@ func ResourceStack() *schema.Resource {
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
 
-		CustomizeDiff: verify.SetTagsDiff,
+		CustomizeDiff: customdiff.All(
+			verify.SetTagsDiff,
+			func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+				if d.Id() == "" {
+					return nil
+				}
+
+				rawConfig := d.GetRawConfig()
+				configApplicationSettings := rawConfig.GetAttr("application_settings")
+				if configApplicationSettings.IsKnown() && !configApplicationSettings.IsNull() && configApplicationSettings.LengthInt() > 0 {
+					return nil
+				}
+
+				rawState := d.GetRawState()
+				stateApplicationSettings := rawState.GetAttr("application_settings")
+				if stateApplicationSettings.IsKnown() && !stateApplicationSettings.IsNull() && stateApplicationSettings.LengthInt() > 0 {
+					setting := stateApplicationSettings.Index(cty.NumberIntVal(0))
+					if setting.IsKnown() && !setting.IsNull() {
+						enabled := setting.GetAttr("enabled")
+						if enabled.IsKnown() && !enabled.IsNull() && enabled.True() {
+							// Trigger a diff
+							return d.SetNew("application_settings", []map[string]any{
+								{
+									"enabled":        false,
+									"settings_group": "",
+								},
+							})
+						}
+					}
+				}
+
+				return nil
+			},
+			func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+				_, enabled := d.GetOk("application_settings.0.enabled")
+				v, sg := d.GetOk("application_settings.0.settings_group")
+				log.Print(v)
+
+				if enabled && !sg {
+					return errors.New("application_settings.settings_group must be set when application_settings.enabled is true")
+				} else if !enabled && sg {
+					return errors.New("application_settings.settings_group must not be set when application_settings.enabled is false")
+				}
+				return nil
+			},
+		),
 	}
 }
 
@@ -338,7 +387,7 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("application_settings") {
-		input.ApplicationSettings = expandApplicationSettings(d.Get("application_settings").(*schema.Set).List())
+		input.ApplicationSettings = expandApplicationSettings(d.Get("application_settings").([]interface{}))
 	}
 
 	if d.HasChange("description") {
@@ -477,38 +526,20 @@ func flattenAccessEndpoints(apiObjects []*appstream.AccessEndpoint) []map[string
 	return tfList
 }
 
-func expandApplicationSetting(tfMap map[string]interface{}) *appstream.ApplicationSettings {
-	if tfMap == nil {
-		return nil
+func expandApplicationSettings(tfList []interface{}) *appstream.ApplicationSettings {
+	if len(tfList) == 0 {
+		return &appstream.ApplicationSettings{
+			Enabled: aws.Bool(false),
+		}
 	}
 
-	apiObject := &appstream.ApplicationSettings{}
+	tfMap := tfList[0].(map[string]interface{})
 
-	if v, ok := tfMap["enabled"]; ok {
-		apiObject.Enabled = aws.Bool(v.(bool))
+	apiObject := &appstream.ApplicationSettings{
+		Enabled: aws.Bool(tfMap["enabled"].(bool)),
 	}
 	if v, ok := tfMap["settings_group"]; ok {
 		apiObject.SettingsGroup = aws.String(v.(string))
-	}
-
-	return apiObject
-}
-
-func expandApplicationSettings(tfList []interface{}) *appstream.ApplicationSettings {
-	if len(tfList) == 0 {
-		return nil
-	}
-
-	var apiObject *appstream.ApplicationSettings
-
-	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
-
-		if !ok {
-			continue
-		}
-
-		apiObject = expandApplicationSetting(tfMap)
 	}
 
 	return apiObject
@@ -519,11 +550,10 @@ func flattenApplicationSetting(apiObject *appstream.ApplicationSettingsResponse)
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
-	tfMap["enabled"] = aws.BoolValue(apiObject.Enabled)
-	tfMap["settings_group"] = aws.StringValue(apiObject.SettingsGroup)
-
-	return tfMap
+	return map[string]interface{}{
+		"enabled":        aws.BoolValue(apiObject.Enabled),
+		"settings_group": aws.StringValue(apiObject.SettingsGroup),
+	}
 }
 
 func flattenApplicationSettings(apiObject *appstream.ApplicationSettingsResponse) []interface{} {

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -66,11 +66,12 @@ func ResourceStack() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Required: true,
 						},
 						"settings_group": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 100),
 						},
 					},
 				},
@@ -182,6 +183,8 @@ func ResourceStack() *schema.Resource {
 			"tags":     tftags.TagsSchemaForceNew(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
+
+		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -336,14 +336,14 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Stack (%s): %w", "access_endpoints", d.Id(), err))
 		}
 		if err = d.Set("application_settings", flattenApplicationSettings(v.ApplicationSettings)); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Stack (%s): %w", "user_settings", d.Id(), err))
+			return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Stack (%s): %w", "application_settings", d.Id(), err))
 		}
 		d.Set("arn", v.Arn)
 		d.Set("created_time", aws.TimeValue(v.CreatedTime).Format(time.RFC3339))
 		d.Set("description", v.Description)
 		d.Set("display_name", v.DisplayName)
 		if err = d.Set("embed_host_domains", flex.FlattenStringList(v.EmbedHostDomains)); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Stack (%s): %w", "user_settings", d.Id(), err))
+			return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Stack (%s): %w", "embed_host_domains", d.Id(), err))
 		}
 		d.Set("feedback_url", v.FeedbackURL)
 		d.Set("name", v.Name)

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -28,10 +28,23 @@ func TestAccAppStreamStack_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(resourceName, &stackOutput),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+					resource.TestCheckResourceAttr(resourceName, "access_endpoints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "application_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "application_settings.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "application_settings.0.settings_group", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "embed_host_domains.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "feedback_url", ""),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", ""),
+					resource.TestCheckResourceAttr(resourceName, "storage_connectors.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
@@ -56,7 +69,7 @@ func TestAccAppStreamStack_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(resourceName, &stackOutput),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappstream.ResourceStack(), resourceName),
 				),
@@ -81,16 +94,30 @@ func TestAccAppStreamStack_complete(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_complete(rName, description),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(resourceName, &stackOutput),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "embed_host_domains.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "embed_host_domains.*", "example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "embed_host_domains.*", "subdomain.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "access_endpoints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "application_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "application_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "application_settings.0.settings_group", "SettingsGroup"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "feedback_url", ""),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", ""),
+					resource.TestCheckResourceAttr(resourceName, "storage_connectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
 				Config: testAccStackConfig_complete(rName, descriptionUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(resourceName, &stackOutput),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
@@ -124,7 +151,7 @@ func TestAccAppStreamStack_withTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_complete(rName, description),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(resourceName, &stackOutput),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
@@ -133,7 +160,7 @@ func TestAccAppStreamStack_withTags(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_tags(rName, descriptionUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(resourceName, &stackOutput),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),

--- a/website/docs/r/appstream_stack.html.markdown
+++ b/website/docs/r/appstream_stack.html.markdown
@@ -60,31 +60,45 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `access_endpoints` - (Optional) Set of configuration blocks defining the interface VPC endpoints. Users of the stack can connect to AppStream 2.0 only through the specified endpoints. See below.
+* `access_endpoints` - (Optional) Set of configuration blocks defining the interface VPC endpoints. Users of the stack can connect to AppStream 2.0 only through the specified endpoints.
+  See [`access_endpoints`](#access_endpoints) below.
 * `application_settings` - (Optional) Settings for application settings persistence.
+  See [`application_settings`](#application_settings) below.
 * `description` - (Optional) Description for the AppStream stack.
 * `display_name` - (Optional) Stack name to display.
 * `embed_host_domains` - (Optional) Domains where AppStream 2.0 streaming sessions can be embedded in an iframe. You must approve the domains that you want to host embedded AppStream 2.0 streaming sessions.
 * `feedback_url` - (Optional) URL that users are redirected to after they click the Send Feedback link. If no URL is specified, no Send Feedback link is displayed. .
 * `redirect_url` - (Optional) URL that users are redirected to after their streaming session ends.
-* `storage_connectors` - (Optional) Configuration block for the storage connectors to enable. See below.
-* `user_settings` - (Optional) Configuration block for the actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled. See below.
+* `storage_connectors` - (Optional) Configuration block for the storage connectors to enable.
+  See [`storage_connectors`](#storage_connectors) below.
+* `user_settings` - (Optional) Configuration block for the actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled.
+  See [`user_settings`](#user_settings) below.
 
 ### `access_endpoints`
 
-* `endpoint_type` - (Required) Type of the interface endpoint. See the [`AccessEndpoint` AWS API documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_AccessEndpoint.html) for valid values.
+* `endpoint_type` - (Required) Type of the interface endpoint.
+  See the [`AccessEndpoint` AWS API documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_AccessEndpoint.html) for valid values.
 * `vpce_id` - (Optional) ID of the VPC in which the interface endpoint is used.
+
+### `application_settings`
+
+* `enabled` - (Required) Whether application settings should be persisted.
+* `settings_group` - (Optional) Name of the settings group.
+  Required when `enabled` is `true`.
 
 ### `storage_connectors`
 
-* `connector_type` - (Required) Type of storage connector. Valid values are: `HOMEFOLDERS`, `GOOGLE_DRIVE`, `ONE_DRIVE`.
+* `connector_type` - (Required) Type of storage connector.
+  Valid values are `HOMEFOLDERS`, `GOOGLE_DRIVE`, or `ONE_DRIVE`.
 * `domains` - (Optional) Names of the domains for the account.
 * `resource_identifier` - (Optional) ARN of the storage connector.
 
 ### `user_settings`
 
-* `action` - (Required) Action that is enabled or disabled. Valid values are: `CLIPBOARD_COPY_FROM_LOCAL_DEVICE`,  `CLIPBOARD_COPY_TO_LOCAL_DEVICE`, `FILE_UPLOAD`, `FILE_DOWNLOAD`, `PRINTING_TO_LOCAL_DEVICE`, `DOMAIN_PASSWORD_SIGNIN`, `DOMAIN_SMART_CARD_SIGNIN`.
-* `permission` - (Required) Whether the action is enabled or disabled. Valid values are: `ENABLED`, `DISABLED`.
+* `action` - (Required) Action that is enabled or disabled.
+  Valid values are `CLIPBOARD_COPY_FROM_LOCAL_DEVICE`,  `CLIPBOARD_COPY_TO_LOCAL_DEVICE`, `FILE_UPLOAD`, `FILE_DOWNLOAD`, `PRINTING_TO_LOCAL_DEVICE`, `DOMAIN_PASSWORD_SIGNIN`, or `DOMAIN_SMART_CARD_SIGNIN`.
+* `permission` - (Required) Whether the action is enabled or disabled.
+  Valid values are `ENABLED` or `DISABLED`.
 
 ## Attributes Reference
 

--- a/website/docs/r/appstream_stack.html.markdown
+++ b/website/docs/r/appstream_stack.html.markdown
@@ -85,6 +85,7 @@ The following arguments are optional:
 * `enabled` - (Required) Whether application settings should be persisted.
 * `settings_group` - (Optional) Name of the settings group.
   Required when `enabled` is `true`.
+  Can be up to 100 characters.
 
 ### `storage_connectors`
 


### PR DESCRIPTION
Reading an `aws_appstream_stack` causes a panic.

Adds validation and improves tests

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27228

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=appstream TESTS=TestAccAppStreamStack_

--- PASS: TestAccAppStreamStack_basic (23.86s)
--- PASS: TestAccAppStreamStack_disappears (26.55s)
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromDisabled (39.51s)
--- PASS: TestAccAppStreamStack_complete (50.26s)
--- PASS: TestAccAppStreamStack_withTags (52.54s)
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromEnabled (56.85s)
--- PASS: TestAccAppStreamStack_applicationSettings_basic (78.10s)
```
