### PR TITLE
Fix SageMaker sweepers

### DIFF
--- a/internal/service/sagemaker/sweep.go
+++ b/internal/service/sagemaker/sweep.go
@@ -179,9 +179,7 @@ func sweepAppImagesConfig(region string) error {
 			d.SetId(name)
 			err = r.Delete(d, client)
 			if err != nil {
-				sweeperErr := fmt.Errorf("deleting SageMaker App Image Config (%s): %w", name, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("deleting SageMaker App Image Config (%s): %w", name, err))
 				continue
 			}
 		}
@@ -218,10 +216,9 @@ func sweepApps(region string) error {
 			d.Set("app_type", app.AppType)
 			d.Set("domain_id", app.DomainId)
 			d.Set("user_profile_name", app.UserProfileName)
-			err := r.Delete(d, client)
 
+			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -273,7 +270,7 @@ func sweepCodeRepositories(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving SageMaker Code Repositorys: %w", err)
+		return fmt.Errorf("retrieving SageMaker Code Repositories: %w", err)
 	}
 
 	return nil
@@ -294,9 +291,9 @@ func sweepDeviceFleets(region string) error {
 			r := ResourceDeviceFleet()
 			d := r.Data(nil)
 			d.SetId(name)
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -332,9 +329,9 @@ func sweepDeviceFleets(region string) error {
 // 			r := ResourceDeviceFleet()
 // 			d := r.Data(nil)
 // 			d.SetId(name)
+
 // 			err := r.Delete(d, client)
 // 			if err != nil {
-// 				log.Printf("[ERROR] %s", err)
 // 				sweeperErrs = multierror.Append(sweeperErrs, err)
 // 				continue
 // 			}
@@ -370,9 +367,9 @@ func sweepDomains(region string) error {
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(domain.DomainId))
 			d.Set("retention_policy.0.home_efs_file_system", "Delete")
+
 			err = r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -410,9 +407,9 @@ func sweepEndpointConfigurations(region string) error {
 			r := ResourceEndpointConfiguration()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(endpointConfig.EndpointConfigName))
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -458,9 +455,7 @@ func sweepEndpoints(region string) error {
 			EndpointName: endpoint.EndpointName,
 		})
 		if err != nil {
-			return fmt.Errorf(
-				"error deleting SageMaker Endpoint (%s): %s",
-				*endpoint.EndpointName, err)
+			return fmt.Errorf("deleting SageMaker Endpoint (%s): %s", aws.StringValue(endpoint.EndpointName), err)
 		}
 	}
 
@@ -498,7 +493,7 @@ func sweepFeatureGroups(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving SageMaker Feature Groups: %w", err)
+		return fmt.Errorf("retrieving SageMaker Feature Groups: %w", err)
 	}
 
 	return nil
@@ -518,9 +513,9 @@ func sweepFlowDefinitions(region string) error {
 			r := ResourceFlowDefinition()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(flowDefinition.FlowDefinitionName))
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -555,9 +550,9 @@ func sweepHumanTaskUIs(region string) error {
 			r := ResourceHumanTaskUI()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(humanTaskUi.HumanTaskUiName))
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -609,7 +604,7 @@ func sweepImages(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving SageMaker Images: %w", err)
+		return fmt.Errorf("retrieving SageMaker Images: %w", err)
 	}
 
 	return nil
@@ -646,7 +641,7 @@ func sweepModelPackageGroups(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving SageMaker Model Package Groups: %w", err)
+		return fmt.Errorf("retrieving SageMaker Model Package Groups: %w", err)
 	}
 
 	return nil
@@ -666,9 +661,9 @@ func sweepModels(region string) error {
 			r := ResourceModel()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(model.ModelName))
+
 			err = r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -744,9 +739,9 @@ func sweepNotebookInstances(region string) error {
 			r := ResourceNotebookInstance()
 			d := r.Data(nil)
 			d.SetId(name)
+
 			err = r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -781,9 +776,9 @@ func sweepStudioLifecyclesConfig(region string) error {
 			r := ResourceStudioLifecycleConfig()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(config.StudioLifecycleConfigName))
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -820,10 +815,9 @@ func sweepUserProfiles(region string) error {
 			d.SetId(aws.StringValue(userProfile.UserProfileName))
 			d.Set("user_profile_name", userProfile.UserProfileName)
 			d.Set("domain_id", userProfile.DomainId)
-			err := r.Delete(d, client)
 
+			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -858,9 +852,9 @@ func sweepWorkforces(region string) error {
 			r := ResourceWorkforce()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(workforce.WorkforceName))
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -895,9 +889,9 @@ func sweepWorkteams(region string) error {
 			r := ResourceWorkteam()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(workteam.WorkteamName))
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
@@ -933,9 +927,9 @@ func sweepProjects(region string) error {
 			r := ResourceProject()
 			d := r.Data(nil)
 			d.SetId(name)
+
 			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}

--- a/internal/service/sagemaker/sweep.go
+++ b/internal/service/sagemaker/sweep.go
@@ -245,18 +245,17 @@ func sweepCodeRepositories(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).SageMakerConn
+	var sweeperErrs *multierror.Error
 
 	err = conn.ListCodeRepositoriesPages(&sagemaker.ListCodeRepositoriesInput{}, func(page *sagemaker.ListCodeRepositoriesOutput, lastPage bool) bool {
 		for _, instance := range page.CodeRepositorySummaryList {
-			name := aws.StringValue(instance.CodeRepositoryName)
+			r := ResourceCodeRepository()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(instance.CodeRepositoryName))
 
-			input := &sagemaker.DeleteCodeRepositoryInput{
-				CodeRepositoryName: instance.CodeRepositoryName,
-			}
-
-			log.Printf("[INFO] Deleting SageMaker Code Repository: %s", name)
-			if _, err := conn.DeleteCodeRepository(input); err != nil {
-				log.Printf("[ERROR] Error deleting SageMaker Code Repository (%s): %s", name, err)
+			err := r.Delete(d, client)
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
 		}
@@ -266,14 +265,14 @@ func sweepCodeRepositories(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping SageMaker Code Repository sweep for %s: %s", region, err)
-		return nil
+		return sweeperErrs.ErrorOrNil()
 	}
 
 	if err != nil {
-		return fmt.Errorf("retrieving SageMaker Code Repositories: %w", err)
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SageMaker Code Repositories: %w", err))
 	}
 
-	return nil
+	return sweeperErrs.ErrorOrNil()
 }
 
 func sweepDeviceFleets(region string) error {
@@ -403,7 +402,6 @@ func sweepEndpointConfigurations(region string) error {
 	}
 	err = conn.ListEndpointConfigsPages(req, func(page *sagemaker.ListEndpointConfigsOutput, lastPage bool) bool {
 		for _, endpointConfig := range page.EndpointConfigs {
-
 			r := ResourceEndpointConfiguration()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(endpointConfig.EndpointConfigName))
@@ -468,18 +466,17 @@ func sweepFeatureGroups(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).SageMakerConn
+	var sweeperErrs *multierror.Error
 
 	err = conn.ListFeatureGroupsPages(&sagemaker.ListFeatureGroupsInput{}, func(page *sagemaker.ListFeatureGroupsOutput, lastPage bool) bool {
 		for _, group := range page.FeatureGroupSummaries {
-			name := aws.StringValue(group.FeatureGroupName)
+			r := ResourceFeatureGroup()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(group.FeatureGroupName))
 
-			input := &sagemaker.DeleteFeatureGroupInput{
-				FeatureGroupName: group.FeatureGroupName,
-			}
-
-			log.Printf("[INFO] Deleting SageMaker Feature Group: %s", name)
-			if _, err := conn.DeleteFeatureGroup(input); err != nil {
-				log.Printf("[ERROR] Error deleting SageMaker Feature Group (%s): %s", name, err)
+			err := r.Delete(d, client)
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
 		}
@@ -489,14 +486,14 @@ func sweepFeatureGroups(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping SageMaker Feature Group sweep for %s: %s", region, err)
-		return nil
+		return sweeperErrs.ErrorOrNil()
 	}
 
 	if err != nil {
-		return fmt.Errorf("retrieving SageMaker Feature Groups: %w", err)
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SageMaker Feature Groups: %w", err))
 	}
 
-	return nil
+	return sweeperErrs.ErrorOrNil()
 }
 
 func sweepFlowDefinitions(region string) error {
@@ -579,18 +576,17 @@ func sweepImages(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).SageMakerConn
+	var sweeperErrs *multierror.Error
 
 	err = conn.ListImagesPages(&sagemaker.ListImagesInput{}, func(page *sagemaker.ListImagesOutput, lastPage bool) bool {
-		for _, Image := range page.Images {
-			name := aws.StringValue(Image.ImageName)
+		for _, image := range page.Images {
+			r := ResourceImage()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(image.ImageName))
 
-			input := &sagemaker.DeleteImageInput{
-				ImageName: Image.ImageName,
-			}
-
-			log.Printf("[INFO] Deleting SageMaker Image: %s", name)
-			if _, err := conn.DeleteImage(input); err != nil {
-				log.Printf("[ERROR] Error deleting SageMaker Image (%s): %s", name, err)
+			err := r.Delete(d, client)
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
 		}
@@ -600,14 +596,14 @@ func sweepImages(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping SageMaker Image sweep for %s: %s", region, err)
-		return nil
+		return sweeperErrs.ErrorOrNil()
 	}
 
 	if err != nil {
-		return fmt.Errorf("retrieving SageMaker Images: %w", err)
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SageMaker Images: %w", err))
 	}
 
-	return nil
+	return sweeperErrs.ErrorOrNil()
 }
 
 func sweepModelPackageGroups(region string) error {
@@ -616,18 +612,17 @@ func sweepModelPackageGroups(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).SageMakerConn
+	var sweeperErrs *multierror.Error
 
 	err = conn.ListModelPackageGroupsPages(&sagemaker.ListModelPackageGroupsInput{}, func(page *sagemaker.ListModelPackageGroupsOutput, lastPage bool) bool {
-		for _, ModelPackageGroup := range page.ModelPackageGroupSummaryList {
-			name := aws.StringValue(ModelPackageGroup.ModelPackageGroupName)
+		for _, modelPackageGroup := range page.ModelPackageGroupSummaryList {
+			r := ResourceModelPackageGroup()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(modelPackageGroup.ModelPackageGroupName))
 
-			input := &sagemaker.DeleteModelPackageGroupInput{
-				ModelPackageGroupName: ModelPackageGroup.ModelPackageGroupName,
-			}
-
-			log.Printf("[INFO] Deleting SageMaker Model Package Group: %s", name)
-			if _, err := conn.DeleteModelPackageGroup(input); err != nil {
-				log.Printf("[ERROR] Error deleting SageMaker Model Package Group (%s): %s", name, err)
+			err := r.Delete(d, client)
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, err)
 				continue
 			}
 		}
@@ -637,14 +632,14 @@ func sweepModelPackageGroups(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping SageMaker Model Package Group sweep for %s: %s", region, err)
-		return nil
+		return sweeperErrs.ErrorOrNil()
 	}
 
 	if err != nil {
-		return fmt.Errorf("retrieving SageMaker Model Package Groups: %w", err)
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SageMaker Model Package Groups: %w", err))
 	}
 
-	return nil
+	return sweeperErrs.ErrorOrNil()
 }
 
 func sweepModels(region string) error {
@@ -689,39 +684,38 @@ func sweepNotebookInstanceLifecycleConfiguration(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).SageMakerConn
+	var sweeperErrs *multierror.Error
 
 	input := &sagemaker.ListNotebookInstanceLifecycleConfigsInput{}
 	err = conn.ListNotebookInstanceLifecycleConfigsPages(input, func(page *sagemaker.ListNotebookInstanceLifecycleConfigsOutput, lastPage bool) bool {
-		if len(page.NotebookInstanceLifecycleConfigs) == 0 {
-			log.Printf("[INFO] No SageMaker Notebook Instance Lifecycle Configuration to sweep")
-			return false
-		}
 		for _, lifecycleConfig := range page.NotebookInstanceLifecycleConfigs {
 			name := aws.StringValue(lifecycleConfig.NotebookInstanceLifecycleConfigName)
 			if !strings.HasPrefix(name, sweep.ResourcePrefix) {
-				log.Printf("[INFO] Skipping SageMaker Notebook Instance Lifecycle Configuration: %s", name)
+				log.Printf("[INFO] Skipping SageMaker Notebook Instance Lifecycle Configuration (%s): not in allow list", name)
 				continue
 			}
 
-			log.Printf("[INFO] Deleting SageMaker Notebook Instance Lifecycle Configuration: %s", name)
-			_, err := conn.DeleteNotebookInstanceLifecycleConfig(&sagemaker.DeleteNotebookInstanceLifecycleConfigInput{
-				NotebookInstanceLifecycleConfigName: aws.String(name),
-			})
+			r := ResourceNotebookInstanceLifeCycleConfiguration()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(lifecycleConfig.NotebookInstanceLifecycleConfigName))
+
+			err := r.Delete(d, client)
 			if err != nil {
-				log.Printf("[ERROR] Failed to delete SageMaker Notebook Instance Lifecycle Configuration %s: %s", name, err)
+				sweeperErrs = multierror.Append(sweeperErrs, err)
+				continue
 			}
 		}
 		return !lastPage
 	})
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker Notebook Instance Lifecycle Configuration sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping SageMaker Notebook Instance Lifecycle Configuration sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("retrieving SageMaker Notebook Instance Lifecycle Configuration: %s", err)
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SageMaker Notebook Instance Lifecycle Configuration: %s", err))
 	}
 
-	return nil
+	return sweeperErrs.ErrorOrNil()
 }
 
 func sweepNotebookInstances(region string) error {

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -226,6 +226,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "UnknownOperationException", "Operation is disabled in this region") {
 		return true
 	}
+	// For example from us-east-1 SageMaker
+	if tfawserr.ErrMessageContains(err, "UnknownOperationException", "The requested operation is not supported in the called region") {
+		return true
+	}
 	// For example from us-west-2 ECR public repository
 	if tfawserr.ErrMessageContains(err, "UnsupportedCommandException", "command is only supported in") {
 		return true


### PR DESCRIPTION
In unsupported regions, such as `us-west-1`, SageMaker returns the error `UnknownOperationException: The requested operation is not supported in the called region.` Treat this as skippable.

Also removes redundant `[ERROR]` log messages and fixes silent failures.
