### PR TITLE
d/aws_outposts_assets - add host id and status filters

### DIFF
--- a/internal/service/outposts/outpost_assets_data_source.go
+++ b/internal/service/outposts/outpost_assets_data_source.go
@@ -25,6 +25,16 @@ func DataSourceOutpostAssets() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"host_id_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status_id_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -36,6 +46,15 @@ func DataSourceOutpostAssetsRead(d *schema.ResourceData, meta interface{}) error
 	input := &outposts.ListAssetsInput{
 		OutpostIdentifier: outpost_id,
 	}
+
+	if v, ok := d.GetOk("host_id_filter"); ok {
+		input.HostIdFilter = aws.StringSlice([]string{v})
+	}
+
+	if v, ok := d.GetOk("status_id_filter"); ok {
+		input.StatusFilter = aws.StringSlice([]string{v.(string)})
+	}
+
 	var asset_ids []string
 	err := conn.ListAssetsPages(input, func(page *outposts.ListAssetsOutput, lastPage bool) bool {
 		if page == nil {

--- a/internal/service/outposts/outpost_assets_data_source.go
+++ b/internal/service/outposts/outpost_assets_data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/outposts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -47,12 +48,12 @@ func DataSourceOutpostAssetsRead(d *schema.ResourceData, meta interface{}) error
 		OutpostIdentifier: outpost_id,
 	}
 
-	if v, ok := d.GetOk("host_id_filter"); ok {
-		input.HostIdFilter = aws.StringSlice([]string{v})
+	if _, ok := d.GetOk("host_id_filter"); ok {
+		input.HostIdFilter = flex.ExpandStringList(d.Get("host_id_filter").([]interface{}))
 	}
 
-	if v, ok := d.GetOk("status_id_filter"); ok {
-		input.StatusFilter = aws.StringSlice([]string{v.(string)})
+	if _, ok := d.GetOk("status_id_filter"); ok {
+		input.StatusFilter = flex.ExpandStringList(d.Get("status_id_filter").([]interface{}))
 	}
 
 	var asset_ids []string


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Provides the ability to query data source aws_outposts_assets by host id and status filters. Outpost assets API does not implement filters in the standard way e.g. aws_ami data source.


### Relations
Closes [#27133](https://github.com/hashicorp/terraform-provider-aws/issues/27133)


Closes #0000

### References
https://docs.aws.amazon.com/outposts/latest/APIReference/API_ListAssets.html
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/outposts/list-assets.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami


### Output from Acceptance Testing
make testacc TESTS=TestAccOutpostsAssetsDataSource_id PKG=outposts
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/outposts/... -v -count 1 -parallel 20 -run='TestAccOutpostsAssetsDataSource_id'  -timeout 180m
=== RUN   TestAccOutpostsAssetsDataSource_id
=== PAUSE TestAccOutpostsAssetsDataSource_id
=== CONT  TestAccOutpostsAssetsDataSource_id
--- PASS: TestAccOutpostsAssetsDataSource_id (13.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts   17.684s