### PR TITLE
skaff: Update datasource `ErrorCheck` generation

### DIFF
--- a/skaff/datasource/datasourcetest.tmpl
+++ b/skaff/datasource/datasourcetest.tmpl
@@ -66,6 +66,9 @@ import (
     // any normal context constants, variables, or functions.
 {{- end }}
 	tf{{ .ServicePackage }} "github.com/hashicorp/terraform-provider-aws/internal/service/{{ .ServicePackage }}"
+{{- if .AWSGoSDKV2 }}
+	"github.com/hashicorp/terraform-provider-aws/names"
+{{- end }}
 )
 {{ if .IncludeComments }}
 // TIP: File Structure. The basic outline for all test files should be as
@@ -172,7 +175,11 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 			acctest.PreCheckPartitionHasService({{ .ServicePackage }}.EndpointsID, t)
 			testAccPreCheck(t)
 		},
+		{{- if .AWSGoSDKV2 }}
+		ErrorCheck:               acctest.ErrorCheck(t, names.{{ .Service }}EndpointID),
+		{{- else }}
 		ErrorCheck:               acctest.ErrorCheck(t, {{ .ServicePackage }}.EndpointsID),
+		{{- end }}
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheck{{ .DataSource }}Destroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
This change brings the generation of the `ErrorCheck` field in data source acceptance tests into alignment with how the same field is generated for resources:

https://github.com/hashicorp/terraform-provider-aws/blob/238ded41ee735e9a9f0fd23569c4d80866961624/skaff/resource/resourcetest.tmpl#L70-L72

https://github.com/hashicorp/terraform-provider-aws/blob/238ded41ee735e9a9f0fd23569c4d80866961624/skaff/resource/resourcetest.tmpl#L183-L187