### PR TITLE
r/aws_glue_catalog_database: Unset create table default permissions when removed

### DIFF
--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -55,6 +55,7 @@ func ResourceCatalogDatabase() *schema.Resource {
 						"permissions": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringInSlice(glue.Permission_Values(), false),
@@ -64,11 +65,13 @@ func ResourceCatalogDatabase() *schema.Resource {
 							Type:     schema.TypeList,
 							MaxItems: 1,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"data_lake_principal_identifier": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 								},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This will fix by just passing an empty `create_table_default_permission` block to remove the default `IAMAllowedPrincipals` setting in glue databases 


### Relations

Closes #27295

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
