### PR TITLE
resource/aws_config_configuration_recorder add retention period

### DIFF
--- a/.changelog/27262.txt
+++ b/.changelog/27262.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_config_configuration_recorder: Add retention period
+```

--- a/internal/service/configservice/configservice_test.go
+++ b/internal/service/configservice/configservice_test.go
@@ -24,7 +24,7 @@ func TestAccConfigService_serial(t *testing.T) {
 		},
 		"ConfigurationRecorder": {
 			"basic":       testAccConfigurationRecorder_basic,
-			"allParams":   testAccConfigurationRecorder_allParams,
+			"allParams":   TestAccConfigurationRecorder_allParams,
 			"importBasic": testAccConfigurationRecorder_importBasic,
 		},
 		"ConformancePack": {

--- a/internal/service/configservice/configservice_test.go
+++ b/internal/service/configservice/configservice_test.go
@@ -23,9 +23,8 @@ func TestAccConfigService_serial(t *testing.T) {
 			"importBasic":  testAccConfigurationRecorderStatus_importBasic,
 		},
 		"ConfigurationRecorder": {
-			"basic":       testAccConfigurationRecorder_basic,
-			"allParams":   TestAccConfigurationRecorder_allParams,
-			"importBasic": testAccConfigurationRecorder_importBasic,
+			"basic":     TestAccConfigServiceConfigurationRecorder_basic,
+			"allParams": TestAccConfigServiceConfigurationRecorder_allParams,
 		},
 		"ConformancePack": {
 			"basic":                     testAccConformancePack_basic,

--- a/internal/service/configservice/configuration_recorder_test.go
+++ b/internal/service/configservice/configuration_recorder_test.go
@@ -40,7 +40,7 @@ func testAccConfigurationRecorder_basic(t *testing.T) {
 	})
 }
 
-func testAccConfigurationRecorder_allParams(t *testing.T) {
+func TestAccConfigurationRecorder_allParams(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	rInt := sdkacctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -61,6 +61,7 @@ func testAccConfigurationRecorder_allParams(t *testing.T) {
 					testAccCheckConfigurationRecorderName(resourceName, expectedName, &cr),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf("role/%s", expectedRoleName)),
 					resource.TestCheckResourceAttr(resourceName, "name", expectedName),
+					resource.TestCheckResourceAttr(resourceName, "retention_period", "35"),
 					resource.TestCheckResourceAttr(resourceName, "recording_group.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "recording_group.0.all_supported", "false"),
 					resource.TestCheckResourceAttr(resourceName, "recording_group.0.include_global_resource_types", "false"),
@@ -228,8 +229,9 @@ resource "aws_config_delivery_channel" "foo" {
 func testAccConfigurationRecorderConfig_allParams(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_config_configuration_recorder" "foo" {
-  name     = "tf-acc-test-%d"
-  role_arn = aws_iam_role.r.arn
+  name             = "tf-acc-test-%d"
+  role_arn         = aws_iam_role.r.arn
+  retention_period = 35
 
   recording_group {
     all_supported                 = false

--- a/internal/service/configservice/configuration_recorder_test.go
+++ b/internal/service/configservice/configuration_recorder_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-func testAccConfigurationRecorder_basic(t *testing.T) {
+func TestAccConfigServiceConfigurationRecorder_basic(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	rInt := sdkacctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -40,7 +40,7 @@ func testAccConfigurationRecorder_basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigurationRecorder_allParams(t *testing.T) {
+func TestAccConfigServiceConfigurationRecorder_allParams(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	rInt := sdkacctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -68,24 +68,6 @@ func TestAccConfigurationRecorder_allParams(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "recording_group.0.resource_types.#", "2"),
 				),
 			},
-		},
-	})
-}
-
-func testAccConfigurationRecorder_importBasic(t *testing.T) {
-	resourceName := "aws_config_configuration_recorder.foo"
-	rInt := sdkacctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, configservice.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckConfigurationRecorderDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccConfigurationRecorderConfig_basic(rInt),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -48,6 +48,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the recorder. Defaults to `default`. Changing it recreates the resource.
 * `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role. Used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account. See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
 * `recording_group` - (Optional) Recording group - see below.
+* `retention_period` - (Optional) Retention period in days.
 
 ### `recording_group`
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds retention period to aws_config_configuration_recorder as per proposed solution and discussion on https://github.com/hashicorp/terraform-provider-aws/issues/13305

Some observations:

* There is no explicit relationship between a retention period and configuration recorder. However, the retention period is only
used to control the retention of configuration captured under a configuration recorder.
* AWS only lets us create a single retention period and configuration recorder per region, so whilst an explicit relationship does not exist a relationship _does_ exist by this virtue.
    * The AWS Console UI shows/groups the retention period under the other configuration recorder settings.
* After a retention configuration is created its given the name 'default'. It is not possible to change this name and all further
interactions with the retention configuration resource require it to be referenced by this name attribute.

Are we happy adding retention period to the existing `aws_config_configuration_recorder` resource based on this behaviour? Please let me know if we would prefer to create this as a seperate resource and I can refactor this PR to reflect that. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #13305

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/config/latest/APIReference/API_PutRetentionConfiguration.html
https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteRetentionConfiguration.html
https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigurationRecorder.html

https://docs.aws.amazon.com/config/latest/APIReference/API_RetentionConfiguration.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
 make testacc TESTS=TestAccConfigServiceConfigurationRecorder_allParams PKG=configservice
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/configservice/... -v -count 1 -parallel 20 -run='TestAccConfigServiceConfigurationRecorder_allParams'  -timeout 180m
=== RUN   TestAccConfigServiceConfigurationRecorder_allParams
--- PASS: TestAccConfigServiceConfigurationRecorder_allParams (48.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      48.738s
```
