### PR TITLE
Relocate Valid4ByteAsn function to common lib, add to CloudWAN Network Policy Doc Data Source

### DIFF
--- a/.changelog/27305.txt
+++ b/.changelog/27305.txt
@@ -1,3 +1,3 @@
-```release-note:note
-Add plan-time validation for `aws_networkmanager_core_network_policy_document.core_network_configuration.edge_locations[].asn`
+```release-note:enhancement
+data-source/aws_networkmanager_core_network_policy_document: Add plan-time validation for `core_network_configuration.edge_locations.asn`
 ```

--- a/.changelog/27305.txt
+++ b/.changelog/27305.txt
@@ -1,0 +1,3 @@
+```release-note:note
+Add plan-time validation for `aws_networkmanager_core_network_policy_document.core_network_configuration.edge_locations[].asn`
+```

--- a/internal/service/ec2/transitgateway_connect_peer.go
+++ b/internal/service/ec2/transitgateway_connect_peer.go
@@ -50,7 +50,7 @@ func ResourceTransitGatewayConnectPeer() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: valid4ByteASN,
+				ValidateFunc: verify.Valid4ByteASN,
 			},
 			"inside_cidr_blocks": {
 				Type:     schema.TypeSet,

--- a/internal/service/ec2/transitgateway_connect_peer.go
+++ b/internal/service/ec2/transitgateway_connect_peer.go
@@ -50,7 +50,7 @@ func ResourceTransitGatewayConnectPeer() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: verify.Valid4ByteASNString,
+				ValidateFunc: verify.Valid4ByteASN,
 			},
 			"inside_cidr_blocks": {
 				Type:     schema.TypeSet,

--- a/internal/service/ec2/transitgateway_connect_peer.go
+++ b/internal/service/ec2/transitgateway_connect_peer.go
@@ -50,7 +50,7 @@ func ResourceTransitGatewayConnectPeer() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: verify.Valid4ByteASN,
+				ValidateFunc: verify.Valid4ByteASNString,
 			},
 			"inside_cidr_blocks": {
 				Type:     schema.TypeSet,

--- a/internal/service/ec2/validate.go
+++ b/internal/service/ec2/validate.go
@@ -64,18 +64,3 @@ func validAmazonSideASN(v interface{}, k string) (ws []string, errors []error) {
 	}
 	return
 }
-
-func valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	asn, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("%q (%q) must be a 64-bit integer", k, v))
-		return
-	}
-
-	if asn < 0 || asn > 4294967295 {
-		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 0 to 4294967295", k, v))
-	}
-	return
-}

--- a/internal/service/ec2/validate_test.go
+++ b/internal/service/ec2/validate_test.go
@@ -74,34 +74,3 @@ func TestValidAmazonSideASN(t *testing.T) {
 		}
 	}
 }
-
-func TestValid4ByteASN(t *testing.T) {
-	validAsns := []string{
-		"0",
-		"1",
-		"65534",
-		"65535",
-		"4294967294",
-		"4294967295",
-	}
-	for _, v := range validAsns {
-		_, errors := valid4ByteASN(v, "bgp_asn")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid ASN: %q", v, errors)
-		}
-	}
-
-	invalidAsns := []string{
-		"-1",
-		"ABCDEFG",
-		"",
-		"4294967296",
-		"9999999999",
-	}
-	for _, v := range invalidAsns {
-		_, errors := valid4ByteASN(v, "bgp_asn")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid ASN", v)
-		}
-	}
-}

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -37,7 +37,7 @@ func ResourceCustomerGateway() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: verify.Valid4ByteASNString,
+				ValidateFunc: verify.Valid4ByteASN,
 			},
 			"certificate_arn": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -76,17 +76,20 @@ func resourceCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) err
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	i64BgpAsn, err := strconv.ParseInt(d.Get("bgp_asn").(string), 10, 64)
-
-	if err != nil {
-		return err
-	}
-
 	input := &ec2.CreateCustomerGatewayInput{
-		BgpAsn:            aws.Int64(i64BgpAsn),
 		IpAddress:         aws.String(d.Get("ip_address").(string)),
 		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeCustomerGateway),
 		Type:              aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("bgp_asn"); ok {
+		v, err := strconv.ParseInt(v.(string), 10, 64)
+
+		if err != nil {
+			return err
+		}
+
+		input.BgpAsn = aws.Int64(v)
 	}
 
 	if v, ok := d.GetOk("certificate_arn"); ok {

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -37,7 +37,7 @@ func ResourceCustomerGateway() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: verify.Valid4ByteASN,
+				ValidateFunc: verify.Valid4ByteASNString,
 			},
 			"certificate_arn": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -37,7 +37,7 @@ func ResourceCustomerGateway() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: valid4ByteASN,
+				ValidateFunc: verify.Valid4ByteASN,
 			},
 			"certificate_arn": {
 				Type:         schema.TypeString,

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -160,9 +160,9 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 										ValidateFunc: verify.ValidRegionName,
 									},
 									"asn": {
-										Type:         schema.TypeInt,
+										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: verify.Valid4ByteASN,
+										ValidateFunc: verify.Valid4ByteASNString,
 									},
 									"inside_cidr_blocks": {
 										Type:     schema.TypeList,
@@ -626,8 +626,14 @@ func expandDataCoreNetworkPolicyNetworkConfigurationEdgeLocations(tfList []inter
 			locMap[edgeLocation.Location] = struct{}{}
 		}
 
-		if v, ok := cfgEdgeLocation["asn"]; ok {
-			edgeLocation.Asn = v.(int)
+		if v, ok := cfgEdgeLocation["asn"].(string); ok && v != "" {
+			v, err := strconv.ParseInt(v, 10, 64)
+
+			if err != nil {
+				return nil, err
+			}
+
+			edgeLocation.Asn = v
 		}
 
 		if cidrs := cfgEdgeLocation["inside_cidr_blocks"].([]interface{}); len(cidrs) > 0 {

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -162,7 +162,7 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 									"asn": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: verify.Valid4ByteASNString,
+										ValidateFunc: verify.Valid4ByteASN,
 									},
 									"inside_cidr_blocks": {
 										Type:     schema.TypeList,

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -160,7 +160,7 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 										ValidateFunc: verify.ValidRegionName,
 									},
 									"asn": {
-										Type:         schema.TypeString,
+										Type:         schema.TypeInt,
 										Optional:     true,
 										ValidateFunc: verify.Valid4ByteASN,
 									},
@@ -627,7 +627,7 @@ func expandDataCoreNetworkPolicyNetworkConfigurationEdgeLocations(tfList []inter
 		}
 
 		if v, ok := cfgEdgeLocation["asn"]; ok {
-			edgeLocation.Asn = v.(string)
+			edgeLocation.Asn = v.(int)
 		}
 
 		if cidrs := cfgEdgeLocation["inside_cidr_blocks"].([]interface{}); len(cidrs) > 0 {

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -160,8 +160,9 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 										ValidateFunc: verify.ValidRegionName,
 									},
 									"asn": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.Valid4ByteASN,
 									},
 									"inside_cidr_blocks": {
 										Type:     schema.TypeList,
@@ -626,7 +627,7 @@ func expandDataCoreNetworkPolicyNetworkConfigurationEdgeLocations(tfList []inter
 		}
 
 		if v, ok := cfgEdgeLocation["asn"]; ok {
-			edgeLocation.Asn = v.(int)
+			edgeLocation.Asn = v.(string)
 		}
 
 		if cidrs := cfgEdgeLocation["inside_cidr_blocks"].([]interface{}); len(cidrs) > 0 {

--- a/internal/service/networkmanager/core_network_policy_document_data_source_test.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source_test.go
@@ -284,7 +284,7 @@ func testAccPolicyDocumentExpectedJSON() string {
     "edge-locations": [
       {
         "location": "us-east-1",
-        "asn": "64555",
+        "asn": 64555,
         "inside-cidr-blocks": [
           "2001:4860:F000::/40",
           "192.128.0.0/10",
@@ -293,7 +293,7 @@ func testAccPolicyDocumentExpectedJSON() string {
       },
       {
         "location": "eu-west-1",
-        "asn": "4200000001",
+        "asn": 4200000001,
         "inside-cidr-blocks": [
           "2001:4860:E000::/40",
           "192.192.0.0/10"

--- a/internal/service/networkmanager/core_network_policy_document_data_source_test.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source_test.go
@@ -284,7 +284,7 @@ func testAccPolicyDocumentExpectedJSON() string {
     "edge-locations": [
       {
         "location": "us-east-1",
-        "asn": 64555,
+        "asn": "64555",
         "inside-cidr-blocks": [
           "2001:4860:F000::/40",
           "192.128.0.0/10",
@@ -293,7 +293,7 @@ func testAccPolicyDocumentExpectedJSON() string {
       },
       {
         "location": "eu-west-1",
-        "asn": 4200000001,
+        "asn": "4200000001",
         "inside-cidr-blocks": [
           "2001:4860:E000::/40",
           "192.192.0.0/10"

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -64,7 +64,7 @@ type CoreNetworkPolicyCoreNetworkConfiguration struct {
 
 type CoreNetworkEdgeLocation struct {
 	Location         string      `json:"location"`
-	Asn              int         `json:"asn,omitempty"`
+	Asn              int64       `json:"asn,omitempty"`
 	InsideCidrBlocks interface{} `json:"inside-cidr-blocks,omitempty"`
 }
 

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -64,7 +64,7 @@ type CoreNetworkPolicyCoreNetworkConfiguration struct {
 
 type CoreNetworkEdgeLocation struct {
 	Location         string      `json:"location"`
-	Asn              int         `json:"asn,omitempty"`
+	Asn              string      `json:"asn,omitempty"`
 	InsideCidrBlocks interface{} `json:"inside-cidr-blocks,omitempty"`
 }
 

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -64,7 +64,7 @@ type CoreNetworkPolicyCoreNetworkConfiguration struct {
 
 type CoreNetworkEdgeLocation struct {
 	Location         string      `json:"location"`
-	Asn              string      `json:"asn,omitempty"`
+	Asn              int         `json:"asn,omitempty"`
 	InsideCidrBlocks interface{} `json:"inside-cidr-blocks,omitempty"`
 }
 

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -20,6 +20,21 @@ var accountIDRegexp = regexp.MustCompile(`^(aws|aws-managed|\d{12})$`)
 var partitionRegexp = regexp.MustCompile(`^aws(-[a-z]+)*$`)
 var regionRegexp = regexp.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d$`)
 
