### PR TITLE
Document data ssm_path_baseline OS as optional and explicit values

### DIFF
--- a/website/docs/d/ssm_patch_baseline.html.markdown
+++ b/website/docs/d/ssm_patch_baseline.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `owner` - (Required) Owner of the baseline. Valid values: `All`, `AWS`, `Self` (the current account).
 * `name_prefix` - (Optional) Filter results by the baseline name prefix.
 * `default_baseline` - (Optional) Filters the results against the baselines default_baseline field.
-* `operating_system` - (Required) Specified OS for the baseline. Valid values: "AMAZON_LINUX", "AMAZON_LINUX_2", "UBUNTU", "REDHAT_ENTERPRISE_LINUX", "SUSE", "CENTOS", "ORACLE_LINUX", "DEBIAN", "MACOS", "RASPBIAN"m "ROCKY_LINUX"
+* `operating_system` - (Required) Specified OS for the baseline. Valid values: `AMAZON_LINUX`, `AMAZON_LINUX_2`, `UBUNTU`, `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN` and `ROCKY_LINUX`.
 
 ## Attributes Reference
 

--- a/website/docs/d/ssm_patch_baseline.html.markdown
+++ b/website/docs/d/ssm_patch_baseline.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `owner` - (Required) Owner of the baseline. Valid values: `All`, `AWS`, `Self` (the current account).
 * `name_prefix` - (Optional) Filter results by the baseline name prefix.
 * `default_baseline` - (Optional) Filters the results against the baselines default_baseline field.
-* `operating_system` - (Optional) Specified OS for the baseline.
+* `operating_system` - (Required) Specified OS for the baseline. Valid values: "AMAZON_LINUX", "AMAZON_LINUX_2", "UBUNTU", "REDHAT_ENTERPRISE_LINUX", "SUSE", "CENTOS", "ORACLE_LINUX", "DEBIAN", "MACOS", "RASPBIAN"m "ROCKY_LINUX"
 
 ## Attributes Reference
 

--- a/website/docs/d/ssm_patch_baseline.html.markdown
+++ b/website/docs/d/ssm_patch_baseline.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `owner` - (Required) Owner of the baseline. Valid values: `All`, `AWS`, `Self` (the current account).
 * `name_prefix` - (Optional) Filter results by the baseline name prefix.
 * `default_baseline` - (Optional) Filters the results against the baselines default_baseline field.
-* `operating_system` - (Required) Specified OS for the baseline. Valid values: `AMAZON_LINUX`, `AMAZON_LINUX_2`, `UBUNTU`, `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN` and `ROCKY_LINUX`.
+* `operating_system` - (Optional) Specified OS for the baseline. Valid values: `AMAZON_LINUX`, `AMAZON_LINUX_2`, `UBUNTU`, `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN` and `ROCKY_LINUX`.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -160,7 +160,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the patch baseline.
 * `description` - (Optional) The description of the patch baseline.
-* `operating_system` - (Optional) Defines the operating system the patch baseline applies to. Supported operating systems include `WINDOWS`, `AMAZON_LINUX`, `AMAZON_LINUX_2`, `SUSE`, `UBUNTU`, `CENTOS`, and `REDHAT_ENTERPRISE_LINUX`. The Default value is `WINDOWS`.
+* `operating_system` - (Optional) Defines the operating system the patch baseline applies to. Supported operating systems are `AMAZON_LINUX`, `AMAZON_LINUX_2`, `UBUNTU`, `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN` and `ROCKY_LINUX`. The Default value is `WINDOWS`.
 * `approved_patches_compliance_level` - (Optional) Defines the compliance level for approved patches. This means that if an approved patch is reported as missing, this is the severity of the compliance violation. Valid compliance levels include the following: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFORMATIONAL`, `UNSPECIFIED`. The default value is `UNSPECIFIED`.
 * `approved_patches` - (Optional) A list of explicitly approved patches for the baseline.
 * `rejected_patches` - (Optional) A list of rejected patches.


### PR DESCRIPTION
### Description
Set `data.aws_ssm_path_baseline.operating_system` as REQUIRED. It was wrongly documented as optional and it throws an error if missing.
Set Document all values for `data.aws_ssm_path_baseline.operating_system` 
Complete values for resource.aws_ssm_path_baseline.operating_system 

### Relations
Closes #27239

### References
[Enumeration of accepted Operative Systems](https://github.com/aws/aws-sdk-go/blob/1b418b64b1c7c36cb29b8455005f1964b75ba55c/models/apis/ssm/2014-11-06/api-2.json#L7414)


