### PR TITLE
resource/aws_ecs_task_definition - prevent panic on null container definition

### DIFF
--- a/.changelog/27263.txt
+++ b/.changelog/27263.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_task_definition: prevent panic when supplying a 'null' container definition
+```

--- a/.changelog/27263.txt
+++ b/.changelog/27263.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ecs_task_definition: prevent panic when supplying a 'null' container definition
+resource/aws_ecs_task_definition: Prevent panic when supplying a `null` value in `container_definitions`
 ```

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -1208,6 +1208,12 @@ func expandContainerDefinitions(rawDefinitions string) ([]*ecs.ContainerDefiniti
 		return nil, fmt.Errorf("Error decoding JSON: %s", err)
 	}
 
+	for i, c := range definitions {
+		if c == nil {
+			return nil, fmt.Errorf("invalid container definition supplied at index (%d)", i)
+		}
+	}
+
 	return definitions, nil
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Prevents a panic when a 'null' element is supplied as part of the `container_definitions` JSON array argument.

This fix validates against null, however we could possibly ignore null here instead? 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #19531

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccECSTaskDefinition_invalidContainerDefinition PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_invalidContainerDefinition'  -timeout 180m
=== RUN   TestAccECSTaskDefinition_invalidContainerDefinition
=== PAUSE TestAccECSTaskDefinition_invalidContainerDefinition
=== CONT  TestAccECSTaskDefinition_invalidContainerDefinition
--- PASS: TestAccECSTaskDefinition_invalidContainerDefinition (2.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        2.363s
```