+func Valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	asn, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q (%q) must be a 64-bit integer", k, v))
+		return
+	}
+
+	if asn < 0 || asn > 4294967295 {
+		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 0 to 4294967295", k, v))
+	}
+	return
+}
+
 func ValidARN(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -20,7 +20,7 @@ var accountIDRegexp = regexp.MustCompile(`^(aws|aws-managed|\d{12})$`)
 var partitionRegexp = regexp.MustCompile(`^aws(-[a-z]+)*$`)
 var regionRegexp = regexp.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d$`)
 
-func Valid4ByteASNString(v interface{}, k string) (ws []string, errors []error) {
+func Valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
 	asn, err := strconv.ParseInt(value, 10, 64)

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -21,6 +21,12 @@ var partitionRegexp = regexp.MustCompile(`^aws(-[a-z]+)*$`)
 var regionRegexp = regexp.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d$`)
 
 func Valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
+	stringValue := strconv.Itoa(v.(int))
+
+	return Valid4ByteASNString(stringValue, k)
+}
+
+func Valid4ByteASNString(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
 	asn, err := strconv.ParseInt(value, 10, 64)

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -20,12 +20,6 @@ var accountIDRegexp = regexp.MustCompile(`^(aws|aws-managed|\d{12})$`)
 var partitionRegexp = regexp.MustCompile(`^aws(-[a-z]+)*$`)
 var regionRegexp = regexp.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d$`)
 
-func Valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
-	stringValue := strconv.Itoa(v.(int))
-
-	return Valid4ByteASNString(stringValue, k)
-}
-
 func Valid4ByteASNString(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -19,7 +19,7 @@ func TestValid4ByteASN(t *testing.T) {
 		"4294967295",
 	}
 	for _, v := range validAsns {
-		_, errors := valid4ByteASN(v, "bgp_asn")
+		_, errors := Valid4ByteASN(v, "bgp_asn")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid ASN: %q", v, errors)
 		}
@@ -33,7 +33,7 @@ func TestValid4ByteASN(t *testing.T) {
 		"9999999999",
 	}
 	for _, v := range invalidAsns {
-		_, errors := valid4ByteASN(v, "bgp_asn")
+		_, errors := Valid4ByteASN(v, "bgp_asn")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid ASN", v)
 		}

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -9,35 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func TestValid4ByteAsn(t *testing.T) {
-	validAsns := []int{
-		0,
-		1,
-		65534,
-		65535,
-		4294967294,
-		4294967295,
-	}
-	for _, v := range validAsns {
-		_, errors := Valid4ByteASN(v, "bgp_asn")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid ASN: %q", v, errors)
-		}
-	}
-
-	invalidAsns := []int{
-		-1,
-		4294967296,
-		9999999999,
-	}
-	for _, v := range invalidAsns {
-		_, errors := Valid4ByteASN(v, "bgp_asn")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid ASN", v)
-		}
-	}
-}
-
 func TestValid4ByteASNString(t *testing.T) {
 	validAsns := []string{
 		"0",

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -9,7 +9,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func TestValid4ByteASN(t *testing.T) {
+func TestValid4ByteAsn(t *testing.T) {
+	validAsns := []int{
+		0,
+		1,
+		65534,
+		65535,
+		4294967294,
+		4294967295,
+	}
+	for _, v := range validAsns {
+		_, errors := Valid4ByteASN(v, "bgp_asn")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid ASN: %q", v, errors)
+		}
+	}
+
+	invalidAsns := []int{
+		-1,
+		4294967296,
+		9999999999,
+	}
+	for _, v := range invalidAsns {
+		_, errors := Valid4ByteASN(v, "bgp_asn")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid ASN", v)
+		}
+	}
+}
+
+func TestValid4ByteASNString(t *testing.T) {
 	validAsns := []string{
 		"0",
 		"1",
@@ -19,7 +48,7 @@ func TestValid4ByteASN(t *testing.T) {
 		"4294967295",
 	}
 	for _, v := range validAsns {
-		_, errors := Valid4ByteASN(v, "bgp_asn")
+		_, errors := Valid4ByteASNString(v, "bgp_asn")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid ASN: %q", v, errors)
 		}
@@ -33,7 +62,7 @@ func TestValid4ByteASN(t *testing.T) {
 		"9999999999",
 	}
 	for _, v := range invalidAsns {
-		_, errors := Valid4ByteASN(v, "bgp_asn")
+		_, errors := Valid4ByteASNString(v, "bgp_asn")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid ASN", v)
 		}

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+func TestValid4ByteASN(t *testing.T) {
+	validAsns := []string{
+		"0",
+		"1",
+		"65534",
+		"65535",
+		"4294967294",
+		"4294967295",
+	}
+	for _, v := range validAsns {
+		_, errors := valid4ByteASN(v, "bgp_asn")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid ASN: %q", v, errors)
+		}
+	}
+
+	invalidAsns := []string{
+		"-1",
+		"ABCDEFG",
+		"",
+		"4294967296",
+		"9999999999",
+	}
+	for _, v := range invalidAsns {
+		_, errors := valid4ByteASN(v, "bgp_asn")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid ASN", v)
+		}
+	}
+}
+
 func TestValidTypeStringNullableBoolean(t *testing.T) {
 	testCases := []struct {
 		val         interface{}

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -19,7 +19,7 @@ func TestValid4ByteASNString(t *testing.T) {
 		"4294967295",
 	}
 	for _, v := range validAsns {
-		_, errors := Valid4ByteASNString(v, "bgp_asn")
+		_, errors := Valid4ByteASN(v, "bgp_asn")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid ASN: %q", v, errors)
 		}
@@ -33,7 +33,7 @@ func TestValid4ByteASNString(t *testing.T) {
 		"9999999999",
 	}
 	for _, v := range invalidAsns {
-		_, errors := Valid4ByteASNString(v, "bgp_asn")
+		_, errors := Valid4ByteASN(v, "bgp_asn")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid ASN", v)
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description


<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR restores the validation for a 4-byte ASN on CloudWAN (Network Manager) Core Network Policy Document data source under Edge Locations. The validation was removed due to build failures on 32-bit systems, but can be restored by re-using the `valid4ByteAsn` function from the `ec2` service provider as a common validation function.

This PR also modifies the `ec2` service provider to use the relocated common validation function (tests below).

When `terraform-plugin-framework` becomes GA, the function can be modified to leverage `Int64` as a new schema type.

No changelog entry created per [these instructions](https://hashicorp.github.io/terraform-provider-aws/changelog-process/#changes-that-should-not-have-a-changelog-entry)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24902

### References

https://github.com/hashicorp/terraform-provider-aws/pull/24890/files#r877631861 
https://github.com/hashicorp/terraform-provider-aws/pull/14030
https://github.com/hashicorp/terraform-provider-aws/pull/1888

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
terraform-provider-aws % make testacc TESTS=TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic PKG=networkmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic'  -timeout 180m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (9.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	13.749s

terraform-provider-aws % make testacc TESTS=TestAccSiteVPNCustomerGateway_4ByteASN PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNCustomerGateway_4ByteASN'  -timeout 180m
=== RUN   TestAccSiteVPNCustomerGateway_4ByteASN
=== PAUSE TestAccSiteVPNCustomerGateway_4ByteASN
=== CONT  TestAccSiteVPNCustomerGateway_4ByteASN
--- PASS: TestAccSiteVPNCustomerGateway_4ByteASN (25.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	29.842s

terraform-provider-aws % make testacc TESTARGS='-run=TestAccTransitGateway_serial/ConnectPeer/BgpAsn' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccTransitGateway_serial/ConnectPeer/BgpAsn -timeout 180m
=== RUN   TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/ConnectPeer
=== RUN   TestAccTransitGateway_serial/ConnectPeer/BgpAsn
--- PASS: TestAccTransitGateway_serial (479.25s)
    --- PASS: TestAccTransitGateway_serial/ConnectPeer (479.25s)
        --- PASS: TestAccTransitGateway_serial/ConnectPeer/BgpAsn (479.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	483.413s

terraform-provider-aws % make test TESTARGS='-v -count=1' TEST=./internal/verify/...
==> Checking that code complies with gofmt requirements...
go test ./internal/verify/... -v -count=1 -timeout=5m
=== RUN   TestBase64Encode
--- PASS: TestBase64Encode (0.00s)
=== RUN   TestCIDRBlocksEqual
--- PASS: TestCIDRBlocksEqual (0.00s)
=== RUN   TestCanonicalCIDRBlock
--- PASS: TestCanonicalCIDRBlock (0.00s)
=== RUN   TestSuppressEquivalentRoundedTime
--- PASS: TestSuppressEquivalentRoundedTime (0.00s)
=== RUN   TestSuppressEquivalentTypeStringBoolean
--- PASS: TestSuppressEquivalentTypeStringBoolean (0.00s)
=== RUN   TestDiffStringMaps
--- PASS: TestDiffStringMaps (0.00s)
=== RUN   TestLooksLikeJSONString
--- PASS: TestLooksLikeJSONString (0.00s)
=== RUN   TestJSONBytesEqualQuotedAndUnquoted
--- PASS: TestJSONBytesEqualQuotedAndUnquoted (0.00s)
=== RUN   TestJSONBytesEqualWhitespaceAndNoWhitespace
--- PASS: TestJSONBytesEqualWhitespaceAndNoWhitespace (0.00s)
=== RUN   TestSecondJSONUnlessEquivalent
--- PASS: TestSecondJSONUnlessEquivalent (0.00s)
=== RUN   TestNormalizeJSONOrYAMLString
--- PASS: TestNormalizeJSONOrYAMLString (0.00s)
=== RUN   TestSuppressEquivalentJSONDiffsWhitespaceAndNoWhitespace
--- PASS: TestSuppressEquivalentJSONDiffsWhitespaceAndNoWhitespace (0.00s)
=== RUN   TestSuppressEquivalentJSONOrYAMLDiffs
--- PASS: TestSuppressEquivalentJSONOrYAMLDiffs (0.00s)
=== RUN   TestSemVerLessThan
--- PASS: TestSemVerLessThan (0.00s)
=== RUN   TestSemVerGreaterThanOrEqual
--- PASS: TestSemVerGreaterThanOrEqual (0.00s)
=== RUN   TestValid4ByteASN
--- PASS: TestValid4ByteASN (0.00s)
=== RUN   TestValidTypeStringNullableBoolean
--- PASS: TestValidTypeStringNullableBoolean (0.00s)
=== RUN   TestValidTypeStringNullableFloat
--- PASS: TestValidTypeStringNullableFloat (0.00s)
=== RUN   TestValidAccountID
--- PASS: TestValidAccountID (0.00s)
=== RUN   TestValidARN
--- PASS: TestValidARN (0.00s)
=== RUN   TestValidateCIDRBlock
--- PASS: TestValidateCIDRBlock (0.00s)
=== RUN   TestValidCIDRNetworkAddress
--- PASS: TestValidCIDRNetworkAddress (0.00s)
=== RUN   TestValidIPv4CIDRBlock
--- PASS: TestValidIPv4CIDRBlock (0.00s)
=== RUN   TestValidIPv6CIDRBlock
--- PASS: TestValidIPv6CIDRBlock (0.00s)
=== RUN   TestIsIPv4CIDRBlockOrIPv6CIDRBlock
--- PASS: TestIsIPv4CIDRBlockOrIPv6CIDRBlock (0.00s)
=== RUN   TestValidIAMPolicyJSONString
--- PASS: TestValidIAMPolicyJSONString (0.00s)
=== RUN   TestValidStringIsJSONOrYAML
--- PASS: TestValidStringIsJSONOrYAML (0.00s)
=== RUN   TestValidOnceAWeekWindowFormat
--- PASS: TestValidOnceAWeekWindowFormat (0.00s)
=== RUN   TestValidOnceADayWindowFormat
--- PASS: TestValidOnceADayWindowFormat (0.00s)
=== RUN   TestValidLaunchTemplateName
--- PASS: TestValidLaunchTemplateName (0.00s)
=== RUN   TestValidLaunchTemplateID
--- PASS: TestValidLaunchTemplateID (0.00s)
=== RUN   TestValidUTCTimestamp
--- PASS: TestValidUTCTimestamp (0.00s)
=== RUN   TestValidateTypeStringIsDateOrInt
--- PASS: TestValidateTypeStringIsDateOrInt (0.00s)
=== RUN   TestFloatGreaterThan
--- PASS: TestFloatGreaterThan (0.00s)
=== RUN   TestCheckYAMLString
--- PASS: TestCheckYAMLString (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/verify	0.625s
```
