### PR TITLE
New Resource `aws_sesv2_dedicated_ip_pool`

### DIFF
--- a/.changelog/27278.txt
+++ b/.changelog/27278.txt
@@ -1,3 +1,7 @@
 ```release-note:new-resource
 aws_sesv2_dedicated_ip_pool
 ```
+
+```release-note:new-data-source
+aws_sesv2_dedicated_ip_pool
+```

--- a/.changelog/27278.txt
+++ b/.changelog/27278.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sesv2_dedicated_ip_pool
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -826,6 +826,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ses_domain_identity":         ses.DataSourceDomainIdentity(),
 			"aws_ses_email_identity":          ses.DataSourceEmailIdentity(),
 
+			"aws_sesv2_dedicated_ip_pool": sesv2.DataSourceDedicatedIPPool(),
+
 			"aws_db_cluster_snapshot":            rds.DataSourceClusterSnapshot(),
 			"aws_db_event_categories":            rds.DataSourceEventCategories(),
 			"aws_db_instance":                    rds.DataSourceInstance(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2062,6 +2062,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ses_template":                     ses.ResourceTemplate(),
 
 			"aws_sesv2_configuration_set": sesv2.ResourceConfigurationSet(),
+			"aws_sesv2_dedicated_ip_pool": sesv2.ResourceDedicatedIPPool(),
 
 			"aws_sfn_activity":      sfn.ResourceActivity(),
 			"aws_sfn_state_machine": sfn.ResourceStateMachine(),

--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -302,7 +302,6 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChanges("reputation_options") {
-		log.Printf("[DEBUG] has change kurwa")
 		in := &sesv2.PutConfigurationSetReputationOptionsInput{
 			ConfigurationSetName: aws.String(d.Id()),
 		}

--- a/internal/service/sesv2/dedicated_ip_pool.go
+++ b/internal/service/sesv2/dedicated_ip_pool.go
@@ -109,7 +109,7 @@ func resourceDedicatedIPPoolCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SESV2Conn
 
-	out, err := findDedicatedIPPoolByID(ctx, conn, d.Id())
+	out, err := FindDedicatedIPPoolByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SESV2 DedicatedIPPool (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -118,6 +118,7 @@ func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameDedicatedIPPool, d.Id(), err)
 	}
+	d.Set("pool_name", d.Id())
 
 	poolNameARN := arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition,
@@ -183,7 +184,7 @@ func resourceDedicatedIPPoolDelete(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func findDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetDedicatedIpsOutput, error) {
+func FindDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetDedicatedIpsOutput, error) {
 	in := &sesv2.GetDedicatedIpsInput{
 		PoolName: aws.String(id),
 	}

--- a/internal/service/sesv2/dedicated_ip_pool.go
+++ b/internal/service/sesv2/dedicated_ip_pool.go
@@ -1,0 +1,227 @@
+package sesv2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceDedicatedIPPool() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceDedicatedIPPoolCreate,
+		ReadWithoutTimeout:   resourceDedicatedIPPoolRead,
+		UpdateWithoutTimeout: resourceDedicatedIPPoolUpdate,
+		DeleteWithoutTimeout: resourceDedicatedIPPoolDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"pool_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dedicated_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"warmup_percentage": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"warmup_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameDedicatedIPPool = "Dedicated IP Pool"
+)
+
+func resourceDedicatedIPPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	in := &sesv2.CreateDedicatedIpPoolInput{
+		PoolName: aws.String(d.Get("pool_name").(string)),
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateDedicatedIpPool(ctx, in)
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameDedicatedIPPool, d.Get("pool_name").(string), err)
+	}
+	if out == nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameDedicatedIPPool, d.Get("pool_name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(d.Get("pool_name").(string))
+	return resourceDedicatedIPPoolRead(ctx, d, meta)
+}
+
+func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	out, err := findDedicatedIPPoolByID(ctx, conn, d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SESV2 DedicatedIPPool (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameDedicatedIPPool, d.Id(), err)
+	}
+
+	poolNameARN := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ses",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("dedicated-ip-pool/%s", d.Id()),
+	}.String()
+	d.Set("arn", poolNameARN)
+
+	d.Set("dedicated_ips", flattenDedicatedIps(out.DedicatedIps))
+
+	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameDedicatedIPPool, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameDedicatedIPPool, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameDedicatedIPPool, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceDedicatedIPPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	if d.HasChanges("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
+			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameDedicatedIPPool, d.Id(), err)
+		}
+	}
+
+	return resourceDedicatedIPPoolRead(ctx, d, meta)
+}
+
+func resourceDedicatedIPPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	log.Printf("[INFO] Deleting SESV2 DedicatedIPPool %s", d.Id())
+	_, err := conn.DeleteDedicatedIpPool(ctx, &sesv2.DeleteDedicatedIpPoolInput{
+		PoolName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+		return create.DiagError(names.SESV2, create.ErrActionDeleting, ResNameDedicatedIPPool, d.Id(), err)
+	}
+
+	return nil
+}
+
+func findDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetDedicatedIpsOutput, error) {
+	in := &sesv2.GetDedicatedIpsInput{
+		PoolName: aws.String(id),
+	}
+	out, err := conn.GetDedicatedIps(ctx, in)
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func flattenDedicatedIps(apiObjects []types.DedicatedIp) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var dedicatedIps []interface{}
+	for _, apiObject := range apiObjects {
+		ip := map[string]interface{}{
+			"ip":                aws.ToString(apiObject.Ip),
+			"warmup_percentage": apiObject.WarmupPercentage,
+			"warmup_status":     string(apiObject.WarmupStatus),
+		}
+
+		dedicatedIps = append(dedicatedIps, ip)
+	}
+
+	return dedicatedIps
+}

