### PR TITLE
Add support for modifying Transit Gateway ASN

### DIFF
--- a/.changelog/27306.txt
+++ b/.changelog/27306.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_transit_gateway: Add support to modify `amazon_side_asn` argument
+```

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -236,7 +236,6 @@ func resourceTransitGatewayUpdate(d *schema.ResourceData, meta interface{}) erro
 			input.Options.AmazonSideAsn = aws.Int64(int64(d.Get("amazon_side_asn").(int)))
 		}
 
-		//aws.Int64(int64(v.(int)))
 
 		if d.HasChange("auto_accept_shared_attachments") {
 			input.Options.AutoAcceptSharedAttachments = aws.String(d.Get("auto_accept_shared_attachments").(string))

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -236,7 +236,6 @@ func resourceTransitGatewayUpdate(d *schema.ResourceData, meta interface{}) erro
 			input.Options.AmazonSideAsn = aws.Int64(int64(d.Get("amazon_side_asn").(int)))
 		}
 
-
 		if d.HasChange("auto_accept_shared_attachments") {
 			input.Options.AutoAcceptSharedAttachments = aws.String(d.Get("auto_accept_shared_attachments").(string))
 		}

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -53,7 +53,6 @@ func ResourceTransitGateway() *schema.Resource {
 			"amazon_side_asn": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 				Default:  64512,
 			},
 			"arn": {
@@ -232,6 +231,12 @@ func resourceTransitGatewayUpdate(d *schema.ResourceData, meta interface{}) erro
 			Options:          &ec2.ModifyTransitGatewayOptions{},
 			TransitGatewayId: aws.String(d.Id()),
 		}
+
+		if d.HasChange("amazon_side_asn") {
+			input.Options.AmazonSideAsn = aws.Int64(int64(d.Get("amazon_side_asn").(int)))
+		}
+
+		//aws.Int64(int64(v.(int)))
 
 		if d.HasChange("auto_accept_shared_attachments") {
 			input.Options.AutoAcceptSharedAttachments = aws.String(d.Get("auto_accept_shared_attachments").(string))

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -241,7 +241,7 @@ func testAccTransitGateway_AmazonSideASN(t *testing.T) {
 				Config: testAccTransitGatewayConfig_amazonSideASN(rName, 64514),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayExists(resourceName, &transitGateway2),
-					testAccCheckTransitGatewayRecreated(&transitGateway1, &transitGateway2),
+					testAccCheckTransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
 					resource.TestCheckResourceAttr(resourceName, "amazon_side_asn", "64514"),
 				),
 			},

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -24,7 +24,7 @@ The following arguments are supported:
 
 * `amazon_side_asn` - (Optional) Private Autonomous System Number (ASN) for the Amazon side of a BGP session. The range is `64512` to `65534` for 16-bit ASNs and `4200000000` to `4294967294` for 32-bit ASNs. Default value: `64512`.
 
--> **NOTE:** Modifying `amazon_side_asn` is not allowed on a Transit Gateway with active BGP sessions. You must first delete all Transit Gateway attachments that have BGP configured prior to modifying `amazon_side_asn`.
+-> **NOTE:** Modifying `amazon_side_asn` on a Transit Gateway with active BGP sessions is [not allowed](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyTransitGatewayOptions.html). You must first delete all Transit Gateway attachments that have BGP configured prior to modifying `amazon_side_asn`.
 
 * `auto_accept_shared_attachments` - (Optional) Whether resource attachment requests are automatically accepted. Valid values: `disable`, `enable`. Default value: `disable`.
 * `default_route_table_association` - (Optional) Whether resource attachments are automatically associated with the default association route table. Valid values: `disable`, `enable`. Default value: `enable`.

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -23,6 +23,9 @@ resource "aws_ec2_transit_gateway" "example" {
 The following arguments are supported:
 
 * `amazon_side_asn` - (Optional) Private Autonomous System Number (ASN) for the Amazon side of a BGP session. The range is `64512` to `65534` for 16-bit ASNs and `4200000000` to `4294967294` for 32-bit ASNs. Default value: `64512`.
+
+-> **NOTE:** Modifying `amazon_side_asn` is not allowed on a Transit Gateway with active BGP sessions. You must first delete all Transit Gateway attachments that have BGP configured prior to modifying `amazon_side_asn`.
+
 * `auto_accept_shared_attachments` - (Optional) Whether resource attachment requests are automatically accepted. Valid values: `disable`, `enable`. Default value: `disable`.
 * `default_route_table_association` - (Optional) Whether resource attachments are automatically associated with the default association route table. Valid values: `disable`, `enable`. Default value: `enable`.
 * `default_route_table_propagation` - (Optional) Whether resource attachments automatically propagate routes to the default propagation route table. Valid values: `disable`, `enable`. Default value: `enable`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add support for modifying the ASN on resource `aws_ec2_transit_gateway`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Closes #0000
--->

Closes #27301

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2@v1.63.1/types#ModifyTransitGatewayOptions
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyTransitGatewayOptions.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccTransitGateway_serial/Gateway/AmazonSideASN' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccTransitGateway_serial/Gateway/AmazonSideASN -timeout 180m
=== RUN   TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/Gateway
=== RUN   TestAccTransitGateway_serial/Gateway/AmazonSideASN
--- PASS: TestAccTransitGateway_serial (140.65s)
    --- PASS: TestAccTransitGateway_serial/Gateway (140.65s)
        --- PASS: TestAccTransitGateway_serial/Gateway/AmazonSideASN (140.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        143.356s

...
```
