### PR TITLE
r/aws_ssm_parameter - add support for aws:ssm:integration data_type

### DIFF
--- a/.changelog/27329.txt
+++ b/.changelog/27329.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ssm_parameter: Add support for 'aws:ssm:integration' data_type
+```

--- a/.changelog/27329.txt
+++ b/.changelog/27329.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_ssm_parameter: Add support for 'aws:ssm:integration' data_type
+resource/aws_ssm_parameter: Support `aws:ssm:integration` as a valid value for `data_type`
 ```

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -51,6 +51,7 @@ func ResourceParameter() *schema.Resource {
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"aws:ec2:image",
+					"aws:ssm:integration",
 					"text",
 				}, false),
 			},

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -763,6 +763,35 @@ func TestAccSSMParameter_DataType_ec2Image(t *testing.T) {
 	})
 }
 
+func TestAccSSMParameter_DataType_ssmIntegration(t *testing.T) {
+	var param ssm.Parameter
+	webhookName := sdkacctest.RandString(16)
+	rName := fmt.Sprintf("/d9d01087-4a3f-49e0-b0b4-d568d7826553/ssm/integrations/webhook/%s", webhookName)
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssm.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterConfig_dataTypeSSMIntegration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "data_type", "aws:ssm:integration"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+		},
+	})
+}
+
 func TestAccSSMParameter_Secure_key(t *testing.T) {
 	var param ssm.Parameter
 	randString := sdkacctest.RandString(10)
@@ -964,6 +993,18 @@ resource "aws_ssm_parameter" "test" {
   data_type = "aws:ec2:image"
   type      = "String"
   value     = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+}
+`, rName))
+}
+
+func testAccParameterConfig_dataTypeSSMIntegration(rName string) string {
+	return acctest.ConfigCompose(
+		fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name      = %[1]q
+  data_type = "aws:ssm:integration"
+  type      = "SecureString"
+  value     = "{\"description\": \"My first webhook integration for Automation.\", \"url\": \"https://example.com\"}"
 }
 `, rName))
 }

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -763,7 +763,7 @@ func TestAccSSMParameter_DataType_ec2Image(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_DataType_ssmIntegration(t *testing.T) {
+func TestAccSSMParameter_DataType_ssmIntegration(t *testing.T) { //nosemgrep:ci.ssm-in-func-name
 	var param ssm.Parameter
 	webhookName := sdkacctest.RandString(16)
 	rName := fmt.Sprintf("/d9d01087-4a3f-49e0-b0b4-d568d7826553/ssm/integrations/webhook/%s", webhookName)
@@ -997,7 +997,7 @@ resource "aws_ssm_parameter" "test" {
 `, rName))
 }
 
-func testAccParameterConfig_dataTypeSSMIntegration(rName string) string {
+func testAccParameterConfig_dataTypeSSMIntegration(rName string) string { // nosemgrep:ci.ssm-in-func-name
 	return acctest.ConfigCompose(
 		fmt.Sprintf(`
 resource "aws_ssm_parameter" "test" {

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -65,7 +65,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `allowed_pattern` - (Optional) Regular expression used to validate the parameter value.
-* `data_type` - (Optional) Data type of the parameter. Valid values: `text` and `aws:ec2:image` for AMI format, see the [Native parameter support for Amazon Machine Image IDs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html).
+* `data_type` - (Optional) Data type of the parameter. Valid values: `text`, `aws:ssm:integration` and `aws:ec2:image` for AMI format, see the [Native parameter support for Amazon Machine Image IDs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html).
 * `description` - (Optional) Description of the parameter.
 * `insecure_value` - (Optional, exactly one of `value` or `insecure_value` is required) Value of the parameter. **Use caution:** This value is _never_ marked as sensitive in the Terraform plan output. This argument is not valid with a `type` of `SecureString`.
 * `key_id` - (Optional) KMS key ID or ARN for encrypting a SecureString.
@@ -73,6 +73,8 @@ The following arguments are optional:
 * `tags` - (Optional) Map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tier` - (Optional) Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`. Downgrading an `Advanced` tier parameter to `Standard` will recreate the resource. For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
 * `value` - (Optional, exactly one of `value` or `insecure_value` is required) Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of `type`. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the [Terraform v0.15 Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values).
+
+~> **NOTE:** `aws:ssm:integration` data_type parameters must be of the type `SecureString` and the name must start with the prefix `/d9d01087-4a3f-49e0-b0b4-d568d7826553/ssm/integrations/webhook/`. See [here](https://docs.aws.amazon.com/systems-manager/latest/userguide/creating-integrations.html) for information on the usage of `aws:ssm:integration` parameters.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add support for `data_type argument` `aws:ssm:integration`

These parameters are only used for creating webhook [integrations ](https://docs.aws.amazon.com/systems-manager/latest/userguide/creating-integrations.html) as part of an 'automation' in [AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/index.html) 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27146

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation.html
https://docs.aws.amazon.com/systems-manager/latest/userguide/creating-integrations.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
 make testacc TESTS=TestAccSSMParameter_DataType_ssmIntegration PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameter_DataType_ssmIntegration'  -timeout 180m
=== RUN   TestAccSSMParameter_DataType_ssmIntegration
=== PAUSE TestAccSSMParameter_DataType_ssmIntegration
=== CONT  TestAccSSMParameter_DataType_ssmIntegration
--- PASS: TestAccSSMParameter_DataType_ssmIntegration (29.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        29.697s
```
