### PR TITLE
Explicit options on AWS Directory docs for size, edition and type

### DIFF
--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -126,7 +126,7 @@ The following arguments are supported:
 
 * `name` - (Required) The fully qualified name for the directory, such as `corp.example.com`
 * `password` - (Required) The password for the directory administrator or connector user.
-* `size` - (Required for `SimpleAD` and `ADConnector`) The size of the directory (`Small` or `Large` are accepted values).
+* `size` - (Required for `SimpleAD` and `ADConnector` types, do not use with `MicrosoftAD`) The size of the directory (`Small` or `Large` are accepted values).
 * `vpc_settings` - (Required for `SimpleAD` and `MicrosoftAD`) VPC related information about the directory. Fields documented below.
 * `connect_settings` - (Required for `ADConnector`) Connector related information about the directory. Fields documented below.
 * `alias` - (Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for `enable_sso`.
@@ -135,7 +135,7 @@ The following arguments are supported:
 * `short_name` - (Optional) The short name of the directory, such as `CORP`.
 * `enable_sso` - (Optional) Whether to enable single-sign on for the directory. Requires `alias`. Defaults to `false`.
 * `type` (Optional) - The directory type (`SimpleAD`, `ADConnector` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
-* `edition` - (Optional) The MicrosoftAD edition (`Standard` or `Enterprise`). Defaults to `Enterprise` (applies to MicrosoftAD type only).
+* `edition` - (Optional, `applies to MicrosoftAD` type only) The MicrosoftAD edition (`Standard` or `Enterprise`). Defaults to `Enterprise`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 **vpc_settings** supports the following:

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -126,7 +126,7 @@ The following arguments are supported:
 
 * `name` - (Required) The fully qualified name for the directory, such as `corp.example.com`
 * `password` - (Required) The password for the directory administrator or connector user.
-* `size` - (Required for `SimpleAD` and `ADConnector` types, do not use with `MicrosoftAD`) The size of the directory (`Small` or `Large` are accepted values).
+* `size` - (Optional) (For `SimpleAD` and `ADConnector` types) The size of the directory (`Small` or `Large` are accepted values). `Large` by default.
 * `vpc_settings` - (Required for `SimpleAD` and `MicrosoftAD`) VPC related information about the directory. Fields documented below.
 * `connect_settings` - (Required for `ADConnector`) Connector related information about the directory. Fields documented below.
 * `alias` - (Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for `enable_sso`.
@@ -135,7 +135,7 @@ The following arguments are supported:
 * `short_name` - (Optional) The short name of the directory, such as `CORP`.
 * `enable_sso` - (Optional) Whether to enable single-sign on for the directory. Requires `alias`. Defaults to `false`.
 * `type` (Optional) - The directory type (`SimpleAD`, `ADConnector` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
-* `edition` - (Optional, `applies to MicrosoftAD` type only) The MicrosoftAD edition (`Standard` or `Enterprise`). Defaults to `Enterprise`.
+* `edition` - (Optional, for type `MicrosoftAD` only) The MicrosoftAD edition (`Standard` or `Enterprise`). Defaults to `Enterprise`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 **vpc_settings** supports the following:


### PR DESCRIPTION
…_service_directory

### Description
When create an aws_directory_service_directory the fields `edition`, `size` have some exclusions depending on the value of `type`. For example, if `type` is `MicrosoftAD`, field `size` is ignored, and only if `type` is not `MicrosoftAD`, `edition` fields should be used.

### Relations
Closes #16487

### References
[directory cli command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ds/create-microsoft-ad.html)