--- a/internal/service/sesv2/dedicated_ip_pool.go
+++ b/internal/service/sesv2/dedicated_ip_pool.go
@@ -40,14 +40,14 @@ func ResourceDedicatedIPPool() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"pool_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/sesv2/dedicated_ip_pool.go
+++ b/internal/service/sesv2/dedicated_ip_pool.go
@@ -129,7 +129,7 @@ func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, me
 	}.String()
 	d.Set("arn", poolNameARN)
 
-	d.Set("dedicated_ips", flattenDedicatedIps(out.DedicatedIps))
+	d.Set("dedicated_ips", flattenDedicatedIPs(out.DedicatedIps))
 
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 	if err != nil {
@@ -208,7 +208,7 @@ func FindDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string)
 	return out, nil
 }
 
-func flattenDedicatedIps(apiObjects []types.DedicatedIp) []interface{} {
+func flattenDedicatedIPs(apiObjects []types.DedicatedIp) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}

--- a/internal/service/sesv2/dedicated_ip_pool_data_source.go
+++ b/internal/service/sesv2/dedicated_ip_pool_data_source.go
@@ -20,11 +20,6 @@ func DataSourceDedicatedIPPool() *schema.Resource {
 		ReadWithoutTimeout: dataSourceDedicatedIPPoolRead,
 
 		Schema: map[string]*schema.Schema{
-			"pool_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -48,6 +43,11 @@ func DataSourceDedicatedIPPool() *schema.Resource {
 						},
 					},
 				},
+			},
+			"pool_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"tags": tftags.TagsSchemaComputed(),
 		},

--- a/internal/service/sesv2/dedicated_ip_pool_data_source.go
+++ b/internal/service/sesv2/dedicated_ip_pool_data_source.go
@@ -1,0 +1,94 @@
+package sesv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceDedicatedIPPool() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceDedicatedIPPoolRead,
+
+		Schema: map[string]*schema.Schema{
+			"pool_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dedicated_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"warmup_percentage": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"warmup_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameDedicatedIPPool = "Dedicated IP Pool Data Source"
+)
+
+func dataSourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+	poolName := d.Get("pool_name").(string)
+
+	out, err := FindDedicatedIPPoolByID(ctx, conn, poolName)
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, DSNameDedicatedIPPool, poolName, err)
+	}
+	d.SetId(poolName)
+
+	poolNameARN := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ses",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("dedicated-ip-pool/%s", d.Id()),
+	}.String()
+	d.Set("arn", poolNameARN)
+
+	d.Set("dedicated_ips", flattenDedicatedIPs(out.DedicatedIps))
+
+	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, DSNameDedicatedIPPool, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameDedicatedIPPool, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/sesv2/dedicated_ip_pool_data_source.go
+++ b/internal/service/sesv2/dedicated_ip_pool_data_source.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -91,4 +93,23 @@ func dataSourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	return nil
+}
+
+func flattenDedicatedIPs(apiObjects []types.DedicatedIp) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var dedicatedIps []interface{}
+	for _, apiObject := range apiObjects {
+		ip := map[string]interface{}{
+			"ip":                aws.ToString(apiObject.Ip),
+			"warmup_percentage": apiObject.WarmupPercentage,
+			"warmup_status":     string(apiObject.WarmupStatus),
+		}
+
+		dedicatedIps = append(dedicatedIps, ip)
+	}
+
+	return dedicatedIps
 }

