### PR TITLE
Fix: Accept deployment_id in the canary_settings of aws_api_gateway_stage

### DIFF
--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -487,6 +487,7 @@ func TestAccAPIGatewayStage_canarySettings(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
+					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.deployment_id", "abcde12345"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.percent_traffic", "33.33"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.stage_variable_overrides.one", "3"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.use_stage_cache", "true"),
@@ -510,6 +511,7 @@ func TestAccAPIGatewayStage_canarySettings(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStageExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
+					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.deployment_id", "12345abcde"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.percent_traffic", "66.66"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.stage_variable_overrides.four", "5"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.use_stage_cache", "false"),
@@ -890,6 +892,7 @@ resource "aws_api_gateway_stage" "test" {
   deployment_id = aws_api_gateway_deployment.dev.id
 
   canary_settings {
+	deployment_id = "abcde12345"
     percent_traffic = "33.33"
     stage_variable_overrides = {
       one = "3"
@@ -912,6 +915,7 @@ resource "aws_api_gateway_stage" "test" {
   deployment_id = aws_api_gateway_deployment.dev.id
 
   canary_settings {
+	deployment_id = "12345abcde"
     percent_traffic = "66.66"
     stage_variable_overrides = {
       four = "5"

--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -892,7 +892,7 @@ resource "aws_api_gateway_stage" "test" {
   deployment_id = aws_api_gateway_deployment.dev.id
 
   canary_settings {
-	deployment_id = "abcde12345"
+	deployment_id   = "abcde12345"
     percent_traffic = "33.33"
     stage_variable_overrides = {
       one = "3"
@@ -915,7 +915,7 @@ resource "aws_api_gateway_stage" "test" {
   deployment_id = aws_api_gateway_deployment.dev.id
 
   canary_settings {
-	deployment_id = "12345abcde"
+	deployment_id   = "12345abcde"
     percent_traffic = "66.66"
     stage_variable_overrides = {
       four = "5"

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -125,6 +125,7 @@ For more information on configuring the log format rules visit the AWS [document
 
 ### Canary Settings
 
+* `deployment_id` - (Required) The identifier of the deployment that the stage points to.
 * `percent_traffic` - (Optional) Percent `0.0` - `100.0` of traffic to divert to the canary deployment.
 * `stage_variable_overrides` - (Optional) Map of overridden stage `variables` (including new variables) for the canary deployment.
 * `use_stage_cache` - (Optional) Whether the canary deployment uses the stage cache. Defaults to false.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
With the current Implementation, `canary_setting` does not accept `deploymentId` as a parameter. instead it uses the root deployment id. With this implementation canary deployment will not be possible, any deployment with canary settings set will be resulting a normal deployment with the traffic flowing 100% to the newly made deployment irrespective of the traffic percent that was set.

Problem for above issue originates here https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/apigateway/stage.go#L512-L513
```
	canarySettings := &apigateway.CanarySettings{
		DeploymentId: aws.String(deploymentId),
```

After the baseline deployment, In order to make a successful canary deployment, we will need to create a new `aws_api_gateway_deployment` and pass the deployment_id of the new deployment to canary_settings.
```
resource "aws_api_gateway_deployment" "baseline" {
     rest_api_id = aws_api_gateway_rest_api.rest-api.id
}

resource "aws_api_gateway_deployment" "canary" {
      rest_api_id = aws_api_gateway_rest_api.rest-api.id
}

resource "aws_api_gateway_stage" "production" {
    deployment_id   = aws_api_gateway_deployment.baseline.id
    rest_api_id     = aws_api_gateway_rest_api.rest-api.id
    stage_name      = "production"
    canary_settings {
       deployment_id       = aws_api_gateway_deployment.canary.id
       percent_traffic     = 10.0
       use_stage_cache     = false
     }
}
```

the `awscc` provider has what we need https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/apigateway_stage#nested-schema-for-canary_setting