--- a/internal/service/sesv2/dedicated_ip_pool_data_source_test.go
+++ b/internal/service/sesv2/dedicated_ip_pool_data_source_test.go
@@ -1,0 +1,50 @@
+package sesv2_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSESV2DedicatedIPPoolDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedIPPoolDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDedicatedIPPoolExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "pool_name", rName),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "ses", regexp.MustCompile(`dedicated-ip-pool/.+`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDedicatedIPPoolDataSourceConfig_basic(poolName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_dedicated_ip_pool" "test" {
+  pool_name = %[1]q
+}
+
+data "aws_sesv2_dedicated_ip_pool" "test" {
+  depends_on = [aws_sesv2_dedicated_ip_pool.test]
+  pool_name  = %[1]q
+}
+`, poolName, poolName)
+}

--- a/internal/service/sesv2/dedicated_ip_pool_test.go
+++ b/internal/service/sesv2/dedicated_ip_pool_test.go
@@ -1,0 +1,136 @@
+package sesv2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSESV2DedicatedIPPool_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_dedicated_ip_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedIPPoolConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDedicatedIPPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "pool_name", rName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ses", regexp.MustCompile(`dedicated-ip-pool/.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2DedicatedIPPool_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_dedicated_ip_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedIPPoolConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDedicatedIPPoolExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceDedicatedIPPool(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDedicatedIPPoolDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sesv2_dedicated_ip_pool" {
+			continue
+		}
+
+		_, err := tfsesv2.FindDedicatedIPPoolByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			var nfe *types.NotFoundException
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			return err
+		}
+
+		return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, tfsesv2.ResNameDedicatedIPPool, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckDedicatedIPPoolExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameDedicatedIPPool, name, errors.New("not found"))
+		}
+		if rs.Primary.ID == "" {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameDedicatedIPPool, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+		ctx := context.Background()
+
+		_, err := tfsesv2.FindDedicatedIPPoolByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameDedicatedIPPool, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+	ctx := context.Background()
+
+	_, err := conn.ListDedicatedIpPools(ctx, &sesv2.ListDedicatedIpPoolsInput{})
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccDedicatedIPPoolConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_dedicated_ip_pool" "test" {
+  pool_name = %[1]q
+}
+`, rName)
+}

--- a/website/docs/d/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/d/sesv2_dedicated_ip_pool.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "SESv2 (Simple Email V2)"
+layout: "aws"
+page_title: "AWS: aws_sesv2_dedicated_ip_pool"
+description: |-
+  Terraform data source for managing an AWS SESv2 (Simple Email V2) Dedicated IP Pool.
+---
+
+# Data Source: aws_sesv2_dedicated_ip_pool
+
+Terraform data source for managing an AWS SESv2 (Simple Email V2) Dedicated IP Pool.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_sesv2_dedicated_ip_pool" "example" {
+  pool_name = "my-pool"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `pool_name` - (Required) Name of the dedicated IP pool.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Dedicated IP Pool.
+* `dedicated_ips` - A list of objects describing the pool's dedicated IP's. See [`dedicated_ips`](#dedicated_ips).
+* `tags` - A map of tags attached to the pool.
+
+### dedicated_ips
+
+* `ip` - IPv4 address.
+* `warmup_percentage` - Indicates how complete the dedicated IP warm-up process is. When this value equals `1`, the address has completed the warm-up process and is ready for use.
+* `warmup_status` - The warm-up status of a dedicated IP address. Valid values: `IN_PROGRESS`, `DONE`.

--- a/website/docs/r/sesv2_configuration_set.html.markdown
+++ b/website/docs/r/sesv2_configuration_set.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 ### suppression_options
 
-- `suppressed_reasons` - (Optional) A list that contains the reasons that email addresses are automatically added to the suppression list for your account. Valid vales: `BOUNCE`, `COMPLAINT`.
+- `suppressed_reasons` - (Optional) A list that contains the reasons that email addresses are automatically added to the suppression list for your account. Valid values: `BOUNCE`, `COMPLAINT`.
 
 ## tracking_options
 

--- a/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
@@ -35,7 +35,7 @@ The following arguments are optional:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the Dedicated IP Pool.
-* `dedicated_ips` - A list of objects describing the pool's dedicated IP's. See [`dedicated_ips`](#dedicated-ips).
+* `dedicated_ips` - A list of objects describing the pool's dedicated IP's. See [`dedicated_ips`](#dedicated_ips).
 
 ### dedicated_ips
 

--- a/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
@@ -35,13 +35,6 @@ The following arguments are optional:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the Dedicated IP Pool.
-* `dedicated_ips` - A list of objects describing the pool's dedicated IP's. See [`dedicated_ips`](#dedicated_ips).
-
-### dedicated_ips
-
-* `ip` - IPv4 address.
-* `warmup_percentage` - Indicates how complete the dedicated IP warm-up process is. When this value equals `1`, the address has completed the warm-up process and is ready for use.
-* `warmup_status` - The warm-up status of a dedicated IP address. Valid values: `IN_PROGRESS`, `DONE`.
 
 ## Timeouts
 

--- a/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
@@ -24,7 +24,7 @@ resource "aws_sesv2_dedicated_ip_pool" "example" {
 
 The following arguments are required:
 
-* `pool_name` - (Required) Name of the dedicated IP pool. 
+* `pool_name` - (Required) Name of the dedicated IP pool.
 
 The following arguments are optional:
 

--- a/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "SESv2 (Simple Email V2)"
+layout: "aws"
+page_title: "AWS: aws_sesv2_dedicated_ip_pool"
+description: |-
+  Terraform resource for managing an AWS SESv2 (Simple Email V2) Dedicated IP Pool.
+---
+
+# Resource: aws_sesv2_dedicated_ip_pool
+
+Terraform resource for managing an AWS SESv2 (Simple Email V2) Dedicated IP Pool.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_sesv2_dedicated_ip_pool" "example" {
+  pool_name = "my-pool"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `pool_name` - (Required) Name of the dedicated IP pool. 
+
+The following arguments are optional:
+
+* `tags` - (Optional) A map of tags to assign to the pool. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Dedicated IP Pool.
+* `dedicated_ips` - A list of objects describing the pool's dedicated IP's. See [`dedicated_ips`](#dedicated-ips).
+
+### dedicated_ips
+
+* `ip` - IPv4 address.
+* `warmup_percentage` - Indicates how complete the dedicated IP warm-up process is. When this value equals `1`, the address has completed the warm-up process and is ready for use.
+* `warmup_status` - The warm-up status of a dedicated IP address. Valid values: `IN_PROGRESS`, `DONE`.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+SESv2 (Simple Email V2) Dedicated IP Pool can be imported using the `pool_name`, e.g.,
+
+```
+$ terraform import aws_sesv2_dedicated_ip_pool.example my-pool
+```


### PR DESCRIPTION
### Description
Adds a new resource and data source `aws_sesv2_dedicated_ip_pool`. 

### Relations
Relates #26796
Closes #10703

### Output from Acceptance Testing
```console
$ make testacc PKG=sesv2 TESTS="TestAccSESV2DedicatedIPPool"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sesv2/... -v -count 1 -parallel 20 -run='TestAccSESV2DedicatedIPPool'  -timeout 180m
=== RUN   TestAccSESV2DedicatedIPPoolDataSource_basic
=== PAUSE TestAccSESV2DedicatedIPPoolDataSource_basic
=== RUN   TestAccSESV2DedicatedIPPool_basic
=== PAUSE TestAccSESV2DedicatedIPPool_basic
=== RUN   TestAccSESV2DedicatedIPPool_disappears
=== PAUSE TestAccSESV2DedicatedIPPool_disappears
=== RUN   TestAccSESV2DedicatedIPPool_tags
=== PAUSE TestAccSESV2DedicatedIPPool_tags
=== CONT  TestAccSESV2DedicatedIPPoolDataSource_basic
=== CONT  TestAccSESV2DedicatedIPPool_disappears
=== CONT  TestAccSESV2DedicatedIPPool_tags
=== CONT  TestAccSESV2DedicatedIPPool_basic
--- PASS: TestAccSESV2DedicatedIPPool_disappears (13.81s)
--- PASS: TestAccSESV2DedicatedIPPoolDataSource_basic (16.93s)
--- PASS: TestAccSESV2DedicatedIPPool_basic (18.25s)
--- PASS: TestAccSESV2DedicatedIPPool_tags (39.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      42.966s
```
